### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: "deps"
+      prefix: "deps:"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     commit-message:
-      prefix: "ci"
+      prefix: "ci:"


### PR DESCRIPTION
Enable weekly Dependabot checks for:

- **Cargo** — keeps Rust crate dependencies up to date
- **GitHub Actions** — keeps workflow action pins up to date

Commit prefixes (deps: / ci:) keep the update PRs easy to filter.