### PR TITLE
CI: add code coverage reporting via Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,38 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  coverage:
+    name: Code coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          components: llvm-tools
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          key: coverage
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            protobuf-compiler libudev-dev \
+            libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Generate coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: lcov.info
+
   bpf-conformance:
     name: BPF conformance (RFC 9669)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Tauri Desktop](https://github.com/Alan-Jowett/sonde/actions/workflows/tauri-desktop.yml/badge.svg?branch=main)](https://github.com/Alan-Jowett/sonde/actions/workflows/tauri-desktop.yml)
 [![Tauri Android](https://github.com/Alan-Jowett/sonde/actions/workflows/tauri-android.yml/badge.svg?branch=main)](https://github.com/Alan-Jowett/sonde/actions/workflows/tauri-android.yml)
 [![Nightly Release](https://github.com/Alan-Jowett/sonde/actions/workflows/nightly-release.yml/badge.svg?branch=main)](https://github.com/Alan-Jowett/sonde/actions/workflows/nightly-release.yml)
+[![Coverage Status](https://coveralls.io/repos/github/Alan-Jowett/sonde/badge.svg?branch=main)](https://coveralls.io/github/Alan-Jowett/sonde?branch=main)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 **A programmable, verifiable runtime for distributed sensor nodes.**


### PR DESCRIPTION
## Summary

Adds code coverage measurement and reporting to CI, closing #303.

### Changes

**`.github/workflows/ci.yml`** — new `coverage` job that:
1. Installs `cargo-llvm-cov` with the `llvm-tools` rustup component
2. Runs `cargo llvm-cov --workspace --lcov` across all workspace crates
3. Uploads the LCOV report to [Coveralls](https://coveralls.io/github/Alan-Jowett/sonde) via `coverallsapp/github-action@v2`

The job runs in parallel with the existing lint/test, BPF conformance, and fuzz jobs. Firmware-only code (`#[cfg(feature = "esp")]`) is automatically excluded since coverage runs without the `esp` feature.

**`README.md`** — adds the Coveralls coverage badge between the Nightly Release and License badges.

### Action SHA pins

| Action | SHA | Version |
|--------|-----|---------|
| `coverallsapp/github-action` | `5cbfd81b66ca5d10c19b062c04de0199c215fb6e` | v2 |

All other action pins match existing usage in CI.

Closes #303
