### PR TITLE
ci: add Tauri desktop app build and artifact upload

### DIFF
--- a/.github/workflows/tauri-desktop.yml
+++ b/.github/workflows/tauri-desktop.yml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Tauri Desktop CI: build sonde-pair-ui for Windows and Linux and
+# upload the installers as CI artifacts.
+
+name: Tauri Desktop Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/sonde-pair/**'
+      - 'crates/sonde-pair-ui/**'
+      - 'crates/sonde-protocol/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/tauri-desktop.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/sonde-pair/**'
+      - 'crates/sonde-pair-ui/**'
+      - 'crates/sonde-protocol/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/tauri-desktop.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-desktop:
+    name: Desktop (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            name: Windows
+            bundle: nsis
+            artifact-name: sonde-pair-windows
+            artifact-path: target/release/bundle/nsis/*.exe
+          - os: ubuntu-latest
+            name: Linux
+            bundle: deb
+            artifact-name: sonde-pair-linux
+            artifact-path: target/release/bundle/deb/*.deb
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - name: Cache Rust build artefacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          workspaces: ". -> target"
+          key: desktop-${{ matrix.os }}-${{ hashFiles('crates/sonde-pair-ui/src-tauri/Cargo.toml') }}
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev \
+            libudev-dev libdbus-1-dev
+
+      - name: Install cargo-tauri
+        run: cargo install tauri-cli --locked
+
+      - name: Build desktop app
+        working-directory: crates/sonde-pair-ui
+        run: cargo tauri build --bundles ${{ matrix.bundle }}
+
+      - name: Upload installer
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.artifact-name }}
+          path: ${{ matrix.artifact-path }}
+          retention-days: 7
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Add a CI workflow that builds the Tauri desktop pairing app (sonde-pair-ui) for **Windows** (NSIS .exe installer) and **Linux** (.deb package) and uploads the installers as CI artifacts.

This completes the 'build everything in the cloud' story:

| Artifact | Status |
|----------|--------|
| Node firmware | done #260 |
| Modem firmware | done #260 |
| Gateway binary | done #260 |
| Android APK | done #262 |
| Desktop pairing app | this PR |

## Changes

- **New file:** `.github/workflows/tauri-desktop.yml`
  - Matrix build: `windows-latest` (NSIS) + `ubuntu-latest` (deb)
  - Installs Linux system dependencies (WebKitGTK, GTK, libudev, libdbus)
  - Installs `cargo-tauri` CLI, builds with `cargo tauri build --bundles <type>`
  - Uploads installers as artifacts with 7-day retention
  - Follows existing patterns: SHA-pinned actions, `Swatinem/rust-cache`, concurrency groups
  - Triggers on changes to `sonde-pair`, `sonde-pair-ui`, `sonde-protocol`, or workspace manifests

Closes #266
