### PR TITLE
fix(sonde-pair): scan for both BLE service UUIDs in a single call

### DIFF
--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -116,10 +116,15 @@ impl AndroidBleTransport {
 impl BleTransport for AndroidBleTransport {
     fn start_scan(
         &mut self,
-        service_uuid: u128,
+        service_uuids: &[u128],
     ) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
         let inner = self.inner.clone();
-        let uuid_string = uuid_to_string(service_uuid);
+        // Android BLE scan uses the first UUID; filtering happens in refresh().
+        let uuid_string = if service_uuids.is_empty() {
+            String::new()
+        } else {
+            uuid_to_string(service_uuids[0])
+        };
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
                 let mut env = inner.vm.attach_current_thread().map_err(jni_err)?;

--- a/crates/sonde-pair/src/btleplug_transport.rs
+++ b/crates/sonde-pair/src/btleplug_transport.rs
@@ -165,17 +165,18 @@ fn find_characteristic(
 impl BleTransport for BtleplugTransport {
     fn start_scan(
         &mut self,
-        service_uuid: u128,
+        service_uuids: &[u128],
     ) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
+        let uuids: Vec<Uuid> = service_uuids.iter().map(|u| to_uuid(*u)).collect();
         Box::pin(async move {
             let filter = ScanFilter {
-                services: vec![to_uuid(service_uuid)],
+                services: uuids.clone(),
             };
             self.adapter
                 .start_scan(filter)
                 .await
                 .map_err(|e| PairingError::ConnectionFailed(format!("scan start failed: {e}")))?;
-            debug!(service = %to_uuid(service_uuid), "BLE scan started");
+            debug!(services = ?uuids, "BLE scan started");
             Ok(())
         })
     }

--- a/crates/sonde-pair/src/discovery.rs
+++ b/crates/sonde-pair/src/discovery.rs
@@ -101,14 +101,12 @@ impl<T: BleTransport> DeviceScanner<T> {
             return Err(PairingError::ScanAlreadyActive);
         }
 
-        self.transport.start_scan(GATEWAY_SERVICE_UUID).await?;
-
-        if let Err(e) = self.transport.start_scan(NODE_SERVICE_UUID).await {
-            // Clean up the first scan so the transport is not left in a
-            // partially-started state.
-            let _ = self.transport.stop_scan().await;
-            return Err(e);
-        }
+        // Scan for both service UUIDs in a single call so the BLE adapter
+        // filters for both simultaneously (avoids the second call replacing
+        // the first filter on platforms like WinRT/btleplug).
+        self.transport
+            .start_scan(&[GATEWAY_SERVICE_UUID, NODE_SERVICE_UUID])
+            .await?;
 
         self.scanning = true;
         self.scan_started_at = Some(Instant::now());

--- a/crates/sonde-pair/src/transport.rs
+++ b/crates/sonde-pair/src/transport.rs
@@ -14,7 +14,7 @@ use std::pin::Pin;
 pub trait BleTransport {
     fn start_scan(
         &mut self,
-        service_uuid: u128,
+        service_uuids: &[u128],
     ) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>>;
 
     fn stop_scan(&mut self) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>>;
@@ -85,7 +85,7 @@ impl MockBleTransport {
 impl BleTransport for MockBleTransport {
     fn start_scan(
         &mut self,
-        _service_uuid: u128,
+        _service_uuids: &[u128],
     ) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
         Box::pin(async { Ok(()) })
     }


### PR DESCRIPTION
## Problem

The desktop pairing tool only discovers node devices, not the modem (gateway). The modem IS advertising (visible on phone and Windows Bluetooth settings), but btleplug's scan filter doesn't find it.

**Root cause:** `DeviceScanner::start()` called `start_scan()` twice — once for gateway UUID (0xFE60), then for node UUID (0xFE50). On btleplug/WinRT, the second call **replaces** the first scan filter. Only node devices matched.

## Fix

Change `BleTransport::start_scan()` to accept `&[u128]` (slice of UUIDs) instead of a single UUID. The btleplug adapter passes both UUIDs to `ScanFilter::services` in a single call. Discovery makes one `start_scan` call instead of two.

## Changes

| File | Change |
|------|--------|
| `transport.rs` | Trait signature: `service_uuid: u128` → `service_uuids: &[u128]` |
| `btleplug_transport.rs` | Build filter from UUID slice |
| `android_transport.rs` | Accept slice, use first UUID for Android API |
| `discovery.rs` | Single `start_scan(&[GATEWAY, NODE])` call |

## Verification

- `cargo test -p sonde-pair` — all 80 tests pass
- `cargo check -p sonde-pair` — clean