### PR TITLE
Add T-1005 export plaintext key leakage test (GW-1001)

### DIFF
--- a/crates/sonde-gateway/tests/phase2c_admin.rs
+++ b/crates/sonde-gateway/tests/phase2c_admin.rs
@@ -5,7 +5,7 @@
 // ingestion is rejected in release builds).
 #![allow(unused_imports, dead_code)]
 
-//! Phase 2C-ii integration tests: gRPC admin API (T-0800 to T-0810).
+//! Phase 2C-ii integration tests: gRPC admin API (T-0800 to T-0810, T-1005).
 //!
 //! Tests call `AdminService` methods directly via tonic `Request`/`Response`
 //! (no gRPC transport needed). Combined admin+protocol tests also create a
@@ -1150,6 +1150,13 @@ async fn t1005_export_plaintext_key_leakage() {
         .await
         .unwrap();
     let bundle = export_resp.into_inner().data;
+
+    // Sanity: a vacuously-empty bundle would make the substring scan below
+    // pass without providing any security signal.
+    assert!(
+        !bundle.is_empty(),
+        "Exported state bundle is empty; ExportState may be returning an invalid payload"
+    );
 
     // Step 3–4: Scan the raw export bytes for PSK byte sequences.
     // No PSK must appear as a contiguous substring anywhere in the bundle.


### PR DESCRIPTION
## Summary

Implements the missing T-1005 test from the gateway validation plan, closing the security test gap identified in audit finding F-008.

### What the test does

1. Registers two nodes with known, distinctive PSKs (\[0x42; 32\] and \[0xDE; 32\])
2. Exports state with a known passphrase
3. **Scans the raw export bytes** — asserts neither PSK appears as a contiguous substring anywhere in the bundle (the core security assertion)
4. Attempts import with the wrong passphrase against the original gateway — asserts rejection and verifies gateway state is unchanged
5. Attempts import with the wrong passphrase against a fresh gateway — asserts nodes are not restored and WAKE is rejected
6. Imports into a fresh gateway with the correct passphrase
7. Verifies both nodes are restored and their PSKs are functional (WAKE accepted)

### Validation reference

- **Test case:** T-1005 (gateway-validation.md §10)
- **Requirement:** GW-1001 — exported state bundles must not leak key material in plaintext
- **Audit finding:** F-008 (round 2 gateway test compliance audit)

Closes #522