### PR TITLE
fix(node): boot version and channel visible in quiet firmware

### DIFF
--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -47,8 +47,8 @@ fn main() {
     #[cfg(not(any(debug_assertions, feature = "verbose")))]
     log::set_max_level(log::LevelFilter::Warn);
 
-    info!("sonde-node booting (commit {})", env!("SONDE_GIT_COMMIT"));
-    info!("firmware ABI version: {}", sonde_node::FIRMWARE_ABI_VERSION);
+    warn!("sonde-node booting (commit {})", env!("SONDE_GIT_COMMIT"));
+    warn!("firmware ABI version: {}", sonde_node::FIRMWARE_ABI_VERSION);
 
     // Log boot reason (ND-1000).
     let reset_reason = unsafe { esp_idf_svc::sys::esp_reset_reason() };
@@ -159,6 +159,8 @@ fn main() {
 
     // Read the stored WiFi channel (falls back to channel 1 if not yet set).
     let channel = storage.read_channel().unwrap_or(1);
+
+    warn!("ESP-NOW channel={} (ND-1016)", channel);
 
     let mut transport = EspNowTransport::new(peripherals.modem, sysloop, nvs_partition, channel)
         .expect("failed to initialize ESP-NOW transport");

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -1263,6 +1263,36 @@ When the node encounters an error at an operator-visible boundary (WiFi scan, HM
 
 ---
 
+### ND-1015  Boot version visibility
+
+**Priority:** Must  
+**Source:** hardware testing
+
+**Description:**  
+The node MUST log the firmware commit hash and ABI version at boot using `warn!()` level so the information is visible even in quiet firmware builds that use `release_max_level_warn`. Operators need to identify which firmware is running on a node without requiring a debug build.
+
+**Acceptance criteria:**
+
+1. The boot commit-hash and ABI-version log lines use `warn!()`, not `info!()`.
+2. The commit hash and ABI version are visible in the serial output of a quiet (release) firmware build.
+
+---
+
+### ND-1016  ESP-NOW channel logging at boot
+
+**Priority:** Must  
+**Source:** hardware testing
+
+**Description:**  
+The node MUST log the WiFi / ESP-NOW channel number at boot using `warn!()` level. Channel mismatches between the node and the gateway modem are a common field debugging issue; operators need the channel number in the boot log to diagnose connectivity problems.
+
+**Acceptance criteria:**
+
+1. The node logs the ESP-NOW channel number at `warn!()` level before initializing the ESP-NOW transport.
+2. The channel number is visible in the serial output of a quiet (release) firmware build.
+
+---
+
 ## Appendix A  Requirement index
 
 | ID | Title | Priority |
@@ -1341,3 +1371,5 @@ When the node encounters an error at an operator-visible boundary (WiFi scan, HM
 | ND-1012 | Build-type–aware log levels | Must |
 | ND-1013 | GPIO sleep preparation | Must |
 | ND-1014 | Error diagnostic observability | Must |
+| ND-1015 | Boot version visibility | Must |
+| ND-1016 | ESP-NOW channel logging at boot | Must |


### PR DESCRIPTION
## Summary

Two small node firmware fixes for operational visibility:

1. **Boot version in quiet firmware**: Change boot commit/ABI log from `info!()` to `warn!()` so operators can identify firmware version even in quiet builds (`release_max_level_warn`)
2. **ESP-NOW channel at boot**: Log the WiFi channel during ESP-NOW init for channel mismatch diagnosis

Both are critical for field debugging.

### Spec
- Added ND-1015 (boot version visibility) and ND-1016 (channel logging)
