### PR TITLE
doc: add gateway design specification

### DIFF
--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -395,8 +395,15 @@ The handler router maps `program_hash` → handler process and manages the handl
 ### 9.1  Configuration
 
 ```rust
+pub enum ProgramMatcher {
+    /// Match any program hash (catch-all).
+    Any,
+    /// Match a specific program hash.
+    Hash(Vec<u8>),
+}
+
 pub struct HandlerConfig {
-    pub program_hashes: Vec<Vec<u8>>,  // or "*" for catch-all
+    pub matchers: Vec<ProgramMatcher>,
     pub command: String,
     pub args: Vec<String>,
 }
@@ -512,7 +519,7 @@ tokio runtime
         └── reads stdout, routes LOG/DATA_REPLY
 ```
 
-Per-node processing tasks are spawned for each inbound frame. The session map is shared via `Arc<RwLock<HashMap<NodeId, Session>>>`. Since sessions are short-lived and contention is low (each node has at most one concurrent frame), a simple `RwLock` is sufficient.
+Per-node processing tasks are spawned for each inbound frame. The session map is shared via `Arc<tokio::sync::RwLock<HashMap<NodeId, Session>>>`. Since sessions are short-lived and contention is low (each node has at most one concurrent frame), a simple async-aware `RwLock` is sufficient, but implementations MUST NOT hold a lock guard across `.await` points. Implementers MAY instead use a concurrent map (e.g., `DashMap<NodeId, Session>`) to reduce lock contention and avoid common async locking pitfalls.
 
 The node registry and program library are accessed through the storage trait behind an `Arc`. Storage implementations are responsible for their own internal synchronization.
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -517,7 +517,7 @@ The gateway's key store SHOULD encrypt PSK material at rest. Plaintext PSKs SHOU
 
 1. When at-rest encryption is enabled, PSKs are not readable without the decryption key.
 2. The gateway can transparently read encrypted PSKs at startup and during operation.
-3. Exporting the key store SHOULD require explicit operator authorization (see GW-1001).
+3. Exporting the key store SHOULD require explicit operator authorization.
 
 ---
 


### PR DESCRIPTION
New file `docs/gateway-design.md` — the architecture and internal design for the Sonde gateway service, intended as the implementation guide for an LLM coding agent (or human developer).

## Technology choices

- **Language:** Rust
- **Async runtime:** tokio (single event loop, per-node tasks)
- **BPF verification:** [prevail-rust](https://github.com/elazarg/prevail-rust) (native Rust, feature-parity with C++ Prevail)
- **CBOR:** ciborium (serde-compatible)
- **HMAC:** RustCrypto (`hmac` + `sha2`)
- **Transport:** Abstract trait (ESP-NOW as first adapter)
- **Storage:** Abstract trait (encryption-agnostic; implementations SHOULD encrypt PSKs at rest)

## Module architecture

| Module | Responsibility |
|---|---|
| Transport (trait) | Send/receive raw frames; carries sender address (MAC) |
| Protocol Codec | Frame serialization, HMAC verification, CBOR message types |
| Session Manager | Per-node session lifecycle, sequence tracking, command dispatch |
| Node Registry | PSK lookup by `key_hint`, node metadata, battery/ABI tracking |
| Program Library | ELF ingestion, Prevail verification, CBOR image encoding, chunk serving |
| Handler Router | Route APP_DATA to handler processes by `program_hash` |
| Handler Process | stdin/stdout lifecycle, DATA/DATA_REPLY/EVENT/LOG messages |
| Storage (trait) | Persist node registry, program library, configuration |

## Key design decisions

- **Transport addressing:** MAC address is session-scoped (stored in session, never persisted). `key_hint` + HMAC is the durable identity mechanism.
- **Program ingestion:** ELF -> Prevail (verify + resolve LDDW relocations) -> extract bytecode + maps -> CBOR encode (deterministic) -> SHA-256 hash -> store. Verification completes at ingestion time; chunk serving is immediate.
- **Concurrency:** Single tokio runtime; per-node tasks spawned for each inbound frame; session map via `Arc<RwLock<HashMap>>`.
- **Error handling:** All protocol errors result in silent discard (no error response). Leveled logging for operational monitoring.

## Also adds

- **GW-0601a** (gateway-requirements.md): Key store SHOULD encrypt PSKs at rest (from security.md section 2.3, was not captured as a requirement)