### PR TITLE
ci: replace QEMU boot test with Wokwi for application-level validation

### DIFF
--- a/.github/workflows/esp32-modem.yml
+++ b/.github/workflows/esp32-modem.yml
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 sonde contributors
 #
-# ESP32-S3 modem firmware CI: build sonde-modem for ESP32-S3 (Xtensa).
+# ESP32-S3 modem firmware CI: build sonde-modem for ESP32-S3 (Xtensa) and run
+# a Wokwi boot test that asserts the Rust application actually starts on UART.
 
 name: ESP32-S3 Modem Firmware CI
 
@@ -25,7 +26,7 @@ concurrency:
 
 jobs:
   esp32s3-modem-build:
-    name: Build ESP32-S3 modem firmware
+    name: Build ESP32-S3 modem firmware and Wokwi boot test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,6 +36,9 @@ jobs:
       # Pre-built ESP32 dev container with Rust stable, ESP Rust toolchain,
       # and ldproxy pre-installed. Published by esp-dev-container.yml.
       image: ghcr.io/alan-jowett/sonde-esp-dev:latest
+
+    env:
+      HAS_WOKWI_TOKEN: ${{ secrets.WOKWI_CLI_TOKEN != '' }}
 
     steps:
       - name: Checkout
@@ -152,6 +156,39 @@ jobs:
             0x10000 "$TARGET_DIR/modem.bin"
 
           echo "flash_image.bin created ($(wc -c < flash_image.bin) bytes)"
+
+      # ------------------------------------------------------------------ #
+      # Wokwi boot test
+      # ------------------------------------------------------------------ #
+
+      - name: Wokwi boot test
+        # Wokwi provides full ESP32-S3 peripheral emulation (including
+        # systimer), so FreeRTOS ticks and app_main() actually runs.
+        # This validates the Rust application starts — not just the
+        # bootloader.  See #227, #223.
+        if: ${{ env.HAS_WOKWI_TOKEN == 'true' }}
+        uses: wokwi/wokwi-ci-action@8d0e92eca93c6fc7832c805bfdc0d50bacff7558 # v1
+        with:
+          token: ${{ secrets.WOKWI_CLI_TOKEN }}
+          path: crates/sonde-modem
+          timeout: 15000
+          expect_text: 'sonde-modem firmware starting'
+          fail_text: 'panic'
+          serial_log_file: wokwi-serial.log
+
+      - name: Print Wokwi serial log
+        if: ${{ env.HAS_WOKWI_TOKEN == 'true' && always() }}
+        run: |
+          LOG="crates/sonde-modem/wokwi-serial.log"
+          if [ -f "$LOG" ]; then
+            echo "=== Wokwi UART output ==="
+            cat "$LOG"
+            echo "========================="
+          fi
+
+      - name: Skip notice (no WOKWI_CLI_TOKEN)
+        if: ${{ env.HAS_WOKWI_TOKEN != 'true' }}
+        run: echo "::warning::Wokwi boot test skipped — WOKWI_CLI_TOKEN secret is not set."
 
       # ------------------------------------------------------------------ #
       # Upload firmware artifact

--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 sonde contributors
 #
 # ESP32-C3 node firmware CI: build sonde-node for ESP32-C3 (RISC-V) and run a
-# QEMU smoke test that asserts the expected boot-marker strings appear on UART.
+# Wokwi boot test that asserts the Rust application actually starts on UART.
 
 name: ESP32-C3 Node Firmware CI
 
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   esp32c3-node-build-and-smoke:
-    name: Build ESP32-C3 node firmware and QEMU smoke test
+    name: Build ESP32-C3 node firmware and Wokwi boot test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,6 +34,9 @@ jobs:
 
     container:
       image: ghcr.io/alan-jowett/sonde-esp-dev:latest
+
+    env:
+      HAS_WOKWI_TOKEN: ${{ secrets.WOKWI_CLI_TOKEN != '' }}
 
     steps:
       - name: Checkout
@@ -139,7 +142,7 @@ jobs:
             "$TARGET_DIR/node"
 
           # Merge bootloader + partition table + app into a single 4MB image.
-          # --fill-flash-size pads to exactly 4MB, which QEMU requires.
+          # --fill-flash-size pads to exactly 4MB for consistent flashing.
           # On ESP32-C3 the bootloader loads at flash offset 0x0 (not 0x1000).
           esptool.py --chip esp32c3 merge_bin \
             --output flash_image.bin \
@@ -151,83 +154,37 @@ jobs:
           echo "flash_image.bin created ($(wc -c < flash_image.bin) bytes)"
 
       # ------------------------------------------------------------------ #
-      # QEMU smoke test
+      # Wokwi boot test
       # ------------------------------------------------------------------ #
 
-      - name: Run QEMU smoke test
-        # Source IDF export.sh so qemu-system-riscv32 is on PATH.
-        #
-        # NOTE: The smoke test checks for ESP-IDF boot markers instead of
-        # Rust-level markers (`sonde-node booting`). ESP32-C3 QEMU support
-        # is experimental — the systimer peripheral used for FreeRTOS tick
-        # generation is not fully emulated, so the FreeRTOS scheduler never
-        # starts and `app_main()` / Rust `main()` is never called. See #105.
-        #
-        # The ESP-IDF markers still prove the firmware was correctly:
-        #   1. Cross-compiled for riscv32imc-esp-espidf
-        #   2. Converted from ELF → binary → merged flash image
-        #   3. Loaded and validated by the ESP-IDF 2nd-stage bootloader
-        #   4. Initialized through CPU start, heap, and flash detection
+      - name: Wokwi boot test
+        # Wokwi provides full ESP32-C3 peripheral emulation (including
+        # systimer), so FreeRTOS ticks and app_main() actually runs.
+        # This validates the Rust application starts — not just the
+        # bootloader.  Replaces the former QEMU smoke test (#105, #227).
+        if: ${{ env.HAS_WOKWI_TOKEN == 'true' }}
+        uses: wokwi/wokwi-ci-action@8d0e92eca93c6fc7832c805bfdc0d50bacff7558 # v1
+        with:
+          token: ${{ secrets.WOKWI_CLI_TOKEN }}
+          path: crates/sonde-node
+          timeout: 15000
+          expect_text: 'sonde-node booting'
+          fail_text: 'panic'
+          serial_log_file: wokwi-serial.log
+
+      - name: Print Wokwi serial log
+        if: ${{ env.HAS_WOKWI_TOKEN == 'true' && always() }}
         run: |
-          . "$IDF_PATH/export.sh"
-          QEMU_OUTPUT="/tmp/qemu_uart.txt"
-
-          # Boot the firmware under QEMU with a hard timeout.
-          # -no-reboot prevents restart loops on early failures.
-          # 15s is enough — ESP-IDF boot markers appear within 2s; the
-          # remaining time is buffer for slow CI runners. The firmware
-          # hangs after eFuse init (before FreeRTOS scheduler start) so
-          # a longer timeout just wastes CI time.
-          set +e
-          timeout 15 qemu-system-riscv32 \
-            -nographic \
-            -machine esp32c3 \
-            -drive file=flash_image.bin,if=mtd,format=raw \
-            -no-reboot \
-            > "$QEMU_OUTPUT" 2>&1
-          QEMU_EXIT=$?
-          set -e
-
-          echo ""
-          echo "=== QEMU UART output ==="
-          cat "$QEMU_OUTPUT"
-          echo "========================"
-
-          # Exit 124 = timeout (expected — QEMU hangs after eFuse init).
-          # Exit 0   = QEMU exited cleanly (unusual but acceptable).
-          # Any other non-zero = QEMU crashed or was killed → fail.
-          if [ "$QEMU_EXIT" -ne 0 ] && [ "$QEMU_EXIT" -ne 124 ]; then
-            echo "ERROR: QEMU exited with unexpected code $QEMU_EXIT" >&2
-            exit 1
+          LOG="crates/sonde-node/wokwi-serial.log"
+          if [ -f "$LOG" ]; then
+            echo "=== Wokwi UART output ==="
+            cat "$LOG"
+            echo "========================="
           fi
 
-          # Assert ESP-IDF boot markers that prove the firmware image is
-          # valid and bootable. These are printed before the FreeRTOS
-          # scheduler starts, so they work even though QEMU can't fully
-          # boot ESP32-C3 firmware (see note above).
-          #
-          # "cpu_start: Pro cpu start user code" — CPU init reached user code
-          # "app_init: Application information"  — app metadata loaded
-          # "heap_init: Initializing"            — RAM layout correct
-          PASS=true
-          for marker in \
-            "cpu_start: Pro cpu start user code" \
-            "app_init: Application information" \
-            "heap_init: Initializing"; do
-            if grep -qF "$marker" "$QEMU_OUTPUT"; then
-              echo "✓  Found marker: '$marker'"
-            else
-              echo "✗  Missing marker: '$marker'" >&2
-              PASS=false
-            fi
-          done
-
-          if [ "$PASS" = "false" ]; then
-            echo "Smoke test FAILED — one or more expected markers were not found." >&2
-            exit 1
-          fi
-
-          echo "Smoke test passed."
+      - name: Skip notice (no WOKWI_CLI_TOKEN)
+        if: ${{ env.HAS_WOKWI_TOKEN != 'true' }}
+        run: echo "::warning::Wokwi boot test skipped — WOKWI_CLI_TOKEN secret is not set."
 
       # ------------------------------------------------------------------ #
       # Upload firmware artifact

--- a/crates/sonde-modem/diagram.json
+++ b/crates/sonde-modem/diagram.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "author": "sonde contributors",
+  "editor": "wokwi",
+  "parts": [
+    {
+      "type": "board-esp32-s3-devkitc-1",
+      "id": "esp"
+    }
+  ],
+  "connections": []
+}

--- a/crates/sonde-modem/wokwi.toml
+++ b/crates/sonde-modem/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = '../../target/xtensa-esp32s3-espidf/firmware/modem'
+elf = '../../target/xtensa-esp32s3-espidf/firmware/modem'

--- a/crates/sonde-node/diagram.json
+++ b/crates/sonde-node/diagram.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "author": "sonde contributors",
+  "editor": "wokwi",
+  "parts": [
+    {
+      "type": "board-esp32-c3-devkitm-1",
+      "id": "esp"
+    }
+  ],
+  "connections": []
+}

--- a/crates/sonde-node/wokwi.toml
+++ b/crates/sonde-node/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = '../../target/riscv32imc-esp-espidf/firmware/node'
+elf = '../../target/riscv32imc-esp-espidf/firmware/node'


### PR DESCRIPTION
## Summary

Replace the QEMU smoke test with Wokwi CI boot tests that validate the **Rust application actually starts** — not just the ESP-IDF bootloader.

### Problem

The QEMU smoke test only checked for bootloader markers (\cpu_start\, \heap_init\, \pp_init\). Due to QEMU's missing systimer emulation (#105), FreeRTOS never ticked and \pp_main()\ was never reached. A firmware that compiles but crashes in \main()\ would pass CI.

### Fix

**ESP32-C3 node** (\sp32.yml\): Replace QEMU test with Wokwi boot test checking for \sonde-node booting\ marker.

**ESP32-S3 modem** (\sp32-modem.yml\): Add Wokwi boot test checking for \sonde-modem firmware starting\ marker (also addresses #223).

Both tests:
- Use \ail_text: panic\ to catch Rust panics
- Skip gracefully when \WOKWI_CLI_TOKEN\ secret is not set (fork PRs)
- Print serial logs on failure for debugging

### New files
- \crates/sonde-node/wokwi.toml\ + \diagram.json\ — ESP32-C3 board config
- \crates/sonde-modem/wokwi.toml\ + \diagram.json\ — ESP32-S3 board config

### What this catches
- #229 — stack protection fault (app never prints boot marker)
- #235 — ABI mismatch boot loop
- Any future regression where firmware compiles but crashes at runtime

### Setup required
Add \WOKWI_CLI_TOKEN\ as a GitHub repo secret ([Wokwi CI docs](https://docs.wokwi.com/wokwi-ci/getting-started)).

Closes #227