### PR TITLE
feat: embed git commit hash in gateway and admin binaries (GW-1303)

### DIFF
--- a/crates/sonde-admin/build.rs
+++ b/crates/sonde-admin/build.rs
@@ -11,5 +11,46 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &["../sonde-gateway/proto/admin.proto"],
             &["../sonde-gateway/proto"],
         )?;
+
+    // Inject the git commit SHA so the binary can display it at runtime (GW-1303).
+    // Prefer an explicit SONDE_GIT_COMMIT env var (set by CI) over running git.
+    let raw = std::env::var("SONDE_GIT_COMMIT")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            std::process::Command::new("git")
+                .args(["rev-parse", "--short", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        });
+    let commit: String = raw.chars().take(7).collect();
+    println!("cargo:rustc-env=SONDE_GIT_COMMIT={commit}");
+    println!("cargo:rerun-if-env-changed=SONDE_GIT_COMMIT");
+
+    if let Some(git_dir) = std::process::Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+    {
+        println!("cargo:rerun-if-changed={git_dir}/HEAD");
+        if let Some(head_ref) = std::process::Command::new("git")
+            .args(["symbolic-ref", "-q", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        {
+            let ref_path = format!("{git_dir}/{head_ref}");
+            println!("cargo:rerun-if-changed={ref_path}");
+        }
+        println!("cargo:rerun-if-changed={git_dir}/packed-refs");
+    }
+
     Ok(())
 }

--- a/crates/sonde-admin/src/main.rs
+++ b/crates/sonde-admin/src/main.rs
@@ -9,7 +9,7 @@ use sonde_admin::grpc_client::AdminClient;
 use sonde_admin::pb;
 
 #[derive(Parser)]
-#[command(name = "sonde-admin", about = "Sonde gateway administration CLI")]
+#[command(name = "sonde-admin", version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("SONDE_GIT_COMMIT"), ")"), about = "Sonde gateway administration CLI")]
 struct Cli {
     /// Gateway admin socket path (UDS on Linux, named pipe on Windows).
     #[arg(

--- a/crates/sonde-gateway/build.rs
+++ b/crates/sonde-gateway/build.rs
@@ -5,5 +5,46 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=proto");
     println!("cargo:rerun-if-changed=proto/admin.proto");
     tonic_prost_build::compile_protos("proto/admin.proto")?;
+
+    // Inject the git commit SHA so the binary can display it at runtime (GW-1303).
+    // Prefer an explicit SONDE_GIT_COMMIT env var (set by CI) over running git.
+    let raw = std::env::var("SONDE_GIT_COMMIT")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            std::process::Command::new("git")
+                .args(["rev-parse", "--short", "HEAD"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        });
+    let commit: String = raw.chars().take(7).collect();
+    println!("cargo:rustc-env=SONDE_GIT_COMMIT={commit}");
+    println!("cargo:rerun-if-env-changed=SONDE_GIT_COMMIT");
+
+    if let Some(git_dir) = std::process::Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+    {
+        println!("cargo:rerun-if-changed={git_dir}/HEAD");
+        if let Some(head_ref) = std::process::Command::new("git")
+            .args(["symbolic-ref", "-q", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        {
+            let ref_path = format!("{git_dir}/{head_ref}");
+            println!("cargo:rerun-if-changed={ref_path}");
+        }
+        println!("cargo:rerun-if-changed={git_dir}/packed-refs");
+    }
+
     Ok(())
 }

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -81,7 +81,7 @@ enum ServiceCommand {
 
 /// Sonde gateway — manages sensor nodes over ESP-NOW radio.
 #[derive(Parser, Debug, Clone)]
-#[command(name = "sonde-gateway", version, about)]
+#[command(name = "sonde-gateway", version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("SONDE_GIT_COMMIT"), ")"), about)]
 struct Cli {
     /// Service management subcommand (Windows only).
     ///
@@ -236,7 +236,13 @@ async fn run_gateway(
     cli: &Cli,
     shutdown: tokio::sync::oneshot::Receiver<()>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!(db = %cli.db, port = %cli.port, channel = cli.channel, "starting sonde-gateway");
+    info!(
+        version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("SONDE_GIT_COMMIT"), ")"),
+        db = %cli.db,
+        port = %cli.port,
+        channel = cli.channel,
+        "starting sonde-gateway"
+    );
     let mut shutdown = shutdown;
 
     // 1. Load master key for at-rest PSK encryption (GW-0601a).

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -800,6 +800,39 @@ The gateway is configured via a configuration file (format TBD — TOML recommen
 
 ---
 
+## 14A  Build metadata
+
+> **Requirement:** GW-1303
+
+Both host binaries (`sonde-gateway` and `sonde-admin`) embed the git commit hash at build time using a `build.rs` script. This mirrors the approach already used by `sonde-node` firmware.
+
+### 14A.1  Build script
+
+Each crate's `build.rs` emits a `cargo:rustc-env=SONDE_GIT_COMMIT=<hash>` directive:
+
+1. Check the `SONDE_GIT_COMMIT` environment variable (set by CI with the full SHA).
+2. If unset, run `git rev-parse --short HEAD` to obtain the short hash.
+3. Normalise to 7 characters for consistency between CI and local builds.
+4. Fall back to `"unknown"` if git is unavailable.
+
+Rebuild triggers watch `.git/HEAD`, the resolved branch ref, and `.git/packed-refs`.
+
+### 14A.2  Version string
+
+The clap `#[command]` attribute uses `concat!()` to build a compile-time version string:
+
+```rust
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("SONDE_GIT_COMMIT"), ")"))]
+```
+
+This produces output like `sonde-gateway 0.1.0 (a1b2c3d)`.
+
+### 14A.3  Startup log
+
+The gateway emits the version string in its first `info!()` log line so that operators can identify the running build from log output.
+
+---
+
 ## 15  Startup sequence
 
 1. Load configuration.

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -993,6 +993,23 @@ The gateway SHOULD log individual modem frames at `DEBUG` level so that develope
 
 ---
 
+### GW-1303  Build metadata in host binaries
+
+**Priority:** Must
+**Source:** Issue #464
+
+**Description:**
+The gateway and admin binaries MUST embed the git commit hash (short, 7 characters) at build time and display it in the `--version` output and (for the gateway) in the startup log. This matches the firmware behaviour (see `sonde-node` boot log) and allows operators to identify exactly which build is running.
+
+**Acceptance criteria:**
+
+1. `sonde-gateway --version` prints the version string in the format `<semver> (<short-hash>)`, e.g., `0.1.0 (a1b2c3d)`.
+2. `sonde-admin --version` prints the same format.
+3. The gateway startup log includes the version string with the embedded commit hash.
+4. When git metadata is unavailable (e.g., building from a tarball), the hash falls back to `unknown`.
+
+---
+
 ### GW-1103  Modem error handling
 
 **Priority:** Must
@@ -1498,3 +1515,4 @@ The admin API MUST expose a `RevokePhone` RPC (and corresponding `sonde-admin pa
 | GW-1222 | Admin API — BLE pairing session | Must |
 | GW-1223 | Admin API — phone listing | Must |
 | GW-1224 | Admin API — phone revocation | Must |
+| GW-1303 | Build metadata in host binaries | Must |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1882,6 +1882,20 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1304  Build metadata in `--version` output
+
+**Validates:** GW-1303
+
+**Procedure:**
+1. Build `sonde-gateway` and `sonde-admin` from a git checkout.
+2. Run `sonde-gateway --version`.
+3. Assert: output matches the pattern `sonde-gateway <semver> (<7-char-hash>)`.
+4. Run `sonde-admin --version`.
+5. Assert: output matches the pattern `sonde-admin <semver> (<7-char-hash>)`.
+6. Assert: the hash portion is a valid 7-character hex string (or `unknown` when built outside a git repo).
+
+---
+
 ## Appendix A  Test-to-requirement traceability
 
 | Requirement | Test(s) |
@@ -1968,3 +1982,4 @@ A configurable stub handler process (or in-process mock) that:
 | GW-1300 | T-1300, T-1301, T-1302 |
 | GW-1301 | *(verified by integration/manual testing)* |
 | GW-1302 | T-1303 |
+| GW-1303 | T-1304 |


### PR DESCRIPTION
## Summary

Closes #464 — the gateway and admin binaries now embed the git commit hash at build time, matching the firmware behaviour.

### Changes

**Spec updates (phase 1):**
- \\docs/gateway-requirements.md\\: new requirement **GW-1303** — host binaries MUST embed the git commit hash and display it via \\--version\\ and in the startup log.
- \\docs/gateway-design.md\\: new section **§14A** (Build metadata) describing the \\uild.rs\\ + \\nv!()\\ approach.
- \\docs/gateway-validation.md\\: new test **T-1304** and traceability entry.

**Code changes (phase 2):**
- \\crates/sonde-gateway/build.rs\\: inject \\SONDE_GIT_COMMIT\\ env var (prefers CI env, falls back to \\git rev-parse --short HEAD\\, normalises to 7 chars).
- \\crates/sonde-admin/build.rs\\: same git hash injection.
- \\crates/sonde-gateway/src/bin/gateway.rs\\: clap \\--version\\ now shows \\