### PR TITLE
doc: slim README to overview + links

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ BPF programs have access to raw bus primitives (I2C, SPI, GPIO, ADC), communicat
 
 ---
 
+## Application handlers
+
+The gateway is a platform service — application logic runs in a separate **handler process**. When a BPF program calls `send()` or `send_recv()`, the gateway forwards the data to the handler via stdin (length-prefixed CBOR). The handler processes it and replies via stdout. Handlers are routed by `program_hash`, so different BPF programs can have different handlers.
+
+The developer ships two artifacts: a **BPF ELF** (node-side) and a **handler** in any language (gateway-side). See [gateway-api.md](docs/gateway-api.md) for the full handler protocol, message format, and examples.
+
+---
+
 ## Operational concerns
 
 - **Gateway failover** — replace the gateway with another instance provisioned with the same key database. Nodes won't notice.


### PR DESCRIPTION
## Summary

Slims the README from 262 to 134 lines by removing content that now lives in dedicated docs.

### What was removed (all duplicated elsewhere)

| Section | Lines removed | Now in |
|---|---|---|
| Node-gateway protocol (handshake, commands, chunked transfer, app data) | ~50 lines | `docs/protocol.md` |
| Authentication (frame format, key provisioning, replay protection) | ~20 lines | `docs/protocol.md` |
| Memory model (table) | ~10 lines | `docs/bpf-environment.md` |
| Helper API (full code listing) | ~30 lines | `docs/bpf-environment.md` |
| Verification (profile table) | ~10 lines | `docs/bpf-environment.md` |
| Operational concerns (detailed subsections) | ~15 lines | `docs/gateway-requirements.md` |

### What remains

- Title, intro, status
- How it works (diagram + 4 steps)
- Architecture (4-layer table)
- BPF programs (brief summary + link)
- Node-gateway protocol (1 paragraph + link)
- Authentication (1 paragraph + link)
- BPF program environment (1 paragraph + link)
- Operational concerns (bullet list + link)
- Example use cases
- Reference implementation (ESP32 table)
- Further reading (links to all docs)
- License

The README is now an overview document that links to detailed specs.