### PR TITLE
docs: close remaining spec gaps (issues #377, #378)

### DIFF
--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -863,7 +863,7 @@ The tool MUST implement the following cryptographic primitives:
 ### PT-1101  HKDF parameters
 
 **Priority:** Must  
-**Source:** ble-pairing-protocol.md §5.5, §6.3
+**Source:** ble-pairing-protocol.md §5.5, §6.4
 
 **Description:**  
 HKDF-SHA256 MUST use `gateway_id` (16 bytes) as salt. The info string MUST be `"sonde-phone-reg-v1"` for Phase 1 (phone registration) and `"sonde-node-pair-v1"` for Phase 2 (node pairing payload). Output length MUST be 32 bytes.

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -44,6 +44,8 @@ This document defines test cases that validate the BLE pairing tool against the 
 | SHA-256 | T-PT-303 |
 | CSPRNG | T-PT-302, T-PT-702 |
 
+**Test ID convention:** Test IDs follow the numeric pattern `T-PT-NNN`. When a test case is added after initial numbering to cover a gap between two adjacent IDs, an alphabetic suffix is used (e.g., `T-PT-208a` for a test inserted between T-PT-208 and T-PT-209).
+
 ---
 
 ## 2  Test environment
@@ -380,7 +382,7 @@ TestNode {
 
 **Procedure:**
 1. Start with an empty pairing store.
-2. Complete a successful gateway authentication.
+2. Complete a successful Phase 1 (phone registration) flow through to `PHONE_REGISTERED`.
 3. Assert: `gw_public_key` and `gateway_id` are persisted in the pairing store.
 
 ---

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -31,7 +31,7 @@
 
 Each requirement uses the following fields:
 
-- **ID** — Unique identifier (`GW-XXXX`).
+- **ID** — Unique identifier (`GW-XXXX`). When a requirement is split into sub-parts after initial numbering, alphabetic suffixes are used (e.g., `GW-0601a`, `GW-0601b`). Intentional numbering gaps (e.g., a removed or reserved requirement) are noted inline.
 - **Title** — Short name.
 - **Description** — What the gateway must do.
 - **Acceptance criteria** — Observable, testable conditions that confirm the requirement is met.
@@ -664,6 +664,8 @@ The gateway MUST inspect the `firmware_abi_version` from `WAKE` messages and ens
 3. An ABI mismatch is reported as a clear error or warning.
 
 ---
+
+> **Note:** GW-0704 is intentionally unassigned (requirement removed during consolidation).
 
 ### GW-0705  Factory reset support
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -280,6 +280,8 @@ The node MUST store its 256-bit PSK in a dedicated flash partition. The firmware
 
 ---
 
+> **Note:** ND-0401 is intentionally unassigned (requirement removed during consolidation).
+
 ### ND-0402  Factory reset
 
 **Priority:** Must  

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -307,6 +307,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 4. Node sleeps. On next wake, mock gateway assigns `starting_seq = 5000`.
 5. Assert: the first outbound message in the second wake cycle uses seq=5000, not a continuation from the first cycle.
 6. Assert: no sequence state is persisted across deep sleep (ND-0303 AC3).
+7. Perform a third wake cycle with `starting_seq = 2000`. Assert: the node uses seq=2000, confirming cross-sleep isolation from both prior cycles.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the last 7 spec-gap findings from issues #377 and #378 that were left open after PR #379.

### Issue #377 - validation traceability (1 remaining gap)

| Gap | Fix |
|-----|-----|
| T-N305 cross-sleep isolation | Added step 7: third wake cycle with `starting_seq = 2000` confirming isolation from both prior cycles |

### Issue #378 - numbering gaps and conventions (all 6 gaps)

| Gap | Fix |
|-----|-----|
| GW-0704 numbering gap | Added inline note documenting intentional gap |
| GW-0601a/b sub-ID convention | Documented alphabetic suffix convention in section 2 ID format |
| ND-0401 numbering gap | Added inline note documenting intentional gap |
| PT-1101 stale section ref | Fixed Source from section 6.3 to section 6.4 |
| T-PT-205 ambiguous wording | Clarified to specify Phase 1 flow |
| T-PT-208a breaks numeric convention | Added test ID convention note documenting alphabetic suffix pattern |

### Previously closed issues (8 of 10)

Issues #335, #336, #337, #371, #372, #373, #374, #376 were already resolved by PRs #379 and #391 and have been closed with evidence comments.

Closes #377
Closes #378