### PR TITLE
Add IETF FAQ document

### DIFF
--- a/docs/ietf-faq.md
+++ b/docs/ietf-faq.md
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: MIT
   Copyright (c) 2026 sonde contributors -->
-# Why Aren’t We Using `$FAMOUS_IETF_PROTOCOL`?
+# Why Aren’t We Using Standard IETF IoT Protocols?
 
 This project deliberately **does not** use several well‑known IETF IoT security protocols. This is not because we are unaware of them. It is because **they do not solve the actual problem we have**.
 


### PR DESCRIPTION
Adds `docs/ietf-faq.md` — a pre-emptive FAQ answering **"why didn't you just use X?"** questions about IETF IoT protocols.

## Covered protocols

| Standard | Why not? (one-liner) |
|---|---|
| **EDHOC** (RFC 9528) | Key exchange, not onboarding |
| **OSCORE** (RFC 8613) | Post-pairing security; assumes CoAP semantics we don't use |
| **DTLS/TLS** | Too heavy for 250 B ESP-NOW frames; no IP stack |
| **BLE SMP/LESC** | Secures links, not identities |
| **CoAP over GATT** | Transport mapping, not trust |
| **Manufacturer PKI** | No factory-installed identities in our model |
| **BRSKI** (RFC 8995) | Requires IDevID certs + MASA cloud service |
| **ACE-OAuth** (RFC 9200) | Authorizes known clients; we bootstrap identity from nothing |
| **COSE** (RFC 9052) | ~10-15 B *additional* CBOR envelope overhead on top of the 32 B HMAC tag we already pay; no interop benefit in a closed system |
| **SUIT** (RFC 9019) | Manifest envelope larger than our 100-300 B BPF payloads |

## Also includes

- **"So what are we doing instead?"** — describes the actual trust model with `security.md` cross-references
- **"When would we adopt IETF standards?"** — honest adoption paths for each protocol
- **References table** — 12 referenced standards and specifications (IETF RFCs, IETF drafts, and Bluetooth SIG) with identifiers and working groups
