### PR TITLE
fix: pin esp32-nimble to git main for IDF v5.4.1 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -132,7 +132,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1282,7 +1282,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1648,7 +1648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1716,8 +1716,7 @@ dependencies = [
 [[package]]
 name = "esp32-nimble"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabfc9f595c551d3270ab2a5feca5f5b961863bcc40bb5549a8f9b4154fd8997"
+source = "git+https://github.com/taks/esp32-nimble?branch=main#aa67d0b80c466121b3f74c8fb25b8ab11cb22c5f"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
@@ -1726,7 +1725,7 @@ dependencies = [
  "embassy-sync",
  "embuild",
  "esp-idf-svc",
- "heapless 0.8.0",
+ "heapless 0.9.2",
  "log",
  "num_enum",
  "once_cell",
@@ -3432,7 +3431,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3530,7 +3529,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4659,7 +4658,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5099,7 +5098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5791,10 +5790,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6328,7 +6327,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6826,7 +6825,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/crates/sonde-modem/Cargo.toml
+++ b/crates/sonde-modem/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 # ESP-IDF dependencies — only pulled in with the "esp" feature.
 esp-idf-hal = { version = "0.46", optional = true }
 esp-idf-svc = { version = "0.52", features = ["binstart"], optional = true }
-esp32-nimble = { version = "0.12", optional = true }
+esp32-nimble = { git = "https://github.com/taks/esp32-nimble", branch = "main", optional = true }
 esp-idf-sys = { version = "0.37", features = ["binstart"], optional = true }
 
 # Device test dependency — only pulled in with the "device-tests" feature.


### PR DESCRIPTION
## Summary

Fixes the `InstrFetchProhibited` crash on Core 1 during NimBLE BLE init on the ESP32-S3 modem. The `esp32-nimble` 0.12.0 crate from crates.io is incompatible with ESP-IDF v5.4.1 (ABI mismatch in NimBLE function pointers). The fix is on the upstream `main` branch.

## Changes

| File | Change |
|------|--------|
| `crates/sonde-modem/Cargo.toml` | Pin `esp32-nimble` to git `main` branch (`aa67d0b8`) |
| `Cargo.lock` | Updated lockfile |

## Checklist
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] Rebased onto latest `main`

Once merged, download the modem firmware artifact from CI, erase flash, and reflash to verify the crash is resolved.