### PR TITLE
ci: group tonic/prost crates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,14 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps:"
+    groups:
+      grpc:
+        patterns:
+          - "tonic"
+          - "tonic-build"
+          - "prost"
+          - "prost-build"
+          - "prost-types"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Dependabot was bumping \	onic\, \	onic-build\, and \prost\ independently, causing build failures due to conflicting \prost\ versions (\	onic 0.12\ needs \prost 0.13\, \	onic 0.14\ needs \prost 0.14\).

This adds a \grpc\ dependency group so they're always upgraded together in a single PR.

The existing individual PRs (#58, #59, #61) can be closed once this merges — Dependabot will replace them with a grouped PR.