### PR TITLE
ci: add Tauri Android APK build workflow with artifact upload

### DIFF
--- a/.github/workflows/tauri-android.yml
+++ b/.github/workflows/tauri-android.yml
@@ -59,15 +59,10 @@ jobs:
       # Build
       # ------------------------------------------------------------------ #
 
-      - name: Install npm dependencies
-        working-directory: crates/sonde-pair-ui
-        run: npm install
-
       - name: Initialize Android project
-        working-directory: crates/sonde-pair-ui/src-tauri
+        working-directory: crates/sonde-pair-ui
         run: |
-          rm -rf gen/android
-          cd ..
+          rm -rf src-tauri/gen/android
           cargo tauri android init
 
       - name: Build Android APK (debug)


### PR DESCRIPTION
## Summary

Fixes #237 — adds a GitHub Actions workflow to build the Tauri Android APK and upload it as a CI artifact.

## Workflow: `.github/workflows/tauri-android.yml`

| Aspect | Detail |
|--------|--------|
| **Container** | `ghcr.io/alan-jowett/sonde-android-dev:latest` (Rust, NDK 27, Tauri CLI 2.10, Node.js 20) |
| **Build** | `cargo tauri android build --debug` |
| **Artifact** | `sonde-pair-android` — unsigned debug APK, 7-day retention |
| **Triggers** | Push to `main` or PR touching `sonde-pair/`, `sonde-pair-ui/`, `sonde-protocol/`, `Cargo.*`, or the workflow |
| **Cache** | `Swatinem/rust-cache` keyed on Cargo.toml + Dockerfile hash |
| **Concurrency** | Per-branch group with cancel-in-progress |

## Usage

```sh
# After CI completes:
gh run download --name sonde-pair-android --dir ./apk/
adb install ./apk/*.apk
```

## Notes

- Builds a **debug** APK (unsigned) — suitable for sideloading via `adb install`
- Follows the same patterns as `esp32.yml` (container, pinned action SHAs, cache, concurrency)
- `sonde-protocol` included in path triggers since it's a transitive dependency
