### PR TITLE
doc: add implementation guide (workspace layout + build order)

### DIFF
--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -122,7 +122,7 @@ sonde-protocol  (no_std + alloc, no platform deps)
 
 **Design doc:** [protocol-crate-design.md](protocol-crate-design.md)  
 **Validation:** [protocol-crate-validation.md](protocol-crate-validation.md) (41 tests)  
-**Dependencies:** `ciborium` only.
+**Runtime dependencies:** `ciborium` only. **Dev-dependencies (for tests):** `hmac`, `sha2`.
 
 **Module order:**
 
@@ -149,7 +149,7 @@ sonde-protocol  (no_std + alloc, no platform deps)
 **Goal:** A working gateway service that can authenticate nodes, manage sessions, serve programs, and route application data.
 
 **Design doc:** [gateway-design.md](gateway-design.md)  
-**Validation:** [gateway-validation.md](gateway-validation.md) (61 tests)  
+**Validation:** [gateway-validation.md](gateway-validation.md)  
 **Dependencies:** `sonde-protocol`, `tokio`, `tonic`, `prevail-rust`, `hmac`, `sha2`, `ciborium`, `toml`.
 
 **Module order:**
@@ -178,7 +178,7 @@ sonde-protocol  (no_std + alloc, no platform deps)
 **Goal:** Working node firmware for ESP32-C3/S3.
 
 **Design doc:** [node-design.md](node-design.md)  
-**Validation:** [node-validation.md](node-validation.md) (55 tests)  
+**Validation:** [node-validation.md](node-validation.md)  
 **Dependencies:** `sonde-protocol`, `esp-idf-hal`, `esp-idf-svc`, BPF interpreter (rbpf or uBPF).
 
 **Module order:**


### PR DESCRIPTION
New file `docs/implementation-guide.md` — the roadmap for building the Sonde system, designed for an LLM coding agent or human developer.

## Workspace layout

Rust workspace with 4 crates:

```
crates/sonde-protocol/   # shared protocol crate (no_std + alloc)
crates/sonde-gateway/    # gateway service (tokio, tonic, prevail-rust)
crates/sonde-node/       # node firmware (esp-idf-hal, esp-idf-svc)
crates/sonde-admin/      # CLI admin tool (tonic client, clap, serialport)
```

Full directory tree with module-level file breakdown for each crate. `sonde-protocol` is the only shared dependency — the other three do not depend on each other.

## Implementation phases

| Phase | Crate | Tests | Exit criteria |
|---|---|---|---|
| 1 | `sonde-protocol` | 41 | `cargo test -p sonde-protocol` passes |
| 2 | `sonde-gateway` | 61 | `cargo test -p sonde-gateway` passes |
| 3 | `sonde-node` | 55 | Host + hardware-in-the-loop tests pass |
| 4 | `sonde-admin` | CLI | Integration against running gateway |

Each phase includes a module-by-module build order table mapping steps to specific validation test IDs from the validation specs.

## Also covers

- Build commands for all targets (host, ESP32-C3 RISC-V, ESP32-S3 Xtensa)
- CI pipeline definition (fmt, clippy, test, build)
- Shared test utilities crate (`sonde-test-utils`)
- Proto file management for gRPC admin API
- Test program compilation from BPF C source