### PR TITLE
fix(ci): restore idf-component-manager<2 pin in ESP dev container

### DIFF
--- a/.github/docker/Dockerfile.esp-dev
+++ b/.github/docker/Dockerfile.esp-dev
@@ -49,6 +49,14 @@ RUN cargo install espup@0.16.0 --locked && \
 # ── ldproxy (ESP-IDF linker proxy) ───────────────────────────────────────────
 RUN cargo install ldproxy@0.3.4 --locked
 
+# ── Pin idf-component-manager <2 ─────────────────────────────────────────────
+# idf-component-manager 2.0 dropped --interface_version 2, which ESP-IDF
+# v5.3.2's cmake scripts still pass. Use PIP_CONSTRAINT so that every pip
+# install (including the venv embuild creates at build time) respects the pin.
+# Remove this pin when the base image is upgraded to ESP-IDF >= 5.4.
+RUN echo 'idf-component-manager<2' > /opt/esp/pip-constraints.txt
+ENV PIP_CONSTRAINT=/opt/esp/pip-constraints.txt
+
 # ── Use bash for remaining RUN steps (export.sh may use bash features) ───────
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
## Problem

PR #198 removed the \idf-component-manager<2\ pin from the ESP dev container, assuming \sp-idf-sys\ 0.37 would resolve the \--interface_version 2\ incompatibility. However, the \--interface_version 2\ flag is emitted by **ESP-IDF v5.3.2's cmake scripts** (\/opt/esp/idf/tools/cmake/build.cmake:552\), not by \mbuild\. 

Once the container was rebuilt without the pin, \idf-component-manager\ 2.x was installed, which rejects \--interface_version 2\ (only accepts 4 or 5). This broke all modem firmware builds on main.

## Fix

Restore the \PIP_CONSTRAINT\ pin from PR #196. Added a comment to remove the pin when the base image is upgraded to ESP-IDF >= 5.4.

## Timeline

1. PR #198 merged → triggered modem build (#461) AND container rebuild (#22)
2. Build #461 succeeded — used the **old cached container** (still had the pin)
3. Container rebuild #22 finished — published new image **without** the pin
4. Subsequent merges pulled the **new container** → \idf-component-manager\ 2.x installed → 💥