### PR TITLE
fix(bpf): work around prevail-rust#1 — move globals to stack

### DIFF
--- a/test-programs/i2c_sensor.c
+++ b/test-programs/i2c_sensor.c
@@ -89,10 +89,6 @@ static __noinline int bme280_trigger_and_read(__u8 *raw)
                           raw, BME280_RAW_DATA_LEN);
 }
 
-/* Error message strings for bpf_trace_printk. */
-static const char err_no_device[] = "bme280: device not found\n";
-static const char err_read_fail[] = "bme280: measurement failed\n";
-
 SEC("sonde")
 int program(struct sonde_context *ctx)
 {
@@ -102,7 +98,8 @@ int program(struct sonde_context *ctx)
     __u8 chip_id = 0;
     int rc = bme280_read_reg(BME280_REG_CHIP_ID, &chip_id);
     if (rc < 0 || chip_id != BME280_CHIP_ID) {
-        bpf_trace_printk(err_no_device, (__u32)(sizeof(err_no_device) - 1));
+        char err[] = "bme280: device not found\n";
+        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
         return 0;
     }
 
@@ -110,7 +107,8 @@ int program(struct sonde_context *ctx)
     __u8 raw[BME280_RAW_DATA_LEN];
     rc = bme280_trigger_and_read(raw);
     if (rc < 0) {
-        bpf_trace_printk(err_read_fail, (__u32)(sizeof(err_read_fail) - 1));
+        char err[] = "bme280: measurement failed\n";
+        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
         return 0;
     }
 

--- a/test-programs/send.c
+++ b/test-programs/send.c
@@ -10,13 +10,12 @@
 
 #include "include/sonde_helpers.h"
 
-/** Fixed payload — deterministic so tests can match on content. */
-static const __u8 SEND_BLOB[] = { 0xAA, 0xBB };
-
+/** Fixed payload — on stack to avoid .rodata global map (prevail-rust#1). */
 SEC("sonde")
 int program(struct sonde_context *ctx)
 {
     (void)ctx;
-    send(SEND_BLOB, sizeof(SEND_BLOB));
+    __u8 blob[] = { 0xAA, 0xBB };
+    send(blob, sizeof(blob));
     return 0;
 }

--- a/test-programs/sht40_sensor.c
+++ b/test-programs/sht40_sensor.c
@@ -60,11 +60,6 @@ crc8_sensirion_2bytes(const __u8 *data)
     return crc;
 }
 
-static const char err_write[] = "sht40: write failed\n";
-static const char err_delay[] = "sht40: delay failed\n";
-static const char err_read[]  = "sht40: read failed\n";
-static const char err_crc[]   = "sht40: crc mismatch\n";
-
 SEC("sonde")
 int program(struct sonde_context *ctx)
 {
@@ -74,14 +69,16 @@ int program(struct sonde_context *ctx)
     __u8 cmd = SHT4X_CMD_MEASURE_HIGH;
     int rc = i2c_write(SHT40_HANDLE, &cmd, 1);
     if (rc < 0) {
-        bpf_trace_printk(err_write, (__u32)(sizeof(err_write) - 1));
+        char err[] = "sht40: write failed\n";
+        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
         return 0;
     }
 
     /* 2) Wait for conversion */
     rc = delay_us(SHT4X_DELAY_HIGH_US);
     if (rc < 0) {
-        bpf_trace_printk(err_delay, (__u32)(sizeof(err_delay) - 1));
+        char err[] = "sht40: delay failed\n";
+        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
         return 0;
     }
 
@@ -89,7 +86,8 @@ int program(struct sonde_context *ctx)
     __u8 buf[6];
     rc = i2c_read(SHT40_HANDLE, buf, sizeof(buf));
     if (rc < 0) {
-        bpf_trace_printk(err_read, (__u32)(sizeof(err_read) - 1));
+        char err[] = "sht40: read failed\n";
+        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
         return 0;
     }
 
@@ -97,7 +95,8 @@ int program(struct sonde_context *ctx)
     __u8 t_crc  = crc8_sensirion_2bytes(&buf[0]);
     __u8 rh_crc = crc8_sensirion_2bytes(&buf[3]);
     if (t_crc != buf[2] || rh_crc != buf[5]) {
-        bpf_trace_printk(err_crc, (__u32)(sizeof(err_crc) - 1));
+        char err[] = "sht40: crc mismatch\n";
+        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
         return 0;
     }
 

--- a/test-programs/tmp102_sensor.c
+++ b/test-programs/tmp102_sensor.c
@@ -35,8 +35,7 @@
  *   temp_mC = raw_12bit * 625 / 10
  * This gives integer millidegrees Celsius (e.g., 25125 = 25.125 °C). */
 
-/* Error messages for trace output. */
-static const char err_read[] = "tmp102: read failed\n";
+/* Error messages — on stack to avoid .rodata global map (prevail-rust#1). */
 
 SEC("sonde")
 int program(struct sonde_context *ctx)
@@ -48,7 +47,8 @@ int program(struct sonde_context *ctx)
     __u8 raw[2];
     int rc = i2c_write_read(TMP102_HANDLE, &reg, 1, raw, 2);
     if (rc < 0) {
-        bpf_trace_printk(err_read, (__u32)(sizeof(err_read) - 1));
+        char err[] = "tmp102: read failed\n";
+        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
         return 0;
     }
 


### PR DESCRIPTION
Prevail Rust bindings don't type map_val from .rodata correctly. Move static const arrays to stack locals so programs pass verification.