### PR TITLE
debug(node): I2C diagnostic logging for TMP102

### DIFF
--- a/crates/sonde-node/sdkconfig.defaults
+++ b/crates/sonde-node/sdkconfig.defaults
@@ -22,8 +22,8 @@ CONFIG_ESP_CONSOLE_UART_NUM=0
 CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED=n
 
-# Log level: INFO captures the boot-marker lines the smoke test asserts on.
-CONFIG_LOG_DEFAULT_LEVEL_INFO=y
+# Log level: DEBUG for development. Change to INFO for production.
+CONFIG_LOG_DEFAULT_LEVEL_DEBUG=y
 
 # Size optimizations — reduce firmware binary size.
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y

--- a/crates/sonde-node/src/esp_hal.rs
+++ b/crates/sonde-node/src/esp_hal.rs
@@ -232,8 +232,22 @@ impl hal::Hal for EspHal {
             let err = esp_idf_sys::i2c_master_cmd_begin(port, cmd, I2C_TIMEOUT_TICKS);
             esp_idf_sys::i2c_cmd_link_delete(cmd);
             if err != esp_idf_sys::ESP_OK as i32 {
+                log::warn!(
+                    "i2c_write_read failed: bus={} addr=0x{:02x} write_len={} read_len={} err={}",
+                    bus,
+                    addr,
+                    write_data.len(),
+                    read_buf.len(),
+                    err
+                );
                 return -1;
             }
+            log::info!(
+                "i2c_write_read ok: bus={} addr=0x{:02x} read={:02x?}",
+                bus,
+                addr,
+                &read_buf[..read_buf.len().min(8)]
+            );
             0
         }
     }


### PR DESCRIPTION
Temporary INFO-level logging in i2c_write_read to diagnose TMP102 failure on hardware. Shows error code on failure, raw bytes on success.