### PR TITLE
Add IETF Internet Draft: security patterns for constrained device onboarding

### DIFF
--- a/.github/workflows/ietf-draft.yml
+++ b/.github/workflows/ietf-draft.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches: [main]
     paths:
-      - 'rfcxml/**'
+      - 'rfcxml/*.xml'
       - '.github/workflows/ietf-draft.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'rfcxml/**'
+      - 'rfcxml/*.xml'
       - '.github/workflows/ietf-draft.yml'
 
 jobs:
@@ -30,7 +30,12 @@ jobs:
         run: |
           shopt -s nullglob
           mkdir -p output
-          for xml in rfcxml/*.xml; do
+          xmls=(rfcxml/*.xml)
+          if [ ${#xmls[@]} -eq 0 ]; then
+            echo "::error::No XML drafts found in rfcxml/"
+            exit 1
+          fi
+          for xml in "${xmls[@]}"; do
             base="$(basename "${xml%.xml}")"
             xml2rfc "$xml" --text --out "output/${base}.txt"
             xml2rfc "$xml" --html --out "output/${base}.html"

--- a/rfcxml/draft-jowett-sec-threat-model-constrained-onboarding-00.xml
+++ b/rfcxml/draft-jowett-sec-threat-model-constrained-onboarding-00.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE rfc [
-  <!ENTITY nbsp "&#160;">
-]>
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude"
      category="info"
      docName="draft-jowett-sec-threat-model-constrained-onboarding-00"


### PR DESCRIPTION
Converts the IETF Internet-Draft on constrained-device onboarding security from hand-formatted text to xml2rfc v3 XML source.

## Changes

- **\fcxml/draft-jowett-sec-threat-model-constrained-onboarding-00.xml\** — Full xml2rfc v3 (RFC 7991) source replacing the previous \.txt\ in \docs/\
- **\.github/workflows/ietf-draft.yml\** — CI workflow that builds \.txt\ and \.html\ via \xml2rfc\ and uploads them as downloadable artifacts
- **Removes** \docs/draft-jowett-sec-threat-model-constrained-onboarding-00.txt\ (superseded by XML source)

## What this document covers

| Section | Topic |
|---|---|
| **4. Common Failure Modes** | Conflating encryption with authentication; trusting the agent to validate; permanent state from unverified bootstraps |
| **5. Threat Model Framework** | Trust boundaries, core assumptions, documenting explicit non-goals |
| **6. Bootstrap vs Steady-State** | The bootstrap problem, dual-transport architectures, stateless replay protection (reference pattern + alternatives) |
| **7. Delegated Onboarding** | Mobile agent pattern (with ASCII diagram), credential lifecycle, trust properties, registration windows, TOFU |
| **8. Unavoidable Races** | MITM race, one-time-use payloads, timestamp windows, bound acknowledgements, self-healing |
| **9. Identity Destruction** | Destroy-and-recreate vs key rotation as a deliberate design choice |
| **10. Security Considerations** | Silent discard, key compromise containment, residual risks |

## Relationship to existing IETF standards

Section 3.3 explicitly addresses the gap vs BRSKI (RFC 8995), EDHOC (RFC 9528), ACE-OAuth (RFC 9200), and OSCORE (RFC 8613).

## What this document does NOT do

- Define a new protocol, message format, or wire encoding
- Replace or compete with any existing IETF standard
- Provide a formal security proof

References: RFC 2104, RFC 2119, RFC 7228, RFC 8174, RFC 8613, RFC 8949, RFC 8995, RFC 9019, RFC 9052, RFC 9200, RFC 9528, BT Core Spec 5.4