### PR TITLE
Publish ESP32 dev container to GitHub Container Registry

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+//
+// VS Code / GitHub Codespaces development container for ESP32 firmware builds.
+// Provides a one-click development environment with all ESP32 toolchain
+// dependencies pre-installed.
+{
+  "name": "Sonde ESP32 Dev",
+  "image": "ghcr.io/alan-jowett/sonde-esp-dev:latest",
+  "remoteUser": "root",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer"
+      ]
+    }
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,11 @@ CARGO_TARGET_DIR=F:\t cargo +esp build -p sonde-node --bin node --features esp -
 # NOTE: sonde-pair crate is planned — see issue #163.
 # docker run --rm -v .:/sonde -w /sonde ghcr.io/alan-jowett/sonde-android-dev:latest \
 #   cargo ndk -t arm64-v8a build -p sonde-pair --release
+
+# Build ESP32 firmware using the dev container (no local toolchain needed):
+docker run --rm -v "$(pwd)":/sonde -w /sonde ghcr.io/alan-jowett/sonde-esp-dev:latest \
+    cargo +esp build -p sonde-node --bin node --features esp --profile firmware \
+    --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort
 ```
 
 ## Architecture

--- a/.github/docker/Dockerfile.esp-dev
+++ b/.github/docker/Dockerfile.esp-dev
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Pre-built ESP32 development container for sonde firmware builds.
+# Includes Rust stable, the Espressif `esp` toolchain (RISC-V + Xtensa),
+# ldproxy, QEMU for RISC-V, and host build dependencies.
+#
+# Published to ghcr.io/alan-jowett/sonde-esp-dev by the
+# esp-dev-container.yml CI workflow.
+
+# Pin the base image by digest for reproducibility.
+# Tag: espressif/idf:v5.3.2
+FROM espressif/idf@sha256:d85ffe6db6162f16589c4c2221de1d5c40c9d9aa2331099e2fe6f5e33d1b8f09
+
+# Avoid interactive prompts during package installation.
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── System packages for gateway/host builds ──────────────────────────────────
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        protobuf-compiler \
+        libudev-dev \
+        pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+# ── Rust stable toolchain ────────────────────────────────────────────────────
+# The IDF image may ship an older Rust; install the latest stable via rustup.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain stable --profile minimal && \
+    echo 'source "$HOME/.cargo/env"' >> /etc/bash.bashrc
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# ── ESP Rust toolchain (RISC-V + Xtensa) ─────────────────────────────────────
+# espup installs the `esp` Rust toolchain (Espressif's nightly fork) which
+# supports both riscv32imc-esp-espidf (ESP32-C3) and xtensa-esp32s3-espidf
+# (ESP32-S3) targets. The export-esp.sh script sets PATH, LIBCLANG_PATH,
+# and CLANG_PATH for the Espressif LLVM/Clang.
+RUN cargo install espup@0.16.0 --locked && \
+    espup install && \
+    echo 'source "$HOME/export-esp.sh"' >> /etc/bash.bashrc
+
+# ── ldproxy (ESP-IDF linker proxy) ───────────────────────────────────────────
+RUN cargo install ldproxy@0.3.4 --locked
+
+# ── Use bash for remaining RUN steps (export.sh may use bash features) ───────
+SHELL ["/bin/bash", "-c"]
+
+# ── QEMU for RISC-V (ESP32-C3 smoke tests) ──────────────────────────────────
+RUN . "$IDF_PATH/export.sh" && \
+    "$IDF_PATH/tools/idf_tools.py" install qemu-riscv32
+
+# ── cargo-fuzz (optional, for local fuzz testing) ────────────────────────────
+RUN cargo install cargo-fuzz@0.12.0 --locked
+
+# ── Clean up cargo caches to reduce image size ───────────────────────────────
+RUN rm -rf /root/.cargo/registry/cache /root/.cargo/registry/src \
+           /root/.cargo/registry/index /root/.cargo/git
+
+# ── Default entrypoint sources ESP-IDF and ESP Rust environments ─────────────
+ENTRYPOINT ["/bin/bash", "-c", ". \"$IDF_PATH/export.sh\" && . \"$HOME/export-esp.sh\" && exec \"$@\"", "--"]
+CMD ["/bin/bash"]

--- a/.github/workflows/esp-dev-container.yml
+++ b/.github/workflows/esp-dev-container.yml
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Build and publish the ESP32 development container to GitHub Container Registry.
+# Triggered on pushes to main that change the Dockerfile, or manually via workflow_dispatch.
+
+name: ESP32 Dev Container
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/docker/Dockerfile.esp-dev'
+      - '.github/workflows/esp-dev-container.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/docker/Dockerfile.esp-dev'
+      - '.github/workflows/esp-dev-container.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: alan-jowett/sonde-esp-dev
+
+jobs:
+  build-and-push:
+    name: Build and publish container
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=v5.3.2-{{date 'YYYYMMDD'}}-{{sha}}
+
+      - name: Build and push container image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        with:
+          context: .github/docker
+          file: .github/docker/Dockerfile.esp-dev
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/esp32-modem.yml
+++ b/.github/workflows/esp32-modem.yml
@@ -17,48 +17,26 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
 
     container:
-      # Pinned ESP-IDF release image — provides IDF_PATH, Python 3, and all
-      # ESP-IDF host tools including esptool.py and idf_tools.py.
-      # Tag: espressif/idf:v5.3.2
-      image: espressif/idf@sha256:d85ffe6db6162f16589c4c2221de1d5c40c9d9aa2331099e2fe6f5e33d1b8f09
+      # Pre-built ESP32 dev container with Rust stable, ESP Rust toolchain,
+      # and ldproxy pre-installed. Published by esp-dev-container.yml.
+      image: ghcr.io/alan-jowett/sonde-esp-dev:latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # ------------------------------------------------------------------ #
-      # Rust toolchain
+      # Build cache
       # ------------------------------------------------------------------ #
-
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-        with:
-          toolchain: stable
 
       - name: Cache Rust build artefacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: ". -> target"
           key: esp32s3-xtensa-${{ hashFiles('crates/sonde-modem/sdkconfig.defaults', 'sdkconfig.defaults.esp32s3') }}
-
-      # ------------------------------------------------------------------ #
-      # Xtensa Rust toolchain (required for xtensa-esp32s3-espidf target)
-      # ------------------------------------------------------------------ #
-
-      - name: Install espup
-        run: cargo install espup --locked
-
-      - name: Install Xtensa Rust toolchain for ESP32-S3
-        # espup installs the `esp` Xtensa Rust toolchain and writes ~/export-esp.sh,
-        # which sets PATH, LIBCLANG_PATH, and CLANG_PATH for Xtensa GCC/LLVM.
-        # The `esp` toolchain must be selected explicitly via `cargo +esp` (espup
-        # v0.16+ does not export RUSTUP_TOOLCHAIN from export-esp.sh).
-        run: espup install --targets esp32s3
-
-      - name: Install ldproxy linker
-        run: cargo install ldproxy --locked
 
       # ------------------------------------------------------------------ #
       # Build

--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -18,61 +18,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
 
     container:
-      # Pinned ESP-IDF release image — provides IDF_PATH, Python 3, and all
-      # ESP-IDF host tools including esptool.py and idf_tools.py.
-      # Tag: espressif/idf:v5.3.2
-      image: espressif/idf@sha256:d85ffe6db6162f16589c4c2221de1d5c40c9d9aa2331099e2fe6f5e33d1b8f09
+      image: ghcr.io/alan-jowett/sonde-esp-dev:latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # ------------------------------------------------------------------ #
-      # Rust toolchain
+      # Build cache
       # ------------------------------------------------------------------ #
-
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-        with:
-          toolchain: stable
 
       - name: Cache Rust build artefacts
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: ". -> target"
           key: esp32c3-riscv-${{ hashFiles('crates/sonde-node/sdkconfig.defaults') }}
-
-      # ------------------------------------------------------------------ #
-      # ESP Rust toolchain (required for riscv32imc-esp-espidf target)
-      # ------------------------------------------------------------------ #
-
-      - name: Install espup
-        run: cargo install espup --locked
-
-      - name: Install ESP Rust toolchain for ESP32-C3
-        # espup install (without --targets) installs the full `esp` Rust
-        # toolchain (the Espressif fork of nightly) and writes ~/export-esp.sh,
-        # which sets PATH, LIBCLANG_PATH, and CLANG_PATH for ESP GCC/LLVM.
-        # --targets esp32c3 would only add RISC-V targets to the *stable*
-        # toolchain without creating the `esp` toolchain, causing
-        # `cargo +esp build` to fail with "toolchain 'esp' is not installed".
-        # The full `esp` toolchain supports all ESP targets including RISC-V.
-        run: espup install
-
-      - name: Install ldproxy linker
-        run: cargo install ldproxy --locked
-
-      # ------------------------------------------------------------------ #
-      # QEMU for RISC-V (ESP32-C3)
-      # ------------------------------------------------------------------ #
-
-      - name: Install QEMU for RISC-V via idf_tools.py
-        # qemu-riscv32 provides experimental ESP32-C3 machine support; install
-        # is idempotent so it is safe to run even if already present.
-        run: |
-          "$IDF_PATH/tools/idf_tools.py" install qemu-riscv32
 
       # ------------------------------------------------------------------ #
       # Build

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@
 
 ## 1  Overview
 
-The Sonde workspace contains multiple crates with different platform requirements:
+The Sonde workspace contains several crates with different platform requirements:
 
 | Crate | Runs on | Toolchain needed |
 |-------|---------|-----------------|
@@ -24,7 +24,7 @@ The Sonde workspace contains multiple crates with different platform requirement
 | `sonde-e2e` | Host | Standard Rust |
 | `sonde-pair` (planned) | Android / Windows / Linux | Standard Rust + Android NDK ([dev container](#9--android--tauri-development-container)) |
 
-You only need the Espressif toolchain once the node or modem firmware crates are available. The protocol crate, gateway, and admin CLI build with a standard Rust toolchain on any platform.
+You only need the Espressif toolchain if you intend to build firmware (`sonde-node` or `sonde-modem`). The remaining crates build with a standard Rust toolchain on any platform.
 
 ---
 
@@ -66,11 +66,60 @@ cargo build -p sonde-protocol -p sonde-gateway
 
 ---
 
-## 3  Espressif Rust toolchain (ESP32 firmware)
+## 3  Docker-based ESP32 development (recommended)
+
+The easiest way to build ESP32 firmware is with the pre-built development container, which has all toolchain dependencies pre-installed.
+
+### 3.1  Using VS Code / GitHub Codespaces (devcontainer)
+
+The repository includes a [devcontainer](../.devcontainer/devcontainer.json) configuration. In VS Code:
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+2. Open the repo and select **"Reopen in Container"** when prompted.
+3. All ESP32 tools are available immediately — build firmware directly in the integrated terminal.
+
+On GitHub Codespaces, open the repo in a codespace and the container starts automatically.
+
+### 3.2  Using Docker directly
+
+Pull the image and mount the repo:
+
+```sh
+docker pull ghcr.io/alan-jowett/sonde-esp-dev:latest
+docker run --rm -v "$(pwd)":/sonde -w /sonde ghcr.io/alan-jowett/sonde-esp-dev:latest \
+    cargo +esp build -p sonde-node --bin node --features esp --profile firmware \
+    --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort
+```
+
+Or start an interactive shell:
+
+```sh
+docker run --rm -it -v "$(pwd)":/sonde -w /sonde ghcr.io/alan-jowett/sonde-esp-dev:latest
+```
+
+### 3.3  Building both firmware targets
+
+**ESP32-C3 node firmware (RISC-V):**
+```sh
+cargo +esp build -p sonde-node --bin node --features esp --profile firmware \
+    --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort
+```
+
+**ESP32-S3 modem firmware (Xtensa):**
+```sh
+cargo +esp build -p sonde-modem --bin modem --features esp --profile firmware \
+    --target xtensa-esp32s3-espidf -Zbuild-std=std,panic_abort
+```
+
+> **Note:** On Windows, use a short `CARGO_TARGET_DIR` (e.g., `F:\t`) to avoid exceeding MAX_PATH. See the [README](../README.md) for details.
+
+---
+
+## 4  Espressif Rust toolchain (manual setup)
 
 The node firmware targets ESP32-C3 (RISC-V) and ESP32-S3 (Xtensa). The modem firmware targets ESP32-S3 (Xtensa) only. Both use the ESP-IDF framework via `esp-idf-hal` and `esp-idf-svc`.
 
-### 3.1  System prerequisites
+### 4.1  System prerequisites
 
 Install these before proceeding:
 
@@ -94,7 +143,7 @@ brew install cmake ninja python3
 3. Install [CMake](https://cmake.org/download/) and [Ninja](https://github.com/nicknisi/ninja/releases) (add both to PATH).
 4. Install [Git for Windows](https://gitforwindows.org/).
 
-### 3.2  Install espup
+### 4.2  Install espup
 
 [espup](https://github.com/esp-rs/espup) manages the Espressif Rust toolchain (Xtensa LLVM fork, RISC-V target, and ESP-IDF source):
 
@@ -108,7 +157,7 @@ cargo install cargo-binstall
 cargo binstall espup
 ```
 
-### 3.3  Install the Espressif toolchain
+### 4.3  Install the Espressif toolchain
 
 ```sh
 espup install
@@ -133,7 +182,7 @@ After installation, **source the environment file** so the custom toolchain is a
 
 > **Tip:** Add the source command to your shell profile (`.bashrc`, `.zshrc`, or PowerShell `$PROFILE`) so it runs automatically in every terminal session.
 
-### 3.4  Install ldproxy
+### 4.4  Install ldproxy
 
 The ESP-IDF build system requires `ldproxy` to wrap the linker:
 
@@ -141,7 +190,7 @@ The ESP-IDF build system requires `ldproxy` to wrap the linker:
 cargo install ldproxy
 ```
 
-### 3.5  Install espflash
+### 4.5  Install espflash
 
 [espflash](https://github.com/esp-rs/espflash) is the tool for flashing firmware and monitoring serial output:
 
@@ -149,9 +198,9 @@ cargo install ldproxy
 cargo install espflash
 ```
 
-### 3.6  Verify the toolchain
+### 4.6  Verify the toolchain
 
-After setup, verify you can target the ESP32 chips. These commands will work once the firmware crates are added to the workspace (see [implementation-guide.md](implementation-guide.md) Phase 5 and Phase 3):
+After setup, verify you can target the ESP32 chips:
 
 ```sh
 # List installed targets (should include esp targets)
@@ -169,11 +218,9 @@ cargo build -p sonde-node --target xtensa-esp32s3-espidf
 
 ---
 
-## 4  Flashing firmware
+## 5  Flashing firmware
 
-> **Note:** The firmware crates (`sonde-modem`, `sonde-node`) are not yet in the workspace. The commands below will work once they are added (see [implementation-guide.md](implementation-guide.md) Phase 3 and Phase 5).
-
-### 4.1  Modem (ESP32-S3)
+### 5.1  Modem (ESP32-S3)
 
 Connect the ESP32-S3 board via USB, then:
 
@@ -183,19 +230,19 @@ cargo espflash flash -p sonde-modem --features esp --target xtensa-esp32s3-espid
 
 The `--monitor` flag opens a serial console after flashing so you can see log output.
 
-### 4.2  Node (ESP32-C3)
+### 5.2  Node (ESP32-C3)
 
 ```sh
 cargo espflash flash -p sonde-node --target riscv32imc-esp-espidf --monitor
 ```
 
-### 4.3  Node (ESP32-S3)
+### 5.3  Node (ESP32-S3)
 
 ```sh
 cargo espflash flash -p sonde-node --target xtensa-esp32s3-espidf --monitor
 ```
 
-### 4.4  Serial port permissions (Linux)
+### 5.4  Serial port permissions (Linux)
 
 On Linux, you may need to add your user to the `dialout` group to access serial ports:
 
@@ -207,9 +254,9 @@ Log out and back in for the group change to take effect.
 
 ---
 
-## 5  Repository setup
+## 6  Repository setup
 
-### 5.1  Clone and configure git hooks
+### 6.1  Clone and configure git hooks
 
 ```sh
 git clone https://github.com/Alan-Jowett/sonde.git
@@ -226,7 +273,7 @@ pip install pre-commit
 pre-commit install --hook-type pre-commit --hook-type commit-msg
 ```
 
-### 5.2  SPDX headers
+### 6.2  SPDX headers
 
 Every `.rs` file must start with:
 ```rust
@@ -242,7 +289,7 @@ Every `.md` file must start with:
 
 ---
 
-## 6  Project structure
+## 7  Project structure
 
 The target workspace layout (see [implementation-guide.md §2](implementation-guide.md) for details):
 
@@ -266,7 +313,7 @@ See [implementation-guide.md](implementation-guide.md) for the full module break
 
 ---
 
-## 7  Common tasks
+## 8  Common tasks
 
 | Task | Command |
 |------|---------|
@@ -275,14 +322,14 @@ See [implementation-guide.md](implementation-guide.md) for the full module break
 | Test protocol crate | `cargo test -p sonde-protocol` |
 | Test gateway | `cargo test -p sonde-gateway` |
 | Build host crates | `cargo build -p sonde-protocol -p sonde-gateway` |
-| Build modem firmware (planned) | `cargo build -p sonde-modem --features esp --target xtensa-esp32s3-espidf` |
-| Build node firmware (planned) | `cargo build -p sonde-node --target riscv32imc-esp-espidf` |
-| Flash modem (planned) | `cargo espflash flash -p sonde-modem --features esp --target xtensa-esp32s3-espidf --monitor` |
-| Flash node (planned) | `cargo espflash flash -p sonde-node --target riscv32imc-esp-espidf --monitor` |
+| Build modem firmware | `cargo +esp build -p sonde-modem --bin modem --features esp --profile firmware --target xtensa-esp32s3-espidf -Zbuild-std=std,panic_abort` |
+| Build node firmware | `cargo +esp build -p sonde-node --bin node --features esp --profile firmware --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort` |
+| Flash modem | `cargo espflash flash -p sonde-modem --features esp --target xtensa-esp32s3-espidf --monitor` |
+| Flash node | `cargo espflash flash -p sonde-node --features esp --target riscv32imc-esp-espidf --monitor` |
 
 ---
 
-## 8  Troubleshooting
+## 9  Troubleshooting
 
 ### espup install fails
 


### PR DESCRIPTION
## Summary

Create a pre-built ESP32 development container published to \ghcr.io/alan-jowett/sonde-esp-dev\, eliminating per-run tool installation in CI and enabling one-command local firmware builds.

### Dockerfile (\.github/docker/Dockerfile.esp-dev\)

Base: \spressif/idf:v5.3.2\ (pinned by SHA digest)

Pre-installed layers (versions pinned):
- Rust stable toolchain
- ESP Rust toolchain via \spup@0.16.0\ (RISC-V + Xtensa)
- \ldproxy@0.3.4\ (ESP-IDF linker proxy)
- QEMU for RISC-V (\qemu-riscv32\) for smoke tests
- \cargo-fuzz@0.12.0\ for local fuzz testing
- \protobuf-compiler\ + \libudev-dev\ for gateway/host builds

### CI workflow (\sp-dev-container.yml\)

- Triggers on pushes to \main\ that change the Dockerfile, PRs (build-only, no push), or manual dispatch
- Publishes to \ghcr.io/alan-jowett/sonde-esp-dev\
- Tags: \:latest\ and \:v5.3.2-YYYYMMDD-<sha>\

### Updated ESP32 CI workflows

Both \sp32.yml\ and \sp32-modem.yml\ now use the pre-built container instead of \spressif/idf\ + per-run tool installation. Expected CI time savings: ~60-90s per ESP firmware job.

**Note:** ESP32 CI jobs will fail until the container image is published for the first time after merge (the push-to-main trigger publishes automatically).

### Devcontainer

\.devcontainer/devcontainer.json\ for VS Code / GitHub Codespaces one-click development.

### Documentation

\docs/getting-started.md\ updated with Docker-based build instructions (§3), devcontainer usage, and both firmware build commands.

Fixes #179