### PR TITLE
fix: source IDF export.sh in QEMU smoke test step

### DIFF
--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -127,9 +127,11 @@ jobs:
             --output "$TARGET_DIR/node.bin" \
             "$TARGET_DIR/node"
 
-          # Merge bootloader + partition table + app into a single image.
+          # Merge bootloader + partition table + app into a single 4MB image.
+          # --fill-flash-size pads to exactly 4MB, which QEMU requires.
           esptool.py --chip esp32 merge_bin \
             --output flash_image.bin \
+            --fill-flash-size 4MB \
             0x1000  "$BOOTLOADER" \
             0x8000  "$PARTITION_TABLE" \
             0x10000 "$TARGET_DIR/node.bin"


### PR DESCRIPTION
The QEMU smoke test step sources export-esp.sh (Rust Xtensa toolchain) but qemu-system-xtensa is an IDF-managed tool that needs IDF_PATH/export.sh on PATH.

This is the same fix applied to the flash-image step in #68, but for the QEMU step which was missed.