### PR TITLE
ci: add firmware smoke tests to dev container build

### DIFF
--- a/.github/workflows/esp-dev-container.yml
+++ b/.github/workflows/esp-dev-container.yml
@@ -86,10 +86,7 @@ jobs:
             -e ESP_IDF_SDKCONFIG_DEFAULTS=crates/sonde-node/sdkconfig.defaults \
             -e ESP_IDF_COMPONENT_MANAGER=off \
             ${{ env.LOCAL_IMAGE }} \
-            bash -c '. "$IDF_PATH/export.sh" && . /opt/esp/export-esp.sh && \
-              cargo +esp build -p sonde-node --bin node --features esp \
-              --profile firmware --target riscv32imc-esp-espidf \
-              -Zbuild-std=std,panic_abort'
+            bash -c '. "$IDF_PATH/export.sh" && . /opt/esp/export-esp.sh && cargo +esp build -p sonde-node --bin node --features esp --profile firmware --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort'
 
       - name: Smoke test — modem firmware (ESP32-S3, Xtensa)
         run: |
@@ -98,17 +95,14 @@ jobs:
             -e "ESP_IDF_SDKCONFIG_DEFAULTS=crates/sonde-modem/sdkconfig.defaults;sdkconfig.defaults.esp32s3" \
             -e ESP_IDF_COMPONENT_MANAGER=off \
             ${{ env.LOCAL_IMAGE }} \
-            bash -c '. /opt/esp/export-esp.sh && \
-              cargo +esp build -p sonde-modem --bin modem --features esp \
-              --profile firmware --target xtensa-esp32s3-espidf \
-              -Zbuild-std=std,panic_abort'
+            bash -c '. /opt/esp/export-esp.sh && cargo +esp build -p sonde-modem --bin modem --features esp --profile firmware --target xtensa-esp32s3-espidf -Zbuild-std=std,panic_abort'
 
       # ------------------------------------------------------------------ #
       # Push — only if smoke tests passed and we're on main
       # ------------------------------------------------------------------ #
 
       - name: Tag for registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: |
           TAGS="${{ steps.meta.outputs.tags }}"
           for TAG in $TAGS; do
@@ -116,7 +110,7 @@ jobs:
           done
 
       - name: Push to GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         run: |
           TAGS="${{ steps.meta.outputs.tags }}"
           for TAG in $TAGS; do


### PR DESCRIPTION
## Summary

Gates the ESP dev container push behind firmware smoke tests. A container that can't compile firmware will never reach `:latest`.

## Problem

The container workflow published to `:latest` without verifying the image could build firmware. This caused three incidents (#211, #235, Rust 1.82 breakage) where a broken container was live for 10-30 minutes before downstream CI on main caught it.

## Changes

**Before:** `docker/build-push-action` with `push: true` — build and push in one step.

**After:** Three-phase pipeline:
1. **Build** (`load: true`, no push) — builds the image locally as `sonde-esp-dev:smoke-test`
2. **Smoke test** — runs both firmware builds against the local image:
   - `sonde-node` for ESP32-C3 (RISC-V, `riscv32imc-esp-espidf`)
   - `sonde-modem` for ESP32-S3 (Xtensa, `xtensa-esp32s3-espidf`)
3. **Push** — only if smoke tests pass and we're on main (not PRs)

The smoke test commands mirror what the downstream firmware CI workflows use (`esp32.yml`, `esp32-modem.yml`), including the `ESP_IDF_SDKCONFIG_DEFAULTS` and `ESP_IDF_COMPONENT_MANAGER=off` env vars.

## Trade-offs

Adds ~5-10 minutes to container build time (two firmware compiles with cold cache). Worth it to prevent broken main.

Closes #245
