### PR TITLE
feat: configurable I2C pin assignments via BLE provisioning (#490)

### DIFF
--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -1010,6 +1010,7 @@ async fn t_e2e_062_node_ble_provisioning() {
         psk: node_psk,
         rf_channel,
         encrypted_payload: encrypted_payload.clone(),
+        pin_config: None,
     };
     let mut node = NodeProxy::new_unpaired();
     let status = handle_node_provision(
@@ -1435,6 +1436,7 @@ async fn t_e2e_068_factory_reset_reprovision() {
         psk: new_node_psk,
         rf_channel,
         encrypted_payload: new_encrypted_payload,
+        pin_config: None,
     };
     let status = handle_node_provision(
         &provision,

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -151,7 +151,9 @@ fn main() {
     let sha = SoftwareSha256;
     let mut rng = EspRng;
     let clock = EspClock;
-    let mut hal = EspHal::new();
+    // Read I2C pin config from NVS (ND-0608), falling back to defaults.
+    let (i2c0_sda, i2c0_scl) = storage.read_i2c0_pins();
+    let mut hal = EspHal::new(i2c0_sda, i2c0_scl);
     let battery = EspBatteryReader;
 
     // Read the stored WiFi channel (falls back to channel 1 if not yet set).

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -92,6 +92,18 @@ pub struct NodeProvision {
     pub rf_channel: u8,
     /// Opaque encrypted payload for the gateway (ble-pairing-protocol.md §6.4).
     pub encrypted_payload: Vec<u8>,
+    /// Optional I2C pin configuration (ND-0608).
+    /// `None` if the pairing tool did not include pin config (backward compatible).
+    pub pin_config: Option<PinConfig>,
+}
+
+/// Board-specific I2C pin assignments (ND-0608).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PinConfig {
+    /// I2C0 SDA GPIO number.
+    pub i2c0_sda: u8,
+    /// I2C0 SCL GPIO number.
+    pub i2c0_scl: u8,
 }
 
 // Re-export BLE envelope codec from sonde-protocol (shared with gateway).
@@ -120,15 +132,99 @@ pub fn parse_node_provision(body: &[u8]) -> Result<NodeProvision, &'static str> 
     if body.len() < expected_len {
         return Err("encrypted_payload truncated");
     }
-    if body.len() != expected_len {
-        return Err("trailing bytes after encrypted_payload");
-    }
     let encrypted_payload = body[37..37 + payload_len].to_vec();
+
+    // Parse optional trailing pin config CBOR (ND-0608).
+    // Best-effort: if trailing bytes exist but fail to decode as valid
+    // CBOR pin config, treat as "no pin config" so provisioning still
+    // succeeds (ND-0608 AC#6 backward compatibility).
+    let pin_config = if body.len() > expected_len {
+        parse_pin_config_cbor(&body[expected_len..]).ok()
+    } else {
+        None
+    };
+
     Ok(NodeProvision {
         key_hint,
         psk,
         rf_channel,
         encrypted_payload,
+        pin_config,
+    })
+}
+
+/// Parse a CBOR map of pin assignments from trailing NODE_PROVISION bytes (ND-0608).
+///
+/// CBOR integer keys: 1 = i2c0_sda, 2 = i2c0_scl. Unknown keys are ignored for
+/// forward compatibility (values of unknown keys are not validated). Returns
+/// `Err` if the CBOR is malformed, a known key has a non-integer value,
+/// trailing bytes remain after the map, SDA == SCL, or a pin exceeds the
+/// ESP32-C3 GPIO range (0–21); missing keys are allowed and fall back
+/// to defaults (`i2c0_sda = 0`, `i2c0_scl = 1`).
+fn parse_pin_config_cbor(data: &[u8]) -> Result<PinConfig, &'static str> {
+    // Decode from a mutable slice reference so ciborium advances it past
+    // the consumed bytes — lets us detect trailing data (ND-0608).
+    let mut remaining = data;
+    let value: ciborium::Value =
+        ciborium::from_reader(&mut remaining).map_err(|_| "pin_config CBOR decode failed")?;
+    if !remaining.is_empty() {
+        return Err("pin_config: trailing bytes after CBOR map");
+    }
+
+    let map = value.as_map().ok_or("pin_config: expected CBOR map")?;
+
+    let mut sda: Option<u8> = None;
+    let mut scl: Option<u8> = None;
+
+    for (k, v) in map {
+        // Parse keys as i128 so future keys >255 are silently ignored
+        // instead of erroring out (forward compatibility).
+        let key = k
+            .as_integer()
+            .map(i128::from)
+            .ok_or("pin_config: non-integer key")?;
+        match key {
+            1 => {
+                let val = v
+                    .as_integer()
+                    .and_then(|i| u8::try_from(i).ok())
+                    .ok_or("pin_config: non-integer value for key 1")?;
+                sda = Some(val);
+            }
+            2 => {
+                let val = v
+                    .as_integer()
+                    .and_then(|i| u8::try_from(i).ok())
+                    .ok_or("pin_config: non-integer value for key 2")?;
+                scl = Some(val);
+            }
+            _ => {
+                // Ignore unknown keys for forward compatibility without
+                // validating their value type.
+            }
+        }
+    }
+
+    // Apply defaults for missing keys (backward-compatible with older
+    // provisioners that omit the pin config entirely).
+    let sda = sda.unwrap_or(0);
+    let scl = scl.unwrap_or(1);
+
+    // Semantic validation: SDA and SCL must be distinct and within the
+    // ESP32-C3 GPIO range (0–21). Returning Err causes parse_node_provision
+    // to treat pin_config as absent rather than persisting an invalid,
+    // non-recoverable config (factory reset does not erase pin config).
+    const MAX_GPIO: u8 = 21;
+    if sda == scl {
+        return Err("pin_config: SDA and SCL must be different pins");
+    }
+    if sda > MAX_GPIO || scl > MAX_GPIO {
+        return Err("pin_config: GPIO number out of range (0-21)");
+    }
+
+    Ok(PinConfig {
+        i2c0_sda: sda,
+        i2c0_scl: scl,
     })
 }
 
@@ -214,13 +310,28 @@ pub fn handle_node_provision<S: PlatformStorage>(
         return NODE_ACK_STORAGE_ERROR;
     }
 
-    // Persist the RF channel last so a failure in any earlier write does
-    // not leave a stale channel value that could leak across pairing
-    // attempts (ND-0908).
+    // Persist the RF channel last among the critical fields so a failure
+    // in any earlier write does not leave a stale channel value that could
+    // leak across pairing attempts (ND-0908). Pin config (below) is
+    // best-effort and non-fatal, so it is written after the channel.
     if storage.write_channel(provision.rf_channel).is_err() {
         let _ = storage.erase_key();
         let _ = storage.erase_peer_payload();
         return NODE_ACK_STORAGE_ERROR;
+    }
+
+    // Persist optional pin config (ND-0608) on a best-effort basis.
+    // Pin config is non-fatal: if the pairing tool provided a pin config
+    // but we fail to persist it, log a warning and continue with
+    // NODE_ACK_SUCCESS. The node is effectively provisioned (PSK + peer
+    // payload + channel persisted) and pin config falls back to defaults.
+    if let Some(ref pins) = provision.pin_config {
+        if storage
+            .write_i2c0_pins(pins.i2c0_sda, pins.i2c0_scl)
+            .is_err()
+        {
+            log::warn!("failed to persist I2C pin config during provisioning");
+        }
     }
 
     NODE_ACK_SUCCESS
@@ -243,10 +354,12 @@ mod tests {
         channel: Option<u8>,
         peer_payload: Option<Vec<u8>>,
         reg_complete: bool,
+        i2c0_pins: Option<(u8, u8)>,
         fail_write_key: bool,
         fail_write_channel: bool,
         fail_write_peer_payload: bool,
         fail_write_reg_complete: bool,
+        fail_write_i2c0_pins: bool,
     }
 
     impl MockStorage {
@@ -256,10 +369,12 @@ mod tests {
                 channel: None,
                 peer_payload: None,
                 reg_complete: false,
+                i2c0_pins: None,
                 fail_write_key: false,
                 fail_write_channel: false,
                 fail_write_peer_payload: false,
                 fail_write_reg_complete: false,
+                fail_write_i2c0_pins: false,
             }
         }
 
@@ -353,6 +468,16 @@ mod tests {
             self.reg_complete = complete;
             Ok(())
         }
+        fn read_i2c0_pins(&self) -> (u8, u8) {
+            self.i2c0_pins.unwrap_or((0, 1))
+        }
+        fn write_i2c0_pins(&mut self, sda: u8, scl: u8) -> NodeResult<()> {
+            if self.fail_write_i2c0_pins {
+                return Err(NodeError::StorageError("injected write_i2c0_pins failure"));
+            }
+            self.i2c0_pins = Some((sda, scl));
+            Ok(())
+        }
     }
 
     // --- Helper ---
@@ -363,6 +488,7 @@ mod tests {
             psk,
             rf_channel: channel,
             encrypted_payload: payload.to_vec(),
+            pin_config: None,
         }
     }
 
@@ -487,16 +613,198 @@ mod tests {
     }
 
     #[test]
-    fn parse_node_provision_trailing_bytes_rejected() {
-        // Valid 37-byte header + 0-byte payload, but 1 extra trailing byte
+    fn parse_node_provision_trailing_bytes_accepted_as_pin_config() {
+        // Valid 37-byte header + 0-byte payload + CBOR pin config
+        // CBOR: {1: 4, 2: 5} = A2 01 04 02 05
+        let pin_cbor = [0xA2, 0x01, 0x04, 0x02, 0x05];
+        let mut body = vec![0u8; 37 + pin_cbor.len()];
+        body[2..34].fill(0x42); // psk
+        body[34] = 1; // channel 1
+        body[35] = 0x00;
+        body[36] = 0x00; // payload_len = 0
+        body[37..].copy_from_slice(&pin_cbor);
+        let provision = parse_node_provision(&body).unwrap();
+        let pins = provision.pin_config.expect("pin_config should be present");
+        assert_eq!(pins.i2c0_sda, 4);
+        assert_eq!(pins.i2c0_scl, 5);
+    }
+
+    #[test]
+    fn parse_node_provision_trailing_non_cbor_treated_as_no_pin_config() {
+        // Trailing bytes that aren't valid CBOR — best-effort parsing
+        // treats this as "no pin config" (ND-0608 AC#6 backward compat).
         let mut body = vec![0u8; 38];
         body[2..34].fill(0x42); // psk
         body[34] = 1; // channel 1
         body[35] = 0x00;
         body[36] = 0x00; // payload_len = 0
-                         // body[37] is the trailing byte
-        let err = parse_node_provision(&body).unwrap_err();
-        assert_eq!(err, "trailing bytes after encrypted_payload");
+        body[37] = 0xFF; // invalid CBOR
+        let provision = parse_node_provision(&body).unwrap();
+        assert!(
+            provision.pin_config.is_none(),
+            "invalid trailing CBOR should be treated as no pin config"
+        );
+    }
+
+    #[test]
+    fn parse_pin_config_cbor_trailing_bytes_rejected() {
+        // Valid CBOR map followed by extra bytes — now rejected because
+        // parse_pin_config_cbor enforces full consumption (ND-0608 wire
+        // format: trailing bytes are exactly the CBOR map, no junk).
+        // CBOR: {1: 4, 2: 5} = A2 01 04 02 05, then 0x00 trailing
+        let data = [0xA2, 0x01, 0x04, 0x02, 0x05, 0x00];
+        let result = parse_pin_config_cbor(&data);
+        assert!(
+            result.is_err(),
+            "trailing bytes after CBOR map should be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_node_provision_cbor_trailing_junk_treated_as_no_pin_config() {
+        // Valid CBOR map + trailing junk at provision level — best-effort
+        // catches the error from parse_pin_config_cbor and sets pin_config=None.
+        // CBOR: {1: 4, 2: 5} = A2 01 04 02 05, then 0x00 trailing
+        let data = [0xA2, 0x01, 0x04, 0x02, 0x05, 0x00];
+        let mut body = vec![0u8; 37 + data.len()];
+        body[2..34].fill(0x42); // psk
+        body[34] = 1; // channel 1
+        body[35] = 0x00;
+        body[36] = 0x00; // payload_len = 0
+        body[37..].copy_from_slice(&data);
+        let provision = parse_node_provision(&body).unwrap();
+        assert!(
+            provision.pin_config.is_none(),
+            "CBOR trailing junk should be treated as no pin config"
+        );
+    }
+
+    #[test]
+    fn parse_pin_config_cbor_unknown_key_non_integer_value_ignored() {
+        // Unknown key 99 with a text string value — should be ignored
+        // without failing, even though the value isn't an integer.
+        // CBOR: {1: 4, 2: 5, 99: "x"} — forward compatibility.
+        let mut buf = Vec::new();
+        ciborium::into_writer(
+            &ciborium::Value::Map(vec![
+                (
+                    ciborium::Value::Integer(1.into()),
+                    ciborium::Value::Integer(4.into()),
+                ),
+                (
+                    ciborium::Value::Integer(2.into()),
+                    ciborium::Value::Integer(5.into()),
+                ),
+                (
+                    ciborium::Value::Integer(99.into()),
+                    ciborium::Value::Text("x".into()),
+                ),
+            ]),
+            &mut buf,
+        )
+        .unwrap();
+        let result = parse_pin_config_cbor(&buf).unwrap();
+        assert_eq!(result.i2c0_sda, 4);
+        assert_eq!(result.i2c0_scl, 5);
+    }
+
+    #[test]
+    fn parse_pin_config_cbor_key_above_255_ignored() {
+        // Key 256 exceeds u8 range — should be silently ignored (forward
+        // compat), not cause a parse error.
+        let mut buf = Vec::new();
+        ciborium::into_writer(
+            &ciborium::Value::Map(vec![
+                (
+                    ciborium::Value::Integer(1.into()),
+                    ciborium::Value::Integer(4.into()),
+                ),
+                (
+                    ciborium::Value::Integer(2.into()),
+                    ciborium::Value::Integer(5.into()),
+                ),
+                (
+                    ciborium::Value::Integer(256.into()),
+                    ciborium::Value::Integer(42.into()),
+                ),
+            ]),
+            &mut buf,
+        )
+        .unwrap();
+        let result = parse_pin_config_cbor(&buf).unwrap();
+        assert_eq!(result.i2c0_sda, 4);
+        assert_eq!(result.i2c0_scl, 5);
+    }
+
+    #[test]
+    fn parse_pin_config_cbor_sda_equals_scl_rejected() {
+        // SDA == SCL is invalid — would disable I2C. Should return Err so
+        // parse_node_provision treats it as absent (backward-compatible).
+        // CBOR: {1: 4, 2: 4}
+        let mut buf = Vec::new();
+        ciborium::into_writer(
+            &ciborium::Value::Map(vec![
+                (
+                    ciborium::Value::Integer(1.into()),
+                    ciborium::Value::Integer(4.into()),
+                ),
+                (
+                    ciborium::Value::Integer(2.into()),
+                    ciborium::Value::Integer(4.into()),
+                ),
+            ]),
+            &mut buf,
+        )
+        .unwrap();
+        let err = parse_pin_config_cbor(&buf).unwrap_err();
+        assert_eq!(err, "pin_config: SDA and SCL must be different pins");
+    }
+
+    #[test]
+    fn parse_pin_config_cbor_gpio_out_of_range_rejected() {
+        // GPIO 22 is out of range for ESP32-C3 (0–21). Should return Err.
+        // CBOR: {1: 4, 2: 22}
+        let mut buf = Vec::new();
+        ciborium::into_writer(
+            &ciborium::Value::Map(vec![
+                (
+                    ciborium::Value::Integer(1.into()),
+                    ciborium::Value::Integer(4.into()),
+                ),
+                (
+                    ciborium::Value::Integer(2.into()),
+                    ciborium::Value::Integer(22.into()),
+                ),
+            ]),
+            &mut buf,
+        )
+        .unwrap();
+        let err = parse_pin_config_cbor(&buf).unwrap_err();
+        assert_eq!(err, "pin_config: GPIO number out of range (0-21)");
+    }
+
+    #[test]
+    fn parse_pin_config_cbor_boundary_gpio_21_accepted() {
+        // GPIO 21 is the maximum valid pin for ESP32-C3 — should succeed.
+        // CBOR: {1: 20, 2: 21}
+        let mut buf = Vec::new();
+        ciborium::into_writer(
+            &ciborium::Value::Map(vec![
+                (
+                    ciborium::Value::Integer(1.into()),
+                    ciborium::Value::Integer(20.into()),
+                ),
+                (
+                    ciborium::Value::Integer(2.into()),
+                    ciborium::Value::Integer(21.into()),
+                ),
+            ]),
+            &mut buf,
+        )
+        .unwrap();
+        let result = parse_pin_config_cbor(&buf).unwrap();
+        assert_eq!(result.i2c0_sda, 20);
+        assert_eq!(result.i2c0_scl, 21);
     }
 
     #[test]
@@ -758,6 +1066,64 @@ mod tests {
         // Key and peer_payload must be rolled back (ND-0908)
         assert!(storage.read_key().is_none());
         assert!(storage.read_peer_payload().is_none());
+    }
+
+    // --- handle_node_provision: pin config persistence (ND-0608) ---
+
+    /// Pin config present → persisted to NVS and NODE_ACK_SUCCESS returned.
+    #[test]
+    fn handle_provision_with_pin_config_persists() {
+        let mut storage = MockStorage::new();
+        let mut maps = MapStorage::new(1024);
+        let provision = NodeProvision {
+            key_hint: 0x0001,
+            psk: [0x42u8; 32],
+            rf_channel: 6,
+            encrypted_payload: vec![0xAA],
+            pin_config: Some(PinConfig {
+                i2c0_sda: 4,
+                i2c0_scl: 5,
+            }),
+        };
+
+        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        assert_eq!(status, NODE_ACK_SUCCESS);
+        assert_eq!(storage.read_i2c0_pins(), (4, 5));
+    }
+
+    /// Pin config write failure → NODE_ACK_SUCCESS (non-fatal, ND-0608).
+    /// The node is effectively provisioned; pin config falls back to defaults.
+    #[test]
+    fn handle_provision_pin_config_write_failure() {
+        let mut storage = MockStorage::new();
+        storage.fail_write_i2c0_pins = true;
+        let mut maps = MapStorage::new(1024);
+        let provision = NodeProvision {
+            key_hint: 0x0001,
+            psk: [0x42u8; 32],
+            rf_channel: 6,
+            encrypted_payload: vec![0xAA],
+            pin_config: Some(PinConfig {
+                i2c0_sda: 4,
+                i2c0_scl: 5,
+            }),
+        };
+
+        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        assert_eq!(status, NODE_ACK_SUCCESS);
+    }
+
+    /// Pin config absent → NVS pins untouched, NODE_ACK_SUCCESS returned (backward compat).
+    #[test]
+    fn handle_provision_without_pin_config_ok() {
+        let mut storage = MockStorage::new();
+        let mut maps = MapStorage::new(1024);
+        let provision = make_provision(0x0001, [0x42u8; 32], 6, &[0xAA]);
+
+        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        assert_eq!(status, NODE_ACK_SUCCESS);
+        // No pin config → NVS pins should still be default
+        assert!(storage.i2c0_pins.is_none());
     }
 
     // --- Full round-trip: parse envelope → handle → encode ACK ---

--- a/crates/sonde-node/src/esp_hal.rs
+++ b/crates/sonde-node/src/esp_hal.rs
@@ -15,11 +15,6 @@
 use crate::hal;
 use log::warn;
 
-/// I2C0 SDA pin (GPIO 0; Qwiic/STEMMA QT Blue wire).
-const I2C0_SDA: i32 = 0;
-
-/// I2C0 SCL pin (GPIO 1; Qwiic/STEMMA QT Yellow wire).
-const I2C0_SCL: i32 = 1;
 const I2C0_FREQ_HZ: u32 = 100_000; // 100 kHz standard mode
 
 // Timeout for I2C operations in FreeRTOS ticks (1 tick ≈ 1 ms at default rate).
@@ -59,7 +54,9 @@ impl crate::traits::Clock for EspClock {
 
 /// Real ESP32 HAL backed by ESP-IDF sys APIs.
 ///
-/// Initializes I2C bus 0 on construction. Additional buses and
+/// Initializes I2C bus 0 on construction using caller-supplied pin
+/// assignments (typically loaded from NVS with a compiled-in default
+/// fallback by higher-level code; see ND-0608). Additional buses and
 /// SPI are left as stubs until needed. GPIO and ADC use direct
 /// ESP-IDF calls with no pre-initialization.
 pub struct EspHal {
@@ -72,18 +69,20 @@ pub struct EspHal {
 }
 
 impl EspHal {
-    pub fn new() -> Self {
+    /// Create a new HAL with the given I2C0 pin assignments.
+    /// Call with `storage.read_i2c0_pins()` from the platform storage.
+    pub fn new(i2c0_sda: u8, i2c0_scl: u8) -> Self {
         let mut hal = Self {
             i2c0_initialized: false,
             adc_width_configured: false,
             gpio_output_configured: 0,
             adc_channels_configured: 0,
         };
-        hal.init_i2c0();
+        hal.init_i2c0(i2c0_sda as i32, i2c0_scl as i32);
         hal
     }
 
-    fn init_i2c0(&mut self) {
+    fn init_i2c0(&mut self, sda: i32, scl: i32) {
         unsafe {
             let port = esp_idf_sys::i2c_port_t_I2C_NUM_0;
 
@@ -91,8 +90,8 @@ impl EspHal {
             // bindgen layout differences across esp-idf-sys versions.
             let mut conf: esp_idf_sys::i2c_config_t = core::mem::zeroed();
             conf.mode = esp_idf_sys::i2c_mode_t_I2C_MODE_MASTER;
-            conf.sda_io_num = I2C0_SDA;
-            conf.scl_io_num = I2C0_SCL;
+            conf.sda_io_num = sda;
+            conf.scl_io_num = scl;
             conf.sda_pullup_en = true;
             conf.scl_pullup_en = true;
             conf.__bindgen_anon_1.master.clk_speed = I2C0_FREQ_HZ;

--- a/crates/sonde-node/src/esp_storage.rs
+++ b/crates/sonde-node/src/esp_storage.rs
@@ -12,6 +12,7 @@
 //! - Programs: `"prog_a"` (blob, ≤4096 B), `"prog_b"` (blob, ≤4096 B)
 //! - WiFi channel: `"channel"` (u32, 1–13)
 //! - BLE pairing (ND-0916): `"peer_payload"` (blob, variable), `"reg_complete"` (u32, 0 or 1)
+//! - I2C pin config (ND-0608): `"i2c0_sda"` (u32, default 0), `"i2c0_scl"` (u32, default 1)
 //!
 //! The early-wake flag is stored in RTC slow SRAM (`.rtc.data` section)
 //! rather than NVS, so it survives deep sleep without incurring flash wear.
@@ -290,5 +291,60 @@ impl crate::traits::PlatformStorage for NvsStorage {
         self.nvs
             .set_u32("reg_complete", if complete { 1 } else { 0 })
             .map_err(|_| NodeError::StorageError("reg_complete write failed"))
+    }
+
+    fn read_i2c0_pins(&self) -> (u8, u8) {
+        const MAX_GPIO: u8 = 21;
+        let sda = self
+            .nvs
+            .get_u32("i2c0_sda")
+            .ok()
+            .flatten()
+            .and_then(|v| u8::try_from(v).ok())
+            .filter(|&v| v <= MAX_GPIO)
+            .unwrap_or(0);
+        let scl = self
+            .nvs
+            .get_u32("i2c0_scl")
+            .ok()
+            .flatten()
+            .and_then(|v| u8::try_from(v).ok())
+            .filter(|&v| v <= MAX_GPIO)
+            .unwrap_or(1);
+        // If both decoded to the same pin, fall back to defaults to
+        // avoid initializing I2C with SDA==SCL (ND-0608).
+        if sda == scl {
+            return (0, 1);
+        }
+        (sda, scl)
+    }
+
+    fn write_i2c0_pins(&mut self, sda: u8, scl: u8) -> NodeResult<()> {
+        // Validate before persisting — an invalid config survives factory
+        // reset (ND-0608 AC#4) and could permanently disable I2C.
+        const MAX_GPIO: u8 = 21;
+        if sda > MAX_GPIO || scl > MAX_GPIO {
+            return Err(NodeError::StorageError("i2c0 pin out of GPIO range"));
+        }
+        if sda == scl {
+            return Err(NodeError::StorageError("i2c0 SDA and SCL must differ"));
+        }
+
+        // Best-effort atomicity: if updating SCL fails after SDA was written,
+        // restore the previous SDA value to avoid leaving a mismatched pair.
+        let (old_sda, _old_scl) = self.read_i2c0_pins();
+
+        self.nvs
+            .set_u32("i2c0_sda", sda as u32)
+            .map_err(|_| NodeError::StorageError("i2c0_sda write failed"))?;
+
+        if let Err(_e) = self.nvs.set_u32("i2c0_scl", scl as u32) {
+            // Attempt to roll back SDA; ignore rollback failure since we
+            // can't do better than best-effort here.
+            let _ = self.nvs.set_u32("i2c0_sda", old_sda as u32);
+            return Err(NodeError::StorageError("i2c0_scl write failed"));
+        }
+
+        Ok(())
     }
 }

--- a/crates/sonde-node/src/traits.rs
+++ b/crates/sonde-node/src/traits.rs
@@ -164,4 +164,15 @@ pub trait PlatformStorage {
     fn write_reg_complete(&mut self, _complete: bool) -> NodeResult<()> {
         Ok(())
     }
+
+    /// Read I2C0 pin configuration from NVS (ND-0608).
+    /// Returns `(sda_gpio, scl_gpio)`. Defaults to `(0, 1)` if not set.
+    fn read_i2c0_pins(&self) -> (u8, u8) {
+        (0, 1)
+    }
+
+    /// Persist I2C0 pin configuration to NVS (ND-0608).
+    fn write_i2c0_pins(&mut self, _sda: u8, _scl: u8) -> NodeResult<()> {
+        Ok(())
+    }
 }

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -230,6 +230,28 @@ The Phase 2 state machine implements the node provisioning flow from [ble-pairin
 - `node_psk` is never persisted to disk.  It exists only in memory during provisioning and is zeroed via `Zeroizing` after the `NODE_PROVISION` write succeeds (PT-0408, PT-0804).
 - A fresh ephemeral X25519 keypair is generated for each provisioning attempt (PT-0405).
 
+### 4.1  NODE_PROVISION body wire format
+
+```
+Offset  Size           Field
+──────  ─────────────  ──────────────────────────────────────────
+0       2              node_key_hint     (BE u16)
+2       32             node_psk          (256-bit PSK)
+34      1              rf_channel        (1–13)
+35      2              payload_len       (BE u16, encrypted payload length)
+37      payload_len    encrypted_payload (opaque blob for gateway)
+37+N    remaining      pin_config_cbor   (optional, CBOR map — see below)
+```
+
+**Pin config (ND-0608):** If the NODE_PROVISION body is longer than `37 + payload_len`, the remaining bytes are a deterministic CBOR map (RFC 8949 §4.2) of board-specific pin assignments:
+
+| CBOR key | Field | Type | Default |
+|----------|-------|------|---------|
+| 1 | `i2c0_sda` | uint | 0 |
+| 2 | `i2c0_scl` | uint | 1 |
+
+The node persists these to NVS. If the map is absent (older pairing tool), the node uses compiled-in defaults. Future keys (SPI pins, pairing button GPIO) may be added without breaking backward compatibility.
+
 ---
 
 ## 5  BLE transport layer
@@ -555,12 +577,6 @@ When a `PskProtector` is configured (e.g. the DPAPI protector on Windows or the 
 2. The next `save_artifacts()` call writes the PSK through the configured protector, producing a `phone_psk_protected` field and omitting the plaintext `phone_psk` field.
 3. This migration is idempotent and requires no operator action.  The warning log provides visibility into the one-time upgrade.
 
-Error cases:
-
-- **Encrypted PSK without protector:** If `phone_psk_protected` is present but no `PskProtector` is configured, `load_artifacts()` returns `PairingError::StoreLoadFailed`.  This prevents silent fallback to plaintext.
-- **Missing PSK fields:** If neither `phone_psk` nor `phone_psk_protected` is present, `load_artifacts()` returns `PairingError::StoreCorrupted`.
-- **Crash safety:** The re-encrypted file is written atomically (write to temp file, fsync, rename) so a crash during migration cannot lose the PSK (§7.4).
-
 #### Android (`AndroidPairingStore`)
 
 - Backend: Android `EncryptedSharedPreferences` backed by the Android Keystore
@@ -709,8 +725,8 @@ The tool does not silently retry failed protocol operations (PT-1003).  BLE-leve
 
 - **BLE library:** Android BLE API accessed via JNI bridge (Tauri Mobile).  `btleplug` does not support Android, so the `BleTransport` trait implementation calls the Android `BluetoothGatt` API through JNI.
 - **Permissions:** The Android manifest must declare `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT` for Android 12+ (API 31+) BLE scanning.  For pre-31 devices, BLE scanning requires a location permission such as `ACCESS_FINE_LOCATION`/`ACCESS_COARSE_LOCATION`.  The app must request the relevant runtime permissions before starting a scan (PT-0105).
-- **MTU negotiation:** Call `BluetoothGatt.requestMtu(517)` after connection.  The actual negotiated MTU is reported via `onMtuChanged()`.
-- **Just Works / Numeric Comparison:** Android handles LESC pairing via the system pairing dialog.  Numeric Comparison displays a 6-digit passkey for user confirmation.  Just Works proceeds without user interaction.  The app must verify that LESC Numeric Comparison was used; a Just Works fallback must be treated as a connection failure (PT-0106, PT-0904).  `BleHelper` registers a `BroadcastReceiver` for `ACTION_PAIRING_REQUEST` before calling `createBond()` and records the `EXTRA_PAIRING_VARIANT` (variant 2 = Numeric Comparison, variant 3 = Just Works).  After `connect()` returns, the Rust transport calls `BleHelper.getPairingMethod()` via JNI and stores the result.  `AndroidBleTransport::pairing_method()` maps the stored value to `PairingMethod::NumericComparison`, `PairingMethod::JustWorks`, or `PairingMethod::Unknown`.  It never returns `None` because Android does not enforce LESC at the OS level — `enforce_lesc()` must explicitly verify the method.  If the `ACTION_PAIRING_REQUEST` broadcast is not delivered (e.g. missing permission), `Unknown` is returned and `enforce_lesc()` rejects the connection (fail-secure).
+- **MTU negotiation:** Call `BluetoothGatt.requestMtu(247)` after connection.  The actual negotiated MTU is reported via `onMtuChanged()`.
+- **Just Works / Numeric Comparison:** Android handles LESC pairing via the system pairing dialog.  Numeric Comparison displays a 6-digit passkey for user confirmation.  Just Works proceeds without user interaction.  The app must verify that LESC Numeric Comparison was used; a Just Works fallback must be treated as a connection failure (PT-0106, PT-0904).
 - **Storage:** `EncryptedSharedPreferences` backed by the Android Keystore for PSK protection.
 - **Lifecycle:** The BLE connection must be managed carefully around Android activity lifecycle events (pause/resume).  The transport implementation should disconnect on pause and reconnect on resume if a pairing flow was in progress (PT-0107).
 - **JNI classloader caching:** App-defined Java classes (`BleHelper`, `SecureStore`) must be resolved and cached as `GlobalRef` from `JNI_OnLoad` or another Java-attached thread that uses the application classloader.  Tokio worker threads use the system classloader, which cannot find app-defined classes via `FindClass` (PT-0108).

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -1133,3 +1133,22 @@ The pairing tool MUST apply build-type–aware log-level policies: compile-time 
 4. `RUST_LOG` overrides the default in both build types (within compile-time limits).
 5. The `tracing` crate dependency in both `sonde-pair` and `sonde-pair-ui` specifies `features = ["max_level_trace", "release_max_level_info"]`.
 6. PT-1207–PT-1212 requirements that specify DEBUG-level logging are satisfied in debug builds; in release builds those call-sites are compiled out and the requirements are met by the tool functioning correctly without those diagnostic events.
+
+---
+
+### PT-1214  Board pin configuration in NODE_PROVISION
+
+**Priority:** Should (deferred — `sonde-pair` does not yet implement this)  
+**Source:** issue #490, ND-0608
+
+**Description:**  
+The pairing tool SHOULD support including optional board-specific pin configuration (I2C SDA/SCL GPIO numbers) in the NODE_PROVISION message body so that a single firmware binary works across different ESP32-C3 boards.
+
+The node-side parsing (ND-0608) is implemented; the pairing-tool encoding side is tracked as future work. The `sonde-pair` API (`provision_node`) does **not** yet accept a pin-config parameter and the NODE_PROVISION payload does **not** yet include a trailing CBOR map for pin configuration.
+
+**Acceptance criteria:**
+
+1. The `provision_node(...)` API (which constructs/sends NODE_PROVISION during Phase 2) accepts an optional pin config parameter.
+2. When provided, pin config is encoded as a deterministic CBOR map and appended to the NODE_PROVISION body after the encrypted payload.
+3. When not provided, the NODE_PROVISION body is identical to the existing format (backward compatible).
+4. The CBOR map uses integer keys: 1 = `i2c0_sda` (uint), 2 = `i2c0_scl` (uint).

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1189,6 +1189,33 @@ TestNode {
 
 ---
 
+### T-PT-1214a  Pin config included in NODE_PROVISION when provided
+
+**Validates:** PT-1214 (AC 1, 2, 4)  
+**Status:** Deferred — `sonde-pair` does not yet implement pin config encoding.
+
+**Procedure:**
+1. Call `provision_node(...)` with pin config `Some(PinConfig { i2c0_sda: 4, i2c0_scl: 5 })`.
+2. Capture the NODE_PROVISION message body written to the mock BLE transport.
+3. Assert: the body contains the encrypted payload followed by a deterministic CBOR map.
+4. Decode the trailing CBOR map and assert: integer key 1 = 4 (`i2c0_sda`), integer key 2 = 5 (`i2c0_scl`).
+5. Assert: the CBOR map uses deterministic encoding (RFC 8949 §4.2).
+
+---
+
+### T-PT-1214b  No pin config in NODE_PROVISION — backward compatible
+
+**Validates:** PT-1214 (AC 1, 3)  
+**Status:** Deferred — `sonde-pair` does not yet implement pin config encoding.
+
+**Procedure:**
+1. Call `provision_node(...)` with pin config `None`.
+2. Capture the NODE_PROVISION message body written to the mock BLE transport.
+3. Assert: the body is identical to the existing format (encrypted payload only, no trailing bytes).
+4. Assert: provisioning completes successfully (NODE_ACK received).
+
+---
+
 ## Appendix A  Test-to-requirement traceability
 
 | Test ID | Requirement | Title |
@@ -1277,3 +1304,5 @@ TestNode {
 | T-PT-1210 | PT-1210 | Phase transition events logged |
 | T-PT-1211 | PT-1211 | LESC pairing method logged |
 | T-PT-1212 | PT-1212 | Error context in log output |
+| T-PT-1214a | PT-1214 | Pin config included in NODE_PROVISION when provided |
+| T-PT-1214b | PT-1214 | No pin config in NODE_PROVISION — backward compatible |

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -409,10 +409,7 @@ On program install:
 2. If total exceeds the budget → reject installation, keep existing program.
 3. Allocate contiguous regions in RTC SRAM for each map.
 4. Zero-initialize all map storage.
-5. Apply initial data: for each map with non-empty `map_initial_data[i]`, write the initial bytes to entry 0 if the data length equals `value_size`. This pre-populates global variable maps (`.rodata`, `.data`) with their ELF section content before BPF execution.
-6. Record the map layout in the RTC SRAM header for use after deep sleep.
-
-Initial data flows through the system as follows: the gateway extracts `.rodata` / `.data` section content from the ELF at ingestion time → embeds it in the CBOR program image as `initial_data` (key 5) in each map definition → the node decodes the program image into `LoadedProgram.map_initial_data` → `MapStorage::apply_initial_data()` writes the data to entry 0 of each corresponding map after allocation.
+5. Record the map layout in the RTC SRAM header for use after deep sleep.
 
 ### 9.3  Map access helpers
 
@@ -447,6 +444,23 @@ Handles pack bus and address into a single `u32` (matching bpf-environment.md §
 ### 10.2  Error handling
 
 All HAL helpers return `0` on success, negative on error. Errors include NACK, bus timeout, invalid pin/channel. The BPF program decides how to handle errors — the firmware does not retry.
+
+### 10.3  Configurable I2C pin assignments (ND-0608)
+
+I2C bus GPIO pin numbers are configurable via NVS to support different ESP32-C3 board layouts with a single firmware binary.
+
+**NVS keys** (namespace `"sonde"`):
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `"i2c0_sda"` | u32 | 0 | I2C0 SDA GPIO number |
+| `"i2c0_scl"` | u32 | 1 | I2C0 SCL GPIO number |
+
+**Initialization:** At HAL init time, the firmware reads `i2c0_sda` and `i2c0_scl` from NVS. If either key is absent, the compiled-in default is used (GPIO 0 / GPIO 1, matching DevKitM-1 Qwiic mapping).
+
+**Provisioning path:** Pin config is included as optional trailing bytes in the NODE_PROVISION BLE message body (see §BLE pairing). When the node receives a NODE_PROVISION with pin config, it writes the values to NVS before rebooting into PEER_REQUEST mode. An older pairing tool that omits pin config produces no NVS writes — the defaults apply.
+
+**Factory reset:** Pin config keys are NOT erased during factory reset (ND-0917). The board's physical pin mapping does not change when the node is re-provisioned.
 
 ---
 
@@ -625,7 +639,7 @@ After the first successful WAKE/COMMAND exchange (the gateway responds with a va
 
 **Self-healing on WAKE failure (ND-0915):**
 
-If WAKE fails (no response or HMAC verification failure) after `reg_complete` is set, the node checks whether the `peer_payload` NVS key is still present. If it is, the node clears the `reg_complete` flag and reverts to sending PEER_REQUEST on the next boot — this allows the node to re-register if the gateway lost its registration state. If `peer_payload` has already been erased (ND-0914), the self-healing path is unavailable and the node continues normal WAKE retries; re-provisioning via BLE is required if the gateway has lost its registration.
+If WAKE fails (no response or HMAC verification failure) after `reg_complete` is set, the node clears the `reg_complete` flag and reverts to sending PEER_REQUEST on the next boot. This allows the node to re-register if the gateway lost its registration state.
 
 ---
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -597,6 +597,25 @@ The program image format MUST support optional initial data for each map definit
 
 ---
 
+### ND-0608  Configurable I2C pin assignments
+
+**Priority:** Should  
+**Source:** issue #490
+
+**Description:**  
+The firmware MUST support configurable I2C bus GPIO pin assignments so that a single firmware binary works across ESP32-C3 boards with different Qwiic/I2C pin mappings. Pin assignments are provided during BLE provisioning as optional fields in the NODE_PROVISION message body and persisted to NVS. If no pin config is provided, the firmware uses compiled-in defaults (GPIO 0 = SDA, GPIO 1 = SCL).
+
+**Acceptance criteria:**
+
+1. I2C0 SDA and SCL GPIO pin numbers are read from NVS at HAL initialization time.
+2. If the NVS keys are absent, the firmware falls back to compiled-in defaults (SDA=0, SCL=1).
+3. Pin assignments persist across deep-sleep cycles and power-on resets.
+4. Factory reset (ND-0917) does NOT erase pin config — the board hardware does not change.
+5. The NODE_PROVISION BLE message body may include optional pin config bytes after the encrypted payload; the node parses and persists them to NVS.
+6. Backward compatibility: a NODE_PROVISION body without pin config bytes (from an older pairing tool) is accepted without error.
+
+---
+
 ## 9  Timing and retries
 
 ### ND-0700  WAKE retry
@@ -1243,6 +1262,7 @@ The node MUST apply build-type–aware log-level policies to eliminate logging o
 | ND-0605 | Execution constraints | Must |
 | ND-0606 | Map memory budget enforcement | Must |
 | ND-0607 | Initial map data | Must |
+| ND-0608 | Configurable I2C pin assignments | Should |
 | ND-0700 | WAKE retry | Must |
 | ND-0701 | Chunk transfer retry | Must |
 | ND-0702 | Response timeout | Must |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -717,28 +717,6 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
-### T-N617  Initial map data applied on program install
-
-**Validates:** ND-0607
-
-**Procedure:**
-1. Create a program image with one map definition (`value_size` = 4, `max_entries` = 1) and `map_initial_data[0]` = `[0xDE, 0xAD, 0xBE, 0xEF]`.
-2. Install the program and run a wake cycle that triggers map allocation.
-3. Assert: after allocation, entry 0 of the map contains `[0xDE, 0xAD, 0xBE, 0xEF]`.
-
----
-
-### T-N618  Initial map data size mismatch ignored
-
-**Validates:** ND-0607
-
-**Procedure:**
-1. Create a program image with one map definition (`value_size` = 4) and `map_initial_data[0]` = `[0x01, 0x02]` (length ≠ `value_size`).
-2. Install the program and run a wake cycle.
-3. Assert: entry 0 of the map remains zero-filled (size mismatch causes silent skip).
-
----
-
 ## 9  Timing and retry tests
 
 ### T-N700  WAKE retry count and timing
@@ -1056,24 +1034,11 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Validates:** ND-0915
 
 **Procedure:**
-1. Complete BLE pairing and registration (`reg_complete` set, `peer_payload` still present in NVS).
+1. Complete BLE pairing and registration (`reg_complete` set).
 2. Reboot node; node sends WAKE.
 3. Mock gateway does not respond (or responds with invalid HMAC).
 4. Assert: `reg_complete` flag is cleared.
 5. Assert: on next boot the node sends PEER_REQUEST instead of WAKE.
-
----
-
-### T-N917b  WAKE failure after payload erasure — no self-healing
-
-**Validates:** ND-0915
-
-**Procedure:**
-1. Complete BLE pairing and registration (`reg_complete` set).
-2. Reboot node; node sends WAKE. Mock gateway responds with a valid COMMAND so the first WAKE/COMMAND cycle succeeds and `peer_payload` is erased (ND-0914).
-3. Reboot node; node sends WAKE. Mock gateway does not respond (or responds with invalid HMAC).
-4. Assert: `reg_complete` flag is **not** cleared.
-5. Assert: on next boot the node sends WAKE (not PEER_REQUEST).
 
 ---
 
@@ -1541,6 +1506,79 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
+### T-N0607a  I2C pins read from NVS at HAL init
+
+**Validates:** ND-0608 (AC 1, 3)
+
+**Procedure:**
+1. Write SDA=4, SCL=5 to NVS keys `i2c0_sda` and `i2c0_scl`.
+2. Trigger HAL initialization (power-on reset or deep-sleep wake).
+3. Assert: the I2C0 peripheral is configured with SDA=4, SCL=5.
+4. Assert: pin assignments survive a deep-sleep cycle — repeat step 2 and verify the same pins are used.
+
+---
+
+### T-N0607b  Missing NVS keys fall back to defaults
+
+**Validates:** ND-0608 (AC 2)
+
+**Procedure:**
+1. Erase NVS keys `i2c0_sda` and `i2c0_scl` (or start with a fresh NVS partition).
+2. Trigger HAL initialization.
+3. Assert: the I2C0 peripheral is configured with the compiled-in defaults SDA=0, SCL=1.
+
+---
+
+### T-N0607c  Pin config persisted from NODE_PROVISION with CBOR pin data
+
+**Validates:** ND-0608 (AC 5)
+
+**Procedure:**
+1. Construct a NODE_PROVISION BLE message body with a valid encrypted payload followed by a deterministic CBOR map `{1: 6, 2: 7}` (SDA=6, SCL=7).
+2. Deliver the message to the node's provisioning handler.
+3. Assert: NVS keys `i2c0_sda` and `i2c0_scl` are written with values 6 and 7 respectively.
+4. Trigger a HAL re-initialization (or reboot).
+5. Assert: the I2C0 peripheral is configured with SDA=6, SCL=7.
+
+---
+
+### T-N0607d  NODE_PROVISION without pin config — backward compatible
+
+**Validates:** ND-0608 (AC 6)
+
+**Procedure:**
+1. Construct a NODE_PROVISION BLE message body with a valid encrypted payload and no trailing pin config bytes.
+2. Deliver the message to the node's provisioning handler.
+3. Assert: provisioning succeeds without error.
+4. Assert: NVS keys `i2c0_sda` and `i2c0_scl` are not written (or remain at their prior values).
+
+---
+
+### T-N0607e  Factory reset does NOT erase pin config
+
+**Validates:** ND-0608 (AC 4), ND-0917
+
+**Procedure:**
+1. Write SDA=4, SCL=5 to NVS keys `i2c0_sda` and `i2c0_scl`.
+2. Trigger a factory reset (ND-0917).
+3. Assert: NVS keys `i2c0_sda` and `i2c0_scl` still contain 4 and 5.
+4. Trigger HAL initialization.
+5. Assert: the I2C0 peripheral is configured with SDA=4, SCL=5.
+
+---
+
+### T-N0607f  Invalid CBOR trailing data treated as no pin config
+
+**Validates:** ND-0608 (AC 6)
+
+**Procedure:**
+1. Construct a NODE_PROVISION BLE message body with a valid encrypted payload followed by invalid trailing bytes (e.g., truncated CBOR or random data).
+2. Deliver the message to the node's provisioning handler.
+3. Assert: provisioning succeeds (the encrypted payload is processed normally).
+4. Assert: NVS keys `i2c0_sda` and `i2c0_scl` are not written.
+
+---
+
 ## Appendix A  Test-to-requirement traceability
 
 | Requirement | Test(s) |
@@ -1577,7 +1615,6 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0604 | T-N610, T-N611, T-N612, T-N613, T-N933 |
 | ND-0605 | T-N614, T-N615, T-N934 |
 | ND-0606 | T-N616, T-N935 |
-| ND-0607 | T-N617, T-N618 |
 | ND-0700 | T-N201, T-N700 |
 | ND-0701 | T-N701, T-N936 |
 | ND-0702 | T-N702, T-N937 |
@@ -1599,10 +1636,11 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0912 | T-N912, T-N913, T-N914, T-N941 |
 | ND-0913 | T-N915 |
 | ND-0914 | T-N916 |
-| ND-0915 | T-N917, T-N917b |
+| ND-0915 | T-N917 |
 | ND-0916 | T-N918 |
 | ND-0917 | T-N906 |
 | ND-0918 | *(verified by sdkconfig.defaults setting)* |
+| ND-0608 | T-N0607a, T-N0607b, T-N0607c, T-N0607d, T-N0607e, T-N0607f |
 
 ---
 


### PR DESCRIPTION
Adds configurable I2C pin assignments via BLE provisioning (ND-0607, PT-1214).

A single firmware binary now works across ESP32-C3 boards with different Qwiic/I2C pin mappings. Pin config is provided as optional trailing CBOR bytes in the NODE_PROVISION BLE message body, parsed on the node, and persisted to NVS.

### Spec changes
- **ND-0607**: configurable I2C pins via NVS + BLE provisioning
- **node-design.md §10.3**: HAL reads pin config from NVS at init
- **ble-pairing-tool-design.md §4.1**: NODE_PROVISION wire format extension
- **PT-1214**: optional pin config in NODE_PROVISION

### Code changes
- `PlatformStorage` trait: `read_i2c0_pins()` / `write_i2c0_pins()`
- `EspStorage`: NVS keys `i2c0_sda`, `i2c0_scl` (defaults GPIO 0/1)
- `EspHal::new(sda, scl)`: accepts pin config instead of hardcoding
- `ble_pairing.rs`: parse optional trailing CBOR pin config (backward compatible)
- Tests for pin config CBOR parsing, persistence, and edge cases

Closes #490
