### PR TITLE
test(modem): add BLE indication flow control, Write Long, and TX backpressure tests

### DIFF
--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -2117,7 +2117,7 @@ mod tests {
     #[test]
     fn t0605_indication_chunks_within_mtu_limit() {
         let mtu = 247u16;
-        let chunk_size = (mtu - ATT_HEADER_BYTES) as usize;
+        let chunk_size = mtu.saturating_sub(ATT_HEADER_BYTES) as usize;
         // 500 bytes → 3 chunks (244 + 244 + 12).
         let payload: Vec<u8> = vec![0xAB; 500];
 
@@ -2149,7 +2149,7 @@ mod tests {
     #[test]
     fn t0605_indication_single_chunk_no_fragmentation() {
         let mtu = 247u16;
-        let chunk_size = (mtu - ATT_HEADER_BYTES) as usize;
+        let chunk_size = mtu.saturating_sub(ATT_HEADER_BYTES) as usize;
         let payload: Vec<u8> = vec![0x42; chunk_size - 10]; // well under ATT value max
 
         let mut bridge = make_bridge_with_fragmenting_ble(mtu);
@@ -2168,7 +2168,7 @@ mod tests {
     #[test]
     fn t0605_indication_exact_mtu_boundary() {
         let mtu = 247u16;
-        let chunk_size = (mtu - ATT_HEADER_BYTES) as usize;
+        let chunk_size = mtu.saturating_sub(ATT_HEADER_BYTES) as usize;
         let payload: Vec<u8> = vec![0x42; chunk_size]; // exactly ATT value max
 
         let mut bridge = make_bridge_with_fragmenting_ble(mtu);
@@ -2228,13 +2228,16 @@ mod tests {
     // GAP 2: MD-0409 AC2 — Write Long reassembly
     // ---------------------------------------------------------------
 
-    /// Validates: T-0613 / MD-0409 AC2 — Write Long payloads reassembled
-    /// by the BLE stack are forwarded as a single `BLE_RECV`.
+    /// Validates: T-0613 / MD-0409 AC2 — large BLE payload forwarded as
+    /// a single `BLE_RECV`.
     ///
     /// NimBLE reassembles Prepare Write + Execute Write before invoking
     /// `on_write`, so the bridge receives a single large `BleEvent::Recv`.
-    /// This test injects a payload larger than (MTU − 3) = 244 bytes and
-    /// asserts it arrives as one `BLE_RECV` serial message.
+    /// This test verifies the *bridge* forwarding path: it injects a
+    /// pre-reassembled payload larger than (MTU − 3) = 244 bytes and
+    /// asserts it arrives as one `BLE_RECV` serial message. The BLE stack
+    /// reassembly itself is a NimBLE responsibility and is not exercised
+    /// here.
     #[test]
     fn t0613_write_long_reassembled_as_single_ble_recv() {
         let mut bridge = make_bridge_with_ble();


### PR DESCRIPTION
## Summary

Add 13 unit tests covering three untested gaps identified in #338:

### GAP 1 — MD-0403 AC3: Indication fragmentation flow control (CRITICAL)

Introduces \FragmentingMockBle\, a mock BLE driver that simulates the real \EspBleDriver\ pacing logic with \waiting_confirm\ flag and per-chunk confirmation gating.

| Test | What it validates |
|------|-------------------|
| \	0605_indication_flow_control_awaits_confirm\ | 3-chunk payload — only one chunk sent per confirmation cycle, reassembly matches original |
| \	0605_indication_chunks_within_mtu_limit\ | Every chunk ≤ (MTU − 3) bytes |
| \	0605_indication_single_chunk_no_fragmentation\ | Payload < MTU-3 → 1 chunk, no fragmentation |
| \	0605_indication_exact_mtu_boundary\ | Payload exactly MTU-3 → 1 chunk |
| \	0605_advance_indication_blocked_while_awaiting_confirm\ | 10 polls without confirmation → no advance |
| \	0605_fragmenting_ble_empty_indicate_discarded\ | Empty data → silent discard |

### GAP 2 — MD-0409 AC2: Write Long reassembly

| Test | What it validates |
|------|-------------------|
| \	0613_write_long_reassembled_as_single_ble_recv\ | 500-byte payload (exceeds MTU-3) forwarded as single \BLE_RECV\ |
| \	0613_ble_recv_payload_forwarded_unmodified\ | All 256 byte values forwarded bit-exact |
| \	0613b_empty_gatt_write_no_ble_recv\ | No event emitted → no \BLE_RECV\ on serial |
| \	0613_multiple_write_longs_separate_ble_recv\ | Two large writes → two distinct \BLE_RECV\ messages |

### GAP 3 — Design §4.3: USB TX backpressure

Introduces \BackpressureSerial\, a mock serial port that can simulate write failures.

| Test | What it validates |
|------|-------------------|
| \	x_backpressure_drops_frames_no_crash\ | 32 radio frames with rejected writes — no crash, \x_count\ stays 0 |
| \	x_backpressure_recovery\ | Bridge resumes normal forwarding after write failures clear |
| \	x_backpressure_ble_events_no_crash\ | BLE events under backpressure handled without crash, bridge recovers |

## Test results

\\\
test result: ok. 77 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
\\\

Closes #338