### PR TITLE
feat(gateway): add INFO logging for APP_DATA handler pipeline (GW-1307)

### DIFF
--- a/crates/sonde-gateway/tests/logging.rs
+++ b/crates/sonde-gateway/tests/logging.rs
@@ -401,8 +401,6 @@ async fn t1303_modem_frame_debug_logging() {
     assert!(logs_contain("peer_mac=[170, 187, 204, 221, 238, 255]"));
     assert!(logs_contain("len=11"));
 }
-<<<<<<< HEAD
-=======
 
 // ── T-1308  APP_DATA handler pipeline logging ──────────────────────────
 
@@ -658,17 +656,26 @@ async fn t1308_app_data_handler_pipeline_logging() {
         .await
         .expect("expected APP_DATA_REPLY");
 
-    // Allow handler process to exit and logs to flush.
-    tokio::time::sleep(Duration::from_millis(100)).await;
-
-    // Send a second APP_DATA to trigger ensure_running() → try_wait(), which
-    // detects that the prior single-shot handler has exited and emits the
-    // "handler exited" log (GW-1308 AC5). ensure_running() may then spawn a new
-    // handler and produce a reply, but this test ignores the reply and only
-    // asserts on the emitted logs.
-    let app_frame2 = node.build_app_data(starting_seq + 1, &blob);
-    let _ = gw.process_frame(&app_frame2, node.peer_address()).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Poll for the "handler exited" log instead of fixed sleep, which is
+    // flaky on slow CI runners. Each iteration sends a second APP_DATA to
+    // trigger ensure_running() → try_wait(), which detects that the prior
+    // single-shot handler has exited and emits the "handler exited" log
+    // (GW-1308 AC5).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let app_frame2 = node.build_app_data(starting_seq + 1, &blob);
+        let _ = gw.process_frame(&app_frame2, node.peer_address()).await;
+        if logs_contain("handler exited") {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "expected 'handler exited' log within 5 seconds — \
+                 handler process may not have exited in time"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
     // GW-1308 AC1: APP_DATA received with node_id, program_hash, len.
     assert!(
@@ -745,4 +752,3 @@ fn decode_command(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
     let msg = GatewayMessage::decode(decoded.header.msg_type, &decoded.payload).unwrap();
     (decoded.header, msg)
 }
->>>>>>> a243124 (fix(test): use require_python!() macro for T-1308 test)

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -1583,6 +1583,80 @@ When the gateway encounters an error at a user-facing or operator-visible bounda
 
 ---
 
+## 13  Installer and service management
+
+### GW-1500  Installer PATH registration
+
+**Priority:** Must  
+**Source:** Issue #524
+
+**Description:**  
+The Windows MSI installer MUST add the `bin` directory (default `%ProgramFiles%\Sonde\bin`) to the system `PATH` environment variable so that `sonde-gateway` and `sonde-admin` are available from any shell without manual PATH editing.
+
+**Acceptance criteria:**
+
+1. After a fresh MSI install, opening a new Command Prompt or PowerShell window and running `sonde-gateway --version` succeeds without specifying the full path.
+2. After MSI uninstall, the PATH entry is removed.
+3. The PATH modification uses the WiX `Environment` element with `Part="last"` to append rather than overwrite.
+4. Existing PATH entries are preserved; no duplicates are created on upgrade installs.
+
+---
+
+### GW-1501  Post-install service registration CLI
+
+**Priority:** Must  
+**Source:** Issue #524
+
+**Description:**  
+The `sonde-gateway` binary MUST support a `sonde-gateway install` subcommand that registers the gateway as a platform service (Windows SCM service or Linux systemd unit). The command accepts `--port`, `--db`, `--key-provider`, `--master-key-file`, and `--channel` parameters that are persisted into the service configuration. On Windows, the service is registered with the Service Control Manager using `SERVICE_AUTO_START`. On Linux, the command writes an environment file to `/etc/sonde/environment` and enables the systemd unit.
+
+**Acceptance criteria:**
+
+1. `sonde-gateway install --port COM5 --db C:\ProgramData\sonde\gateway.db --master-key-file C:\ProgramData\sonde\master-key.hex` registers a Windows service named `sonde-gateway` with the correct `ImagePath` (including CLI flags).
+2. `sonde-gateway install --port /dev/ttyACM0 --db /var/lib/sonde/gateway.db --key-provider file` writes `SERIAL_PORT=/dev/ttyACM0` (and other parameters) to `/etc/sonde/environment` and runs `systemctl enable sonde-gateway.service`.
+3. If the service is already registered, the command updates the existing registration (idempotent).
+4. The command requires elevated privileges (Administrator on Windows, root on Linux) and exits with a clear error message if run unprivileged.
+5. The `--port` parameter is required; the command exits with an error if omitted.
+
+---
+
+### GW-1502  Post-install service unregistration CLI
+
+**Priority:** Must  
+**Source:** Issue #524
+
+**Description:**  
+The `sonde-gateway` binary MUST support a `sonde-gateway uninstall` subcommand that stops and removes the platform service registration. On Windows, this stops the SCM service (if running) and deletes the service entry. On Linux, this stops and disables the systemd unit. The command MUST NOT delete the database, configuration files, or master key material.
+
+**Acceptance criteria:**
+
+1. After `sonde-gateway uninstall`, the Windows service is no longer listed in `sc query sonde-gateway`.
+2. After `sonde-gateway uninstall`, the systemd unit is stopped and disabled (`systemctl is-enabled sonde-gateway.service` returns `disabled`).
+3. Running `sonde-gateway uninstall` when no service is registered exits successfully with an informational message (idempotent).
+4. The database file, master key file, and configuration directory are preserved after uninstall.
+5. The command requires elevated privileges and exits with a clear error message if run unprivileged.
+
+---
+
+### GW-1503  Linux package systemd integration
+
+**Priority:** Should  
+**Source:** Issue #524
+
+**Description:**  
+The `.deb` package SHOULD include a systemd unit file and `postinst` / `prerm` scripts that create a `sonde` system user, enable the service, and configure the environment file at `/etc/sonde/environment`. The operator MUST edit `/etc/sonde/environment` to set `SERIAL_PORT` before the service will start successfully. The `prerm` script stops and disables the service on package removal (but not on upgrade).
+
+**Acceptance criteria:**
+
+1. Installing the `.deb` on a systemd-based system creates the `sonde` user and group.
+2. The `sonde` user is added to the `dialout` group for serial port access.
+3. The service unit file reads `SERIAL_PORT` from `/etc/sonde/environment` via `EnvironmentFile=`.
+4. `dpkg -L sonde` lists `/lib/systemd/system/sonde-gateway.service` and `/etc/sonde/environment`.
+5. On package removal, the service is stopped and disabled; on upgrade, the service is stopped but not disabled.
+6. `/etc/sonde/environment` is listed in `conffiles` so `dpkg` prompts before overwriting operator edits.
+
+---
+
 ## Appendix A  Requirement index
 
 | ID | Title | Priority |


### PR DESCRIPTION
## Summary

Adds structured 	racing logging at INFO level for every stage of the APP_DATA → handler pipeline, closing the observability gap described in #556.

## Log points added

| Stage | Message | Fields |
|---|---|---|
| Receipt | \APP_DATA received\ | \
ode_id\, \program_hash\ (hex, 8 chars), \len\ |
| Routing | \handler matched\ / \
o handler configured\ | \program_hash\, \command\ |
| Spawn | \handler spawned\ | \command\ |
| Invocation | \handler invoked\ | \command\ |
| Reply | \handler replied\ / \handler produced no reply\ | \len\ |
| Exit | \handler exited\ | \command\, \code\ |

## Spec changes

- **\gateway-requirements.md\**: Added GW-1307 requirement with 5 acceptance criteria
- **\gateway-design.md\**: Documented logging points in new section 9.5
- **\gateway-validation.md\**: Added T-1307 test case and traceability entry

## Code changes

- **\ngine.rs\**: Log \APP_DATA received\ with \
ode_id\, \program_hash\, \len\ in \handle_app_data\
- **\handler.rs\**: Log handler match/no-match in \oute_app_data\, handler spawn/invoked/replied/exited at appropriate points. Upgraded \debug!\ → \info!\ for spawn and exit events.
- **\	ests/logging.rs\**: Added \	1307_app_data_handler_pipeline_logging\ test using \#[traced_test]\ with a Python echo handler

## Testing

- \cargo fmt --check\ ✅
- \cargo clippy --workspace -- -D warnings\ ✅
- \cargo test --workspace\ ✅ (all existing tests pass)
- \cargo test -p sonde-gateway --features python-tests t1307\ ✅

Closes #556