### PR TITLE
Add node negative and forward-compatibility tests (4 gaps)

### DIFF
--- a/crates/sonde-node/src/bpf_dispatch.rs
+++ b/crates/sonde-node/src/bpf_dispatch.rs
@@ -1246,6 +1246,90 @@ mod tests {
     }
 
     #[test]
+    fn test_helper_delay_us_max_enforcement() {
+        // ND-0604 AC3: delay_us with value exceeding MAX_DELAY_US (1 s)
+        // must return an error (-1) and must NOT busy-wait. A tracking
+        // clock verifies that delay_ms is only called for accepted values.
+        use std::cell::Cell;
+
+        struct TrackingClock {
+            delay_calls: Cell<u32>,
+        }
+        impl Clock for TrackingClock {
+            fn elapsed_ms(&self) -> u64 {
+                0
+            }
+            fn delay_ms(&self, _ms: u32) {
+                self.delay_calls.set(self.delay_calls.get() + 1);
+            }
+        }
+
+        let mut hal = TestHal::new();
+        let mut transport = TestTransport::new();
+        let mut maps = MapStorage::new(4096);
+        let mut sleep = SleepManager::new(60, WakeReason::Scheduled);
+        let clock = TrackingClock {
+            delay_calls: Cell::new(0),
+        };
+        let hmac = TestHmac;
+        let identity = default_identity();
+        let mut seq = 0u64;
+        let mut trace = Vec::new();
+
+        unsafe {
+            install(
+                &mut hal as *mut TestHal as *mut dyn Hal,
+                &mut transport as *mut TestTransport as *mut dyn Transport,
+                &mut maps as *mut MapStorage,
+                &mut sleep as *mut SleepManager,
+                &clock as *const TrackingClock as *const dyn Clock,
+                &hmac as *const TestHmac as *const dyn HmacProvider,
+                &identity as *const NodeIdentity,
+                &mut seq as *mut u64,
+                ProgramClass::Resident,
+                &mut trace as *mut Vec<String>,
+                1_710_000_000_000,
+                100,
+                3300,
+            );
+        }
+        let _guard = DispatchGuard;
+
+        // Exactly at the limit — must succeed and invoke delay
+        assert_eq!(helper_delay_us(1_000_000, 0, 0, 0, 0), 0);
+        assert!(
+            clock.delay_calls.get() > 0,
+            "accepted delay must invoke clock"
+        );
+
+        clock.delay_calls.set(0);
+
+        // One over the limit — must reject WITHOUT calling delay
+        assert_eq!(
+            helper_delay_us(1_000_001, 0, 0, 0, 0),
+            (-1i64) as u64,
+            "delay exceeding MAX_DELAY_US must return error"
+        );
+        assert_eq!(
+            clock.delay_calls.get(),
+            0,
+            "rejected delay must not invoke clock"
+        );
+
+        // Far above the limit
+        assert_eq!(
+            helper_delay_us(u64::MAX, 0, 0, 0, 0),
+            (-1i64) as u64,
+            "extremely large delay must return error"
+        );
+        assert_eq!(
+            clock.delay_calls.get(),
+            0,
+            "rejected delay must not invoke clock"
+        );
+    }
+
+    #[test]
     fn test_helper_set_next_wake() {
         // set_next_wake for resident program succeeds.
         let mut hal = TestHal::new();

--- a/crates/sonde-node/src/sonde_bpf_adapter.rs
+++ b/crates/sonde-node/src/sonde_bpf_adapter.rs
@@ -353,4 +353,45 @@ mod tests {
         let result = interp.execute(0, 2).unwrap();
         assert_eq!(result, 42);
     }
+
+    #[test]
+    fn test_stack_frame_overflow() {
+        // ND-0605 AC3: A BPF program that stores beyond the total stack
+        // boundary must trigger a MemoryAccessViolation → RuntimeError.
+        //
+        // The interpreter allocates STACK_SIZE_PER_FRAME * MAX_CALL_DEPTH
+        // bytes. r10 starts at the stack top. Accessing 8 bytes past the
+        // bottom of the stack must fail.
+        //
+        // Bytecode:
+        //   mov64 r0, 0x42
+        //   stxdw [r10 - (STACK_SIZE + 8)], r0   ← past stack bottom
+        //   exit
+        use sonde_bpf::ebpf::{MAX_CALL_DEPTH, STACK_SIZE_PER_FRAME};
+
+        let total_stack = STACK_SIZE_PER_FRAME * MAX_CALL_DEPTH;
+        let overflow_offset = -(total_stack as i16 + 8);
+
+        let mut bytecode = Vec::new();
+        // mov64 r0, 0x42
+        bytecode.extend_from_slice(&[0xb7, 0x00, 0x00, 0x00, 0x42, 0x00, 0x00, 0x00]);
+        // stxdw [r10 + overflow_offset], r0
+        let offset_bytes = overflow_offset.to_le_bytes();
+        bytecode.extend_from_slice(&[0x7b, 0x0a, offset_bytes[0], offset_bytes[1]]);
+        bytecode.extend_from_slice(&[0x00, 0x00, 0x00, 0x00]);
+        // exit
+        bytecode.extend_from_slice(&[0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+        let mut interp = SondeBpfInterpreter::new();
+        interp.load(&bytecode, &[], &[]).unwrap();
+        let result = interp.execute(0, 100_000);
+        assert!(
+            result.is_err(),
+            "stack access beyond frame boundary must fail"
+        );
+        assert!(
+            matches!(result, Err(BpfError::RuntimeError(_))),
+            "expected RuntimeError for stack overflow, got {result:?}"
+        );
+    }
 }

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -3250,6 +3250,214 @@ mod tests {
         assert!(!storage.reg_complete);
     }
 
+    // ===================================================================
+    // ND-0101: Unknown CBOR keys — forward compatibility (AC2)
+    // ===================================================================
+
+    #[test]
+    fn test_unknown_cbor_keys_ignored() {
+        // ND-0101 AC2: Node MUST ignore unknown CBOR keys in inbound
+        // messages. Gateway sends a COMMAND with extra future-extension
+        // keys (99, 100) alongside the standard fields. The node must
+        // decode the message, treat it as NOP, and sleep normally.
+        let psk = [0xF1; 32];
+        let key_hint = 1u16;
+        let mut transport = MockTransport::new();
+
+        // Build a COMMAND NOP with extra unknown keys 99 and 100.
+        let cbor_map = ciborium::Value::Map(vec![
+            (
+                ciborium::Value::Integer(4.into()),    // command_type
+                ciborium::Value::Integer(0x00.into()), // NOP
+            ),
+            (
+                ciborium::Value::Integer(13.into()), // starting_seq
+                ciborium::Value::Integer(1000.into()),
+            ),
+            (
+                ciborium::Value::Integer(14.into()), // timestamp_ms
+                ciborium::Value::Integer(1710000000000u64.into()),
+            ),
+            (
+                ciborium::Value::Integer(99.into()), // unknown future key
+                ciborium::Value::Text("future_field".into()),
+            ),
+            (
+                ciborium::Value::Integer(100.into()), // another unknown key
+                ciborium::Value::Integer(42.into()),
+            ),
+        ]);
+        let mut payload_cbor = Vec::new();
+        ciborium::into_writer(&cbor_map, &mut payload_cbor).unwrap();
+        let header = FrameHeader {
+            key_hint,
+            msg_type: MSG_COMMAND,
+            nonce: 1,
+        };
+        let command_frame = encode_frame(&header, &payload_cbor, &psk, &TestHmac).unwrap();
+        transport.queue_response(Some(command_frame));
+
+        let mut storage = MockStorage::new().with_key(key_hint, psk);
+        let mut hal = MockHal;
+        let mut rng = MockRng(0);
+        let clock = MockClock;
+        let mut interp = MockBpfInterpreter::new();
+        let mut map_storage = MapStorage::new(DEFAULT_MAP_BUDGET);
+
+        let outcome = run_wake_cycle(
+            &mut transport,
+            &mut storage,
+            &mut hal,
+            &mut rng,
+            &clock,
+            &MockBattery,
+            &mut interp,
+            &mut map_storage,
+            &TestHmac,
+            &TestSha256,
+        );
+
+        // Node must decode successfully and sleep normally.
+        assert_eq!(outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+        assert_eq!(transport.outbound.len(), 1, "exactly one WAKE sent");
+    }
+
+    // ===================================================================
+    // ND-0200: No second COMMAND exchange before sleep
+    // ===================================================================
+
+    #[test]
+    fn test_second_command_not_consumed() {
+        // ND-0200 AC2: Node processes at most one COMMAND per cycle and
+        // MUST NOT initiate a second COMMAND exchange before sleep.
+        //
+        // A resident program is installed so BPF execution runs after the
+        // first COMMAND. The second COMMAND (REBOOT) is queued in the
+        // transport but must remain unconsumed: the wake cycle's recv()
+        // calls are strictly limited to the WAKE→COMMAND exchange (and
+        // optionally to APP_DATA_REPLY via send_recv during BPF helpers).
+        // No code path calls recv() for a second COMMAND-type message.
+        let psk = [0xF2; 32];
+        let key_hint = 1u16;
+        let mut transport = MockTransport::new();
+
+        // First COMMAND — NOP (consumed)
+        let nop_frame = build_command_response(
+            &psk,
+            key_hint,
+            1, // echo nonce = rng(0)+1
+            1000,
+            1710000000000,
+            CommandPayload::Nop,
+        );
+        transport.queue_response(Some(nop_frame));
+
+        // Second COMMAND — REBOOT (must NOT be consumed)
+        let reboot_frame = build_command_response(
+            &psk,
+            key_hint,
+            1,
+            1001,
+            1710000000000,
+            CommandPayload::Reboot,
+        );
+        transport.queue_response(Some(reboot_frame));
+
+        // Install a resident program so BPF execution actually runs.
+        let image = sonde_protocol::ProgramImage {
+            bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            maps: vec![],
+        };
+        let image_cbor = image.encode_deterministic().unwrap();
+
+        let mut storage = MockStorage::new().with_key(key_hint, psk);
+        storage.programs[0] = Some(image_cbor);
+        let mut hal = MockHal;
+        let mut rng = MockRng(0);
+        let clock = MockClock;
+        let mut interp = MockBpfInterpreter::new();
+        let mut map_storage = MapStorage::new(DEFAULT_MAP_BUDGET);
+
+        let outcome = run_wake_cycle(
+            &mut transport,
+            &mut storage,
+            &mut hal,
+            &mut rng,
+            &clock,
+            &MockBattery,
+            &mut interp,
+            &mut map_storage,
+            &TestHmac,
+            &TestSha256,
+        );
+
+        // Outcome must be Sleep (NOP), NOT Reboot.
+        assert_eq!(outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+        // BPF must have executed (proving the program was loaded and run).
+        assert!(interp.executed, "BPF must execute after first COMMAND");
+        // The second frame must remain unconsumed in the transport queue.
+        assert_eq!(
+            transport.inbound.len(),
+            1,
+            "second COMMAND must not be consumed"
+        );
+    }
+
+    // ===================================================================
+    // ND-0605: Per-frame stack overflow — graceful termination
+    // ===================================================================
+
+    #[test]
+    fn test_stack_overflow_graceful() {
+        // ND-0605 AC3: A BPF stack violation must terminate the program
+        // and the node must sleep normally (no crash). The mock
+        // interpreter returns RuntimeError to simulate the overflow
+        // that the real sonde-bpf interpreter would produce when a
+        // program accesses memory beyond the 512-byte per-frame stack.
+        let psk = [0xF3; 32];
+        let key_hint = 1u16;
+        let mut transport = MockTransport::new();
+        let command_frame =
+            build_command_response(&psk, key_hint, 1, 1000, 1710000000000, CommandPayload::Nop);
+        transport.queue_response(Some(command_frame));
+
+        let image = sonde_protocol::ProgramImage {
+            bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            maps: vec![],
+        };
+        let image_cbor = image.encode_deterministic().unwrap();
+
+        let mut storage = MockStorage::new().with_key(key_hint, psk);
+        storage.programs[0] = Some(image_cbor);
+        let mut hal = MockHal;
+        let mut rng = MockRng(0);
+        let clock = MockClock;
+        let mut interp = MockBpfInterpreter {
+            loaded: false,
+            executed: false,
+            execute_result: Err(BpfError::RuntimeError("stack overflow")),
+            captured_ctx: None,
+        };
+        let mut map_storage = MapStorage::new(DEFAULT_MAP_BUDGET);
+
+        let outcome = run_wake_cycle(
+            &mut transport,
+            &mut storage,
+            &mut hal,
+            &mut rng,
+            &clock,
+            &MockBattery,
+            &mut interp,
+            &mut map_storage,
+            &TestHmac,
+            &TestSha256,
+        );
+
+        // Node sleeps normally despite stack overflow
+        assert_eq!(outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+        assert!(interp.executed, "interpreter must have executed");
+    }
+
     /// WAKE failure after peer_payload erased does NOT clear reg_complete.
     /// Once peer_payload is gone, transient WAKE failures should not revert
     /// to PEER_REQUEST since there is no payload to re-send.


### PR DESCRIPTION
Cover the four validation gaps from issue #359:

1. **ND-0101** — \	est_unknown_cbor_keys_ignored\: send COMMAND with extra unknown CBOR keys (99, 100) and verify the node decodes it as NOP and sleeps normally (forward-compatibility AC2).

2. **ND-0200** — \	est_second_command_not_consumed\: queue a NOP COMMAND followed by a REBOOT COMMAND; assert the node processes only the first, sleeps (not reboots), and leaves the second frame unconsumed in the transport queue.

3. **ND-0604** — \	est_helper_delay_us_max_enforcement\: call \delay_us\ at exact boundary (1,000,000 µs) and above; verify the helper rejects excessive values with \-1\ (AC3).

4. **ND-0605** — \	est_stack_frame_overflow\ + \	est_stack_overflow_graceful\: exercise a BPF store beyond the 4,096-byte total stack to trigger \MemoryAccessViolation\, and verify the wake cycle handles it gracefully (node sleeps, no crash).

**Spec references:** \docs/node-requirements.md\ ND-0101, ND-0200, ND-0604, ND-0605; \docs/node-validation.md\ T-N101, T-N200, T-N610–T-N615.

Closes #359