### PR TITLE
test(sonde-modem): add 10 missing validation tests (BLE relay + serial framing)

### DIFF
--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -362,7 +362,9 @@ impl<S: SerialPort, R: Radio, B: Ble> Bridge<S, R, B> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sonde_protocol::modem::{decode_modem_frame, BleIndicate, ModemMessage, SERIAL_MAX_LEN};
+    use sonde_protocol::modem::{
+        decode_modem_frame, BleIndicate, ModemMessage, SERIAL_MAX_FRAME_SIZE, SERIAL_MAX_LEN,
+    };
     use std::cell::RefCell;
     use std::collections::VecDeque;
 
@@ -1324,7 +1326,8 @@ mod tests {
         max_frame.extend_from_slice(&vec![0xAA; max_body]); // padding
         bridge.usb.inject(&max_frame);
         // Frame is > 64 bytes (rx_buf size) — needs multiple polls.
-        for _ in 0..20 {
+        let max_polls = SERIAL_MAX_FRAME_SIZE / bridge.rx_buf.len() + 1;
+        for _ in 0..max_polls {
             if bridge.usb.rx_data.is_empty() {
                 break;
             }
@@ -1351,9 +1354,9 @@ mod tests {
 
     /// Validates: T-0103
     ///
-    /// Send RESET, then an oversized LEN header (len=1000 > 512 max), then
-    /// RESET again to resynchronize. Assert: modem recovers and sends
-    /// MODEM_READY.
+    /// Send RESET, then an oversized LEN header (len = SERIAL_MAX_LEN + 1,
+    /// exceeding the 512-byte max), then RESET again to resynchronize.
+    /// Assert: modem recovers and sends MODEM_READY.
     #[test]
     fn serial_framing_oversized_len() {
         let mut bridge = make_bridge();
@@ -1540,7 +1543,8 @@ mod tests {
         .unwrap();
         bridge.usb.inject(&frame);
         // Frame is > 64 bytes (rx_buf size) — needs multiple polls.
-        for _ in 0..20 {
+        let max_polls = frame.len() / bridge.rx_buf.len() + 1;
+        for _ in 0..max_polls {
             if bridge.usb.rx_data.is_empty() {
                 break;
             }


### PR DESCRIPTION
## Summary

Fixes #220 — adds the 10 missing validation tests identified by the requirements audit comparing the modem validation spec against `crates/sonde-modem/src/bridge.rs`.

## Tests added

### Serial framing (2 tests)

| Test | Spec ID | Description |
|------|---------|-------------|
| `serial_framing_valid_frame_and_max_length` | T-0102 | RESET → STATUS → max-length frame (len=SERIAL_MAX_LEN, unknown type) silently discarded → STATUS still works |
| `serial_framing_oversized_len` | T-0103 | Oversized LEN (SERIAL_MAX_LEN + 1) → decoder reset → RESET recovers modem |

### BLE relay (8 tests)

| Test | Spec ID | Description |
|------|---------|-------------|
| `ble_gatt_setup_via_enable_and_connect` | T-0601 | BLE_ENABLE → BLE_CONNECTED flow confirms GATT setup path |
| `ble_mtu_negotiation_reported` | T-0602 | BLE_CONNECTED with MTU = 247 forwarded with exact value preserved |
| `ble_mtu_below_minimum_no_connected_event` | T-0602a | Low-MTU BleEvent::Connected rejected by protocol codec (mtu < 247) |
| `ble_write_to_usb_relay` | T-0603 | BLE GATT write → BLE_RECV on USB-CDC with verbatim payload |
| `usb_to_ble_indication_relay` | T-0604 | BLE_INDICATE from USB → BLE layer with exact payload |
| `ble_indicate_large_payload_forwarded` | T-0605 | Large payload (400 bytes > MTU-3) forwarded intact for BLE-layer fragmentation |
| `ble_opaque_relay_no_inspection` | T-0606 | Garbage bytes relayed without content inspection or error |
| `ble_pairing_confirm_no_auto_reply` | T-0622 | Bridge forwards BLE_PAIRING_CONFIRM but does not auto-accept/reject |

## Notes

- T-0601, T-0602 are primarily BLE-stack tests on real hardware. The bridge-level tests verify the bridge's role in these flows.
- T-0602a verifies the protocol codec rejects `BleConnected` with `mtu < BLE_MTU_MIN` at encode time.
- T-0605 fragmentation is handled by the BLE driver layer; the bridge-level test verifies the payload is forwarded intact.
- T-0622 timeout is enforced by the BLE stack; the bridge-level test verifies no automatic reply is sent.
- Poll loop bounds are derived from `SERIAL_MAX_FRAME_SIZE / rx_buf.len()` with an assertion that all data is consumed.
