### PR TITLE
fix: log WiFi scan errors instead of silently swallowing (#444)

### DIFF
--- a/crates/sonde-modem/src/espnow.rs
+++ b/crates/sonde-modem/src/espnow.rs
@@ -392,7 +392,10 @@ impl Radio for EspNowDriver {
                 results
             }
             Err(e) => {
-                warn!("WiFi scan failed: {:?} — returning empty results", e);
+                warn!(
+                    "WiFi scan failed: {:?} — treating as 0 APs on all channels",
+                    e
+                );
                 Vec::new()
             }
         };


### PR DESCRIPTION
Replaces \\self.wifi.scan().unwrap_or_default()\\ in \\crates/sonde-modem/src/espnow.rs\\ with an explicit match that logs the ESP-IDF error code at WARN level. Previously, scan failures produced 0 APs / 0 dBm on all channels with no diagnostic output.

Operators can now see the failure reason on UART (especially with the verbose firmware variant from #500).

Closes #444