### PR TITLE
fix(node): bail early on first \is_high()\ in pairing button check

### DIFF
--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -102,10 +102,11 @@ fn main() {
 
         const SAMPLE_INTERVAL_MS: u32 = 10;
         const SAMPLE_COUNT: u32 = 500 / SAMPLE_INTERVAL_MS; // 50 samples over 500 ms
-        let mut held_count: u32 = 0;
+        let mut held = true;
         for _ in 0..SAMPLE_COUNT {
-            if button.is_low() {
-                held_count += 1;
+            if button.is_high() {
+                held = false;
+                break; // not pressed — no point sampling further
             }
             // Busy-wait 10 ms between samples
             unsafe {
@@ -114,7 +115,6 @@ fn main() {
                 );
             }
         }
-        let held = held_count == SAMPLE_COUNT;
         if held {
             info!("pairing button held ≥ 500 ms — will factory reset on BLE provision");
         }


### PR DESCRIPTION
The pairing button sampling loop ran all 50 iterations (500ms) on every boot even when the button was not pressed. This wastes ~500ms of battery on every wake cycle.

**Fix:** Break on the first \is_high()\ sample so the common case (button not pressed) exits in ~10ms instead of 500ms.

**Before:**
\\\ust
let mut held_count: u32 = 0;
for _ in 0..SAMPLE_COUNT {
    if button.is_low() { held_count += 1; }
    vTaskDelay(10ms);  // always delays all 50 iterations
}
let held = held_count == SAMPLE_COUNT;
\\\

**After:**
\\\ust
let mut held = true;
for _ in 0..SAMPLE_COUNT {
    if button.is_high() {
        held = false;
        break;  // not pressed — no point sampling further
    }
    vTaskDelay(10ms);
}
\\\

Fixes #476