### PR TITLE
docs: add BLE pairing tool design specification

### DIFF
--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -139,11 +139,6 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
 └────┬────────────┘                      disconnect
      │ MTU ≥ 247
      ▼
-┌─────────────────┐
-│ TOFU Check      │──── key mismatch ──► Error("public key mismatch")
-└────┬────────────┘                      disconnect
-     │ first use or key matches
-     ▼
 ┌─────────────────────────┐
 │ Authenticating          │
 │ write REQUEST_GW_INFO   │
@@ -152,7 +147,11 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
 │                         │──── bad signature ──► Error("auth failed")
 └────┬────────────────────┘                      disconnect
      │ signature valid
-     │ persist gw_public_key + gateway_id (TOFU)
+     ▼
+┌─────────────────┐
+│ TOFU Check      │──── key mismatch ──► Error("public key mismatch")
+└────┬────────────┘                      disconnect
+     │ first use → pin key; or key matches stored key
      ▼
 ┌─────────────────────────┐
 │ Registering             │
@@ -176,7 +175,7 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
 
 **Key design decisions:**
 
-- TOFU check occurs *before* writing `REQUEST_GW_INFO`.  If the store already contains a `gw_public_key`, the tool compares it with the key from `GW_INFO_RESPONSE` after authentication.  This means the challenge–response still executes (to verify the gateway is live), but the result is rejected if keys don't match (PT-0302).
+- TOFU check occurs *after* the challenge–response exchange.  The tool first authenticates the gateway via Ed25519 signature verification, then compares the received `gw_public_key` against any previously pinned key in the store.  On first use, the key is pinned; on subsequent connections, a mismatch is rejected.  This ordering ensures the gateway is live and holds the claimed private key before the TOFU decision is made (PT-0302).
 - No artifacts are persisted until the entire flow succeeds.  On any error, the BLE connection is released and the store is left unchanged (PT-0502).
 - Already-paired detection: if the store contains a `gw_public_key`, the tool warns the operator before starting Phase 1 and offers to proceed or cancel (PT-0601).
 
@@ -641,6 +640,13 @@ pub enum PairingError {
 
     #[error("pairing store I/O error: {0}")]
     StoreIo(String),
+
+    // ── Internal errors ──
+    #[error("malformed BLE envelope — incomplete or invalid header")]
+    MalformedEnvelope,
+
+    #[error("random number generation failed — OS CSPRNG unavailable")]
+    RngFailed,
 }
 ```
 
@@ -702,12 +708,19 @@ The `envelope.rs` module handles encoding and decoding the BLE message envelope 
 
 ```rust
 /// Encode a BLE message envelope.
-pub fn encode_envelope(msg_type: u8, body: &[u8]) -> Vec<u8> {
+/// Returns an error if body exceeds 65535 bytes (u16::MAX).
+pub fn encode_envelope(msg_type: u8, body: &[u8]) -> Result<Vec<u8>, PairingError> {
+    if body.len() > u16::MAX as usize {
+        return Err(PairingError::PayloadTooLarge {
+            size: body.len(),
+            max: u16::MAX as usize,
+        });
+    }
     let mut buf = Vec::with_capacity(3 + body.len());
     buf.push(msg_type);
     buf.extend_from_slice(&(body.len() as u16).to_be_bytes());
     buf.extend_from_slice(body);
-    buf
+    Ok(buf)
 }
 
 /// Decode a BLE message envelope.


### PR DESCRIPTION
## Summary

Creates \docs/ble-pairing-tool-design.md\ — the missing design specification for the BLE pairing tool, completing the requirements → design → validation doc chain.

## What the design doc covers

Following the pattern established by \gateway-design.md\:

1. **Overview** — tool purpose, two-phase protocol summary
2. **Technology choices** — Tauri v2, \tleplug\, RustCrypto stack (\d25519-dalek\, \x25519-dalek\, \hkdf\, \es-gcm\), \getrandom\ for CSPRNG
3. **Crate structure** — \sonde-pair\ layout with 12 modules, dependency rules (no \sonde-gateway\/\sonde-node\/\sonde-modem\ deps)
4. **Architecture** — Phase 1 (gateway pairing) and Phase 2 (node provisioning) state machine diagrams, four-layer separation (UI → protocol → transport → persistence)
5. **BLE transport layer** — \BleTransport\ trait, GATT service discovery, MTU negotiation, indication reassembly, connection lifecycle, \MockBleTransport\ for CI
6. **Cryptographic operations** — Ed25519 signature verification, Ed25519 → X25519 conversion with low-order point rejection, X25519 ECDH, HKDF-SHA256 key derivation, AES-256-GCM encrypt/decrypt, HMAC-SHA256 authentication, \key_hint\ derivation, cryptographic material lifecycle with \Zeroizing\
7. **Persistence** — \PairingStore\ trait, platform backends (\FilePairingStore\ for Windows, \AndroidPairingStore\ via EncryptedSharedPreferences, \MockPairingStore\ for tests), atomic persistence
8. **Error handling** — three-category \PairingError\ enum (device/transport/protocol), actionable operator messages, no partial state on failure, no implicit retries
9. **Platform-specific considerations** — Windows WinRT BLE stack quirks, Android permissions and lifecycle, cross-platform MTU defaults
10. **Module-by-module implementation order** — four-phase build plan (P1: foundation → P2: crypto + CBOR → P3: state machines → P4: platform + UI)

## Cross-references

- All PT-0100 through PT-1206 requirement IDs from \le-pairing-tool-requirements.md\
- Protocol wire format sections from \le-pairing-protocol.md\ (§3–§11)
- Requirement traceability matrix in §14

## Checklist

- [x] SPDX header + copyright
- [x] Draft status, Related links
- [x] Covers all 10 sections from issue description
- [x] Cross-references PT-XXXX requirement IDs
- [x] Cross-references \le-pairing-protocol.md\ wire format sections
- [x] Sufficient detail for LLM agent implementation without ambiguity
- [x] Follows \gateway-design.md\ doc conventions

Closes #177