### PR TITLE
fix: rename duplicate test_stack_overflow_graceful on main

### DIFF
--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -4091,10 +4091,7 @@ mod tests {
     // ===================================================================
 
     #[test]
-    fn test_stack_overflow_graceful() {
-        // ND-0605 AC4: A BPF program that writes beyond the 512-byte
-        // per-frame stack boundary is terminated with a stack violation.
-        // The node must still sleep normally (no crash).
+    fn test_stack_violation_graceful() {
         let psk = [0x65; 32];
         let key_hint = 1u16;
         let mut transport = MockTransport::new();


### PR DESCRIPTION
Two tests at lines 3467 and 4094 of \wake_cycle.rs\ had the same name, causing E0428 on every PR branch CI merge. Renamed the AC4 variant to \	est_stack_violation_graceful\.