### PR TITLE
fix: pin idf-component-manager<2 in ESP dev container

### DIFF
--- a/.github/docker/Dockerfile.esp-dev
+++ b/.github/docker/Dockerfile.esp-dev
@@ -49,6 +49,13 @@ RUN cargo install espup@0.16.0 --locked && \
 # ── ldproxy (ESP-IDF linker proxy) ───────────────────────────────────────────
 RUN cargo install ldproxy@0.3.4 --locked
 
+# ── Pin idf-component-manager <2 ─────────────────────────────────────────────
+# idf-component-manager 2.0 dropped --interface_version 2, which esp-idf-sys
+# 0.36 / embuild 0.33 still passes. Use PIP_CONSTRAINT so that every pip
+# install (including the venv embuild creates at build time) respects the pin.
+RUN echo 'idf-component-manager<2' > /opt/esp/pip-constraints.txt
+ENV PIP_CONSTRAINT=/opt/esp/pip-constraints.txt
+
 # ── Use bash for remaining RUN steps (export.sh may use bash features) ───────
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
`idf-component-manager` 2.0 dropped support for `--interface_version 2`, which `esp-idf-sys` 0.36 / `embuild` 0.33 still passes during the CMake configuration step. This broke all ESP32-S3 modem firmware builds across every branch starting ~17:03 UTC today.

## Fix

Pin `idf-component-manager<2` in the dev container via `PIP_CONSTRAINT` so the constraint applies to all pip installs, including the virtualenv that `embuild` creates at build time.

**Note:** The container must be rebuilt and pushed (the `esp-dev-container.yml` workflow handles this on merge to main). Until the new container is published, modem CI will continue to fail.

Fixes #195
