### PR TITLE
docs: BLE pairing protocol specification and security model update

### DIFF
--- a/docs/ble-pairing-protocol.md
+++ b/docs/ble-pairing-protocol.md
@@ -545,7 +545,7 @@ An active BLE MITM attacker who defeats Just Works pairing can observe `NODE_PRO
 The gateway performs these steps **in order**.  Failure at any step causes **silent discard** — no `PEER_ACK` is sent.  This is consistent with the radio protocol's error handling ([protocol.md §8](protocol.md#8--error-handling)):
 
 1. **Parse header.** Extract key_hint, verify msg_type = 0x05.  If not → discard.
-2. **Unknown key_hint.** The node is not yet registered — the gateway cannot verify the HMAC yet.  Proceed tentatively.
+2. **Bypass normal key-hint lookup.**  Because the node is not yet registered, the `key_hint` may be unknown **or may collide** with an existing node's key_hint (key_hint is a 16-bit non-unique value).  For `msg_type = 0x05` (PEER_REQUEST), the gateway MUST NOT attempt the normal radio fast-path (key-hint lookup → HMAC verification).  Instead, skip directly to CBOR parsing and decryption — the frame HMAC is verified later (step 8) using the `node_psk` extracted from the decrypted payload.
 3. **Parse CBOR.** Extract `encrypted_payload` (key 1, bstr).  If missing or malformed → discard.
 4. **Decrypt.**
    - Extract `eph_public[32] ‖ nonce[12] ‖ ciphertext[...]` from encrypted_payload.
@@ -570,7 +570,7 @@ The gateway performs these steps **in order**.  Failure at any step causes **sil
 9. **Verify timestamp.** If `|now − timestamp| > 86400` → discard.
 10. **Check node_id uniqueness.** If node_id already registered → discard.
 11. **Verify key_hint consistency.** Frame header key_hint must match `node_key_hint` in the PairingRequest.  If mismatch → discard.
-12. **Register node.** Store (node_id, node_key_hint, node_psk, rf_channel, sensors, registered_by = phone_key_hint).
+12. **Register node.** Store (node_id, node_key_hint, node_psk, rf_channel, sensors, registered_by = phone_id) where `phone_id` is the gateway's internal identifier for the phone PSK record (e.g., database primary key or a stable fingerprint of the phone PSK).  The `phone_key_hint` is a 16-bit non-unique lookup hint and MUST NOT be used as the sole audit identifier — collisions would misattribute registrations.
 13. **Send PEER_ACK(0).** Compute `registration_proof` = `HMAC-SHA256(node_psk, "sonde-peer-ack-v1" ‖ encrypted_payload)`.  Build CBOR payload `{ 1: 0, 2: registration_proof }`.  HMAC the frame with the node PSK.  The `nonce` field echoes the `nonce` from the PEER_REQUEST header.
 
 ### 7.4  HMAC bootstrap rationale

--- a/docs/security.md
+++ b/docs/security.md
@@ -158,6 +158,7 @@ Properties:
 
 - The private key (stored as a 32-byte Ed25519 seed) is encrypted at rest (protected by the master key from GW-0601a).
 - The public key is not secret — it provides identity verification and payload confidentiality in transit.  Authentication of pairing requests is provided by the phone's HMAC.
+- **Failover / backup:** The gateway keypair and `gateway_id` MUST be replicated to any failover or replacement gateway.  Phones pin the gateway public key on first contact (TOFU, §5.3), so a new keypair would require all phones to re-register.  Similarly, in-flight encrypted pairing payloads (§5.5) use `gateway_id` as HKDF salt and GCM AAD — a different `gateway_id` would fail decryption.  Operators MUST back up the Ed25519 seed and `gateway_id` alongside the node key database when configuring high-availability deployments.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `docs/ble-pairing-protocol.md` — a wire-level specification for BLE-mediated node pairing using a mobile phone as a delegated agent. Updates `docs/security.md` to reflect the new trust model.

**This is a protocol-only change.** Requirements (`gateway-requirements.md`, `node-requirements.md`), design (`gateway-design.md`, `node-design.md`), and validation docs will follow in subsequent PRs.

## BLE pairing protocol (new doc)

A mobile phone acts as a pairing agent, communicating with the gateway and node over BLE:

1. **Phase 1 (one-time):** Phone pairs with gateway over BLE — receives a phone PSK and the gateway's Ed25519 public key. Gateway authenticates via challenge-response signature. Operator must open a registration window.
2. **Phase 2 (per node):** Phone generates a node PSK, builds an HMAC-authenticated + encrypted pairing request, and provisions the node over BLE. Node relays the opaque encrypted payload to the gateway over ESP-NOW (new `PEER_REQUEST` msg_type `0x05`, `PEER_ACK` msg_type `0x84`).

### Key design decisions

- **Phone PSK trust delegation** — symmetric HMAC-SHA256, not certificates
- **Hybrid encryption** — phone HMAC for auth, gateway Ed25519/X25519 + AES-256-GCM for confidentiality
- **Node stays symmetric-only** — no new crypto on the constrained device
- **Gateway challenge-response** — prevents rogue gateway impersonation
- **Registration window** — operator must explicitly enable phone registration
- **Forged PEER_ACK defense** — `registration_proof` HMAC + deferred payload erasure
- **Silent discard** — consistent with existing radio protocol error model

### Wire formats specified

- BLE GATT service/characteristic UUIDs and properties
- BLE message envelope (TYPE + LEN + BODY)
- All message byte layouts with offset tables
- CBOR schemas with integer key assignments
- ESP-NOW `PEER_REQUEST`/`PEER_ACK` frame formats
- Encrypted payload construction (ECDH + HKDF + AES-GCM parameters)
- Size budget analysis (fits in 250B ESP-NOW frame)

## Security model update (`security.md`)

- Added **Phone** (delegated trust, revocable) and **BLE transport** (untrusted) to trust boundaries
- Added phone PSK assumptions and compromise remediation (§2.5.2)
- Split key provisioning into USB (§2.4.1) and BLE (§2.4.2) paths
- New §2.7: phone PSK lifecycle, trust properties, gateway Ed25519 keypair
- Expanded §9.3 pairing channel tradeoffs (USB vs BLE vs ESP-NOW)

## Files changed

| File | Change |
|------|--------|
| `docs/ble-pairing-protocol.md` | New file (735 lines) |
| `docs/security.md` | Updated trust model, key provisioning, tradeoffs |