### PR TITLE
docs: narrow ND-0915 self-healing to \peer_payload\-present window

### DIFF
--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -622,7 +622,7 @@ After the first successful WAKE/COMMAND exchange (the gateway responds with a va
 
 **Self-healing on WAKE failure (ND-0915):**
 
-If WAKE fails (no response or HMAC verification failure) after `reg_complete` is set, the node clears the `reg_complete` flag and reverts to sending PEER_REQUEST on the next boot. This allows the node to re-register if the gateway lost its registration state.
+If WAKE fails (no response or HMAC verification failure) after `reg_complete` is set, the node checks whether the `peer_payload` NVS key is still present. If it is, the node clears the `reg_complete` flag and reverts to sending PEER_REQUEST on the next boot — this allows the node to re-register if the gateway lost its registration state. If `peer_payload` has already been erased (ND-0914), the self-healing path is unavailable and the node continues normal WAKE retries; re-provisioning via BLE is required if the gateway has lost its registration.
 
 ---
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -924,12 +924,13 @@ After the first successful WAKE/COMMAND exchange (the gateway responds with a va
 **Source:** ble-pairing-protocol.md §8.3.1
 
 **Description:**  
-If WAKE fails (no response or HMAC verification failure) after `reg_complete` is set, the node MUST clear the `reg_complete` flag and revert to sending PEER_REQUEST on the next boot.
+If WAKE fails (no response or HMAC verification failure) after `reg_complete` is set **and** the `peer_payload` NVS key is still present, the node MUST clear the `reg_complete` flag and revert to sending PEER_REQUEST on the next boot. The `peer_payload` is retained between a successful PEER_ACK and the first successful WAKE/COMMAND cycle (see ND-0914); self-healing is only possible during this window because the peer payload contains the encrypted registration material needed to re-run the PEER_REQUEST flow. Once ND-0914 erases `peer_payload`, the node cannot self-heal and must be re-provisioned via BLE if the gateway loses its registration.
 
 **Acceptance criteria:**
 
-1. A WAKE failure when `reg_complete` is set clears the flag.
+1. A WAKE failure when `reg_complete` is set **and** `peer_payload` is present clears the flag.
 2. The next boot enters the PEER_REQUEST path instead of the normal WAKE cycle.
+3. A WAKE failure when `reg_complete` is set but `peer_payload` has been erased (ND-0914) does **not** clear the flag; the node continues normal WAKE retries.
 
 ---
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1034,11 +1034,24 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Validates:** ND-0915
 
 **Procedure:**
-1. Complete BLE pairing and registration (`reg_complete` set).
+1. Complete BLE pairing and registration (`reg_complete` set, `peer_payload` still present in NVS).
 2. Reboot node; node sends WAKE.
 3. Mock gateway does not respond (or responds with invalid HMAC).
 4. Assert: `reg_complete` flag is cleared.
 5. Assert: on next boot the node sends PEER_REQUEST instead of WAKE.
+
+---
+
+### T-N917b  WAKE failure after payload erasure — no self-healing
+
+**Validates:** ND-0915
+
+**Procedure:**
+1. Complete BLE pairing and registration (`reg_complete` set).
+2. Reboot node; node sends WAKE. Mock gateway responds with a valid COMMAND so the first WAKE/COMMAND cycle succeeds and `peer_payload` is erased (ND-0914).
+3. Reboot node; node sends WAKE. Mock gateway does not respond (or responds with invalid HMAC).
+4. Assert: `reg_complete` flag is **not** cleared.
+5. Assert: on next boot the node sends WAKE (not PEER_REQUEST).
 
 ---
 
@@ -1563,7 +1576,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0912 | T-N912, T-N913, T-N914, T-N941 |
 | ND-0913 | T-N915 |
 | ND-0914 | T-N916 |
-| ND-0915 | T-N917 |
+| ND-0915 | T-N917, T-N917b |
 | ND-0916 | T-N918 |
 | ND-0917 | T-N906 |
 | ND-0918 | *(verified by sdkconfig.defaults setting)* |


### PR DESCRIPTION
## Summary

Updates ND-0915 (self-healing on WAKE failure) across requirements, design, and validation docs to document the \has_peer_payload\ guard that already exists in code.

### Problem

The spec said the node MUST clear \eg_complete\ on any WAKE failure after registration. The code only does this when \peer_payload\ is still present in NVS — an intentional guard that prevents clearing credentials after the peer payload has been erased (ND-0914).

### Changes

- **\
ode-requirements.md\** — ND-0915 description and acceptance criteria now require \peer_payload\ to be present for self-healing. Added AC #3 for the no-peer-payload case.
- **\
ode-design.md\** — ND-0915 paragraph explains both branches (payload present → clear flag; payload erased → continue WAKE retries, re-provision via BLE).
- **\
ode-validation.md\** — T-N917 procedure clarified; added T-N917b for the post-erasure case. Traceability table updated.

No code changes — spec-only fix (Option 2 from issue).

Closes #454