### PR TITLE
fix(android): cache JNI class refs in JNI_OnLoad to fix classloader crash

### DIFF
--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -538,7 +538,9 @@ pub extern "system" fn JNI_OnLoad(
 }
 
 #[cfg(target_os = "android")]
-fn jni_on_load_inner(vm: *mut jni::sys::JavaVM) -> Result<jni::sys::jint, Box<dyn std::error::Error>> {
+fn jni_on_load_inner(
+    vm: *mut jni::sys::JavaVM,
+) -> Result<jni::sys::jint, Box<dyn std::error::Error>> {
     let vm1 = unsafe { jni::JavaVM::from_raw(vm)? };
     let vm2 = unsafe { jni::JavaVM::from_raw(vm)? };
     AndroidBleTransport::cache_vm(vm1);

--- a/crates/sonde-pair/src/android_store.rs
+++ b/crates/sonde-pair/src/android_store.rs
@@ -100,8 +100,7 @@ impl AndroidPairingStore {
         // SAFETY: The GlobalRef was created from find_class(), which returns
         // a JClass.  We reconstruct a JClass from the raw jobject pointer;
         // the GlobalRef keeps the underlying reference alive.
-        let store_class =
-            unsafe { JClass::from_raw(cached.as_obj().as_raw()) };
+        let store_class = unsafe { JClass::from_raw(cached.as_obj().as_raw()) };
 
         let store_obj = env
             .new_object(

--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -101,8 +101,7 @@ impl AndroidBleTransport {
         // SAFETY: The GlobalRef was created from find_class(), which returns
         // a JClass.  We reconstruct a JClass from the raw jobject pointer;
         // the GlobalRef keeps the underlying reference alive.
-        let helper_class =
-            unsafe { JClass::from_raw(cached.as_obj().as_raw()) };
+        let helper_class = unsafe { JClass::from_raw(cached.as_obj().as_raw()) };
 
         let helper = env
             .new_object(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@
 > **Document status:** Draft
 > **Scope:** Developer environment setup for building, testing, and flashing all Sonde crates.
 > **Audience:** Contributors and LLM agents working on any part of the Sonde codebase.
-> **Related:** [implementation-guide.md](implementation-guide.md), [README.md](../README.md)
+> **Related:** [implementation-guide.md](implementation-guide.md), [node-bom.md](node-bom.md), [README.md](../README.md)
 
 > **Repository status:** Active development — pre-1.0. Core crates (protocol, gateway, modem, node) are implemented and tested. See the [Project status](../README.md#project-status) section in the README for the current state of each crate and the roadmap.
 


### PR DESCRIPTION
## Problem

The sonde-pair Android app crashes with `ClassNotFoundException: io.sonde.pair.BleHelper` immediately when starting a BLE scan, even though the class is compiled into the APK DEX files.

## Root Cause

Classic Android JNI classloader issue. Tauri command handlers call `from_cached_vm()` inside `spawn_blocking()`, which runs on a tokio native thread. When `vm.attach_current_thread()` is called on this thread, the resulting `JNIEnv` only has access to the system classloader, not the application classloader. So `FindClass` for app-defined classes like `BleHelper` and `SecureStore` fails.

## Fix

Cache `GlobalRef` to each app-defined Java class during `JNI_OnLoad` (which runs on the main thread with the application classloader). `AndroidBleTransport::new()` and `AndroidPairingStore::new()` now use these cached refs instead of calling `find_class()`.

### Changes
- `android_transport.rs`: Added `CACHED_HELPER_CLASS` + `cache_helper_class()`
- `android_store.rs`: Added `CACHED_STORE_CLASS` + `cache_store_class()`
- `lib.rs` (sonde-pair-ui): Updated `JNI_OnLoad` to resolve and cache both classes

## Crash log

`
FATAL EXCEPTION: Thread-3
Process: com.sonde.pair, PID: 27048
java.lang.ClassNotFoundException: Didn't find class "io.sonde.pair.BleHelper"
`

## Testing

- `cargo clippy --workspace -- -D warnings` clean
- `cargo test --workspace` all 780+ tests pass
- Pending: redeploy APK to device and verify BLE scan works
