### PR TITLE
fix(ci): use cp -r for nightly release asset staging

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -71,9 +71,9 @@ jobs:
           cp artifacts/gateway-linux-x86_64/sonde-gateway  release-assets/sonde-gateway
           cp artifacts/node-firmware/flash_image.bin        release-assets/node-flash_image.bin
           cp artifacts/modem-firmware/flash_image.bin       release-assets/modem-flash_image.bin
-          for f in artifacts/sonde-pair-windows/*; do cp "$f" release-assets/; done
-          for f in artifacts/sonde-pair-linux/*;   do cp "$f" release-assets/; done
-          for f in artifacts/sonde-pair-android/*; do cp "$f" release-assets/; done
+          for f in artifacts/sonde-pair-windows/*; do cp -r "$f" release-assets/; done
+          for f in artifacts/sonde-pair-linux/*;   do cp -r "$f" release-assets/; done
+          for f in artifacts/sonde-pair-android/*; do cp -r "$f" release-assets/; done
 
           # Build release notes
           cat > notes.md <<'EOF'


### PR DESCRIPTION
The Android APK artifact contains a subdirectory (\pp/\) which \cp\ without \-r\ skips, causing the nightly release job to fail with:

```
cp: -r not specified; omitting directory 'artifacts/sonde-pair-android/app'
```

One character fix: `cp` → `cp -r` on all three glob copy loops.