### PR TITLE
fix(node): remove RngHealthCheckFailed match arm from firmware binary

### DIFF
--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -175,13 +175,5 @@ fn main() {
             info!("unexpected unpaired state — rebooting");
             sleep_ctrl.reboot();
         }
-        WakeCycleOutcome::RngHealthCheckFailed => {
-            // Hardware RNG is degraded — nonces would be predictable.
-            // Reboot in hopes the RNG recovers. If it fails persistently,
-            // the node will reboot-loop, which is safer than transmitting
-            // predictable nonces (ND-0304 AC3).
-            warn!("hardware RNG health check failed — rebooting");
-            sleep_ctrl.reboot();
-        }
     }
 }


### PR DESCRIPTION
## Problem

The ESP32-C3 firmware build fails with:
\\\
error[E0599]: no variant or associated item named \RngHealthCheckFailed\ found for enum \WakeCycleOutcome\
\\\

## Root cause

During PR #418 merge conflict resolution, the \RngHealthCheckFailed\ enum variant was removed from \WakeCycleOutcome\ (main uses \Sleep\ for graceful degradation on RNG failure). However, \in/node.rs\ still had a match arm referencing the removed variant — it was auto-merged from the PR branch without conflict since the file wasn't in the conflict set.

## Fix

Remove the dead match arm. RNG health-check failure now returns \WakeCycleOutcome::Sleep { seconds: base_interval_s }\, so the node sleeps and retries rather than rebooting.