### PR TITLE
fix(modem): clear \dvertise_on_disconnect\ in BLE \disable()\ to prevent race

### DIFF
--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -461,6 +461,9 @@ impl Ble for EspBleDriver {
         let ble_device = BLEDevice::take();
         let ble_advertising = ble_device.get_advertising();
 
+        // Re-enable auto re-advertise after disconnect (cleared in disable()).
+        ble_device.get_server().advertise_on_disconnect(true);
+
         let mut adv_data = BLEAdvertisementData::new();
         adv_data.name(BLE_DEVICE_NAME);
         adv_data.add_service_uuid(GATEWAY_SERVICE_UUID);
@@ -484,6 +487,10 @@ impl Ble for EspBleDriver {
         let ble_device = BLEDevice::take();
         let ble_advertising = ble_device.get_advertising();
 
+        // Clear auto re-advertise BEFORE stopping so a concurrent disconnect
+        // cannot race and restart advertising (issue #453, MD-0407).
+        ble_device.get_server().advertise_on_disconnect(false);
+
         if let Err(e) = ble_advertising.lock().stop() {
             warn!("BLE: stop_advertising failed: {:?}", e);
         }
@@ -495,13 +502,6 @@ impl Ble for EspBleDriver {
         };
         if let Some(handle) = conn_handle {
             let _ = ble_device.get_server().disconnect(handle);
-        }
-
-        // NimBLE's advertise_on_disconnect may restart advertising after the
-        // disconnect above.  Stop again to guarantee advertising stays OFF
-        // after BLE_DISABLE/RESET (MD-0407/MD-0412/MD-0413).
-        if let Err(e) = ble_advertising.lock().stop() {
-            warn!("BLE: post-disconnect stop failed: {:?}", e);
         }
 
         if let Ok(mut s) = self.state.lock() {


### PR DESCRIPTION
## Summary

Fixes #453 — NimBLE \dvertise_on_disconnect(true)\ was set once in \EspBleDriver::new()\ and never cleared. When \disable()\ called \stop()\ + \disconnect()\, NimBLE could automatically restart advertising due to the flag, racing with the BLE_DISABLE intent.

## Changes

- **\disable()\**: Call \dvertise_on_disconnect(false)\ **before** stopping advertising, eliminating the race window. The previous workaround (a second \stop()\ call after disconnect) is removed since it is no longer needed.
- **\nable()\**: Call \dvertise_on_disconnect(true)\ before starting advertising to restore auto re-advertise behavior.

## Testing

- \cargo fmt --check\ — clean
- \cargo clippy --workspace -- -D warnings\ — clean
- \cargo test --workspace\ — all tests pass