### PR TITLE
docs: update spec timeout values to match implementation (50ms/100ms)

### DIFF
--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -627,12 +627,12 @@ The firmware MUST support configurable I2C bus GPIO pin assignments so that a si
 **Source:** protocol.md §9.1
 
 **Description:**  
-If the node sends `WAKE` and receives no `COMMAND` response within the transport timeout, the node MUST retry up to 3 times with 400 ms delay between attempts. After max retries, the node MUST sleep until the next scheduled wake interval.
+If the node sends `WAKE` and receives no `COMMAND` response within the transport timeout, the node MUST retry up to 3 times with 100 ms delay between attempts. After max retries, the node MUST sleep until the next scheduled wake interval.
 
 **Acceptance criteria:**
 
 1. The node retries up to 3 times.
-2. The delay between retries is 400 ms.
+2. The delay between retries is 100 ms.
 3. After 3 failures, the node sleeps without executing BPF.
 
 ---
@@ -643,7 +643,7 @@ If the node sends `WAKE` and receives no `COMMAND` response within the transport
 **Source:** protocol.md §9.2
 
 **Description:**  
-If the node sends `GET_CHUNK` and receives no `CHUNK` response, the node MUST retry up to 3 times per chunk with 400 ms delay. After max retries, the node MUST abort the transfer and sleep. On the next wake, the transfer restarts from chunk 0.
+If the node sends `GET_CHUNK` and receives no `CHUNK` response, the node MUST retry up to 3 times per chunk with 100 ms delay. After max retries, the node MUST abort the transfer and sleep. On the next wake, the transfer restarts from chunk 0.
 
 **Acceptance criteria:**
 
@@ -659,12 +659,12 @@ If the node sends `GET_CHUNK` and receives no `CHUNK` response, the node MUST re
 **Source:** protocol.md §9.3
 
 **Description:**  
-The node MUST wait for a response for the transport-appropriate timeout before retrying or moving on. On ESP-NOW with a USB-CDC modem bridge, the response timeout is 200 ms to account for the serial round-trip latency (node → ESP-NOW → modem → USB-CDC → gateway → USB-CDC → modem → ESP-NOW → node). The retry delay between attempts is 400 ms.
+The node MUST wait for a response for the transport-appropriate timeout before retrying or moving on. On ESP-NOW with a USB-CDC modem bridge, the response timeout is 50 ms to account for the serial round-trip latency (node → ESP-NOW → modem → USB-CDC → gateway → USB-CDC → modem → ESP-NOW → node). The retry delay between attempts is 100 ms.
 
 **Acceptance criteria:**
 
-1. On ESP-NOW with a USB-CDC modem bridge, the node uses a response timeout of 200 ms, measured from completion of frame transmission to the point where the node treats the response as lost.
-2. The retry delay between attempts is 400 ms.
+1. On ESP-NOW with a USB-CDC modem bridge, the node uses a response timeout of 50 ms, measured from completion of frame transmission to the point where the node treats the response as lost.
+2. The retry delay between attempts is 100 ms.
 3. The node waits the full configured timeout interval before treating a response as lost or initiating a retry.
 4. For transports other than ESP-NOW, the transport definition MUST specify a numeric response timeout in milliseconds.
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -143,7 +143,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 **Procedure:**
 1. Boot node. Mock gateway does not respond.
-2. Assert: node sends WAKE, retries up to 3 times (400 ms apart).
+2. Assert: node sends WAKE, retries up to 3 times (100 ms apart).
 3. Assert: after 3 failures, node sleeps without executing BPF.
 
 ---
@@ -750,7 +750,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Procedure:**
 1. Mock gateway does not respond.
 2. Assert: node sends exactly 4 WAKE frames (1 initial + 3 retries).
-3. Assert: ~400 ms between each attempt.
+3. Assert: ~100 ms between each attempt.
 4. Assert: node sleeps after final retry.
 
 ---
@@ -772,8 +772,8 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Validates:** ND-0702
 
 **Procedure:**
-1. Mock gateway delays response by 300 ms (>200 ms timeout).
-2. Assert: node treats it as timeout and retries after 400 ms delay.
+1. Mock gateway delays response by 80 ms (>50 ms timeout).
+2. Assert: node treats it as timeout and retries after 100 ms delay.
 
 ---
 
@@ -1476,7 +1476,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
-### T-N936  Chunked transfer inter-retry delay ≈ 400 ms
+### T-N936  Chunked transfer inter-retry delay ≈ 100 ms
 
 **Validates:** ND-0701
 
@@ -1484,19 +1484,19 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 1. Begin a chunked transfer.
 2. Simulate a missing-chunk scenario that triggers retries.
 3. Measure the delay between consecutive retry transmissions.
-4. Assert: the inter-retry delay is approximately 400 ms (±20 ms).
+4. Assert: the inter-retry delay is approximately 100 ms (±20 ms).
 
 ---
 
-### T-N937  Response timeout boundary at 200 ms
+### T-N937  Response timeout boundary at 50 ms
 
 **Validates:** ND-0702
 
 **Procedure:**
 1. Node sends a request.
-2. Mock gateway responds at 150 ms after the request.
-3. Assert: node accepts the response (under 200 ms timeout).
-4. Repeat: node sends a request; mock gateway responds at 250 ms.
+2. Mock gateway responds at 30 ms after the request.
+3. Assert: node accepts the response (under 50 ms timeout).
+4. Repeat: node sends a request; mock gateway responds at 80 ms.
 5. Assert: node treats the late response as a timeout.
 
 ---
@@ -1783,5 +1783,5 @@ Test functions in `crates/sonde-node/src/` are unit tests; those in `crates/sond
 > **Note:** Spec cases marked *(hardware — validated on target)* require the
 > NimBLE BLE stack or physical peripherals and cannot run in the host-based
 > test suite. T-N702 (response timeout — mock gateway delays
-> \> 200 ms) is host-testable but not yet implemented.
+> \> 50 ms) is host-testable but not yet implemented.
 > T-N919–T-N926, T-N928, T-N930–T-N939: spec procedures added — implementation pending.


### PR DESCRIPTION
## Summary

Aligns the requirements and validation specs with the implemented timeout values.

### Changes

**
ode-requirements.md** — ND-0700, ND-0701, ND-0702:
- \RESPONSE_TIMEOUT_MS\: 200 ms → **50 ms**
- \RETRY_DELAY_MS\: 400 ms → **100 ms**

**\
ode-validation.md\** — T-N201, T-N700, T-N702, T-N936, T-N937, and the notes section:
- Updated all delay/timeout values and mock-gateway timings to match the new constants.

### Context

The node design doc and implementation already use 50 ms / 100 ms (\RESPONSE_TIMEOUT_MS\ / \RETRY_DELAY_MS\). The requirements and validation docs still referenced the original 200 ms / 400 ms values. This is a spec-follows-code correction — no code changes.

Closes #523