### PR TITLE
Gateway: persist ESP-NOW channel in database (GW-0808)

### DIFF
--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -670,6 +670,11 @@ impl GatewayAdmin for AdminService {
     }
 
     /// Set the modem's ESP-NOW radio channel.
+    ///
+    /// Persists the new channel in the database (GW-0808) after a successful
+    /// modem channel change so that reconnects and BLE pairing use the
+    /// updated value. If persistence fails, the modem is rolled back to the
+    /// previous channel to avoid inconsistency.
     async fn set_modem_channel(
         &self,
         request: Request<SetModemChannelRequest>,
@@ -684,10 +689,35 @@ impl GatewayAdmin for AdminService {
             return Err(Status::invalid_argument("channel must be between 1 and 14"));
         }
 
+        // Read the current persisted channel before changing the modem so we
+        // can roll back if the DB write fails.
+        let previous_channel = self
+            .storage
+            .get_config("espnow_channel")
+            .await
+            .ok()
+            .flatten();
+
         transport
             .change_channel(channel as u8)
             .await
             .map_err(|e| Status::internal(format!("set modem channel failed: {e}")))?;
+
+        // GW-0808: persist the new channel so reconnects and BLE pairing use it.
+        if let Err(e) = self
+            .storage
+            .set_config("espnow_channel", &channel.to_string())
+            .await
+        {
+            // Roll back the modem to the previous channel to avoid
+            // inconsistency between modem and database.
+            if let Some(prev) = &previous_channel {
+                if let Ok(prev_ch) = prev.parse::<u8>() {
+                    let _ = transport.change_channel(prev_ch).await;
+                }
+            }
+            return Err(Status::internal(format!("persist channel failed: {e}")));
+        }
 
         Ok(Response::new(Empty {}))
     }

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -258,8 +258,28 @@ async fn run_gateway(
     info!(provider = ?cli.key_provider, "master key loaded");
 
     // 2. Open persistent storage
-    let storage = Arc::new(SqliteStorage::open(&cli.db, master_key)?);
+    let storage: Arc<SqliteStorage> = Arc::new(SqliteStorage::open(&cli.db, master_key)?);
     info!("storage opened: {}", cli.db);
+
+    // 2b. Seed or load persisted ESP-NOW channel (GW-0808).
+    //     If the database already has a channel, use it (ignoring --channel).
+    //     Otherwise, seed the database with the CLI --channel value.
+    let persisted_channel: u8 = match storage.get_config("espnow_channel").await? {
+        Some(v) => v
+            .parse::<u8>()
+            .map_err(|e| format!("invalid persisted espnow_channel `{v}`: {e}"))?,
+        None => {
+            storage
+                .set_config("espnow_channel", &cli.channel.to_string())
+                .await?;
+            cli.channel
+        }
+    };
+    info!(
+        persisted_channel,
+        cli_channel = cli.channel,
+        "ESP-NOW channel resolved (GW-0808)"
+    );
 
     // 2a. Load or generate gateway identity (GW-1200, GW-1201)
     {
@@ -375,7 +395,15 @@ async fn run_gateway(
         // GW-1301: log serial connection.
         info!("modem serial connected");
 
-        let transport = match UsbEspNowTransport::new(serial_port, cli.channel).await {
+        // GW-0808: read the current channel from the database on each
+        // reconnect iteration so that `SetModemChannel` changes survive
+        // modem restarts.
+        let channel_for_transport = match storage.get_config("espnow_channel").await {
+            Ok(Some(v)) => v.parse::<u8>().unwrap_or(persisted_channel),
+            _ => persisted_channel,
+        };
+
+        let transport = match UsbEspNowTransport::new(serial_port, channel_for_transport).await {
             Ok(t) => Arc::new(t),
             Err(e) => {
                 error!("modem startup failed: {e}");
@@ -385,7 +413,7 @@ async fn run_gateway(
                 continue;
             }
         };
-        info!(channel = cli.channel, "modem transport ready");
+        info!(channel = channel_for_transport, "modem transport ready");
         backoff = Duration::from_secs(1); // reset on success
 
         // 7. Start gRPC admin server (only on first iteration)
@@ -435,7 +463,9 @@ async fn run_gateway(
         // 8a. BLE event processing loop (Phase 1 phone pairing via modem relay).
         let ble_transport = transport.clone();
         let ble_storage: Arc<dyn Storage> = storage.clone();
-        let ble_channel = cli.channel;
+        // GW-0808: read channel from the database for each BLE pairing request
+        // rather than capturing the CLI startup value.
+        let ble_channel = channel_for_transport;
         let ble_ctrl = Arc::clone(&ble_controller);
         let ble_loop = tokio::spawn(async move {
             use sonde_gateway::ble_pairing::handle_ble_recv;
@@ -469,12 +499,20 @@ async fn run_gateway(
 
                 match ble_transport.recv_ble_event().await {
                     Some(BleEvent::Recv(br)) => {
+                        // GW-0808: read the current channel from the database
+                        // so BLE pairing always returns the latest persisted
+                        // channel, even if SetModemChannel was called after
+                        // the BLE loop started.
+                        let current_channel = match ble_storage.get_config("espnow_channel").await {
+                            Ok(Some(v)) => v.parse::<u8>().unwrap_or(ble_channel),
+                            _ => ble_channel,
+                        };
                         if let Some(response) = handle_ble_recv(
                             &br.ble_data,
                             &identity,
                             &ble_storage,
                             &mut window,
-                            ble_channel,
+                            current_channel,
                             Some(&ble_ctrl),
                         )
                         .await

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -414,6 +414,11 @@ CREATE TABLE IF NOT EXISTS battery_readings (
     battery_mv INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_battery_readings_node ON battery_readings(node_id, timestamp_epoch_s);
+
+CREATE TABLE IF NOT EXISTS gateway_config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
 ";
 
 /// SQLite-backed persistent storage for the gateway.
@@ -1441,6 +1446,37 @@ impl Storage for SqliteStorage {
         })
         .await
     }
+
+    // ── Gateway config (GW-0808) ───────────────────────────────
+
+    async fn get_config(&self, key: &str) -> Result<Option<String>, StorageError> {
+        let key = key.to_owned();
+        self.with_conn(move |conn| {
+            conn.query_row(
+                "SELECT value FROM gateway_config WHERE key = ?1",
+                params![key],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_err)
+        })
+        .await
+    }
+
+    async fn set_config(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        let key = key.to_owned();
+        let value = value.to_owned();
+        self.with_conn(move |conn| {
+            conn.execute(
+                "INSERT INTO gateway_config (key, value) VALUES (?1, ?2) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![key, value],
+            )
+            .map_err(map_err)?;
+            Ok(())
+        })
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -2063,5 +2099,35 @@ mod tests {
         // (the oldest 5 were pruned).
         assert_eq!(loaded.battery_history[0].battery_mv, 3005);
         assert_eq!(loaded.battery_history[99].battery_mv, 3104);
+    }
+
+    // ── Gateway config (GW-0808) ───────────────────────────────
+
+    #[tokio::test]
+    async fn test_config_set_and_get() {
+        let store = SqliteStorage::in_memory(test_key()).unwrap();
+
+        // Initially empty.
+        assert_eq!(store.get_config("espnow_channel").await.unwrap(), None);
+
+        // Set a value.
+        store.set_config("espnow_channel", "7").await.unwrap();
+        assert_eq!(
+            store.get_config("espnow_channel").await.unwrap(),
+            Some("7".to_string())
+        );
+
+        // Overwrite the value (upsert).
+        store.set_config("espnow_channel", "11").await.unwrap();
+        assert_eq!(
+            store.get_config("espnow_channel").await.unwrap(),
+            Some("11".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_config_unknown_key_returns_none() {
+        let store = SqliteStorage::in_memory(test_key()).unwrap();
+        assert_eq!(store.get_config("nonexistent").await.unwrap(), None);
     }
 }

--- a/crates/sonde-gateway/src/storage.rs
+++ b/crates/sonde-gateway/src/storage.rs
@@ -93,6 +93,12 @@ pub trait Storage: Send + Sync {
     async fn revoke_phone_psk(&self, phone_id: u32) -> Result<(), StorageError>;
     async fn delete_phone_psk(&self, phone_id: u32) -> Result<(), StorageError>;
 
+    // ── Gateway config (GW-0808) ───────────────────────────────
+    /// Retrieve a gateway configuration value by key.
+    async fn get_config(&self, key: &str) -> Result<Option<String>, StorageError>;
+    /// Set a gateway configuration value (insert or update).
+    async fn set_config(&self, key: &str, value: &str) -> Result<(), StorageError>;
+
     /// Atomically replace all phone PSK registrations with the given set.
     ///
     /// `phone_id` values on the incoming records are ignored — each
@@ -121,6 +127,7 @@ pub struct InMemoryStorage {
     identity: RwLock<Option<GatewayIdentity>>,
     phone_psks: RwLock<Vec<PhonePskRecord>>,
     next_phone_id: RwLock<u32>,
+    config: RwLock<HashMap<String, String>>,
 }
 
 impl InMemoryStorage {
@@ -131,6 +138,7 @@ impl InMemoryStorage {
             identity: RwLock::new(None),
             phone_psks: RwLock::new(Vec::new()),
             next_phone_id: RwLock::new(1),
+            config: RwLock::new(HashMap::new()),
         }
     }
 }
@@ -306,6 +314,19 @@ impl Storage for InMemoryStorage {
                 .ok_or_else(|| StorageError::Internal("phone_id overflow".into()))?;
             psks.push(stored);
         }
+        Ok(())
+    }
+
+    // ── Gateway config ─────────────────────────────────────────
+
+    async fn get_config(&self, key: &str) -> Result<Option<String>, StorageError> {
+        let config = self.config.read().await;
+        Ok(config.get(key).cloned())
+    }
+
+    async fn set_config(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        let mut config = self.config.write().await;
+        config.insert(key.to_owned(), value.to_owned());
         Ok(())
     }
 }

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -143,7 +143,7 @@ pub struct UsbEspNowTransport {
 3. Send `RESET`.
 4. Wait for `MODEM_READY` (timeout: 5 seconds, up to 3 retries).
 5. Extract `firmware_version` and `mac_address` from `MODEM_READY`; log both.
-6. Send `SET_CHANNEL` with the configured channel.
+6. Send `SET_CHANNEL` with the persisted channel from the database (GW-0808). If no channel is persisted yet, seed the database with the CLI `--channel` value and use that.
 7. Wait for `SET_CHANNEL_ACK` (timeout: 2 seconds).
 8. Start the health monitor task.
 
@@ -163,7 +163,7 @@ When the serial reader task encounters an OS I/O error (e.g. USB-CDC disconnect,
 
 1. The reader task logs a warning and enters a reconnection loop.
 2. The loop attempts to reopen the serial port with exponential backoff (1 s → 2 s → 4 s → … → 30 s cap).
-3. Once the port reopens, the adapter re-executes the startup sequence (`RESET` → `MODEM_READY` → `SET_CHANNEL`).
+3. Once the port reopens, the adapter re-executes the startup sequence (`RESET` → `MODEM_READY` → `SET_CHANNEL`), reading the channel from the database (GW-0808) rather than the CLI startup value.
 4. The `recv()` and BLE event channels remain open during reconnection — callers block until the transport recovers.
 5. If the port cannot be reopened (e.g. device permanently removed), the backoff loop continues indefinitely; the operator can shut down the gateway via Ctrl-C or service stop.
 
@@ -573,6 +573,27 @@ The storage trait is async to support different backends (file, SQLite, network)
 
 Storage implementations SHOULD encrypt PSK material at rest (GW-0601a). The `NodeRecord.psk` field contains the raw 256-bit key — implementations are responsible for encrypting it before persisting and decrypting on read. The storage trait itself is agnostic to the encryption mechanism.
 
+### 10.1  Gateway configuration storage (GW-0808)
+
+The storage trait includes methods for persisting gateway-level configuration values such as the ESP-NOW radio channel:
+
+```rust
+// Gateway config (GW-0808)
+async fn get_config(&self, key: &str) -> Result<Option<String>, StorageError>;
+async fn set_config(&self, key: &str, value: &str) -> Result<(), StorageError>;
+```
+
+The `SqliteStorage` backend stores these in a `gateway_config` table:
+
+```sql
+CREATE TABLE IF NOT EXISTS gateway_config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+```
+
+The `espnow_channel` key stores the current radio channel. The `--channel` CLI flag seeds this value on first startup only; subsequent changes via `SetModemChannel` update the database entry. On modem reconnect and BLE pairing, the persisted value is read from the database.
+
 ---
 
 ## 10a  Master key provider
@@ -818,7 +839,7 @@ The gRPC server runs on a local socket: a **Unix domain socket** on Linux/macOS 
 | Export state | `ExportState` | Serializes gateway state (node registry, program library, and registered identity/phone PSKs, if applicable). Does not include handler routing configuration (deferred). Encrypted with AES-256-GCM using an operator-supplied passphrase. |
 | Import state | `ImportState` | Restores node registry, program library, and registered identity/phone PSKs from a previously exported, encrypted bundle. Handler routing configuration is not restored (deferred and not part of the bundle). |
 | Modem status | `GetModemStatus` | Returns modem status: radio channel, TX/RX/fail counters, uptime. |
-| Set modem channel | `SetModemChannel` | Sets the ESP-NOW radio channel (1–14). |
+| Set modem channel | `SetModemChannel` | Sets the ESP-NOW radio channel (1–14). Persists the new channel in the database (GW-0808). |
 | Scan channels | `ScanModemChannels` | Scans all WiFi channels for AP activity, returns AP counts and RSSI per channel. |
 | Open BLE pairing | `OpenBlePairing` | Opens the phone registration window and sends `BLE_ENABLE` to modem. Server-streaming RPC returning events (passkey, phone connected/disconnected/registered, window closed). |
 | Close BLE pairing | `CloseBlePairing` | Closes the registration window and sends `BLE_DISABLE` to modem. |
@@ -921,7 +942,7 @@ The gateway emits the version string in its first `info!()` log line so that ope
 1. Load configuration.
 2. Initialize storage backend.
 3. Load node registry and program library from storage.
-4. Initialize transport (e.g., open ESP-NOW interface, or for USB modem: open serial port → `RESET` → `MODEM_READY` → `SET_CHANNEL`; see §4.2).
+4. Initialize transport (e.g., open ESP-NOW interface, or for USB modem: open serial port → `RESET` → `MODEM_READY` → `SET_CHANNEL`; see §4.2). The channel is read from the database (GW-0808); if no value is persisted, the CLI `--channel` flag seeds the database.
 5. Start gRPC admin API server.
 6. Start handler processes for configured handlers.
 7. Start session reaper background task.

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -858,6 +858,29 @@ The admin API MUST support querying modem status (radio channel, TX/RX/fail coun
 
 ---
 
+### GW-0808  ESP-NOW channel persistence
+
+**Priority:** Must  
+**Source:** Issue #558, Issue #541, Issue #555
+
+**Description:**  
+The gateway MUST persist the current ESP-NOW radio channel in the database so that the value survives gateway and modem restarts.
+
+1. The `--channel` CLI flag seeds the initial channel value **only** if no channel entry exists in the database yet. If a persisted channel exists, the database value takes precedence.
+2. `SetModemChannel` (admin RPC) MUST update both the modem and the database atomically — if the modem channel change succeeds, the new channel MUST be written to the database before the RPC returns.
+3. On modem reconnect (GW-1103), the gateway MUST restore the channel from the database (not the CLI `--channel` value).
+4. BLE pairing (`REGISTER_PHONE` response) MUST include the `rf_channel` read from the database, not the CLI startup value.
+
+**Acceptance criteria:**
+
+1. After `SetModemChannel(7)`, restarting the gateway (without `--channel`) uses channel 7 from the database.
+2. After `SetModemChannel(7)`, a modem reconnect sends `SET_CHANNEL(7)` (not the CLI default).
+3. After `SetModemChannel(7)`, a BLE `REGISTER_PHONE` response contains `rf_channel = 7`.
+4. On a fresh database with `--channel 3`, the database is seeded with channel 3.
+5. On an existing database with persisted channel 7, `--channel 3` is ignored — the gateway starts on channel 7.
+
+---
+
 ## 10  Operational requirements
 
 ### GW-1000  Gateway failover / replaceability
@@ -1060,7 +1083,7 @@ The gateway and admin binaries MUST embed the git commit hash (short, 7 characte
 **Description:**
 On receiving an `ERROR` message from the modem, the gateway MUST log the error code and human-readable message. The gateway MAY attempt a `RESET` to recover.
 
-When the serial port itself becomes unavailable (e.g. USB-CDC disconnect due to modem reset, OS error 995 on Windows), the gateway MUST NOT exit. Instead, the serial reader task MUST signal the transport layer, which MUST attempt to reopen the serial port with exponential backoff (starting at 1 s, capped at 30 s). Once the port reopens, the gateway MUST re-execute the modem startup sequence (`RESET` → `MODEM_READY` → `SET_CHANNEL`). Frame processing and BLE event loops MUST block (not exit) while reconnection is in progress.
+When the serial port itself becomes unavailable (e.g. USB-CDC disconnect due to modem reset, OS error 995 on Windows), the gateway MUST NOT exit. Instead, the serial reader task MUST signal the transport layer, which MUST attempt to reopen the serial port with exponential backoff (starting at 1 s, capped at 30 s). Once the port reopens, the gateway MUST re-execute the modem startup sequence (`RESET` → `MODEM_READY` → `SET_CHANNEL`), using the persisted channel from the database (GW-0808), not the CLI `--channel` startup value. Frame processing and BLE event loops MUST block (not exit) while reconnection is in progress.
 
 **Acceptance criteria:**
 
@@ -1558,6 +1581,7 @@ When the gateway rejects a program due to Prevail verification failure, the erro
 | GW-0805 | Admin API — state export/import | Should |
 | GW-0806 | Admin CLI tool | Must |
 | GW-0807 | Admin API — modem management | Must |
+| GW-0808 | ESP-NOW channel persistence | Must |
 | GW-1000 | Gateway failover / replaceability | Must |
 | GW-1004 | Program hash consistency across failover group | Must |
 | GW-1001 | Exportable / importable state | Should |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1239,6 +1239,64 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-0815a  Channel persisted after SetModemChannel
+
+**Validates:** GW-0808
+
+**Procedure:**
+1. Open a gateway with an in-memory or temporary database; CLI `--channel 1`.
+2. Call `SetModemChannel(7)`.
+3. Read the `espnow_channel` config value from the database.
+4. Assert: the persisted value is `"7"`.
+
+---
+
+### T-0815b  Modem reconnect restores persisted channel
+
+**Validates:** GW-0808, GW-1103
+
+**Procedure:**
+1. Start gateway with `--channel 1`.
+2. Call `SetModemChannel(7)` — channel 7 is persisted.
+3. Simulate a modem disconnect and reconnect.
+4. Assert: the reconnect startup sequence sends `SET_CHANNEL(7)`, not `SET_CHANNEL(1)`.
+
+---
+
+### T-0815c  BLE pairing uses persisted channel
+
+**Validates:** GW-0808
+
+**Procedure:**
+1. Start gateway with `--channel 1`.
+2. Call `SetModemChannel(7)`.
+3. Trigger a `REGISTER_PHONE` BLE pairing flow.
+4. Assert: the encrypted response contains `rf_channel = 7`, not `1`.
+
+---
+
+### T-0815d  CLI --channel seeds database on first startup
+
+**Validates:** GW-0808
+
+**Procedure:**
+1. Start gateway with `--channel 3` and a fresh (empty) database.
+2. Assert: the database `espnow_channel` config value is `"3"`.
+3. Assert: modem startup sends `SET_CHANNEL(3)`.
+
+---
+
+### T-0815e  Persisted channel overrides CLI --channel
+
+**Validates:** GW-0808
+
+**Procedure:**
+1. Pre-populate a database with `espnow_channel = "7"`.
+2. Start gateway with `--channel 3`.
+3. Assert: modem startup sends `SET_CHANNEL(7)` (database wins).
+
+---
+
 ### T-0816  Admin CLI JSON output
 
 **Validates:** GW-0806
@@ -2065,6 +2123,7 @@ A configurable stub handler process (or in-process mock) that:
 | GW-0805 | T-0810, T-1005b |
 | GW-0806 | T-0812, T-0816, T-0817 |
 | GW-0807 | T-0813, T-0814, T-0815 |
+| GW-0808 | T-0815a, T-0815b, T-0815c, T-0815d, T-0815e |
 | GW-1000 | T-1000 |
 | GW-1001 | T-1002, T-1005, T-1005b |
 | GW-1002 | T-0609 |


### PR DESCRIPTION
## Summary

Fixes three related bugs where the ESP-NOW radio channel was ephemeral — lost on gateway restart, modem reconnect, and reported incorrectly during BLE pairing.

Closes #558 · Fixes #555 · Fixes #541

## Problem

The ESP-NOW channel existed only in the CLI \--channel\ flag (baked at startup) and the modem's RAM. This caused:
- **#558:** \sonde-admin modem set-channel 7\ was lost on any restart
- **#555:** Modem reconnect sent \SET_CHANNEL(cli.channel)\ instead of the last-set channel
- **#541:** BLE pairing told the phone \cli.channel\ instead of the modem's current channel

## Solution

### Spec changes
- **GW-0808** (new requirement): gateway MUST persist the ESP-NOW channel in the database
- Updated **GW-1103** to reference persisted channel on reconnect
- Added design docs for \gateway_config\ table and \get_config\/\set_config\ trait methods
- Added test cases **T-0815a** through **T-0815e**

### Code changes
- Added \gateway_config\ table (\key TEXT PRIMARY KEY, value TEXT NOT NULL\) with migration for existing databases
- Added \get_config\/\set_config\ to \Storage\ trait, \InMemoryStorage\, and \SqliteStorage\
- \SetModemChannel\ admin RPC now persists the channel to the database after successful modem change
- Gateway startup seeds the DB with \--channel\ only if no entry exists; otherwise the DB value wins
- Modem reconnect re-reads the channel from the database on each iteration
- BLE pairing reads the channel from the database on each \REGISTER_PHONE\ event

## Testing
- \cargo fmt --check\ ✅
- \cargo clippy --workspace -- -D warnings\ ✅
- \cargo test --workspace\ ✅ (all existing + 2 new config tests pass)
