### PR TITLE
fix(gateway): switch from tokio-serial to serial2-tokio for USB-CDC compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,22 +3281,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mio-serial"
-version = "5.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029e1f407e261176a983a6599c084efd322d9301028055c87174beac71397ba3"
-dependencies = [
- "log",
- "mio",
- "nix 0.29.0",
- "serialport",
- "winapi",
 ]
 
 [[package]]
@@ -4957,6 +4943,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1401f562d358cdfdbdf8946e51a7871ede1db68bd0fd99bedc79e400241550"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "serial2-tokio"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b253fd088ff95a617a48e4f01e5543be9072e48663cc4e5a9544f0b258de1e36"
+dependencies = [
+ "libc",
+ "serial2",
+ "tokio",
+ "winapi",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5185,11 +5194,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "serial2-tokio",
  "sha2",
  "sonde-protocol",
  "tempfile",
  "tokio",
- "tokio-serial",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -5935,20 +5944,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-serial"
-version = "5.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1d5427f11ba7c5e6384521cfd76f2d64572ff29f3f4f7aa0f496282923fdc8"
-dependencies = [
- "cfg-if",
- "futures",
- "log",
- "mio-serial",
- "serialport",
- "tokio",
 ]
 
 [[package]]

--- a/crates/sonde-gateway/Cargo.toml
+++ b/crates/sonde-gateway/Cargo.toml
@@ -29,7 +29,7 @@ x25519-dalek = { version = "2", features = ["static_secrets"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
 clap = { version = "4", features = ["derive"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tokio-serial = "5.4"
+serial2-tokio = "0.1"
 tokio-stream = "0.1"
 futures = "0.3"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -239,8 +239,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     // 6. Open serial port and create modem transport
-    let serial_port =
-        tokio_serial::SerialStream::open(&tokio_serial::new(&cli.port, cli.baud_rate))?;
+    let serial_port = serial2_tokio::SerialPort::open(&cli.port, cli.baud_rate)?;
     let transport = Arc::new(UsbEspNowTransport::new(serial_port, cli.channel).await?);
     info!(channel = cli.channel, "modem transport ready");
 


### PR DESCRIPTION
## Summary

Fix the gateway failing to open ESP32-S3 USB-CDC serial ports (e.g. COM5) on Windows with:

```
Error { kind: Unknown, description: "Invalid stop bits setting encountered" }
```

## Root cause

`tokio-serial` calls `GetCommState` during `SerialStream::open()` and rejects the invalid stop-bits value that USB-CDC virtual COM ports return. This is a [known upstream issue](https://github.com/berkowski/mio-serial/issues/41).

## Fix

Replace `tokio-serial` with `serial2-tokio`, which handles USB-CDC gracefully without calling `GetCommState` for validation.

The modem transport (`UsbEspNowTransport::new()`) is generic over `AsyncRead + AsyncWrite + Send + Unpin`, so **only the port-open call** in the gateway binary needed updating. All tests continue to pass unchanged since they use `tokio::io::duplex()` mocks.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | `tokio-serial = "5.4"` -> `serial2-tokio = "0.1"` |
| `gateway.rs` | `tokio_serial::SerialStream::open(...)` -> `serial2_tokio::SerialPort::open(...)` |
| `Cargo.lock` | Updated lockfile |

Closes #274
