### PR TITLE
test(node): add protocol robustness and lifecycle tests (6 gaps)

### DIFF
--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -4577,23 +4577,27 @@ mod tests {
 
     // --- Gap 2: ND-0103 — send_recv() frame size enforcement ---
 
+    /// Derive the maximum AppData blob size that fits within MAX_PAYLOAD_SIZE
+    /// after CBOR encoding, to avoid coupling tests to encoding overhead.
+    fn max_app_data_blob_len() -> usize {
+        let mut size = sonde_protocol::MAX_PAYLOAD_SIZE;
+        while size > 0 {
+            let probe = NodeMessage::AppData {
+                blob: vec![0x00; size],
+            };
+            if probe.encode().unwrap().len() <= sonde_protocol::MAX_PAYLOAD_SIZE {
+                return size;
+            }
+            size -= 1;
+        }
+        0
+    }
+
     #[test]
     fn test_send_recv_max_blob() {
         // ND-0103 / T-N103: send_recv() with maximum blob that fits
         // within the frame budget succeeds.
-        //
-        // Derive the maximum blob size dynamically to avoid coupling
-        // to CBOR encoding details (overhead varies with blob length).
-        let mut max_blob_size = sonde_protocol::MAX_PAYLOAD_SIZE;
-        while max_blob_size > 0 {
-            let probe = NodeMessage::AppData {
-                blob: vec![0x00; max_blob_size],
-            };
-            if probe.encode().unwrap().len() <= sonde_protocol::MAX_PAYLOAD_SIZE {
-                break;
-            }
-            max_blob_size -= 1;
-        }
+        let max_blob_size = max_app_data_blob_len();
 
         let psk = [0xC2; 32];
         let key_hint = 1u16;
@@ -4627,19 +4631,7 @@ mod tests {
     fn test_send_recv_oversized_blob_rejected() {
         // ND-0103 / T-N104: send_recv() with oversized blob is rejected.
         // Seq is not advanced and no frame is sent.
-        //
-        // Derive the boundary dynamically: max_blob_size + 1 must be
-        // rejected by the post-encoding size check.
-        let mut max_blob_size = sonde_protocol::MAX_PAYLOAD_SIZE;
-        while max_blob_size > 0 {
-            let probe = NodeMessage::AppData {
-                blob: vec![0x00; max_blob_size],
-            };
-            if probe.encode().unwrap().len() <= sonde_protocol::MAX_PAYLOAD_SIZE {
-                break;
-            }
-            max_blob_size -= 1;
-        }
+        let max_blob_size = max_app_data_blob_len();
 
         let psk = [0xC3; 32];
         let key_hint = 1u16;
@@ -4733,9 +4725,13 @@ mod tests {
         );
         assert_eq!(outcome1, WakeCycleOutcome::Sleep { seconds: 60 });
 
-        // Verify cycle 1 used starting_seq_1 for GET_CHUNK
-        let gc1 = decode_frame(&transport1.outbound[1]).unwrap();
-        assert_eq!(gc1.header.msg_type, MSG_GET_CHUNK);
+        // Verify cycle 1 used starting_seq_1 for the first GET_CHUNK it sent
+        let gc1 = transport1
+            .outbound
+            .iter()
+            .filter_map(|frame| decode_frame(frame).ok())
+            .find(|msg| msg.header.msg_type == MSG_GET_CHUNK)
+            .expect("no MSG_GET_CHUNK frame sent in cycle 1");
         assert_eq!(gc1.header.nonce, starting_seq_1);
 
         // --- Cycle 2: starting_seq = 5000 (fresh, no carryover) ---
@@ -4785,8 +4781,12 @@ mod tests {
         assert_eq!(outcome2, WakeCycleOutcome::Sleep { seconds: 60 });
 
         // Verify cycle 2 uses starting_seq_2, NOT a continuation of cycle 1.
-        let gc2 = decode_frame(&transport2.outbound[1]).unwrap();
-        assert_eq!(gc2.header.msg_type, MSG_GET_CHUNK);
+        let gc2 = transport2
+            .outbound
+            .iter()
+            .filter_map(|frame| decode_frame(frame).ok())
+            .find(|msg| msg.header.msg_type == MSG_GET_CHUNK)
+            .expect("no MSG_GET_CHUNK frame sent in cycle 2");
         assert_eq!(
             gc2.header.nonce, starting_seq_2,
             "cycle 2 must start fresh from gateway-provided starting_seq"
@@ -5002,10 +5002,11 @@ mod tests {
         // Verify the node entered the chunk-transfer path by sending
         // at least one MSG_GET_CHUNK before the wrong msg_type was
         // received and discarded.
-        let sent_get_chunk = transport
-            .outbound
-            .iter()
-            .any(|f| decode_frame(f).map(|d| d.header.msg_type == MSG_GET_CHUNK).unwrap_or(false));
+        let sent_get_chunk = transport.outbound.iter().any(|f| {
+            decode_frame(f)
+                .map(|d| d.header.msg_type == MSG_GET_CHUNK)
+                .unwrap_or(false)
+        });
         assert!(
             sent_get_chunk,
             "node must have sent MSG_GET_CHUNK before discarding wrong msg_type"


### PR DESCRIPTION
## Summary

Adds 10 tests covering the 6 validation gaps from #355:

| Gap | Requirement | Test(s) |
|-----|-------------|---------|
| 1 | ND-0101 AC2 — CBOR forward compatibility | \	est_cbor_forward_compat_unknown_keys\ |
| 2 | ND-0103 — \send_recv()\ frame size enforcement | \	est_send_recv_max_blob\, \	est_send_recv_oversized_blob_rejected\ |
| 3 | ND-0303 — Sequence number reset across sleep | \	est_sequence_reset_across_wake_cycles\ |
| 4 | ND-0203 — Base interval restore after \set_next_wake()\ | \	est_set_next_wake_e2e_base_interval_restore\ |
| 5 | ND-0801 AC2 — Wrong \msg_type\ for expected context | \	est_wrong_msg_type_command_when_chunk_expected\, \	est_wrong_msg_type_chunk_when_app_data_reply_expected\ |
| 6 | ND-0702 — Response timeout (50 ms) | \	est_response_timeout_constant_is_50ms\, \	est_response_timeout_send_recv_deadline\, \	est_wake_command_timeout_retries\ |

### Key implementation details

- **CBOR forward compat** (gap 1): Manually builds a COMMAND frame with extra unknown integer keys (99, 100) and verifies the node processes it as NOP without error.
- **\send_recv()\ size enforcement** (gap 2): Mirrors existing \send_app_data\ tests (T-N103/T-N104) for the \send_recv_app_data\ path.
- **Sequence reset** (gap 3): Runs two full wake cycles with \starting_seq=1000\ and \starting_seq=5000\; asserts the second cycle's first outbound message uses 5000, not a continuation.
- **Base interval restore** (gap 4): Introduces \SetNextWakeInterpreter\ — a mock BPF interpreter that calls \helper_set_next_wake()\ through the installed dispatch context. Cycle 1 sleeps 10s (min(10, 300)), cycle 2 restores to 300s.
- **Wrong msg_type** (gap 5): Tests COMMAND-when-CHUNK-expected (chunked transfer) and CHUNK-when-APP_DATA_REPLY-expected (\send_recv\).
- **Timeout** (gap 6): Introduces \AdvancingClock\ mock to test deadline expiry in \send_recv_app_data\. Also asserts \RESPONSE_TIMEOUT_MS == 50\ and verifies WAKE/COMMAND retry on timeout.

All 169 node tests pass. No production code changed.

Closes #355