### PR TITLE
doc: add node validation specification

### DIFF
--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -153,11 +153,11 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Procedure:**
 1. Install a known program (hash X). Set battery to 3300 mV via mock ADC.
 2. Boot node.
-3. Capture WAKE frame, decode payload.
+3. Capture WAKE frame, parse the fixed 11-byte frame header, and decode the CBOR payload.
 4. Assert: `firmware_abi_version` matches firmware ABI.
 5. Assert: `program_hash` = hash X.
 6. Assert: `battery_mv` = 3300.
-7. Assert: WAKE includes a `nonce` field sourced from hardware RNG.
+7. Assert: the WAKE frame header `nonce` field (in the fixed 11-byte header, not the CBOR payload) is present and sourced from the hardware RNG.
 
 ---
 
@@ -472,7 +472,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Procedure:**
 1. Mock gateway sends `timestamp_ms = 1710000000000`.
 2. Install a program that reads `ctx->timestamp`, `ctx->battery_mv`, `ctx->firmware_abi_version`, `ctx->wake_reason` and sends them via `send()`.
-3. Assert: `timestamp` ≈ 1710000000000 (within a few ms of local elapsed).
+3. Assert: `timestamp` ≈ 1710000000000 + elapsed time since COMMAND was processed (within a few ms tolerance).
 4. Assert: `battery_mv` matches ADC reading.
 5. Assert: `firmware_abi_version` matches firmware.
 6. Assert: `wake_reason` = `WAKE_SCHEDULED` (0x00).
@@ -635,7 +635,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Procedure:**
 1. Mock gateway sends `timestamp_ms = 1710000000000`.
 2. Install program that calls `get_time()` and `get_battery_mv()`.
-3. Assert: `get_time()` ≈ 1710000000000.
+3. Assert: `get_time()` ≈ 1710000000000 + elapsed time since COMMAND was processed (within a few ms tolerance).
 4. Assert: `get_battery_mv()` matches mock ADC.
 
 ---


### PR DESCRIPTION
New file `docs/node-validation.md` with 55 integration test cases covering all 39 node requirements.

## Test environment

- **Mock gateway:** simulates gateway protocol responses (configurable: delays, drops, invalid HMAC, wrong nonce)
- **Mock HAL:** stub I2C/SPI/GPIO/ADC drivers with configurable responses
- **Flash simulation:** in-memory backing for key, program, and schedule partitions
- **Test program library:** pre-compiled BPF CBOR images (nop, send, send_recv, map, early_wake, oversized_map, deep_call, budget_exceeded)

## Test coverage

| Section | Tests | Requirements |
|---|---|---|
| Protocol & communication | T-N100 to T-N104 | ND-0100 to ND-0103 |
| Wake cycle | T-N200 to T-N209 | ND-0200 to ND-0203 |
| Auth & replay protection | T-N300 to T-N306 | ND-0300 to ND-0304 |
| Key storage & provisioning | T-N400 to T-N404 | ND-0400 to ND-0402 |
| Program transfer & execution | T-N500 to T-N510 | ND-0500 to ND-0506 |
| BPF environment | T-N600 to T-N616 | ND-0600 to ND-0606 |
| Timing & retries | T-N700 to T-N702 | ND-0700 to ND-0702 |
| Error handling | T-N800 to T-N802 | ND-0800 to ND-0802 |

Two requirements (ND-0403 secure boot, ND-0403a flash encryption) are platform-level and verified by platform-specific tests.

Includes full test-to-requirement traceability matrix in Appendix A.