### PR TITLE
docs: convert ASCII sequence diagrams to Mermaid

### DIFF
--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -81,20 +81,18 @@ Maximum message size: **1 MB** (1,048,576 bytes). Messages with a length field e
 
 ### 2.2  Lifecycle
 
-```
-Gateway                          Handler process
-  │                                  │
-  │  [spawn]                         │
-  │                                  │
-  │──── stdin: DATA (CBOR) ─────────►│
-  │◄──── stdout: DATA_REPLY (CBOR) ──│
-  │                                  │
-  │──── stdin: DATA (CBOR) ─────────►│  (handler still alive — keep going)
-  │◄──── stdout: DATA_REPLY (CBOR) ──│
-  │                                  │
-  │  ... or handler exits ...        │
-  │                                  │
-  │  [respawn on next message]       │
+```mermaid
+sequenceDiagram
+    participant Gateway
+    participant Handler as Handler process
+
+    Note over Gateway,Handler: spawn
+    Gateway->>Handler: stdin: DATA (CBOR)
+    Handler->>Gateway: stdout: DATA_REPLY (CBOR)
+    Gateway->>Handler: stdin: DATA (CBOR) — handler still alive
+    Handler->>Gateway: stdout: DATA_REPLY (CBOR)
+    Note over Gateway,Handler: ... or handler exits ...
+    Note over Gateway: respawn on next message
 ```
 
 **Exit handling:** If the handler exits with code 0 between messages, the gateway respawns it on the next message. If it exits with non-zero (or crashes mid-message), the gateway logs the error and does not send an `APP_DATA_REPLY` to the node (the node's `send_recv()` will timeout if it was waiting).

--- a/docs/modem-protocol.md
+++ b/docs/modem-protocol.md
@@ -240,18 +240,17 @@ Reports an unrecoverable modem error. The gateway should log this and may attemp
 
 The gateway MUST always send `RESET` when opening the serial port, regardless of whether the modem was just powered on or was already running. This ensures deterministic state.
 
-```
-Gateway                          Modem
-   │                               │
-   │──── [open serial port] ──────►│
-   │──── RESET ───────────────────►│
-   │                               │
-   │◄──── MODEM_READY ─────────────│
-   │                               │
-   │──── SET_CHANNEL(ch) ─────────►│
-   │◄──── SET_CHANNEL_ACK(ch) ─────│
-   │                               │
-   │  ════ normal operation ════   │
+```mermaid
+sequenceDiagram
+    participant Gateway
+    participant Modem
+
+    Gateway->>Modem: [open serial port]
+    Gateway->>Modem: RESET
+    Modem->>Gateway: MODEM_READY
+    Gateway->>Modem: SET_CHANNEL(ch)
+    Modem->>Gateway: SET_CHANNEL_ACK(ch)
+    Note over Gateway,Modem: normal operation
 ```
 
 Any `MODEM_READY` received before `RESET` completes (e.g., from USB enumeration) is discarded. The gateway only accepts `MODEM_READY` after it has sent `RESET`.
@@ -262,58 +261,59 @@ During normal operation, two independent flows run concurrently:
 
 **Inbound (radio → gateway):** The modem sends `RECV_FRAME` whenever an ESP-NOW frame arrives. These are asynchronous — they can arrive at any time, interleaved with responses to gateway commands.
 
-```
-Gateway                          Modem
-   │                               │
-   │◄──── RECV_FRAME ──────────────│  (node sent a WAKE)
-   │                               │
-   │──── SEND_FRAME ──────────────►│  (gateway sends COMMAND)
-   │                               │
-   │◄──── RECV_FRAME ──────────────│  (node sent GET_CHUNK)
-   │──── SEND_FRAME ──────────────►│  (gateway sends CHUNK)
-   │          ⋮                    │
+```mermaid
+sequenceDiagram
+    participant Gateway
+    participant Modem
+
+    Modem->>Gateway: RECV_FRAME (node sent a WAKE)
+    Gateway->>Modem: SEND_FRAME (gateway sends COMMAND)
+    Modem->>Gateway: RECV_FRAME (node sent GET_CHUNK)
+    Gateway->>Modem: SEND_FRAME (gateway sends CHUNK)
+    Note over Gateway,Modem: ⋮
 ```
 
 **Outbound (gateway → radio):** The gateway sends `SEND_FRAME` which the modem transmits immediately. No per-frame response is expected.
 
 ### 5.3  Health check
 
-```
-Gateway                          Modem
-   │                               │
-   │──── GET_STATUS ──────────────►│
-   │◄──── STATUS ──────────────────│
-   │                               │
+```mermaid
+sequenceDiagram
+    participant Gateway
+    participant Modem
+
+    Gateway->>Modem: GET_STATUS
+    Modem->>Gateway: STATUS
 ```
 
 The gateway polls periodically (recommended: every 30 seconds). A rising `tx_fail_count` indicates radio delivery problems.
 
 ### 5.4  Channel survey
 
-```
-Gateway                          Modem
-   │                               │
-   │──── SCAN_CHANNELS ───────────►│
-   │        (radio scanning        │
-   │         ~2–3 seconds)         │
-   │◄──── SCAN_RESULT ─────────────│
-   │                               │
+```mermaid
+sequenceDiagram
+    participant Gateway
+    participant Modem
+
+    Gateway->>Modem: SCAN_CHANNELS
+    Note right of Modem: radio scanning ~2–3 seconds
+    Modem->>Gateway: SCAN_RESULT
 ```
 
 ESP-NOW reception is interrupted during the scan. This flow is only used during setup or maintenance.
 
 ### 5.5  Error recovery
 
-```
-Gateway                          Modem
-   │                               │
-   │◄──── ERROR(code, msg) ────────│
-   │                               │
-   │──── RESET ───────────────────►│
-   │◄──── MODEM_READY ─────────────│
-   │──── SET_CHANNEL(ch) ─────────►│
-   │◄──── SET_CHANNEL_ACK(ch) ─────│
-   │                               │
+```mermaid
+sequenceDiagram
+    participant Gateway
+    participant Modem
+
+    Modem->>Gateway: ERROR(code, msg)
+    Gateway->>Modem: RESET
+    Modem->>Gateway: MODEM_READY
+    Gateway->>Modem: SET_CHANNEL(ch)
+    Modem->>Gateway: SET_CHANNEL_ACK(ch)
 ```
 
 On `ERROR`, the gateway logs the error and sends `RESET` to attempt recovery.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -333,49 +333,42 @@ If a `send_recv()` call on the node times out waiting for `APP_DATA_REPLY`, the 
 
 ### 6.1  Normal wake cycle (no update needed)
 
-```
-    Node                          Gateway
-     │                               │
-     │──── WAKE ────────────────────►│
-     │                               │  (lookup node, verify HMAC,
-     │                               │   check program_hash — matches)
-     │◄──── COMMAND {NOP} ───────────│
-     │                               │
-     │  [execute resident BPF]       │
-     │                               │
-     │──── APP_DATA ────────────────►│  (zero or more, send or send_recv)
-     │◄──── APP_DATA_REPLY ──────────│  (only if handler replies with data)
-     │                               │
-     │  [sleep]                      │
+```mermaid
+sequenceDiagram
+    participant Node
+    participant Gateway
+
+    Node->>Gateway: WAKE
+    Note right of Gateway: lookup node, verify HMAC,<br/>check program_hash — matches
+    Gateway->>Node: COMMAND {NOP}
+    Note left of Node: execute resident BPF
+    Node->>Gateway: APP_DATA (zero or more, send or send_recv)
+    Gateway-->>Node: APP_DATA_REPLY (only if handler replies)
+    Note left of Node: sleep
 ```
 
 ### 6.2  Program update (chunked transfer)
 
-```
-    Node                          Gateway
-     │                               │
-     │──── WAKE ────────────────────►│
-     │                               │  (program_hash mismatch)
-     │◄── COMMAND {UPDATE_PROGRAM} ──│  (includes program_hash, size, chunk info)
-     │                               │
-     │──── GET_CHUNK {index=0} ─────►│
-     │◄──── CHUNK {index=0, data} ───│
-     │                               │
-     │──── GET_CHUNK {index=1} ─────►│
-     │◄──── CHUNK {index=1, data} ───│
-     │                               │
-     │        ... repeat ...         │
-     │                               │
-     │  [verify hash, store to flash]│
-     │                               │
-     │──── PROGRAM_ACK ─────────────►│
-     │                               │
-     │  [execute new program]        │
-     │                               │
-     │──── APP_DATA ────────────────►│  (zero or more)
-     │◄──── APP_DATA_REPLY ──────────│  (only if handler replies with data)
-     │                               │
-     │  [sleep]                      │
+```mermaid
+sequenceDiagram
+    participant Node
+    participant Gateway
+
+    Node->>Gateway: WAKE
+    Note right of Gateway: program_hash mismatch
+    Gateway->>Node: COMMAND {UPDATE_PROGRAM}<br/>(program_hash, size, chunk info)
+
+    loop for each chunk
+        Node->>Gateway: GET_CHUNK {index=N}
+        Gateway->>Node: CHUNK {index=N, data}
+    end
+
+    Note left of Node: verify hash, store to flash
+    Node->>Gateway: PROGRAM_ACK
+    Note left of Node: execute new program
+    Node->>Gateway: APP_DATA (zero or more)
+    Gateway-->>Node: APP_DATA_REPLY (only if handler replies)
+    Note left of Node: sleep
 ```
 
 After sending `PROGRAM_ACK`, the node **executes the new program immediately** in the same wake cycle. This avoids wasting a sleep/wake cycle and battery. The node then sleeps on the program's schedule as normal.
@@ -384,44 +377,40 @@ After sending `PROGRAM_ACK`, the node **executes the new program immediately** i
 
 Ephemeral programs use the same chunked transfer as resident programs (see §6.2). The `command_type` (`RUN_EPHEMERAL`) tells the node to store the program in RAM and discard it after execution.
 
-```
-    Node                          Gateway
-     │                               │
-     │──── WAKE ────────────────────►│
-     │                               │  (gateway wants diagnostics)
-     │◄── COMMAND {RUN_EPHEMERAL} ───│  (includes program_hash, size, chunk info)
-     │                               │
-     │──── GET_CHUNK {index=0} ─────►│
-     │◄──── CHUNK {index=0, data} ───│
-     │                               │
-     │──── GET_CHUNK {index=1} ─────►│
-     │◄──── CHUNK {index=1, data} ───│
-     │                               │
-     │        ... repeat ...         │
-     │                               │
-     │  [verify hash, load to RAM]   │
-     │                               │
-     │──── PROGRAM_ACK ─────────────►│
-     │                               │
-     │  [execute ephemeral program]  │
-     │                               │
-     │──── APP_DATA ────────────────►│  (diagnostic results)
-     │◄──── APP_DATA_REPLY ──────────│  (only if handler replies with data)
-     │                               │
-     │  [sleep — ephemeral discarded]│
+```mermaid
+sequenceDiagram
+    participant Node
+    participant Gateway
+
+    Node->>Gateway: WAKE
+    Note right of Gateway: gateway wants diagnostics
+    Gateway->>Node: COMMAND {RUN_EPHEMERAL}<br/>(program_hash, size, chunk info)
+
+    loop for each chunk
+        Node->>Gateway: GET_CHUNK {index=N}
+        Gateway->>Node: CHUNK {index=N, data}
+    end
+
+    Note left of Node: verify hash, load to RAM
+    Node->>Gateway: PROGRAM_ACK
+    Note left of Node: execute ephemeral program
+    Node->>Gateway: APP_DATA (diagnostic results)
+    Gateway-->>Node: APP_DATA_REPLY (only if handler replies)
+    Note left of Node: sleep — ephemeral discarded
 ```
 
 ### 6.4  Schedule update
 
-```
-    Node                          Gateway
-     │                               │
-     │──── WAKE ────────────────────►│
-     │◄── COMMAND {UPDATE_SCHEDULE} ─│  (new interval_s)
-     │                               │
-     │  [store new interval]         │
-     │  [execute resident BPF]       │
-     │  [sleep for new interval]     │
+```mermaid
+sequenceDiagram
+    participant Node
+    participant Gateway
+
+    Node->>Gateway: WAKE
+    Gateway->>Node: COMMAND {UPDATE_SCHEDULE}<br/>(new interval_s)
+    Note left of Node: store new interval
+    Note left of Node: execute resident BPF
+    Note left of Node: sleep for new interval
 ```
 
 ### 6.5  Application data exchange
@@ -431,20 +420,18 @@ The BPF program and gateway application communicate through `APP_DATA` messages.
 - **Fire-and-forget** (`send()`): The BPF program sends data without waiting for a reply.
 - **Request-response** (`send_recv()`): The BPF program sends data and blocks until `APP_DATA_REPLY` arrives or the timeout expires.
 
-```
-    Node                          Gateway
-     │                               │
-     │──── WAKE ────────────────────►│
-     │◄──── COMMAND {NOP} ───────────│
-     │                               │
-     │  [execute BPF]                │
-     │                               │
-     │──── APP_DATA (send) ─────────►│  (fire-and-forget, no reply)
-     │                               │
-     │──── APP_DATA (send_recv) ────►│  (node waits for reply)
-     │◄──── APP_DATA_REPLY {resp} ───│  (handler replied with data)
-     │                               │
-     │  [sleep]                      │
+```mermaid
+sequenceDiagram
+    participant Node
+    participant Gateway
+
+    Node->>Gateway: WAKE
+    Gateway->>Node: COMMAND {NOP}
+    Note left of Node: execute BPF
+    Node->>Gateway: APP_DATA (send) — fire-and-forget
+    Node->>Gateway: APP_DATA (send_recv) — node waits
+    Gateway->>Node: APP_DATA_REPLY {resp}
+    Note left of Node: sleep
 ```
 
 The number of exchanges per wake cycle is determined by the BPF program. The protocol imposes no limit beyond the node's power budget.


### PR DESCRIPTION
Convert 11 sequence diagrams across 3 docs from ASCII art to Mermaid `sequenceDiagram` blocks that render natively in GitHub markdown preview.

## Changes

| File | Diagrams converted |
|------|--------------------|
| `protocol.md` §6.1–6.5 | Normal wake cycle, program update, ephemeral execution, schedule update, app data exchange |
| `modem-protocol.md` §5.1–5.5 | Startup, normal frame relay, health check, channel survey, error recovery |
| `gateway-api.md` §2.2 | Handler lifecycle (spawn/stdin/stdout) |

## Not converted (intentionally)

Binary wire-format layouts (frame envelopes, field tables) remain as ASCII box-drawing art — Mermaid has no primitive for byte-level protocol diagrams. Architecture block diagrams and state machines in `gateway-design.md` and `node-design.md` are also left as-is.
