### PR TITLE
docs: update copilot-instructions with code quality guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,16 +6,24 @@
 # Build all crates
 cargo build --workspace
 
+# Lint all crates
+cargo clippy --workspace -- -D warnings
+
+# Test all crates
+cargo test --workspace
+
 # Test protocol crate (fast, no deps — run this first)
 cargo test -p sonde-protocol
 
 # Run a single test
 cargo test -p sonde-protocol test_p001
 
-# Future crates (not yet implemented)
-cargo build -p sonde-gateway
-cargo build -p sonde-node --target riscv32imc-esp-espidf
-cargo build -p sonde-admin
+# Build ESP32-C3 firmware (requires esp toolchain).
+# ESP-IDF generates deeply nested build paths that exceed Windows MAX_PATH (260 chars).
+# Use a short CARGO_TARGET_DIR at the root of the current drive to avoid this.
+# Pick a single-letter directory name not already in use (e.g., E:\b, F:\t, C:\z).
+# Example (adjust drive letter and dir name to your environment):
+CARGO_TARGET_DIR=F:\t cargo +esp build -p sonde-node --bin node --features esp --profile firmware --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort
 ```
 
 ## Architecture
@@ -23,9 +31,11 @@ cargo build -p sonde-admin
 Sonde is a programmable sensor node platform. Nodes run BPF programs distributed by a gateway over ESP-NOW radio. The system has four crates in a Cargo workspace:
 
 - **`sonde-protocol`** — Shared `no_std` protocol crate. Frame codec, CBOR messages, program image format. Used by all other crates. No platform dependencies; all crypto is injected via `HmacProvider`/`Sha256Provider` traits.
-- **`sonde-gateway`** (planned) — Async gateway service (tokio). Authenticates nodes, manages sessions, distributes BPF programs, routes app data to handler processes via stdin/stdout. Admin interface via local gRPC.
-- **`sonde-node`** (planned) — ESP32-C3/S3 firmware (Rust + ESP-IDF). Cyclic state machine: wake → WAKE/COMMAND → BPF execution → sleep. BPF interpreter behind a `BpfInterpreter` trait (backend TBD).
-- **`sonde-admin`** (planned) — CLI tool wrapping the gateway gRPC API. Handles USB-mediated node pairing.
+- **`sonde-gateway`** — Async gateway service (tokio). Authenticates nodes, manages sessions, distributes BPF programs, routes app data to handler processes via stdin/stdout. Admin interface via local gRPC.
+- **`sonde-node`** — ESP32-C3/S3 firmware (Rust + ESP-IDF). Cyclic state machine: wake → WAKE/COMMAND → BPF execution → sleep. BPF interpreter behind a `BpfInterpreter` trait.
+- **`sonde-admin`** — CLI tool wrapping the gateway gRPC API. Handles USB-mediated node pairing.
+- **`sonde-bpf`** — Safe BPF interpreter with tagged register tracking. Used by `sonde-node`.
+- **`sonde-e2e`** — End-to-end test harness.
 
 The implementation order is: protocol → gateway → node → admin. See `docs/implementation-guide.md` for the full phased build plan with module-by-module ordering and test references.
 
@@ -38,6 +48,57 @@ The implementation order is: protocol → gateway → node → admin. See `docs/
 - **Program images** are CBOR-encoded (bytecode + map definitions), not raw ELF. The gateway extracts from ELF at ingestion time. `program_hash` = SHA-256 of the CBOR image. Deterministic CBOR encoding (RFC 8949 §4.2) is required.
 - **Platform-specific behavior** is always injected via traits (`HmacProvider`, `Sha256Provider`, `Transport`, `Storage`, `BpfInterpreter`), never hard-coded.
 - **Error handling on the radio protocol** is silent discard — no error responses are ever sent. This is a security design decision.
+
+## Code quality guidelines
+
+These guidelines address the most common review feedback patterns. Following them will significantly reduce PR round-trips.
+
+### Database and schema changes
+
+- **Always add migrations** when changing database schemas. Adding a column to `CREATE TABLE` does not update existing databases. Use `PRAGMA table_info()` + `ALTER TABLE ADD COLUMN` in `open()` for SQLite.
+- **Wrap multi-row mutations in a transaction.** Especially for migrations — a crash mid-loop must not leave a partially-migrated database.
+
+### Input validation and error handling
+
+- **Validate all input lengths and ranges before use.** Hex parsers should validate ASCII-only before byte-indexing (non-ASCII UTF-8 causes panics on `&s[i..i+2]`). Validate expected sizes (e.g., SHA-256 hashes must be exactly 32 bytes / 64 hex chars).
+- **Use checked/saturating arithmetic** for any size or offset calculation that feeds into `unsafe` code or allocation. Wrapping overflow can violate safety invariants.
+- **Don't mask errors.** Matching all non-OK error codes as a single "already exists" case hides real failures. Handle specific error codes explicitly.
+- **Don't silently truncate I/O.** If `write()` returns 0 bytes written (timeout), treat it as an error or retry — don't return `Ok(())` with unsent data.
+- **Validate array indices** from external input (e.g., `map_arg`, partition indices) before indexing. Out-of-bounds panics crash the firmware.
+
+### Cryptography and security
+
+- **Use `getrandom::fill()` for cryptographic randomness**, not `rand::rng()`. The `rand::rng()` API is unstable across versions and doesn't explicitly guarantee OS CSPRNG.
+- **Wrap key material in `zeroize::Zeroizing<[u8; N]>`** to ensure it's zeroed on drop. Pass by reference (`&[u8; 32]`) to internal functions to minimize copies.
+- **`key_hint` derivation** is `u16::from_be_bytes(SHA-256(PSK)[30..32])` — the **lower** 16 bits (least-significant bytes), not the first two bytes.
+- **Never accept plaintext fallbacks in decryption paths.** Legacy format handling must be confined to explicit migration functions that run once at startup, not in the general read path where it creates an injection vector.
+
+### Testing
+
+- **Every new code path needs a test.** If the PR description mentions a test, it must exist in the diff.
+- **Test boundary conditions**, not just the happy path. For budget/limit features, test exact-boundary (succeeds) and boundary+1 (fails).
+- **Test new API fields end-to-end.** If you add `abi_version` to the proto/storage, add a test that ingests with a value and asserts it round-trips through list/get.
+- **Capture tracing output** when asserting that warnings/errors are logged. Use `tracing-test` with `#[traced_test]` or a per-test subscriber — don't claim "verified structurally."
+- **Use clearly non-zero test keys.** `[0x42u8; 32]` not `[0u8; 32]` — avoids normalizing insecure patterns in example code.
+
+### Documentation and API consistency
+
+- **Keep doc comments in sync with implementation.** If behavior changes (e.g., function gains a parameter, return conditions change), update the doc comment in the same commit.
+- **Update crate-level docs** when public API changes. If `HelperDescriptor` replaces `(id, fn)` registration, the crate docs must reflect the new interface.
+- **New public API parameters need doc comments** explaining their purpose and how to use the common case (e.g., `UNLIMITED_BUDGET` constant for opt-out).
+
+### Embedded / ESP-IDF specific
+
+- **Never hard-code FreeRTOS tick rates.** If the code depends on `CONFIG_FREERTOS_HZ`, either derive the value from ESP-IDF at build time or pin it in `sdkconfig.defaults` and document the coupling.
+- **`sdkconfig.defaults` must explicitly set every value the code depends on.** Don't assume ESP-IDF defaults match your expectations (e.g., stack size, tick rate, console UART).
+- **Minimize heap allocations in loops.** Pre-compute constant frames, pass slices instead of cloning with `to_vec()`, and only allocate `Vec`s when the data is truly variable.
+- **Avoid `format!()` in error paths on embedded.** `format!()` allocates on the heap. Use `&'static str` or `Cow<'static, str>` for error messages in `no_std`-adjacent code.
+
+### Unsafe code
+
+- **Minimize the `unsafe` surface.** If only one code path needs `unsafe` (e.g., map regions), provide a safe wrapper for the common case (e.g., `execute_program_no_maps`).
+- **Don't update `self` state before validation is complete.** Build results into temporaries and commit only after all checks pass — a failed `load()` should not leave the interpreter in a partially-initialized state.
+- **Validate raw pointer inputs** (null check, range check) at the `unsafe` boundary, not deep inside the call chain.
 
 ## Documentation structure
 


### PR DESCRIPTION
Analyzed **57 review comments** across **8 merged PRs** (#97, #98, #100, #117, #118, #119, #120, #124) to identify the most frequent reviewer complaints. Added a new `Code quality guidelines` section to `.github/copilot-instructions.md` to reduce PR round-trips.

## Top complaint categories addressed

| Category | Occurrences | Guideline |
|----------|-------------|-----------|
| Test coverage | 5 | Test every new path, boundary conditions, round-trip new API fields |
| Input validation | 4 | Validate lengths/ranges, checked arithmetic for unsafe paths |
| Doc sync | 4 | Keep doc comments and crate docs in sync with implementation |
| RNG misuse | 3 | Use `getrandom::fill()`, not `rand::rng()` |
| Heap allocation | 3 | Pre-compute constant frames, pass slices, avoid `format!()` on embedded |
| DB migration | 2 | Always add ALTER TABLE migrations, wrap in transactions |
| API ergonomics | 2 | Safe wrappers for common cases, document new parameters |
| Hardcoded constants | 2 | Pin sdkconfig values, don't assume ESP-IDF defaults |

## Other changes

- Updated build commands (added `cargo clippy`, ESP32 firmware build, removed stale `(planned)` labels)
- Added `sonde-bpf` and `sonde-e2e` to the architecture list

## Files changed

| File | Change |
|------|--------|
| `.github/copilot-instructions.md` | +64/−7 lines |