### PR TITLE
Add 18 integration tests for sonde-node wake cycle

### DIFF
--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -1713,14 +1713,8 @@ mod tests {
         let psk = [0xA1; 32];
         let key_hint = 1u16;
         let mut transport = MockTransport::new();
-        let command_frame = build_command_response(
-            &psk,
-            key_hint,
-            1,
-            1000,
-            1710000000000,
-            CommandPayload::Nop,
-        );
+        let command_frame =
+            build_command_response(&psk, key_hint, 1, 1000, 1710000000000, CommandPayload::Nop);
         transport.queue_response(Some(command_frame));
 
         let mut storage = MockStorage::new().with_key(key_hint, psk);
@@ -1772,14 +1766,8 @@ mod tests {
         let psk = [0xA2; 32];
         let key_hint = 42u16;
         let mut transport = MockTransport::new();
-        let command_frame = build_command_response(
-            &psk,
-            key_hint,
-            1,
-            1000,
-            1710000000000,
-            CommandPayload::Nop,
-        );
+        let command_frame =
+            build_command_response(&psk, key_hint, 1, 1000, 1710000000000, CommandPayload::Nop);
         transport.queue_response(Some(command_frame));
 
         let mut storage = MockStorage::new().with_key(key_hint, psk);
@@ -1873,14 +1861,8 @@ mod tests {
         let psk = [0xB2; 32];
         let key_hint = 5u16;
         let mut transport = MockTransport::new();
-        let command_frame = build_command_response(
-            &psk,
-            key_hint,
-            1,
-            1000,
-            1710000000000,
-            CommandPayload::Nop,
-        );
+        let command_frame =
+            build_command_response(&psk, key_hint, 1, 1000, 1710000000000, CommandPayload::Nop);
         transport.queue_response(Some(command_frame));
 
         let mut storage = MockStorage::new().with_key(key_hint, psk);
@@ -1913,7 +1895,7 @@ mod tests {
             } => {
                 assert_eq!(firmware_abi_version, FIRMWARE_ABI_VERSION);
                 assert_eq!(battery_mv, 3300); // MockBattery
-                // No program installed → empty hash
+                                              // No program installed → empty hash
                 assert!(program_hash.is_empty());
             }
             _ => panic!("expected Wake message"),
@@ -1955,7 +1937,10 @@ mod tests {
         let wake_msg = NodeMessage::decode(decoded.header.msg_type, &decoded.payload).unwrap();
         match wake_msg {
             NodeMessage::Wake { program_hash, .. } => {
-                assert!(program_hash.is_empty(), "no program should yield empty hash");
+                assert!(
+                    program_hash.is_empty(),
+                    "no program should yield empty hash"
+                );
             }
             _ => panic!("expected Wake message"),
         }
@@ -2028,14 +2013,8 @@ mod tests {
         let key_hint = 1u16;
         let mut transport = MockTransport::new();
         let timestamp_ms = 1710000000000u64;
-        let command_frame = build_command_response(
-            &psk,
-            key_hint,
-            1,
-            1000,
-            timestamp_ms,
-            CommandPayload::Nop,
-        );
+        let command_frame =
+            build_command_response(&psk, key_hint, 1, 1000, timestamp_ms, CommandPayload::Nop);
         transport.queue_response(Some(command_frame));
 
         // Install a resident program so BPF execution happens
@@ -2469,14 +2448,8 @@ mod tests {
         let key_hint = 1u16;
         let mut transport = MockTransport::new();
 
-        let command_frame = build_command_response(
-            &psk,
-            key_hint,
-            1,
-            1000,
-            1710000000000,
-            CommandPayload::Nop,
-        );
+        let command_frame =
+            build_command_response(&psk, key_hint, 1, 1000, 1710000000000, CommandPayload::Nop);
         transport.queue_response(Some(command_frame));
 
         let mut storage = MockStorage::new().with_key(key_hint, psk);
@@ -2571,7 +2544,10 @@ mod tests {
 
         assert_eq!(outcome, WakeCycleOutcome::Sleep { seconds: 60 });
         assert!(interp.loaded, "program should be loaded");
-        assert!(interp.executed, "program should execute immediately after install");
+        assert!(
+            interp.executed,
+            "program should execute immediately after install"
+        );
         assert!(storage.programs[1].is_some());
         assert_eq!(storage.active_partition, 1);
     }


### PR DESCRIPTION
## Summary

Adds 18 new integration tests covering spec validation tests (T-Nxxx) that don't require BPF helper dispatch. Test count: 43 → 61 (all passing).

Also enhances \MockBpfInterpreter\ to capture the \SondeContext\ during \xecute()\, enabling wake-reason and context-field assertions.

## Tests added

### Protocol conformance (T-N101, T-N102/T-N300, T-N103, T-N104)
- WAKE CBOR uses integer keys
- Outbound frame format: 11B header + payload + 32B HMAC, ≤250B, valid HMAC
- Max blob size (203B) accepted / oversized blob rejected by \send_app_data\

### Wake cycle integration (T-N202, T-N203, T-N207, T-N507)
- WAKE fields: \irmware_abi_version\, \program_hash\, \attery_mv\
- No program → empty \program_hash\
- Unknown \command_type\ treated as NOP per ND-0202
- BPF execution context fields (\	imestamp\, \attery_mv\, \irmware_abi_version\, \wake_reason\)

### Auth & replay protection (T-N304, T-N305, T-N306)
- CHUNK with wrong echoed seq → silent discard
- Sequence numbers increment correctly across GET_CHUNK + PROGRAM_ACK
- 1000 wake cycles produce unique nonces

### Program transfer & execution (T-N502, T-N505, T-N508, T-N509, T-N510)
- Hash mismatch → no PROGRAM_ACK, sleep
- \RUN_EPHEMERAL\ executes in RAM, flash untouched
- \wake_reason\ = \ProgramUpdate\ (0x02) after resident install
- \wake_reason\ = \Early\ (0x01) when \arly_wake_flag\ set
- Post-update immediate execution in same cycle

### Error handling (T-N800, T-N801)
- Malformed CBOR in valid-HMAC frame → silent discard
- Unexpected \msg_type\ → silent discard

## Remaining gaps

17 spec tests (T-N600–T-N616) still require the BPF helper dispatch mechanism to be implemented before they can be written.