### PR TITLE
fix(ci): use static permissions in android-dev-container workflow

### DIFF
--- a/.github/workflows/android-dev-container.yml
+++ b/.github/workflows/android-dev-container.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: ${{ github.event_name != 'pull_request' && 'write' || 'read' }}
+      packages: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
GitHub Actions does not support expressions in permissions values. The dynamic expression caused the workflow to fail on merge to main. Use packages: write statically; login and push steps are already guarded by if: github.event_name != 'pull_request'.
