### PR TITLE
ci: upload firmware and gateway binaries as CI artifacts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,10 +38,15 @@ docker run --rm -v "$(pwd)":/sonde -w /sonde ghcr.io/alan-jowett/sonde-esp-dev:l
 # Cloud build + local flash (PREFERRED for hardware testing):
 # Push your branch, wait ~2-3 min for CI, then download the firmware artifact.
 # This is 10x faster than local Docker builds and requires no ESP toolchain.
-gh run download --name node-firmware --dir ./firmware/   # ESP32-C3 node
-gh run download --name modem-firmware --dir ./firmware/   # ESP32-S3 modem
-gh run download --name gateway-linux-x86_64 --dir ./bin/  # gateway binary
-espflash flash ./firmware/node --monitor                  # flash + serial monitor
+# Always pin to your branch's run to avoid downloading the wrong binary:
+BRANCH=$(git branch --show-current)
+gh run download "$(gh run list --branch "$BRANCH" -w 'ESP32-C3 Node Firmware CI' --json databaseId -q '.[0].databaseId')" \
+  --name node-firmware --dir ./firmware/                    # ESP32-C3 node
+gh run download "$(gh run list --branch "$BRANCH" -w 'ESP32-S3 Modem Firmware CI' --json databaseId -q '.[0].databaseId')" \
+  --name modem-firmware --dir ./firmware/                   # ESP32-S3 modem
+gh run download "$(gh run list --branch "$BRANCH" -w CI --json databaseId -q '.[0].databaseId')" \
+  --name gateway-linux-x86_64 --dir ./bin/                 # gateway binary
+espflash flash ./firmware/node --monitor                   # flash + serial monitor
 ```
 
 ## Architecture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           name: gateway-linux-x86_64
           path: target/release/sonde-gateway
+          if-no-files-found: error
           retention-days: 7
 
   bpf-conformance:

--- a/.github/workflows/esp32-modem.yml
+++ b/.github/workflows/esp32-modem.yml
@@ -97,4 +97,5 @@ jobs:
         with:
           name: modem-firmware
           path: target/xtensa-esp32s3-espidf/firmware/modem
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -236,5 +236,6 @@ jobs:
         with:
           name: node-firmware
           path: target/riscv32imc-esp-espidf/firmware/node
+          if-no-files-found: error
           retention-days: 7
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -276,12 +276,18 @@ The fastest way to get a flashable binary is to let CI build it:
 4. Flash directly with `espflash`.
 
 ```sh
+# Find the latest CI run for your branch, then download its artifacts:
+RUN_ID=$(gh run list --branch "$(git branch --show-current)" \
+  -w "ESP32-C3 Node Firmware CI" --json databaseId -q '.[0].databaseId')
+
 # Node firmware (ESP32-C3)
-gh run download --name node-firmware --dir ./firmware/
+gh run download "$RUN_ID" --name node-firmware --dir ./firmware/
 espflash flash ./firmware/node --monitor
 
-# Modem firmware (ESP32-S3)
-gh run download --name modem-firmware --dir ./firmware/
+# Modem firmware (ESP32-S3) — use the modem workflow name instead:
+RUN_ID=$(gh run list --branch "$(git branch --show-current)" \
+  -w "ESP32-S3 Modem Firmware CI" --json databaseId -q '.[0].databaseId')
+gh run download "$RUN_ID" --name modem-firmware --dir ./firmware/
 espflash flash ./firmware/modem --monitor
 ```
 
@@ -290,7 +296,7 @@ espflash flash ./firmware/modem --monitor
 - **No local toolchain needed** — only `espflash` and USB access required.
 - **Consistent builds** — the same binary that CI tests is what gets flashed.
 
-> **Prerequisites:** Install the [GitHub CLI](https://cli.github.com/) (`gh`) and [`espflash`](https://github.com/esp-rs/espflash) (`cargo install espflash`). The gateway binary is also available as a CI artifact (`gh run download --name gateway-linux-x86_64`).
+> **Prerequisites:** Install the [GitHub CLI](https://cli.github.com/) (`gh`) and [`espflash`](https://github.com/esp-rs/espflash) (`cargo install espflash`). The gateway binary is also available as a CI artifact (`gh run download "$(gh run list --branch "$(git branch --show-current)" -w CI --json databaseId -q '.[0].databaseId')" --name gateway-linux-x86_64`).
 
 ### 5.2  Modem (ESP32-S3) — local build
 


### PR DESCRIPTION
## Summary

Adds `actions/upload-artifact` steps to all three build workflows so firmware and gateway binaries are downloadable after each CI run. Also documents the cloud-build + local-flash workflow in `getting-started.md` and `copilot-instructions.md`.

## Changes

| Workflow | Artifact name | Binary |
|----------|--------------|--------|
| `esp32.yml` | `node-firmware` | ESP32-C3 node ELF |
| `esp32-modem.yml` | `modem-firmware` | ESP32-S3 modem ELF |
| `ci.yml` | `gateway-linux-x86_64` | Gateway release binary |

All artifacts have 7-day retention. The `upload-artifact` action is SHA-pinned (`ea165f8d...@v4`) following the repo convention.

### Cloud-build + local-flash workflow

```sh
# Push branch, wait ~2-3 min for CI, then:
gh run download --name node-firmware --dir ./firmware/
espflash flash ./firmware/node --monitor
```

### Documentation updates
- **`getting-started.md`** - new section 5.1 `Cloud build + local flash (recommended)` with full instructions; renumbered subsequent subsections
- **`copilot-instructions.md`** - added cloud-build commands as PREFERRED path for hardware testing

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Rebased onto latest `main`

Closes #236
