### PR TITLE
fix: disable IDF component manager for ESP-IDF v5.4 compatibility

### DIFF
--- a/.github/docker/Dockerfile.esp-dev
+++ b/.github/docker/Dockerfile.esp-dev
@@ -59,7 +59,7 @@ SHELL ["/bin/bash", "-c"]
 # embuild 0.33.1 passes --interface_version 3, which IDF v5.4's
 # idf-component-manager rejects (only accepts 4+). Sonde firmware uses
 # no managed components, so disabling the component manager is safe.
-# The firmware Cargo.toml files also set esp_idf_component_manager = "0"
+# The firmware Cargo.toml files also set esp_idf_component_manager = "n"
 # (embuild overrides env vars), but this ENV covers interactive Docker use.
 # Remove this when embuild is updated to pass --interface_version 4+.
 ENV IDF_COMPONENT_MANAGER=0

--- a/.github/workflows/esp32-modem.yml
+++ b/.github/workflows/esp32-modem.yml
@@ -61,6 +61,7 @@ jobs:
         # pre-compiled std for the xtensa-esp32s3-espidf target.
         env:
           ESP_IDF_SDKCONFIG_DEFAULTS: crates/sonde-modem/sdkconfig.defaults;sdkconfig.defaults.esp32s3
+          ESP_IDF_COMPONENT_MANAGER: "off"
         run: |
           . /opt/esp/export-esp.sh
           find target -name sdkconfig -path "*/esp-idf-sys-*/out/sdkconfig" -delete 2>/dev/null || true

--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -67,6 +67,7 @@ jobs:
         # cache so a stale rust-cache restore cannot override our settings.
         env:
           ESP_IDF_SDKCONFIG_DEFAULTS: crates/sonde-node/sdkconfig.defaults
+          ESP_IDF_COMPONENT_MANAGER: "off"
         run: |
           . "$IDF_PATH/export.sh"
           . /opt/esp/export-esp.sh

--- a/crates/sonde-modem/Cargo.toml
+++ b/crates/sonde-modem/Cargo.toml
@@ -32,7 +32,7 @@ embuild = { version = "0.33", optional = true }
 
 [package.metadata.esp-idf-sys]
 esp_idf_sdkconfig_defaults = ["sdkconfig.defaults"]
-esp_idf_component_manager = "0"
+esp_idf_component_manager = "n"
 
 [dev-dependencies]
 sonde-protocol = { path = "../sonde-protocol" }

--- a/crates/sonde-node/Cargo.toml
+++ b/crates/sonde-node/Cargo.toml
@@ -29,4 +29,4 @@ embuild = { version = "0.33", optional = true }
 
 [package.metadata.esp-idf-sys]
 esp_idf_sdkconfig_defaults = ["sdkconfig.defaults"]
-esp_idf_component_manager = "0"
+esp_idf_component_manager = "n"


### PR DESCRIPTION
## Problem

embuild 0.33.1 passes --interface_version 3 to idf-component-manager, but IDF v5.4 only accepts 4 or 5. This breaks firmware builds with:

```
error: argument --interface_version: invalid choice: 3 (choose from 4, 5)
```

## Fix

Set `esp_idf_component_manager = "0"` in each firmware crate's `[package.metadata.esp-idf-sys]` section. This tells embuild to skip the component manager. Sonde firmware uses no IDF managed components.

Also set `IDF_COMPONENT_MANAGER=0` in the Dockerfile for interactive Docker users.

Remove this workaround when embuild releases a version that passes `--interface_version 4+`.

Discovered while debugging #238.
