### PR TITLE
docs: add node and gateway BOMs (Rev A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ See [Getting Started](docs/getting-started.md) for full toolchain setup.
 
 - [Overview](docs/overview.md) — project summary, status, and goals
 - [Getting Started](docs/getting-started.md) — developer environment setup, toolchain installation, build and flash commands
+- [Node BOM](docs/node-bom.md) — off-the-shelf parts list for building a sonde node (no custom PCB required)
+- [Gateway BOM](docs/gateway-bom.md) — off-the-shelf parts list for building a USB-attached ESP-NOW gateway
 - [Contributing](docs/contributing.md) — contribution guidelines, DCO, SPDX requirements
 - [Why BPF?](docs/why-bpf.md) — rationale for using uBPF + Prevail as the execution model
 - [BPF Environment](docs/bpf-environment.md) — program API, memory model, verification, and development workflow

--- a/docs/gateway-bom.md
+++ b/docs/gateway-bom.md
@@ -1,0 +1,228 @@
+<!-- SPDX-License-Identifier: MIT
+   Copyright (c) 2026 sonde contributors -->
+# Sonde Gateway BOM (Rev A)
+
+> **Document status:** Draft
+> **Scope:** Minimal, off-the-shelf hardware platform for a USB-attached ESP-NOW gateway.
+> **Audience:** Contributors, developers, and anyone building a sonde gateway from commodity parts.
+> **Related:** [gateway-design.md](gateway-design.md), [getting-started.md](getting-started.md), [node-bom.md](node-bom.md)
+
+---
+
+## Design philosophy
+
+- **Simple** — no custom PCBs, no soldering required.
+- **Stable** — USB-powered, always-on, designed for long-running gateway service.
+- **Vendor-agnostic** — at least two sources for every part; no lock-in.
+- **Reproducible** — a contributor anywhere in the world can order the same parts and get a working gateway.
+- **Zero RF risk** — proven on-board antenna designs; no external RF components.
+
+---
+
+## 1  Core compute (choose one)
+
+Both options are fully supported. Contributors can pick either board.
+
+### Option A: ESP32-S3 DevKitC-1 (recommended)
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| ESP32-S3-DevKitC-1 | ESP32-S3 dev board with USB-C | Native USB OTG, plenty of RAM/flash |
+
+**Why this board:**
+- Native USB OTG — reliable CDC device on the host.
+- Generous RAM and flash headroom for gateway logic.
+- Stable, official Espressif board with proven antenna design.
+- Globally available from multiple distributors.
+
+**Where to buy:**
+
+| Vendor | Link |
+|--------|------|
+| Espressif (official) | <https://www.espressif.com/en/products/devkits/esp32-s3-devkitc-1> |
+| DigiKey | <https://www.digikey.com/en/products/filter/rf-evaluation-and-development-kits-boards/859?s=N4IgjCBcpgDAdFAZhQMYBsDOBTANCAPZQDaIALGGABxwDsIAuoQA4AuUIAyuQE4CWAOwDmIAL4EAtKhCYcBEGUo0GLNl14ChYiQHpxQA> |
+| Mouser | <https://www.mouser.com/ProductDetail/Espressif-Systems/ESP32-S3-DevKitC-1-N8R8> |
+
+### Option B: ESP32-C3 DevKitM-1
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| ESP32-C3-DevKitM-1 | ESP32-C3 dev board with USB-C | Low-power RISC-V, native USB, simpler |
+
+**Why this board:**
+- Lower power draw, simpler architecture.
+- Native USB support.
+- Adequate for gateway workloads (ESP-NOW RX + USB framing).
+- Slightly less headroom than S3 but fully sufficient.
+
+**Where to buy:**
+
+| Vendor | Link |
+|--------|------|
+| Espressif (official) | <https://www.espressif.com/en/products/devkits/esp32-c3-devkitm-1> |
+| DigiKey | <https://www.digikey.com/en/products/filter/rf-evaluation-and-development-kits-boards/859?s=N4IgjCBcpgDAdFAZhQMYBsDOBTANCAPZQDaIALGGABxwDsIAuoQA4AuUIAyuQE4CWAOwDmIAL4EAtKhCYcBEGUo0GLNl14ChYiQHpxQA> |
+| Mouser | <https://www.mouser.com/ProductDetail/Espressif-Systems/ESP32-C3-DevKitM-1> |
+
+### Which to choose
+
+Your gateway workload is light — ESP-NOW receive plus USB CDC framing. The S3 gives more margin; the C3 gives simplicity. Either works.
+
+---
+
+## 2  USB connectivity
+
+The gateway needs two physical USB ports:
+
+1. **Runtime USB (CDC)** — stays plugged into the PC host running the gateway service.
+2. **Flashing USB** — used only when updating firmware.
+
+Because dev boards expose a single USB port, the simplest solution is a USB data switch. This provides a second physical USB port without modifying the board.
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| USB-C Data Switch (2-port) | Manual toggle switch | Provides dedicated runtime and flashing ports |
+| USB-C Cable (1–2 ft) | Runtime connection | Stays plugged into the PC |
+| USB-C Cable (short) | Flashing connection | Only used during firmware updates |
+
+### How it works
+
+```
+Board USB-C  ──→  USB Data Switch Input
+                        ├── Output A  ──→  PC host (runtime CDC)
+                        └── Output B  ──→  Flashing cable
+```
+
+- The board's single USB port connects to the switch input.
+- Output A goes to the PC host for the always-on gateway service.
+- Output B is used only when flashing firmware.
+- Toggle the switch to flash. The gateway service will briefly lose the CDC device during the switch, but you avoid physically replugging cables or changing ports.
+
+### Where to buy — USB data switch
+
+| Vendor | Link |
+|--------|------|
+| Amazon | <https://www.amazon.com/usb-c-switch-2-port/s?k=usb+c+switch+2+port> |
+| AliExpress | <https://www.aliexpress.com/w/wholesale-usb-c-data-switch-2-port.html> |
+
+> **Note:** Any manual USB-C 2-to-1 selector/sharing switch works. Look for
+> "USB-C sharing switch" or "USB-C selector switch" — these are generic
+> commodity parts. Ensure it supports data (not power-only).
+
+### Where to buy — USB-C cables
+
+| Vendor | Link |
+|--------|------|
+| Amazon | <https://www.amazon.com/usb-c-cable-short/s?k=usb+c+cable+short> |
+| Monoprice | <https://www.monoprice.com/category/cables/usb-cables/usb-c-cables> |
+| DigiKey | <https://www.digikey.com/en/products/filter/usb-cables/458?s=N4IgTCBcDaIGYFMC2BjALiAugXyA> |
+
+---
+
+## 3  Power
+
+The gateway is USB-powered only. No regulator, no battery, no charging circuitry.
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| USB-C 5 V from PC | Power supplied by the host USB port | Board draws < 200 mA |
+| USB Power Meter (optional) | Inline USB-C power monitor | Useful for debugging power draw |
+
+### Where to buy — power meter (optional)
+
+| Vendor | Link |
+|--------|------|
+| Amazon | <https://www.amazon.com/usb-c-power-meter/s?k=usb+c+power+meter> |
+| AliExpress | <https://www.aliexpress.com/w/wholesale-usb-c-power-meter.html> |
+
+---
+
+## 4  RF
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| Onboard antenna (ESP32-S3 or C3) | PCB antenna on the dev board | Adequate for desk or under-desk placement |
+| USB Extension Cable (optional) | USB-C or USB-A extension | Lets you reposition the gateway for better RF coverage |
+
+No external RF components required. The onboard antenna is sufficient for typical indoor deployments (desk, shelf, or under-desk).
+
+### Where to buy — USB extension cable (optional)
+
+| Vendor | Link |
+|--------|------|
+| Amazon | <https://www.amazon.com/usb-c-extension-cable/s?k=usb+c+extension+cable> |
+| Monoprice | <https://www.monoprice.com/category/cables/usb-cables/usb-c-cables> |
+
+---
+
+## 5  Enclosure (optional)
+
+If you want a tidy, publishable enclosure:
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| Hammond 1591XXS or 1591XS | Small ABS project box | Fits the dev board comfortably |
+| Panel-mount USB-C passthrough (optional) | Bulkhead USB-C connector | Clean front-panel connection |
+| Silicone Adhesive (RTV) | General-purpose RTV sealant | Internal mounting — no screws or standoffs needed |
+
+The enclosure is entirely optional. Many contributors will leave the board bare on their desk.
+
+### Where to buy — enclosure
+
+| Vendor | Link |
+|--------|------|
+| DigiKey | <https://www.digikey.com/en/product-highlight/h/hammond/1591-series-multipurpose-enclosures> |
+| Mouser | <https://www.mouser.com/c/enclosures/enclosures-boxes-cases/?m=Hammond&series=1591> |
+| Newark | <https://www.newark.com/hammond/1591asbk/enclosure-multipurpose-abs-black/dp/87F2522> |
+
+### Where to buy — USB-C passthrough (optional)
+
+| Vendor | Link |
+|--------|------|
+| Amazon | <https://www.amazon.com/usb-c-panel-mount/s?k=usb+c+panel+mount> |
+| DigiKey | <https://www.digikey.com/en/products/filter/usb-connectors/312?s=N4IgTCBcDaIGYFMC2BjALiAugXyA> |
+
+---
+
+## 6  Block diagram
+
+```
++------------------+     +-------------------+     +---------------------+
+| PC Host          |     | USB Data Switch   |     | ESP32-S3/C3 DevKit  |
+| (gateway service)|---->| (2-port toggle)   |---->| sonde-modem fw      |
++------------------+     +-------------------+     +---------------------+
+                                ↑                           |
+                         [Flashing Port]                    | ESP-NOW
+                                                            v
+                                                     +--------------+
+                                                     |  Sonde Nodes |
+                                                     +--------------+
+```
+
+**Runtime mode:** PC host ↔ USB CDC ↔ ESP32 dev board ↔ ESP-NOW radio ↔ sonde nodes.
+
+---
+
+## 7  Estimated per-gateway cost
+
+| Category | Approximate cost (USD) |
+|----------|----------------------:|
+| ESP32-S3-DevKitC-1 (or C3) | ~$10 |
+| USB-C data switch | ~$10 |
+| USB-C cables (× 2) | ~$6 |
+| Enclosure (optional) | ~$5 |
+| Misc (silicone, passthrough) | ~$3 |
+| **Total** | **~$34** |
+
+Prices are approximate single-unit retail. Volume discounts apply. Cost is lower without the optional enclosure (~$26).
+
+---
+
+## 8  Notes
+
+- **No battery is required.** The gateway is USB-powered and designed to run continuously.
+- **No custom PCB is required.** Everything connects with off-the-shelf cables and a USB switch.
+- **No soldering is required.** The entire build is plug-and-play.
+- **The USB data switch is the key part.** It cleanly satisfies the two-USB-port requirement without board modifications.
+- **International availability.** Every part is available globally from multiple distributors.
+- **Both S3 and C3 are valid choices.** The S3 is recommended for headroom; the C3 is fine for simplicity.
+- **The BOM is intentionally conservative.** All parts are in active production with long product life cycles.

--- a/docs/node-bom.md
+++ b/docs/node-bom.md
@@ -1,0 +1,218 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Standard Sonde Node BOM (Rev A)
+
+> **Document status:** Draft
+> **Scope:** Minimal, off-the-shelf hardware platform for battery-powered ESP-NOW sonde nodes with Qwiic/STEMMA QT sensors.
+> **Audience:** Contributors, field deployers, and anyone building a sonde node from commodity parts.
+> **Related:** [node-design.md](node-design.md), [getting-started.md](getting-started.md)
+
+---
+
+## Design philosophy
+
+- **Simple** — no custom PCBs, no specialized tools.
+- **Stable** — all parts are commodity, in-production, and globally available.
+- **Vendor-agnostic** — no lock-in to a single supplier; at least two sources listed for every part.
+- **Sensor-agnostic** — the platform makes no assumptions about what sensors you attach. Sensor logic lives in BPF programs, not firmware.
+- **Reproducible** — a contributor anywhere in the world can order the same parts and get a working node.
+
+---
+
+## 1  Core compute
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| Adafruit QT Py ESP32-C3 | ESP32-C3 dev board with STEMMA QT | Low-power RISC-V MCU, Qwiic-compatible, USB-C |
+
+**Why this board:**
+- Excellent deep-sleep current (~5 µA).
+- Built-in Qwiic/STEMMA QT connector for I²C sensors.
+- No RF layout risk — proven antenna design.
+- No custom PCB required.
+- Globally available from multiple distributors.
+
+> **Note:** Adafruit does not currently produce an ESP32-C3 board in the Feather
+> form factor. The QT Py ESP32-C3 (product 5405) is the recommended board. If
+> you need a Feather-sized board, the
+> [ESP32-C6 Feather](https://www.adafruit.com/product/5933) (product 5933) is
+> the closest alternative, but `sonde-node` firmware currently targets the C3
+> (`riscv32imc-esp-espidf`). A C6 port would require minor target changes.
+
+**Where to buy:**
+
+| Vendor | Link |
+|--------|------|
+| Adafruit (official) | <https://www.adafruit.com/product/5405> |
+| Mouser | <https://www.mouser.com/ProductDetail/Adafruit/5405> |
+| Newark | <https://www.newark.com/adafruit/5405/adafruit-qt-py-esp32-c3-wifi-dev/dp/47AK0768> |
+| Pimoroni (UK) | <https://shop.pimoroni.com/products/adafruit-qt-py-esp32-c3-wifi-dev-board-with-stemma-qt> |
+| Core Electronics (AU) | <https://core-electronics.com.au/adafruit-qt-py-esp32-c3-wifi-dev-board-with-stemma-qt.html> |
+
+---
+
+## 2  Power system
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| 2× Energizer L91 AA Lithium | Primary lithium (non-rechargeable) | Long shelf life (20 yr), cold-tolerant (−40 °C), low self-discharge |
+| AA Battery Holder (2-cell, series) | Side-by-side or stacked, wire leads | Choose based on enclosure fit |
+| Pololu S7V8F3 Buck/Boost Regulator | 3.3 V fixed output, 2.7–11.8 V input | Efficient across the full AA discharge curve |
+
+### Power wiring
+
+```
+AA holder (+) ──→ Pololu VIN
+Pololu 3.3V  ──→ QT Py 3V pin
+Pololu GND   ──→ QT Py GND
+```
+
+This bypasses any on-board charging circuitry and ensures stable 3.3 V operation across the entire AA discharge curve (3.0 V fresh → ~1.8 V depleted × 2 cells = 3.6–3.0 V input range).
+
+### Where to buy — batteries
+
+| Vendor | Link |
+|--------|------|
+| DigiKey | <https://www.digikey.com/en/products/detail/energizer-battery-company/L91/704843> |
+| Newark | <https://www.newark.com/energizer/l91/battery-non-rechargeable-1-5v/dp/18T1822> |
+| Amazon | <https://www.amazon.com/energizer-aa-lithium-batteries/s?k=energizer+aa+lithium+batteries> |
+
+### Where to buy — battery holder
+
+| Vendor | Link |
+|--------|------|
+| Adafruit (with switch + JST) | <https://www.adafruit.com/product/4193> |
+| Adafruit (open, with JST) | <https://www.adafruit.com/product/4194> |
+| DigiKey | <https://www.digikey.com/en/products/filter/battery-holders-clips-contacts/aa/86> |
+| Mouser | <https://www.mouser.com/c/power/battery-holders-clips-contacts/?battery%20cell%20size=AA&number%20of%20batteries=2%20Battery> |
+
+### Where to buy — regulator
+
+| Vendor | Link |
+|--------|------|
+| Pololu (official) | <https://www.pololu.com/product/2122> |
+| Pimoroni (UK) | <https://shop.pimoroni.com/products/pololu-3-3v-step-up-step-down-voltage-regulator-s7v8f3> |
+| RobotShop | <https://www.robotshop.com/products/pololu-33v-step-up-step-down-voltage-regulator-s7v8f3> |
+
+---
+
+## 3  Sensor connectivity
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| Qwiic/STEMMA QT Cable (100–200 mm) | JST SH 4-pin, I²C | Main sensor lead exiting enclosure; length depends on deployment |
+| Qwiic MultiPort (optional) | 4-port hub for branching | Only needed if cable routing prevents daisy-chaining |
+
+Any 3.3 V I²C sensor with a Qwiic/STEMMA QT connector is supported. Sensor logic lives entirely in BPF programs — no firmware changes needed when swapping sensors.
+
+### Where to buy — cable
+
+| Vendor | Link |
+|--------|------|
+| Adafruit (100 mm) | <https://www.adafruit.com/product/4210> |
+| Adafruit (200 mm) | <https://www.adafruit.com/product/4401> |
+| SparkFun | <https://www.sparkfun.com/components/cables/qwiic-cables.html> |
+| Newark (100 mm) | <https://www.newark.com/adafruit/4210/stemma-qt-qwiic-jst-sh-4-pin-cable/dp/27AH9039> |
+
+### Where to buy — multiport (optional)
+
+| Vendor | Link |
+|--------|------|
+| SparkFun (official) | <https://www.sparkfun.com/sparkfun-qwiic-multiport.html> |
+| Adafruit | <https://www.adafruit.com/product/4861> |
+| Mouser | <https://www.mouser.com/ProductDetail/SparkFun/BOB-18012> |
+
+---
+
+## 4  Enclosure and mounting
+
+| Item | Description | Notes |
+|------|-------------|-------|
+| Hammond 1591B or 1591G | Small ABS project box | Fits QT Py + AA holder + regulator |
+| Cable Gland (PG7 or PG9) | Nylon, IP68 rated | Weather-resistant strain relief for sensor cable exit |
+| Silicone Adhesive (RTV) | General-purpose RTV sealant | Internal mounting — no screws or standoffs needed |
+
+**Why silicone adhesive (not screws):**
+- Vibration-resistant.
+- Easy to service (peel apart).
+- Works across wide temperature range.
+- No standoffs or hardware to source.
+
+### Where to buy — enclosure
+
+| Vendor | Link |
+|--------|------|
+| DigiKey | <https://www.digikey.com/en/product-highlight/h/hammond/1591-series-multipurpose-enclosures> |
+| Mouser | <https://www.mouser.com/c/enclosures/enclosures-boxes-cases/?m=Hammond&series=1591> |
+| Newark | <https://www.newark.com/hammond/1591asbk/enclosure-multipurpose-abs-black/dp/87F2522> |
+
+### Where to buy — cable gland
+
+| Vendor | Link |
+|--------|------|
+| DigiKey | <https://www.digikey.com/en/products/detail/phoenix-contact/1424495/7557542> |
+| Mouser | <https://www.mouser.com/c/?product%20type=Cable%20Glands&screw%2Fthread%20size=PG7> |
+| Amazon | <https://www.amazon.com/pg7-cable-gland/s?k=pg7+cable+gland> |
+
+---
+
+## 5  Optional quality-of-life items
+
+These are not required but improve build quality in the field:
+
+| Item | Purpose |
+|------|---------|
+| Small perfboard (25 × 50 mm) | Clean mounting surface for the regulator |
+| Heat-shrink tubing (assorted) | Strain relief on power leads |
+| Desiccant pack | Moisture control if enclosure is sealed |
+| Conformal coating spray | PCB protection for high-humidity deployments |
+
+These are generic supplies available at any electronics distributor or hardware store.
+
+---
+
+## 6  Block diagram
+
+```
++----------------+     +---------------------+     +------------------+     +--------------+
+| 2x AA          |     | Pololu S7V8F3       |     | QT Py ESP32-C3   |     | Qwiic/STEMMA |
+| Lithium L91    |---->| 3.3 V Buck/Boost    |---->| sonde-node fw    |---->| QT Sensor(s) |
++----------------+     +---------------------+     +------------------+     +--------------+
+                                                           |
+                                                           | ESP-NOW
+                                                           v
+                                                    +--------------+
+                                                    |   Gateway    |
+                                                    |  (via modem) |
+                                                    +--------------+
+```
+
+**Duty cycle:** Wake → run BPF program → read sensors → ESP-NOW transmit → deep sleep.
+
+---
+
+## 7  Estimated per-node cost
+
+| Category | Approximate cost (USD) |
+|----------|----------------------:|
+| QT Py ESP32-C3 | ~$10 |
+| 2× AA Lithium | ~$3 |
+| Battery holder | ~$2 |
+| Pololu regulator | ~$10 |
+| Qwiic cable | ~$1 |
+| Enclosure | ~$8 |
+| Cable gland | ~$1 |
+| Misc (silicone, heat-shrink) | ~$2 |
+| **Total (excluding sensor)** | **~$37** |
+
+Prices are approximate single-unit retail. Volume discounts apply.
+
+---
+
+## 8  Notes
+
+- **Sensors are not included in this BOM.** Sonde follows a BYOS (Bring Your Own Sensor) model — any 3.3 V I²C Qwiic/STEMMA QT sensor works. Sensor behavior is defined by BPF programs distributed by the gateway.
+- **No custom PCB is required.** Everything connects with wire leads and Qwiic cables.
+- **The BOM is intentionally conservative.** All parts are in active production with long product life cycles.
+- **International availability.** Every part is listed with at least two vendors spanning North America, Europe, and Oceania.
+- **Lithium battery shipping restrictions** may apply. Check your carrier's hazmat policies before ordering large quantities.


### PR DESCRIPTION
Add Bills of Materials for both hardware components of the Sonde platform.

## Node BOM (`node-bom.md`)
- **Core compute** — Adafruit QT Py ESP32-C3 with STEMMA QT
- **Power** — 2× AA lithium batteries + Pololu 3.3 V buck/boost regulator
- **Sensor connectivity** — Qwiic/STEMMA QT (BYOS model)
- **Enclosure** — Hammond 1591B/G + cable gland
- **Cost estimate** — ~$37 per node (excluding sensor)

## Gateway BOM (`gateway-bom.md`)
- **Core compute** — ESP32-S3 DevKitC-1 (recommended) or ESP32-C3 DevKitM-1
- **USB connectivity** — USB-C data switch for dual-port (runtime CDC + flashing)
- **Power** — USB-powered only, no battery
- **RF** — onboard antenna, no external components
- **Enclosure** — optional Hammond 1591 series
- **Cost estimate** — ~$34 per gateway

Both documents follow the same format: numbered sections, multi-vendor sourcing tables, block diagrams, and cost estimates. All parts are off-the-shelf with global availability.
