### PR TITLE
docs: replace uBPF references with sonde-bpf (RFC 9669)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Each node acts as a programmable sonde: a constrained probe that autonomously samples its environment and reports observations upstream.
 
-Nodes run uniform firmware and execute behavior defined by [uBPF](https://github.com/iovisor/ubpf) programs verified with [Prevail](https://github.com/vbpf/ebpf-verifier). A gateway distributes programs, schedules, and configuration over the air — no firmware updates required. The architecture is hardware-agnostic; the reference implementation targets ESP32-C3/S3.
+Nodes run uniform firmware and execute behavior defined by BPF programs ([RFC 9669](https://www.rfc-editor.org/rfc/rfc9669.html)) verified with [Prevail](https://github.com/vbpf/ebpf-verifier). A gateway distributes programs, schedules, and configuration over the air — no firmware updates required. The architecture is hardware-agnostic; the reference implementation targets ESP32-C3/S3.
 
 > **Status:** Active development — protocol, gateway, modem, and node crates are implemented and tested. See [Project status](#project-status) below.
 
@@ -174,7 +174,7 @@ The reference implementation targets ESP32-C3 (RISC-V) and ESP32-S3 (Xtensa) run
 | **Hardware crypto** | SHA-256, HMAC-SHA256, AES-128/256, hardware RNG (~10x faster than software) |
 | **RAM** | C3: 400 KB (16 KB cache). S3: 512 KB |
 | **Flash endurance** | ~100K erase cycles per 4 KB sector (273+ years at 1 update/day) |
-| **BPF execution** | Interpreter only (no uBPF JIT for RISC-V/Xtensa) |
+| **BPF execution** | Interpreter only (`sonde-bpf`, RFC 9669 compliant; no JIT for RISC-V/Xtensa). The `BpfInterpreter` trait allows alternative backends (e.g., rbpf, uBPF) to be plugged in. |
 | **Max program size** | 4 KB resident, 2 KB ephemeral (recommended) |
 | **Chunked transfer** | 4 KB program ≈ 20 round-trips over ESP-NOW |
 
@@ -216,7 +216,7 @@ See [Getting Started](docs/getting-started.md) for full toolchain setup.
 - [Node BOM](docs/node-bom.md) — off-the-shelf parts list for building a sonde node (no custom PCB required)
 - [Gateway BOM](docs/gateway-bom.md) — off-the-shelf parts list for building a USB-attached ESP-NOW gateway
 - [Contributing](docs/contributing.md) — contribution guidelines, DCO, SPDX requirements
-- [Why BPF?](docs/why-bpf.md) — rationale for using uBPF + Prevail as the execution model
+- [Why BPF?](docs/why-bpf.md) — rationale for using BPF + Prevail as the execution model
 - [BPF Environment](docs/bpf-environment.md) — program API, memory model, verification, and development workflow
 - [Application API](docs/gateway-api.md) — data-plane API for building applications on the Sonde platform
 - [Protocol](docs/protocol.md) — node-gateway wire protocol specification
@@ -236,6 +236,9 @@ Prior work has explored the use of eBPF‑derived virtual machines on microcontr
 Subsequent work, including **μBPF**, extends this line of research with just‑in‑time (JIT) compilation, over‑the‑air deployment pipelines, and formal verification to improve performance and provide stronger correctness guarantees for eBPF execution on microcontrollers. Key references include:
 - [μBPF paper](https://marioskogias.github.io/docs/microbpf.pdf)
 - [μBPF code](https://github.com/SzymonKubica/micro-bpf)
+
+**rbpf** is a pure‑Rust user‑space eBPF interpreter (and optional JIT) that demonstrates BPF execution outside the Linux kernel in a safe, portable runtime:
+- [rbpf code](https://github.com/qmonnet/rbpf)
 
 Related efforts also focus on formally verified eBPF interpreters and JITs for RIOT‑based systems, emphasizing proof‑carrying safety and memory isolation rather than general application architecture. See also:
 - [End‑to‑end mechanized proof of rBPF](https://link.springer.com/chapter/10.1007/978-3-031-65627-9_16)

--- a/crates/sonde-node/src/bpf_runtime.rs
+++ b/crates/sonde-node/src/bpf_runtime.rs
@@ -48,8 +48,9 @@ impl std::error::Error for BpfError {}
 
 /// BPF interpreter abstraction.
 ///
-/// Both sonde-bpf and uBPF can implement this trait. The choice of interpreter
-/// backend does not affect the rest of the firmware design.
+/// The `sonde-node` crate provides an adapter backed by `sonde-bpf`.
+/// The choice of interpreter backend does not affect the rest of the
+/// firmware design.
 pub trait BpfInterpreter {
     /// Register a helper function by call number.
     ///

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -515,7 +515,7 @@ clang -target bpf -O2 -c my_program.c -o my_program.o
 Sonde provides a test library (`libsonde_test`) that lets developers verify, load, and execute BPF programs from unit tests. The library includes:
 
 - **Prevail verification** — runs the verifier against the chosen profile (resident or ephemeral).
-- **uBPF execution** — loads and runs the program in a sandboxed environment.
+- **BPF execution** — loads and runs the program in a sandboxed interpreter (`sonde-bpf`).
 - **Bus mocking** — register mock I2C/SPI/GPIO/ADC devices so you can observe how the BPF program interacts with sensors (what it reads, what it writes, in what order).
 - **Map inspection** — examine map contents before and after execution.
 - **APP_DATA capture** — capture `send()` / `send_recv()` calls and provide mock replies.

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -5,7 +5,7 @@
 > **Document status:** Draft  
 > **Scope:** Architecture and internal design of the Sonde node firmware.  
 > **Audience:** Implementers (human or LLM agent) building the node firmware.  
-> **Related:** [node-requirements.md](node-requirements.md), [protocol.md](protocol.md), [security.md](security.md), [bpf-environment.md](bpf-environment.md)
+> **Related:** [node-requirements.md](node-requirements.md), [protocol.md](protocol.md), [security.md](security.md), [bpf-environment.md](bpf-environment.md), [node-bom.md](node-bom.md)
 
 ---
 
@@ -30,7 +30,7 @@ The firmware is **uniform across all nodes** — application behavior is defined
 | Language | Rust | Same language as gateway; memory safety on bare metal |
 | Protocol crate | `sonde-protocol` (shared with gateway) | `no_std`-compatible; frame codec, CBOR messages, constants |
 | Platform bindings | `esp-idf-hal` + `esp-idf-svc` | Full ESP-IDF feature access (ESP-NOW, deep sleep, hardware crypto, flash partitions) |
-| BPF interpreter | **⚠ OPEN** — `rbpf` (pure Rust) or `uBPF` (C, via FFI). Both require extension for BPF-to-BPF function calls. |
+| BPF interpreter | `sonde-bpf` — custom RFC 9669 interpreter with tagged registers and zero heap allocation |
 | CBOR | Via `sonde-protocol` (`ciborium`) | serde-compatible; matches protocol crate implementation |
 | HMAC | ESP-IDF hardware HMAC peripheral (implements `sonde-protocol::HmacProvider` trait) | Hardware-accelerated; ~10x faster than software |
 | SHA-256 | ESP-IDF hardware SHA peripheral | Hardware-accelerated; used for program hash verification |
@@ -72,7 +72,7 @@ The node firmware is divided into eight functional modules arranged in two tiers
 | **Wake Cycle Engine** | State machine: WAKE → COMMAND → transfer/execute → sleep | ND-0200–0203, ND-0700–0702 |
 | **Key Store** | PSK storage in dedicated flash partition, pairing, factory reset | ND-0400–0402 |
 | **Program Store** | A/B flash partitions, program image decoding, LDDW resolution | ND-0500–0503, ND-0501a |
-| **BPF Runtime** | rbpf interpreter, helper dispatch, execution constraints | ND-0504–0506, ND-0600–0606 |
+| **BPF Runtime** | `sonde-bpf` interpreter, helper dispatch, execution constraints | ND-0504–0506, ND-0600–0606 |
 | **Map Storage** | Sleep-persistent maps in RTC slow SRAM | ND-0603, ND-0606 |
 | **HAL** | I2C, SPI, GPIO, ADC bus access for BPF helpers | ND-0601 |
 | **Sleep Manager** | Deep sleep entry, wake interval, RTC memory management | ND-0203 |
@@ -270,14 +270,9 @@ Ephemeral programs are stored in RAM (heap allocation), not flash. They are deco
 
 ### 8.1  Interpreter
 
-**⚠ OPEN:** The BPF interpreter choice is an open design decision:
+The BPF interpreter choice is resolved:
 
-| Option | Pros | Cons |
-|---|---|---|
-| `rbpf` (Rust) | Pure Rust, no FFI, same language as firmware | Less established; needs BPF-to-BPF call extension |
-| `uBPF` (C, via FFI) | Larger ecosystem, used by eBPF for Windows | Requires unsafe FFI; needs BPF-to-BPF call extension |
-
-Both options require extension to support BPF-to-BPF function calls (max 8 call frames, 512 bytes stack each). The firmware wraps whichever interpreter behind a `BpfInterpreter` trait, so the choice can be changed without affecting the rest of the design.
+The project uses `sonde-bpf`, a custom RFC 9669 compliant interpreter written in pure Rust. It provides zero-allocation execution, tagged register tracking for pointer provenance, and `#![no_std]` compatibility. The firmware wraps the interpreter behind a `BpfInterpreter` trait, so the backend can be changed without affecting the rest of the design.
 
 ### 8.1a  BPF interpreter trait
 
@@ -290,29 +285,33 @@ pub trait BpfInterpreter {
 
     /// Load bytecode and resolve LDDW src=1 map references.
     /// `map_ptrs` maps map_index → runtime pointer for relocation.
-    fn load(&mut self, bytecode: &[u8], map_ptrs: &[u64]) -> Result<(), BpfError>;
+    /// `map_defs` carries MapDef entries for bounds checking.
+    fn load(
+        &mut self,
+        bytecode: &[u8],
+        map_ptrs: &[u64],
+        map_defs: &[sonde_protocol::MapDef],
+    ) -> Result<(), BpfError>;
 
     /// Execute the loaded program with the given context pointer.
     /// `instruction_budget` limits execution; returns the program's
     /// return value or an error if budget/call-depth is exceeded.
-    fn execute(
-        &mut self,
-        ctx_ptr: u64,
-        instruction_budget: u64,
-    ) -> Result<u64, BpfError>;
+    fn execute(&mut self, ctx_ptr: u64, instruction_budget: u64) -> Result<u64, BpfError>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum BpfError {
     InstructionBudgetExceeded,
     CallDepthExceeded,
-    InvalidBytecode,
+    InvalidBytecode(&'static str),
     HelperNotRegistered(u32),
-    LoadError(String),
+    LoadError(&'static str),
+    MapLoadError { index: usize, kind: &'static str },
+    RuntimeError(&'static str),
 }
 ```
 
-This trait is defined in the node firmware (not in `sonde-protocol`, since the gateway does not execute BPF). Both `rbpf` and `uBPF` adapters implement it.
+This trait is defined in the node firmware (not in `sonde-protocol`, since the gateway does not execute BPF). The `sonde-node` crate provides an adapter backed by `sonde-bpf`.
 
 The interpreter runs in bounded mode — an instruction counter enforces the instruction budget. If the budget is exceeded, execution is terminated and the program returns an error.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,7 +13,7 @@
 
 Sonde is a programmable, verifiable runtime for distributed sensor nodes. Each node acts as a constrained probe — an instrument that autonomously samples its environment and reports observations to a gateway upstream.
 
-Nodes run **uniform firmware** and execute behavior defined by [uBPF](https://github.com/iovisor/ubpf) programs verified by [Prevail](https://github.com/vbpf/ebpf-verifier). A gateway distributes programs, schedules, and configuration over the air — no firmware updates required. The reference implementation targets ESP32-C3/S3.
+Nodes run **uniform firmware** and execute behavior defined by BPF programs ([RFC 9669](https://www.rfc-editor.org/rfc/rfc9669.html)) verified by [Prevail](https://github.com/vbpf/ebpf-verifier). A gateway distributes programs, schedules, and configuration over the air — no firmware updates required. The reference implementation targets ESP32-C3/S3.
 
 ---
 
@@ -86,4 +86,4 @@ The workspace contains:
 - [Protocol](protocol.md) — node-gateway wire protocol specification
 - [Security Model](security.md) — threat model, key provisioning, authentication, and replay protection
 - [BPF Environment](bpf-environment.md) — BPF program API, memory model, and development workflow
-- [Why BPF?](why-bpf.md) — rationale for using uBPF + Prevail as the execution model
+- [Why BPF?](why-bpf.md) — rationale for using BPF + Prevail as the execution model

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -188,7 +188,7 @@ BPF programs reference maps via `LDDW` instructions (RFC 9669 §4.3). In the ori
 - **Resolution:** Prevail's loader performs this transformation as part of verification — no additional pass is required.
 - **Node-side handling:** The node's BPF interpreter recognizes `LDDW src=1` and replaces the immediate with the runtime pointer to the corresponding map (allocated from sleep-persistent memory at program install time).
 
-This encoding is consistent with the standard BPF loader convention (`src=1` = map reference by index) and is already supported by uBPF.
+This encoding is consistent with the standard BPF loader convention (`src=1` = map reference by index).
 
 #### Ingestion pipeline
 

--- a/docs/why-bpf.md
+++ b/docs/why-bpf.md
@@ -4,7 +4,7 @@
 
 ## Summary
 
-This document describes the rationale for using BPF (via [uBPF](https://github.com/iovisor/ubpf) + [Prevail](https://github.com/vbpf/ebpf-verifier)) as the execution model for Sonde nodes. The goal is to make node firmware static and uniform, while all behavior — sampling logic, thresholds, batching, anomaly detection, diagnostics — is delivered dynamically as verified BPF bytecode. This enables a safe, flexible, low-power distributed system without OTA firmware updates.
+This document describes the rationale for using BPF ([RFC 9669](https://www.rfc-editor.org/rfc/rfc9669.html), verified by [Prevail](https://github.com/vbpf/ebpf-verifier)) as the execution model for Sonde nodes. The goal is to make node firmware static and uniform, while all behavior — sampling logic, thresholds, batching, anomaly detection, diagnostics — is delivered dynamically as verified BPF bytecode. This enables a safe, flexible, low-power distributed system without OTA firmware updates.
 
 ---
 
@@ -51,16 +51,16 @@ Prevail provides static guarantees:
 
 This ensures predictable wake-time energy usage and prevents runaway programs.
 
-### Tiny, portable runtime (uBPF)
+### Tiny, portable runtime (sonde-bpf)
 
-uBPF provides:
+`sonde-bpf` provides:
 
-- A small interpreter suitable for ESP32-C3/S3
-- Optional JIT (where supported)
-- A simple embedding model
+- A zero-allocation BPF interpreter (RFC 9669 compliant)
+- Tagged registers for pointer provenance and memory safety
+- `#![no_std]`-compatible — runs on ESP32-C3/S3
 - No OS dependencies
 
-This keeps node firmware minimal and uniform.
+This keeps node firmware minimal and uniform. The interpreter is injected via a `BpfInterpreter` trait, so alternative backends (e.g., rbpf, uBPF) can be substituted without changing the firmware.
 
 ### Dynamic behavior without firmware updates
 
@@ -141,4 +141,4 @@ Only new BPF programs.
 
 ## Conclusion
 
-BPF provides a safe, verifiable, low-power execution model that allows Sonde nodes to remain simple, uniform, and long-lived while still supporting dynamic behavior. The combination of uBPF + Prevail gives us a correctness-critical runtime with strong safety guarantees and a clean operational story. This architecture is significantly more flexible and maintainable than traditional firmware-centric IoT designs.
+BPF provides a safe, verifiable, low-power execution model that allows Sonde nodes to remain simple, uniform, and long-lived while still supporting dynamic behavior. The combination of `sonde-bpf` (a custom RFC 9669 interpreter) + Prevail gives us a correctness-critical runtime with strong safety guarantees and a clean operational story. This architecture is significantly more flexible and maintainable than traditional firmware-centric IoT designs.


### PR DESCRIPTION
Replace all references to uBPF with `sonde-bpf`, the project's custom RFC 9669 compliant BPF interpreter. The project does not use uBPF — it has its own zero-allocation, `#![no_std]` interpreter with tagged register tracking.

## Changes (7 files)

**README.md**
- Intro: link to RFC 9669 instead of uBPF GitHub
- Reference table: `sonde-bpf` with RFC 9669 note instead of "no uBPF JIT"
- Further reading: "BPF + Prevail" instead of "uBPF + Prevail"
- Related Work: add rbpf as prior art

**docs/overview.md** — same intro and link fixes

**docs/why-bpf.md** — summary, runtime section (`sonde-bpf` replaces uBPF description), conclusion

**docs/protocol.md** — remove trailing "and is already supported by uBPF" from LDDW note

**docs/bpf-environment.md** — test harness: "BPF execution" via `sonde-bpf` instead of "uBPF execution"

**docs/node-design.md** — interpreter selection resolved (was marked OPEN with rbpf/uBPF options); now states `sonde-bpf` is the chosen interpreter

**crates/sonde-node/src/bpf_runtime.rs** — `BpfInterpreter` trait doc comment updated
