### PR TITLE
gateway: add ETW tracing layer for Windows service mode

### DIFF
--- a/crates/sonde-gateway/Cargo.toml
+++ b/crates/sonde-gateway/Cargo.toml
@@ -49,6 +49,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Memory",
 ] }
 windows-service = "0.8.0"
+tracing-etw = "0.2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 secret-service = { version = "5", features = ["rt-tokio-crypto-rust"] }

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -604,12 +604,17 @@ fn service_entry(_arguments: Vec<std::ffi::OsString>) {
     let _ = status_handle.set_service_status(stopped_status);
 }
 
-/// Initialise tracing to write to a log file (used in service mode where there
-/// is no console).
+/// Initialise tracing to write to a log file **and** emit ETW events (used in
+/// service mode where there is no console).
+///
+/// The file layer honours `RUST_LOG`; the ETW layer receives all events so that
+/// ETW-side filtering (via `logman` / `tracelog`) controls verbosity
+/// independently.
 ///
 /// The log file path defaults to `<db-path>.log` when `--log-file` is not set.
 #[cfg(windows)]
 fn init_service_logging(cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
+    use tracing_subscriber::prelude::*;
     use tracing_subscriber::EnvFilter;
 
     let log_path = cli.log_file.clone().unwrap_or_else(|| {
@@ -624,12 +629,20 @@ fn init_service_logging(cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
         .open(&log_path)
         .map_err(|e| format!("cannot open log file {}: {e}", log_path.display()))?;
 
-    tracing_subscriber::fmt()
+    let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::sync::Mutex::new(file))
         .with_ansi(false)
-        .with_env_filter(
+        .with_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| "sonde_gateway=info".into()),
-        )
+        );
+
+    let etw_layer = tracing_etw::LayerBuilder::new("sonde-gateway")
+        .build()
+        .map_err(|e| format!("failed to initialise ETW provider: {e}"))?;
+
+    tracing_subscriber::registry()
+        .with(fmt_layer)
+        .with(etw_layer)
         .init();
 
     Ok(())


### PR DESCRIPTION
## Summary

When the gateway runs as a Windows NT service, stderr/stdout are unavailable so all tracing output is lost. This PR adds an ETW (Event Tracing for Windows) subscriber layer to the service-mode logging, so structured events are emitted to ETW alongside the existing file-based log.

## Changes

- **crates/sonde-gateway/Cargo.toml** - Add `tracing-etw` as a `cfg(windows)`-only dependency.
- **crates/sonde-gateway/src/bin/gateway.rs** - Refactor `init_service_logging()` to use `tracing_subscriber::registry()` with two layers:
  - **fmt layer** - file-based logging (unchanged behavior, honours `RUST_LOG`).
  - **ETW layer** - emits all events to ETW under provider name `sonde-gateway`.

## Diagnostics

With ETW enabled, operators can use standard Windows tools:
- **Live viewing** via `tracelog` / `traceview` or `logman`
- **Post-capture analysis** with WPA / PerfView
- **Event Viewer** for persistent logs

Console mode is unchanged - only the service-mode subscriber stack is affected.

Closes #319
