### PR TITLE
node: update timeout constants to match spec (50ms/100ms)

### DIFF
--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -24,10 +24,10 @@ use crate::sleep::{SleepManager, WakeReason};
 use crate::traits::{Clock, PlatformStorage, Rng, Transport};
 use crate::FIRMWARE_ABI_VERSION;
 
-/// Retry and timing constants (protocol.md §9).
+/// Retry and timing constants (protocol.md §9, node-requirements.md ND-0700/ND-0702).
 const WAKE_MAX_RETRIES: u32 = 3;
-const RETRY_DELAY_MS: u32 = 400;
-const RESPONSE_TIMEOUT_MS: u32 = 200;
+const RETRY_DELAY_MS: u32 = 100;
+const RESPONSE_TIMEOUT_MS: u32 = 50;
 
 /// Default instruction budget for BPF execution.
 const DEFAULT_INSTRUCTION_BUDGET: u64 = 100_000;
@@ -3707,12 +3707,12 @@ mod tests {
     }
 
     // ===================================================================
-    // Gap 1 (ND-0701): Chunk retry delay timing — 400 ms between retries
+    // Gap 1 (ND-0701): Chunk retry delay timing — 100 ms between retries
     // ===================================================================
 
     #[test]
     fn test_chunk_retry_delay_timing() {
-        // T-N701 gap: Verify 400 ms delay between chunk retries.
+        // T-N701 gap: Verify 100 ms delay between chunk retries.
         // Existing T-N701 checks retry count but never asserts the delay.
         let psk = [0x71; 32];
         let key_hint = 1u16;
@@ -3760,8 +3760,8 @@ mod tests {
 
         assert_eq!(outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
-        // Chunk retries should have 400 ms delay between each attempt.
-        // The first attempt has no delay; retries 2, 3, 4 each delay 400 ms.
+        // Chunk retries should have 100 ms delay between each attempt.
+        // The first attempt has no delay; retries 2, 3, 4 each delay 100 ms.
         let delays = clock.recorded_delays();
         let retry_delays: Vec<_> = delays
             .iter()
@@ -3790,15 +3790,15 @@ mod tests {
 
     #[test]
     fn test_response_accepted_under_timeout() {
-        // T-N702 gap: A valid response arriving within the 200 ms timeout
-        // must be accepted. Existing test only proves >200 ms triggers timeout.
+        // T-N702 gap: A valid response arriving within the 50 ms timeout
+        // must be accepted. Existing test only proves >50 ms triggers timeout.
         // Uses RecordingTransport to verify the production code passes the
         // correct RESPONSE_TIMEOUT_MS to recv().
         let psk = [0x72; 32];
         let key_hint = 1u16;
         let mut transport = RecordingTransport::new();
 
-        // Queue a valid COMMAND response (arrives immediately = ~0 ms < 200 ms)
+        // Queue a valid COMMAND response (arrives immediately = ~0 ms < 50 ms)
         let command_frame =
             build_command_response(&psk, key_hint, 1, 1000, 1710000000000, CommandPayload::Nop);
         transport.queue_response(Some(command_frame));
@@ -3832,7 +3832,7 @@ mod tests {
 
         // Verify the production code used the correct timeout constant.
         // The first recv() call (WAKE/COMMAND exchange) must use
-        // RESPONSE_TIMEOUT_MS (200 ms).
+        // RESPONSE_TIMEOUT_MS (50 ms).
         assert!(!transport.recv_timeouts.is_empty());
         assert_eq!(
             transport.recv_timeouts[0], RESPONSE_TIMEOUT_MS,
@@ -5174,7 +5174,7 @@ mod tests {
         assert_eq!(seq, 43, "seq must still advance after send");
     }
 
-    // --- Gap 6: ND-0702 — Response timeout (200 ms) ---
+    // --- Gap 6: ND-0702 — Response timeout (50 ms) ---
 
     /// Clock whose elapsed_ms advances by a fixed step each call.
     struct AdvancingClock {
@@ -5201,15 +5201,15 @@ mod tests {
     }
 
     #[test]
-    fn test_response_timeout_constant_is_200ms() {
+    fn test_response_timeout_constant_is_50ms() {
         // ND-0702: On ESP-NOW with USB-CDC modem bridge, the response timeout
-        // MUST be 200 ms to account for serial round-trip latency.
-        assert_eq!(RESPONSE_TIMEOUT_MS, 200);
+        // MUST be 50 ms to account for serial round-trip latency.
+        assert_eq!(RESPONSE_TIMEOUT_MS, 50);
     }
 
     #[test]
     fn test_response_timeout_send_recv_deadline() {
-        // ND-0702 / T-N702: send_recv uses the 200 ms timeout as a
+        // ND-0702 / T-N702: send_recv uses the 50 ms timeout as a
         // deadline. With a clock that advances, once the deadline
         // expires the node returns Timeout even if recv would produce
         // a frame later.
@@ -5224,13 +5224,13 @@ mod tests {
 
         let identity = NodeIdentity { key_hint, psk };
         let mut seq = 42u64;
-        // Clock starts at 0, advances 30ms per call.
-        // Call 1 (deadline calc): elapsed=0, deadline=200
-        // Call 2 (loop check): elapsed=30, 30<200 → recv
+        // Clock starts at 0, advances 10ms per call.
+        // Call 1 (deadline calc): elapsed=0, deadline=50
+        // Call 2 (loop check): elapsed=10, 10<50 → recv
         // recv returns wrong-nonce frame → continue
-        // Call 3 (loop check): elapsed=60, ...
-        // Eventually elapsed >= 200 → Timeout
-        let clock = AdvancingClock::new(0, 30);
+        // Call 3 (loop check): elapsed=20, ...
+        // Eventually elapsed >= 50 → Timeout
+        let clock = AdvancingClock::new(0, 10);
 
         let result = send_recv_app_data(
             &mut transport,
@@ -5244,13 +5244,13 @@ mod tests {
 
         assert!(
             matches!(result, Err(NodeError::Timeout)),
-            "must timeout when clock exceeds 200 ms deadline"
+            "must timeout when clock exceeds 50 ms deadline"
         );
     }
 
     #[test]
     fn test_wake_command_timeout_retries() {
-        // ND-0702 / T-N702: WAKE/COMMAND exchange uses 200 ms timeout.
+        // ND-0702 / T-N702: WAKE/COMMAND exchange uses 50 ms timeout.
         // First response times out (None), second succeeds.
         let psk = [0xC9; 32];
         let key_hint = 1u16;

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -627,12 +627,12 @@ The firmware MUST support configurable I2C bus GPIO pin assignments so that a si
 **Source:** protocol.md §9.1
 
 **Description:**  
-If the node sends `WAKE` and receives no `COMMAND` response within the transport timeout, the node MUST retry up to 3 times with 400 ms delay between attempts. After max retries, the node MUST sleep until the next scheduled wake interval.
+If the node sends `WAKE` and receives no `COMMAND` response within the transport timeout, the node MUST retry up to 3 times with 100 ms delay between attempts. After max retries, the node MUST sleep until the next scheduled wake interval.
 
 **Acceptance criteria:**
 
 1. The node retries up to 3 times.
-2. The delay between retries is 400 ms.
+2. The delay between retries is 100 ms.
 3. After 3 failures, the node sleeps without executing BPF.
 
 ---
@@ -643,7 +643,7 @@ If the node sends `WAKE` and receives no `COMMAND` response within the transport
 **Source:** protocol.md §9.2
 
 **Description:**  
-If the node sends `GET_CHUNK` and receives no `CHUNK` response, the node MUST retry up to 3 times per chunk with 400 ms delay. After max retries, the node MUST abort the transfer and sleep. On the next wake, the transfer restarts from chunk 0.
+If the node sends `GET_CHUNK` and receives no `CHUNK` response, the node MUST retry up to 3 times per chunk with 100 ms delay. After max retries, the node MUST abort the transfer and sleep. On the next wake, the transfer restarts from chunk 0.
 
 **Acceptance criteria:**
 
@@ -659,12 +659,12 @@ If the node sends `GET_CHUNK` and receives no `CHUNK` response, the node MUST re
 **Source:** protocol.md §9.3
 
 **Description:**  
-The node MUST wait for a response for the transport-appropriate timeout before retrying or moving on. On ESP-NOW with a USB-CDC modem bridge, the response timeout is 200 ms to account for the serial round-trip latency (node → ESP-NOW → modem → USB-CDC → gateway → USB-CDC → modem → ESP-NOW → node). The retry delay between attempts is 400 ms.
+The node MUST wait for a response for the transport-appropriate timeout before retrying or moving on. On ESP-NOW with a USB-CDC modem bridge, the response timeout is 50 ms to account for the serial round-trip latency (node → ESP-NOW → modem → USB-CDC → gateway → USB-CDC → modem → ESP-NOW → node). The retry delay between attempts is 100 ms.
 
 **Acceptance criteria:**
 
-1. On ESP-NOW with a USB-CDC modem bridge, the node uses a response timeout of 200 ms, measured from completion of frame transmission to the point where the node treats the response as lost.
-2. The retry delay between attempts is 400 ms.
+1. On ESP-NOW with a USB-CDC modem bridge, the node uses a response timeout of 50 ms, measured from completion of frame transmission to the point where the node treats the response as lost.
+2. The retry delay between attempts is 100 ms.
 3. The node waits the full configured timeout interval before treating a response as lost or initiating a retry.
 4. For transports other than ESP-NOW, the transport definition MUST specify a numeric response timeout in milliseconds.
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -143,7 +143,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 **Procedure:**
 1. Boot node. Mock gateway does not respond.
-2. Assert: node sends WAKE, retries up to 3 times (400 ms apart).
+2. Assert: node sends WAKE, retries up to 3 times (100 ms apart).
 3. Assert: after 3 failures, node sleeps without executing BPF.
 
 ---
@@ -750,7 +750,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Procedure:**
 1. Mock gateway does not respond.
 2. Assert: node sends exactly 4 WAKE frames (1 initial + 3 retries).
-3. Assert: ~400 ms between each attempt.
+3. Assert: ~100 ms between each attempt.
 4. Assert: node sleeps after final retry.
 
 ---
@@ -772,8 +772,8 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Validates:** ND-0702
 
 **Procedure:**
-1. Mock gateway delays response by 300 ms (>200 ms timeout).
-2. Assert: node treats it as timeout and retries after 400 ms delay.
+1. Mock gateway delays response by 80 ms (>50 ms timeout).
+2. Assert: node treats it as timeout and retries after 100 ms delay.
 
 ---
 
@@ -1476,7 +1476,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
-### T-N936  Chunked transfer inter-retry delay ≈ 400 ms
+### T-N936  Chunked transfer inter-retry delay ≈ 100 ms
 
 **Validates:** ND-0701
 
@@ -1484,19 +1484,19 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 1. Begin a chunked transfer.
 2. Simulate a missing-chunk scenario that triggers retries.
 3. Measure the delay between consecutive retry transmissions.
-4. Assert: the inter-retry delay is approximately 400 ms (±20 ms).
+4. Assert: the inter-retry delay is approximately 100 ms (±20 ms).
 
 ---
 
-### T-N937  Response timeout boundary at 200 ms
+### T-N937  Response timeout boundary at 50 ms
 
 **Validates:** ND-0702
 
 **Procedure:**
 1. Node sends a request.
-2. Mock gateway responds at 150 ms after the request.
-3. Assert: node accepts the response (under 200 ms timeout).
-4. Repeat: node sends a request; mock gateway responds at 250 ms.
+2. Mock gateway responds at 30 ms after the request.
+3. Assert: node accepts the response (under 50 ms timeout).
+4. Repeat: node sends a request; mock gateway responds at 80 ms.
 5. Assert: node treats the late response as a timeout.
 
 ---
@@ -1783,5 +1783,5 @@ Test functions in `crates/sonde-node/src/` are unit tests; those in `crates/sond
 > **Note:** Spec cases marked *(hardware — validated on target)* require the
 > NimBLE BLE stack or physical peripherals and cannot run in the host-based
 > test suite. T-N702 (response timeout — mock gateway delays
-> \> 200 ms) is host-testable but not yet implemented.
+> \> 50 ms) is host-testable but not yet implemented.
 > T-N919–T-N926, T-N928, T-N930–T-N939: spec procedures added — implementation pending.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -547,7 +547,7 @@ If the node sends `WAKE` and receives no `COMMAND` response:
 | Parameter | Value |
 |---|---|
 | Retry count | 3 |
-| Retry delay | Fixed, 400 ms between attempts |
+| Retry delay | Fixed, 100 ms between attempts |
 | After max retries | Sleep until next scheduled wake interval. |
 
 Exponential backoff is unnecessary — if the gateway isn't responding after 3 attempts, it's likely unavailable. Sleeping preserves battery.
@@ -559,7 +559,7 @@ If the node sends `GET_CHUNK` and receives no `CHUNK` response:
 | Parameter | Value |
 |---|---|
 | Retry count | 3 per chunk |
-| Retry delay | Fixed, 400 ms between attempts |
+| Retry delay | Fixed, 100 ms between attempts |
 | Sequence numbers | Each `GET_CHUNK` retry MUST use the next sequence number (not reuse the original). This maintains strict session sequencing and lets the gateway reject duplicates when the original request was received but the response was lost; it also provides replay protection as a secondary benefit. |
 | After max retries | Abort transfer, sleep. Retry from chunk 0 on next wake. |
 
@@ -569,7 +569,7 @@ The node waits for a response before considering it lost and retrying (or sleepi
 
 | Transport | Timeout |
 |---|---|
-| ESP-NOW (with USB-CDC modem bridge) | 200 ms |
+| ESP-NOW (with USB-CDC modem bridge) | 50 ms |
 
 The timeout must comfortably exceed the round-trip time for the full transport path (node → ESP-NOW → modem → USB-CDC → gateway → USB-CDC → modem → ESP-NOW → node) plus gateway processing. Implementations may make this configurable.
 


### PR DESCRIPTION
## Summary

Updates \RESPONSE_TIMEOUT_MS\ from 200 → **50** and \RETRY_DELAY_MS\ from 400 → **100** to match ND-0700 and ND-0702.

### Changes

**\crates/sonde-node/src/wake_cycle.rs\**
- \RETRY_DELAY_MS\: 400 → 100
- \RESPONSE_TIMEOUT_MS\: 200 → 50
- Updated assertion (\	est_response_timeout_constant_is_50ms\)
- Updated test comments and \AdvancingClock\ step from 30ms to 10ms to stay under the new 50ms deadline
- All test comment references updated (200 ms → 50 ms, 400 ms → 100 ms)

**\docs/node-requirements.md\** — ND-0700, ND-0701, ND-0702 updated to 100ms/50ms (subsumes PR #549)

**\docs/node-validation.md\** — T-N201, T-N700, T-N702, T-N936, T-N937 and notes section updated (subsumes PR #549)

Closes #552