### PR TITLE
fix(docker): pin crosstool GCC to match IDF v5.3.2

### DIFF
--- a/.github/docker/Dockerfile.esp-dev
+++ b/.github/docker/Dockerfile.esp-dev
@@ -40,8 +40,14 @@ ENV RUSTUP_HOME="/root/.rustup" \
 # supports both riscv32imc-esp-espidf (ESP32-C3) and xtensa-esp32s3-espidf
 # (ESP32-S3) targets. The export-esp.sh script sets PATH, LIBCLANG_PATH,
 # and CLANG_PATH for the Espressif LLVM/Clang.
+#
+# IMPORTANT: The crosstool (GCC) version MUST match the version expected by
+# the base IDF image. IDF v5.3.2 expects esp-13.2.0_20240530. If espup
+# installs a newer GCC (e.g. esp-15.2.0), the Xtensa toolchain's bundled
+# std source targets a different IDF version, causing ABI incompatibility
+# that manifests as InstrFetchProhibited crashes on Core 1 at boot.
 RUN cargo install espup@0.16.0 --locked && \
-    espup install && \
+    espup install --crosstool-toolchain-version 13.2.0_20240530 && \
     mkdir -p /opt/esp && \
     cp /root/export-esp.sh /opt/esp/export-esp.sh && \
     echo 'source /opt/esp/export-esp.sh' >> /etc/bash.bashrc


### PR DESCRIPTION
## Summary

Pins the crosstool GCC version in the ESP dev container Dockerfile to `13.2.0_20240530`, matching what IDF v5.3.2 expects. Fixes #232.

## Problem

`espup install` (without version pin) installs the latest `esp` Rust toolchain which bundles GCC `esp-15.2.0` and `std` source targeting IDF v5.5.x. When building with `-Zbuild-std`, Rust's `std` is compiled from v5.5.x source but linked against the container's v5.3.2 C libraries, causing an ABI mismatch.

The symptom is a deterministic `Guru Meditation Error: Core 1 panic'ed (InstrFetchProhibited)` immediately after `app_main()` entry. The crash address resolves to `__rust_begin_short_backtrace` — the Rust startup trampoline.

## Fix

```dockerfile
espup install --crosstool-toolchain-version 13.2.0_20240530
```

This ensures the GCC bundled in the `esp` toolchain matches the IDF v5.3.2 expectation (`esp-13.2.0_20240530`).

## What was tried before finding the root cause

- Symlinking container's GCC over toolchain's GCC (cmake version check passes but runtime still crashes)
- Flashing cmake-built bootloader (v5.3.2 to replace v5.5.1)
- Full flash erase + reflash
- Increasing `CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE` to 16384
- Adding `CONFIG_ESP_MAIN_TASK_AFFINITY_CPU0=y`
- Using `xtensa-esp32s3-elf-addr2line` + linker map to trace crash to `__rust_begin_short_backtrace`
