### PR TITLE
fix(gateway): share pending_commands when handler config is used

### DIFF
--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -319,7 +319,8 @@ async fn run_gateway(
             pending_commands.clone(),
             session_manager.clone(),
         );
-        gw.set_handler_router(router);
+        gw.set_handler_router(router)
+            .expect("handler_router must not already be set during gateway init");
         Arc::new(gw)
     } else {
         Arc::new(Gateway::new_with_pending(

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -72,6 +72,14 @@ impl Gateway {
     }
 
     /// Create a new gateway with a handler router for APP_DATA dispatch.
+    ///
+    /// # Warning
+    ///
+    /// This constructor allocates its own `pending_commands` and
+    /// `SessionManager`. It is **not** suitable for production use where
+    /// the admin API must share those objects. Use [`new_with_pending`]
+    /// followed by [`set_handler_router`] instead. This method exists
+    /// for test convenience only (D-485).
     pub fn new_with_handler(
         storage: Arc<dyn Storage>,
         session_timeout: Duration,
@@ -122,12 +130,14 @@ impl Gateway {
     /// Called after construction when `--handler-config` is provided,
     /// allowing the gateway to share `pending_commands` with the admin
     /// API while also routing APP_DATA to handler processes.
-    pub fn set_handler_router(&mut self, router: Arc<HandlerRouter>) {
-        assert!(
-            self.handler_router.is_none(),
-            "handler_router is already set; set_handler_router must only be called once during initialization"
-        );
+    pub fn set_handler_router(&mut self, router: Arc<HandlerRouter>) -> Result<(), &'static str> {
+        if self.handler_router.is_some() {
+            return Err(
+                "handler_router is already set; set_handler_router must only be called once during initialization",
+            );
+        }
         self.handler_router = Some(router);
+        Ok(())
     }
 
     /// Expose the session manager for test inspection.

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -463,14 +463,18 @@ pub struct HandlerConfig {
 
 Multiple program hashes can map to the same handler (GW-0504).
 
-> **Shared state (D-485):** The `Gateway` instance MUST be constructed
-> so that the admin API and the handler router share the same
-> `pending_commands`/`SessionManager`. In practice, `new_with_handler`
-> MUST either accept the shared `pending_commands` or delegate
-> internally to `new_with_pending` + `set_handler_router`, rather than
-> creating its own map. D-485 occurred when a constructor created a
-> separate `pending_commands` map, breaking the admin→engine path;
-> that pattern is forbidden.
+> **Shared state (D-485):** The `Gateway` instance MUST be wired so
+> that the admin API and the handler router share the same
+> `pending_commands`/`SessionManager`. In production, construct the
+> gateway via `new_with_pending` and then call `set_handler_router`
+> with the same shared state; do **not** create an independent
+> `pending_commands` map for the handler path. D-485 occurred when a
+> constructor created a separate `pending_commands` map, breaking the
+> admin→engine path; that pattern is forbidden. The convenience
+> constructor `new_with_handler` currently allocates its own internal
+> `pending_commands`/`SessionManager` and is only safe to use in
+> contexts that do not expose the admin API or otherwise require
+> shared state.
 
 ### 9.2  Routing
 


### PR DESCRIPTION
When `--handler-config` is used, `new_with_handler()` created a separate `pending_commands` map. Ephemeral programs queued via admin API were invisible to the engine. Fix: use `new_with_pending()` + `set_handler_router()` to share state. Fixes #485.