### PR TITLE
fix: restore AndroidManifest.xml removed by artifact cleanup

### DIFF
--- a/.github/workflows/tauri-android.yml
+++ b/.github/workflows/tauri-android.yml
@@ -63,9 +63,6 @@ jobs:
       - name: Initialize Android project
         working-directory: crates/sonde-pair-ui
         run: |
-          # Save our custom AndroidManifest.xml (with BLE permissions)
-          # before `tauri android init` overwrites it with a minimal default.
-          cp src-tauri/gen/android/app/src/main/AndroidManifest.xml /tmp/AndroidManifest.xml.bak
           rm -rf src-tauri/gen/android
           cargo tauri android init
 
@@ -76,8 +73,8 @@ jobs:
         # `tauri android init` regenerates gen/android/.
         working-directory: crates/sonde-pair-ui/src-tauri/gen/android
         run: |
-          # Restore custom AndroidManifest.xml with BLE permissions.
-          cp /tmp/AndroidManifest.xml.bak app/src/main/AndroidManifest.xml
+          # Restore custom AndroidManifest.xml with BLE permissions from persistent location.
+          cp ../../../../../crates/sonde-pair-ui/android/AndroidManifest.xml app/src/main/AndroidManifest.xml
 
           # Copy Java source files into the standard Android source tree
           mkdir -p app/src/main/java/io/sonde/pair

--- a/crates/sonde-pair-ui/android/AndroidManifest.xml
+++ b/crates/sonde-pair-ui/android/AndroidManifest.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- BLE pairing permissions -->
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
+
+    <!-- AndroidTV support -->
+    <uses-feature android:name="android.software.leanback" android:required="false" />
+
+    <application
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:theme="@style/Theme.sonde_pair_ui"
+        android:usesCleartextTraffic="${usesCleartextTraffic}">
+        <activity
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"
+            android:launchMode="singleTask"
+            android:label="@string/main_activity_title"
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <!-- AndroidTV support -->
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <provider
+          android:name="androidx.core.content.FileProvider"
+          android:authorities="${applicationId}.fileprovider"
+          android:exported="false"
+          android:grantUriPermissions="true">
+          <meta-data
+            android:name="android.support.FILE_PROVIDER_PATHS"
+            android:resource="@xml/file_paths" />
+        </provider>
+    </application>
+</manifest>


### PR DESCRIPTION
PR #435 removed gen/android/ including the custom AndroidManifest.xml with BLE permissions. This broke the APK build on main. Fix: store the manifest in a persistent location (crates/sonde-pair-ui/android/) outside gen/ and update CI to copy from there.