### PR TITLE
test(protocol): close 4 validation gaps — direction-bit, nonce echo, multi-APP_DATA, HMAC (T-P063..T-P068)

### DIFF
--- a/crates/sonde-protocol/tests/validation.rs
+++ b/crates/sonde-protocol/tests/validation.rs
@@ -1643,7 +1643,7 @@ fn test_p064() {
     }
 }
 
-// T-P065: Nonce echo verification — WAKE → COMMAND pair.
+// T-P065: Nonce field round-trip fidelity — WAKE → COMMAND pair (codec layer only).
 #[test]
 fn test_p065() {
     // Protocol §7.3: The response frame echoes the request nonce so the
@@ -1729,7 +1729,7 @@ fn test_p065() {
     );
 }
 
-// T-P066: Nonce echo verification — GET_CHUNK → CHUNK and APP_DATA → APP_DATA_REPLY pairs.
+// T-P066: Nonce field round-trip fidelity — GET_CHUNK → CHUNK and APP_DATA → APP_DATA_REPLY pairs (codec layer only).
 #[test]
 fn test_p066() {
     let psk = [0x42u8; 32];
@@ -1816,12 +1816,15 @@ fn test_p066() {
     );
 }
 
-// T-P067: Multiple APP_DATA nonce round-trip fidelity.
+// T-P067: Multiple APP_DATA nonce/sequence round-trip fidelity (codec layer only).
 #[test]
 fn test_p067() {
-    // This test verifies that the codec faithfully round-trips distinct
-    // nonce values across multiple frames. Sequence enforcement is the
-    // responsibility of the node/gateway state machines, not the codec.
+    // Verifies that the codec faithfully round-trips distinct nonce values
+    // across multiple APP_DATA frames. Per protocol §5.6, post-WAKE messages
+    // carry a gateway-assigned sequence number in the nonce field; this test
+    // confirms the codec preserves those values through encode → decode.
+    // Monotonic ordering enforcement is the responsibility of the
+    // node/gateway state machines, not the codec layer.
     let psk = [0x42u8; 32];
 
     let payloads: Vec<Vec<u8>> = vec![


### PR DESCRIPTION
## Summary

Adds 6 tests (T-P063 through T-P068) closing the four protocol validation gaps identified in #347.

### Gap 1 — Direction-bit cross-direction rejection (T-P063, T-P064)
- T-P063: `NodeMessage::decode` rejects all gateway `msg_type` codes (0x81–0x84).
- T-P064: `GatewayMessage::decode` rejects all node `msg_type` codes (0x01–0x05).

### Gap 2 — Nonce field round-trip fidelity (T-P065, T-P066)
- T-P065: Builds a WAKE → COMMAND frame pair and asserts the codec round-trips the nonce field correctly, illustrating nonce-based correlation. Protocol-level nonce binding enforcement is the responsibility of the node/gateway state machines, not the codec layer.
- T-P066: Builds GET_CHUNK → CHUNK and APP_DATA → APP_DATA_REPLY pairs, verifying nonce field round-trip fidelity for both codec paths.

### Gap 3 — Multiple APP_DATA nonce/sequence round-trip (T-P067)
- Encodes 5 APP_DATA frames with incrementing nonce values (which carry the gateway-assigned sequence number for post-WAKE messages per protocol §5.6), decodes each, and asserts codec round-trip fidelity. Monotonic ordering enforcement is the responsibility of the node/gateway state machines, not the codec layer.

### Gap 4 — HMAC constant-time comparison (T-P068)
- Exercises `SoftwareHmac::verify` directly (not via `verify_frame`) with correct, zeroed, single-bit-flipped, last-byte-flipped, wrong-data, and wrong-key inputs. The implementation delegates to `hmac::Mac::verify_slice` which uses `subtle::ConstantTimeEq`.

### Validation
- `cargo fmt --check` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test --workspace` — all tests pass (including the 6 new ones)

Closes #347