### PR TITLE
Fix esp32.yml YAML syntax error on idf_tools.py step

### DIFF
--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Install QEMU for Xtensa via idf_tools.py
         # qemu-xtensa is bundled in the espressif/idf image but install is
         # idempotent; this ensures the tool is present regardless of image version.
-        run: $IDF_PATH/tools/idf_tools.py install qemu-xtensa
+        run: |
+          "$IDF_PATH/tools/idf_tools.py" install qemu-xtensa
 
       # ------------------------------------------------------------------ #
       # Build


### PR DESCRIPTION
The idf_tools.py step used a shell-quoted path as a bare YAML value, which YAML parsed as a quoted string followed by unexpected tokens. Switch to a block scalar so the shell handles quoting correctly.