### PR TITLE
fix(sonde-pair-ui): add Android mobile entry point and cdylib crate type

### DIFF
--- a/crates/sonde-pair-ui/src-tauri/Cargo.toml
+++ b/crates/sonde-pair-ui/src-tauri/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 license = "MIT"
 description = "Tauri v2 BLE pairing tool for sonde sensor nodes"
 
+[lib]
+name = "sonde_pair_ui"
+crate-type = ["staticlib", "cdylib", "rlib"]
+
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"

--- a/crates/sonde-pair-ui/src-tauri/build.rs
+++ b/crates/sonde-pair-ui/src-tauri/build.rs
@@ -2,5 +2,10 @@
 // Copyright (c) 2026 sonde contributors
 
 fn main() {
+    // Android 15+ requires 16KB page-aligned ELF load segments.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("android") {
+        println!("cargo:rustc-link-arg=-z");
+        println!("cargo:rustc-link-arg=max-page-size=16384");
+    }
     tauri_build::build();
 }

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -335,6 +335,12 @@ mod hex {
 // App entry point
 // ---------------------------------------------------------------------------
 
+#[cfg(mobile)]
+#[tauri::mobile_entry_point]
+fn main() {
+    run();
+}
+
 pub fn run() {
     let logs = Arc::new(Mutex::new(Vec::<String>::new()));
 


### PR DESCRIPTION
Two fixes required for the Tauri app to build and run on Android:

1. **`[lib]` block with cdylib** — Android needs a shared library (`.so`), not just an rlib.
2. **`#[tauri::mobile_entry_point]`** — Tauri requires this macro to register JNI symbols for the Android runtime.

Validated on a Pixel 6 via the Android dev container:
- APK built successfully with `cargo tauri android build --debug --target aarch64`
- Installed via `adb install` and launched — app runs, WebView renders, no crashes.