### PR TITLE
fix: increase modem factory partition to ~4MB

### DIFF
--- a/.github/workflows/esp32-modem.yml
+++ b/.github/workflows/esp32-modem.yml
@@ -86,6 +86,8 @@ jobs:
             || { echo "ERROR: CONFIG_BT_NIMBLE_ENABLED=y not found — sdkconfig.defaults.esp32s3 may not have been applied" >&2; exit 1; }
           grep -q 'CONFIG_ESP_TASK_WDT_EN=y' "$SDKCONFIG" \
             || { echo "ERROR: CONFIG_ESP_TASK_WDT_EN=y not found — crate sdkconfig.defaults may not have been applied" >&2; exit 1; }
+          grep -q 'CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y' "$SDKCONFIG" \
+            || { echo "ERROR: CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y not found — factory partition may be too small" >&2; exit 1; }
           echo "sdkconfig.defaults verified ✓"
 
       # ------------------------------------------------------------------ #

--- a/crates/sonde-modem/sdkconfig.defaults
+++ b/crates/sonde-modem/sdkconfig.defaults
@@ -32,3 +32,10 @@ CONFIG_LOG_MAXIMUM_LEVEL_DEBUG=y
 
 # --- WiFi / ESP-NOW ---
 CONFIG_ESP_WIFI_ENABLED=y
+
+# --- Partition table ---
+# Use the "Single factory app (large)" table.  The default
+# "Single factory app" table provides only 1 MB for the factory
+# partition, which is too small for the modem firmware (~1.2 MB).
+# The "large" variant provides ~4 MB (0x3F0000 bytes).
+CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y


### PR DESCRIPTION
## Summary

The modem firmware (~1.2 MB) doesn't fit in the default ESP-IDF factory partition (1 MB), causing boot failure:

```
E (376) esp_image: Image length 1146352 doesn't fit in partition length 1048576
E (379) boot: Factory app partition is not bootable
```

## Fix

Add `CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y` to `crates/sonde-modem/sdkconfig.defaults`. This switches from the default "Single factory app" table (1 MB factory partition) to the "large" variant (~4 MB / `0x3F0000` bytes), matching the node firmware configuration.

## Changes

| File | Change |
|------|--------|
| `crates/sonde-modem/sdkconfig.defaults` | Add `CONFIG_PARTITION_TABLE_SINGLE_APP_LARGE=y` |
| `.github/workflows/esp32-modem.yml` | Add CI assertion for the partition table setting |

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Rebased onto latest `main`