### PR TITLE
Update I2C0 pin mapping for hardware board

### DIFF
--- a/crates/sonde-node/src/esp_hal.rs
+++ b/crates/sonde-node/src/esp_hal.rs
@@ -15,13 +15,11 @@
 use crate::hal;
 use log::warn;
 
-/// Default I2C0 SDA pin for ESP32 dev boards.
-/// Change these constants and rebuild for different boards.
-const I2C0_SDA: i32 = 4;
+/// I2C0 SDA pin (yellow wire).
+const I2C0_SDA: i32 = 0;
 
-/// Default I2C0 SCL pin for ESP32 dev boards.
-/// Change these constants and rebuild for different boards.
-const I2C0_SCL: i32 = 5;
+/// I2C0 SCL pin (blue wire).
+const I2C0_SCL: i32 = 1;
 const I2C0_FREQ_HZ: u32 = 100_000; // 100 kHz standard mode
 
 // Timeout for I2C operations in FreeRTOS ticks (1 tick ≈ 1 ms at default rate).


### PR DESCRIPTION
Updates I2C0 pin assignments to match the physical board wiring:

- SDA: GPIO 4 → GPIO 0 (yellow wire)
- SCL: GPIO 5 → GPIO 1 (blue wire)