### PR TITLE
fix(modem,node): set WiFi to station mode for ESP-NOW TX

### DIFF
--- a/crates/sonde-modem/src/espnow.rs
+++ b/crates/sonde-modem/src/espnow.rs
@@ -8,7 +8,7 @@ use esp_idf_hal::modem::Modem;
 use esp_idf_svc::espnow::{EspNow, PeerInfo, SendStatus};
 use esp_idf_svc::eventloop::EspSystemEventLoop;
 use esp_idf_svc::nvs::EspDefaultNvsPartition;
-use esp_idf_svc::wifi::{BlockingWifi, EspWifi};
+use esp_idf_svc::wifi::{BlockingWifi, ClientConfiguration, Configuration, EspWifi};
 use log::{debug, info, warn};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -217,10 +217,11 @@ impl EspNowDriver {
             ));
         }
 
-        // Initialize WiFi in station mode (required for ESP-NOW).
+        // Initialize WiFi in station mode (required for ESP-NOW TX — MD-0200).
         let esp_wifi = EspWifi::new(modem, sysloop.clone(), Some(nvs))?;
         let mut wifi = BlockingWifi::wrap(esp_wifi, sysloop)?;
 
+        wifi.set_configuration(&Configuration::Client(ClientConfiguration::default()))?;
         wifi.start()?;
         info!("WiFi started in station mode");
 

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -17,7 +17,7 @@ use esp_idf_hal::modem::Modem;
 use esp_idf_svc::espnow::{EspNow, PeerInfo};
 use esp_idf_svc::eventloop::EspSystemEventLoop;
 use esp_idf_svc::nvs::EspDefaultNvsPartition;
-use esp_idf_svc::wifi::{BlockingWifi, EspWifi};
+use esp_idf_svc::wifi::{BlockingWifi, ClientConfiguration, Configuration, EspWifi};
 
 use sonde_protocol::modem::ESPNOW_MAX_DATA_SIZE;
 
@@ -188,11 +188,13 @@ impl EspNowTransport {
             return Err(NodeError::Transport("invalid WiFi channel (must be 1–13)"));
         }
 
-        // WiFi STA mode (required for ESP-NOW)
+        // WiFi STA mode (required for ESP-NOW TX)
         let esp_wifi = EspWifi::new(modem, sysloop.clone(), Some(nvs))
             .map_err(|_| NodeError::Transport("WiFi init failed"))?;
         let mut wifi = BlockingWifi::wrap(esp_wifi, sysloop)
             .map_err(|_| NodeError::Transport("WiFi wrap failed"))?;
+        wifi.set_configuration(&Configuration::Client(ClientConfiguration::default()))
+            .map_err(|_| NodeError::Transport("WiFi set STA mode failed"))?;
         wifi.start()
             .map_err(|_| NodeError::Transport("WiFi start failed"))?;
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -833,7 +833,7 @@ In the post-provision boot path (PSK stored, `reg_complete` NOT set) the node MU
 
 **Acceptance criteria:**
 
-1. ESP-NOW is initialised on the channel stored during provisioning.
+1. ESP-NOW is initialised in WiFi station mode on the channel stored during provisioning.
 2. The frame uses `msg_type` 0x05 and a random 8-byte nonce.
 3. The CBOR payload contains key 1 mapped to `encrypted_payload`.
 4. The HMAC is computed with `node_psk` over header and payload.


### PR DESCRIPTION
## ESP-NOW TX fails — WiFi never set to station mode

### Root cause

Both modem and node call `EspWifi::new()` + `wifi.start()` without `wifi.set_configuration()`. ESP-IDF defaults to AP mode (`wifi:mode : softAP`). ESP-NOW TX requires the STA interface — RX works in AP mode (promiscuous) but TX returns `ESP_ERR_ESPNOW_IF`.

### Fix

Add `wifi.set_configuration(&Configuration::Client(ClientConfiguration::default()))` before `wifi.start()` in both:
- `crates/sonde-modem/src/espnow.rs`
- `crates/sonde-node/src/esp_transport.rs`

The spec (MD-0200) already says "WiFi station mode" — the code just didn't implement it (D10 constraint violation).

Also clarified ND-0909 AC1 to explicitly require WiFi station mode.

Fixes #447.
