### PR TITLE
fix(modem): set BLE GAP device name to `sonde-modem`

### DIFF
--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -170,8 +170,9 @@ impl EspBleDriver {
 
         // Set the GAP device name so connected clients (e.g. Android) see
         // "sonde-modem" instead of the NimBLE default ("nimble").
-        BLEDevice::set_device_name(BLE_DEVICE_NAME)
-            .unwrap_or_else(|e| panic!("failed to set BLE GAP device name: {e}"));
+        if let Err(e) = BLEDevice::set_device_name(BLE_DEVICE_NAME) {
+            warn!("failed to set BLE GAP device name, continuing with default: {e}");
+        }
 
         // Configure LESC Numeric Comparison security (MD-0404).
         ble_device


### PR DESCRIPTION
## Summary

Calls `set_device_name("sonde-modem")` on the `BLEDevice` singleton immediately after `BLEDevice::take()` in `EspBleDriver::new()` so that connected clients (e.g. Android) see **sonde-modem** instead of the NimBLE default (**nimble**).

The advertising payload already set the name via `BLEAdvertisementData::name()`, but the GAP device name — which Android reads after connecting — was never configured.

Closes #324