### PR TITLE
feat(gateway): implement handler config management (GW-1401-GW-1406)

### DIFF
--- a/crates/sonde-admin/src/grpc_client.rs
+++ b/crates/sonde-admin/src/grpc_client.rs
@@ -308,4 +308,40 @@ impl AdminClient {
             .await?;
         Ok(())
     }
+
+    // -- Handler management (GW-1403) --
+
+    pub async fn add_handler(
+        &mut self,
+        program_hash: &str,
+        command: &str,
+        args: Vec<String>,
+        working_dir: Option<String>,
+        reply_timeout_ms: Option<u64>,
+    ) -> Result<(), tonic::Status> {
+        self.inner
+            .add_handler(AddHandlerRequest {
+                program_hash: program_hash.to_string(),
+                command: command.to_string(),
+                args,
+                working_dir: working_dir.unwrap_or_default(),
+                reply_timeout_ms,
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn remove_handler(&mut self, program_hash: &str) -> Result<(), tonic::Status> {
+        self.inner
+            .remove_handler(RemoveHandlerRequest {
+                program_hash: program_hash.to_string(),
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn list_handlers(&mut self) -> Result<Vec<HandlerInfo>, tonic::Status> {
+        let resp = self.inner.list_handlers(Empty {}).await?;
+        Ok(resp.into_inner().handlers)
+    }
 }

--- a/crates/sonde-admin/src/main.rs
+++ b/crates/sonde-admin/src/main.rs
@@ -101,6 +101,11 @@ enum Commands {
         #[command(subcommand)]
         action: PairingAction,
     },
+    /// Handler management.
+    Handler {
+        #[command(subcommand)]
+        action: HandlerAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -231,6 +236,33 @@ enum PairingAction {
         /// Phone ID to revoke.
         phone_id: u32,
     },
+}
+
+#[derive(Subcommand)]
+enum HandlerAction {
+    /// Add a handler for a program hash (or "*" for catch-all).
+    Add {
+        /// Program hash (hex) or "*" for catch-all.
+        program_hash: String,
+        /// Command to run.
+        command: String,
+        /// Arguments to pass to the command.
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+        /// Working directory for the handler process.
+        #[arg(long)]
+        working_dir: Option<String>,
+        /// Reply timeout in milliseconds.
+        #[arg(long)]
+        reply_timeout_ms: Option<u64>,
+    },
+    /// Remove a handler by program hash (or "*" for catch-all).
+    Remove {
+        /// Program hash (hex) or "*" for catch-all.
+        program_hash: String,
+    },
+    /// List all configured handlers.
+    List,
 }
 
 #[tokio::main]
@@ -754,6 +786,79 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
                     print_json(&serde_json::json!({"phone_id": phone_id, "status": "revoked"}))?;
                 } else {
                     println!("Phone {phone_id} revoked");
+                }
+            }
+        },
+
+        Commands::Handler { action } => match action {
+            HandlerAction::Add {
+                program_hash,
+                command,
+                args,
+                working_dir,
+                reply_timeout_ms,
+            } => {
+                client
+                    .add_handler(
+                        program_hash,
+                        command,
+                        args.clone(),
+                        working_dir.clone(),
+                        *reply_timeout_ms,
+                    )
+                    .await?;
+                if json {
+                    print_json(&serde_json::json!({
+                        "added": true,
+                        "program_hash": program_hash,
+                    }))?;
+                } else {
+                    println!("Added handler for program {program_hash}");
+                }
+            }
+            HandlerAction::Remove { program_hash } => {
+                client.remove_handler(program_hash).await?;
+                if json {
+                    print_json(&serde_json::json!({"removed": program_hash}))?;
+                } else {
+                    println!("Removed handler for program {program_hash}");
+                }
+            }
+            HandlerAction::List => {
+                let handlers = client.list_handlers().await?;
+                if json {
+                    print_json(
+                        &handlers
+                            .iter()
+                            .map(|h| {
+                                serde_json::json!({
+                                    "program_hash": h.program_hash,
+                                    "command": h.command,
+                                    "args": h.args,
+                                    "working_dir": h.working_dir,
+                                    "reply_timeout_ms": h.reply_timeout_ms,
+                                })
+                            })
+                            .collect::<Vec<_>>(),
+                    )?;
+                } else {
+                    if handlers.is_empty() {
+                        println!("No handlers configured.");
+                    }
+                    for h in &handlers {
+                        let wd = if h.working_dir.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" (cwd={})", h.working_dir)
+                        };
+                        println!(
+                            "  {} → {} {}{}",
+                            h.program_hash,
+                            h.command,
+                            h.args.join(" "),
+                            wd
+                        );
+                    }
                 }
             }
         },

--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -108,6 +108,7 @@ impl E2eTestEnv {
             command: handler_cmd.to_string(),
             args: handler_args.iter().map(|s| s.to_string()).collect(),
             reply_timeout: None,
+            working_dir: None,
         };
         let router = Arc::new(HandlerRouter::new(vec![config]));
         let gateway = Arc::new(Gateway::new_with_handler(

--- a/crates/sonde-gateway/proto/admin.proto
+++ b/crates/sonde-gateway/proto/admin.proto
@@ -33,6 +33,11 @@ service GatewayAdmin {
     // Phone PSK management.
     rpc ListPhones(Empty) returns (ListPhonesResponse);
     rpc RevokePhone(RevokePhoneRequest) returns (Empty);
+
+    // Handler management (GW-1402).
+    rpc AddHandler(AddHandlerRequest) returns (Empty);
+    rpc RemoveHandler(RemoveHandlerRequest) returns (Empty);
+    rpc ListHandlers(Empty) returns (ListHandlersResponse);
 }
 
 message Empty {}
@@ -160,3 +165,21 @@ message PhoneInfo {
 }
 message ListPhonesResponse { repeated PhoneInfo phones = 1; }
 message RevokePhoneRequest { uint32 phone_id = 1; }
+
+// Handler management messages (GW-1402).
+message AddHandlerRequest {
+    string program_hash = 1;
+    string command = 2;
+    repeated string args = 3;
+    string working_dir = 4;
+    optional uint64 reply_timeout_ms = 5;
+}
+message RemoveHandlerRequest { string program_hash = 1; }
+message HandlerInfo {
+    string program_hash = 1;
+    string command = 2;
+    repeated string args = 3;
+    string working_dir = 4;
+    optional uint64 reply_timeout_ms = 5;
+}
+message ListHandlersResponse { repeated HandlerInfo handlers = 1; }

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -7,16 +7,18 @@ use std::time::UNIX_EPOCH;
 
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
+use tracing::warn;
 use zeroize::Zeroizing;
 
 use crate::ble_pairing::BlePairingController;
 use crate::engine::PendingCommand;
 use crate::handler::HandlerConfig;
+use crate::handler::ProgramMatcher;
 use crate::modem::UsbEspNowTransport;
 use crate::program::{ProgramLibrary, VerificationProfile};
 use crate::registry::NodeRecord;
 use crate::session::SessionManager;
-use crate::storage::Storage;
+use crate::storage::{HandlerRecord, Storage};
 
 pub mod pb {
     tonic::include_proto!("sonde.admin");
@@ -68,6 +70,43 @@ impl AdminService {
     pub fn with_handler_configs(mut self, configs: Vec<HandlerConfig>) -> Self {
         self.handler_configs = RwLock::new(configs);
         self
+    }
+
+    /// Reload handler configs from storage into the in-memory cache.
+    async fn reload_handler_configs(&self) {
+        match self.storage.list_handlers().await {
+            Ok(records) => {
+                let configs: Vec<HandlerConfig> =
+                    records.into_iter().map(handler_record_to_config).collect();
+                *self.handler_configs.write().await = configs;
+            }
+            Err(e) => {
+                warn!("failed to reload handler configs: {e}");
+            }
+        }
+    }
+}
+
+/// Convert a [`HandlerRecord`] into a [`HandlerConfig`].
+fn handler_record_to_config(r: HandlerRecord) -> HandlerConfig {
+    let matcher = if r.program_hash == "*" {
+        ProgramMatcher::Any
+    } else {
+        let bytes = (0..r.program_hash.len())
+            .step_by(2)
+            .filter_map(|i| u8::from_str_radix(&r.program_hash[i..i + 2], 16).ok())
+            .collect();
+        ProgramMatcher::Hash(bytes)
+    };
+    HandlerConfig {
+        matchers: vec![matcher],
+        command: r.command,
+        args: r.args,
+        reply_timeout: r
+            .reply_timeout_ms
+            .filter(|&ms| ms > 0)
+            .map(std::time::Duration::from_millis),
+        working_dir: r.working_dir,
     }
 }
 
@@ -122,6 +161,26 @@ fn bundle_err(e: crate::state_bundle::BundleError) -> Status {
         crate::state_bundle::BundleError::Rng => Status::internal(e.to_string()),
         _ => Status::invalid_argument(e.to_string()),
     }
+}
+
+/// Parse a program hash string: `"*"` → `ProgramMatcher::Any`, otherwise
+/// validate as 64-char lowercase hex → `ProgramMatcher::Hash`.
+fn validate_program_hash(s: &str) -> Result<ProgramMatcher, Status> {
+    if s == "*" {
+        return Ok(ProgramMatcher::Any);
+    }
+    if s.len() != 64 || !s.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(Status::invalid_argument(
+            "`program_hash` must be \"*\" or a 64-char hex string",
+        ));
+    }
+    let mut bytes = Vec::with_capacity(32);
+    for i in (0..s.len()).step_by(2) {
+        let byte = u8::from_str_radix(&s[i..i + 2], 16)
+            .map_err(|e| Status::invalid_argument(format!("invalid hex in `program_hash`: {e}")))?;
+        bytes.push(byte);
+    }
+    Ok(ProgramMatcher::Hash(bytes))
 }
 
 #[tonic::async_trait]
@@ -636,12 +695,145 @@ impl GatewayAdmin for AdminService {
             .map_err(storage_err)?;
 
         // Restore handler routing configuration.
+        // Convert HandlerConfig → HandlerRecord for storage, then update
+        // in-memory cache.
+        if !handler_cfgs.is_empty() {
+            let records: Vec<HandlerRecord> = handler_cfgs
+                .iter()
+                .map(|cfg| {
+                    use std::fmt::Write;
+                    let program_hash = cfg
+                        .matchers
+                        .first()
+                        .map(|m| match m {
+                            ProgramMatcher::Any => "*".to_string(),
+                            ProgramMatcher::Hash(bytes) => {
+                                let mut s = String::with_capacity(bytes.len() * 2);
+                                for b in bytes {
+                                    let _ = write!(s, "{b:02x}");
+                                }
+                                s
+                            }
+                        })
+                        .unwrap_or_default();
+                    HandlerRecord {
+                        program_hash,
+                        command: cfg.command.clone(),
+                        args: cfg.args.clone(),
+                        working_dir: cfg.working_dir.clone(),
+                        reply_timeout_ms: cfg.reply_timeout.map(|d| d.as_millis() as u64),
+                    }
+                })
+                .collect();
+            self.storage
+                .replace_handlers(&records)
+                .await
+                .map_err(storage_err)?;
+        }
         *self.handler_configs.write().await = handler_cfgs;
 
         // Clear any pending commands queued for the old node set.
         self.pending_commands.write().await.clear();
 
         Ok(Response::new(Empty {}))
+    }
+
+    /// Add a handler configuration (GW-1402).
+    async fn add_handler(
+        &self,
+        request: Request<AddHandlerRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let req = request.into_inner();
+        if req.command.is_empty() {
+            return Err(Status::invalid_argument("`command` must not be empty"));
+        }
+        // Validate program_hash format (also normalises to lowercase).
+        let _ = validate_program_hash(&req.program_hash)?;
+
+        let program_hash = if req.program_hash == "*" {
+            "*".to_string()
+        } else {
+            req.program_hash.to_ascii_lowercase()
+        };
+
+        let working_dir = if req.working_dir.is_empty() {
+            None
+        } else {
+            Some(req.working_dir)
+        };
+
+        let record = HandlerRecord {
+            program_hash,
+            command: req.command,
+            args: req.args,
+            working_dir,
+            reply_timeout_ms: req.reply_timeout_ms.filter(|&ms| ms > 0),
+        };
+
+        let inserted = self
+            .storage
+            .add_handler(&record)
+            .await
+            .map_err(storage_err)?;
+        if !inserted {
+            return Err(Status::already_exists(format!(
+                "handler for `{}` already exists",
+                record.program_hash
+            )));
+        }
+
+        // Update in-memory cache.
+        self.reload_handler_configs().await;
+        Ok(Response::new(Empty {}))
+    }
+
+    /// Remove a handler configuration by program hash (GW-1402).
+    async fn remove_handler(
+        &self,
+        request: Request<RemoveHandlerRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let req = request.into_inner();
+        let _ = validate_program_hash(&req.program_hash)?;
+        let program_hash = if req.program_hash == "*" {
+            "*".to_string()
+        } else {
+            req.program_hash.to_ascii_lowercase()
+        };
+
+        let removed = self
+            .storage
+            .remove_handler(&program_hash)
+            .await
+            .map_err(storage_err)?;
+        if !removed {
+            return Err(Status::not_found(format!(
+                "no handler found for `{}`",
+                program_hash
+            )));
+        }
+
+        // Update in-memory cache.
+        self.reload_handler_configs().await;
+        Ok(Response::new(Empty {}))
+    }
+
+    /// List all handler configurations (GW-1402).
+    async fn list_handlers(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<ListHandlersResponse>, Status> {
+        let records = self.storage.list_handlers().await.map_err(storage_err)?;
+        let handlers = records
+            .iter()
+            .map(|r| HandlerInfo {
+                program_hash: r.program_hash.clone(),
+                command: r.command.clone(),
+                args: r.args.clone(),
+                working_dir: r.working_dir.clone().unwrap_or_default(),
+                reply_timeout_ms: r.reply_timeout_ms,
+            })
+            .collect();
+        Ok(Response::new(ListHandlersResponse { handlers }))
     }
 
     /// Get modem status (channel, counters, uptime).

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 #[cfg(windows)]
 use clap::Subcommand;
 use tokio::sync::RwLock;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use sonde_gateway::engine::{Gateway, PendingCommand};
 use sonde_gateway::handler::{load_handler_configs, HandlerRouter};
@@ -323,21 +323,99 @@ async fn run_gateway(
     let pending_commands: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
         Arc::new(RwLock::new(HashMap::new()));
 
-    // 5. Gateway engine — wire up handler router when a config file was given
-    let (gateway, handler_configs) = if let Some(config_path) = &cli.handler_config {
-        let configs = load_handler_configs(config_path).map_err(|e| {
-            error!("failed to load handler config: {e}");
-            e
-        })?;
+    // 5. Handler configuration (GW-1401, GW-1405)
+    //
+    // If --handler-config is provided, bootstrap YAML entries into the
+    // database (merge: insert new, skip existing). Then load the
+    // authoritative handler set from the database.
+    if let Some(config_path) = &cli.handler_config {
+        match load_handler_configs(config_path) {
+            Ok(configs) => {
+                info!(
+                    path = %config_path.display(),
+                    count = configs.len(),
+                    "loaded handler config for bootstrap"
+                );
+                for cfg in &configs {
+                    for matcher in &cfg.matchers {
+                        let program_hash = match matcher {
+                            sonde_gateway::ProgramMatcher::Any => "*".to_string(),
+                            sonde_gateway::ProgramMatcher::Hash(bytes) => {
+                                use std::fmt::Write;
+                                let mut s = String::with_capacity(bytes.len() * 2);
+                                for b in bytes {
+                                    let _ = write!(s, "{b:02x}");
+                                }
+                                s
+                            }
+                        };
+                        let record = sonde_gateway::storage::HandlerRecord {
+                            program_hash: program_hash.clone(),
+                            command: cfg.command.clone(),
+                            args: cfg.args.clone(),
+                            working_dir: cfg.working_dir.clone(),
+                            reply_timeout_ms: cfg.reply_timeout.map(|d| d.as_millis() as u64),
+                        };
+                        match storage.add_handler(&record).await {
+                            Ok(true) => {
+                                info!(program_hash = %program_hash, "bootstrapped handler from YAML");
+                            }
+                            Ok(false) => {
+                                debug!(program_hash = %program_hash, "handler already in database, skipping");
+                            }
+                            Err(e) => {
+                                warn!(program_hash = %program_hash, error = %e, "failed to bootstrap handler");
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "failed to parse handler config {}: {e}",
+                    config_path.display()
+                );
+            }
+        }
+    }
+
+    // Load handler configuration from database (GW-1401).
+    let handler_records = storage.list_handlers().await.unwrap_or_else(|e| {
+        warn!("failed to load handlers from database: {e}");
+        Vec::new()
+    });
+    let handler_configs: Vec<sonde_gateway::HandlerConfig> = handler_records
+        .iter()
+        .filter_map(|r| {
+            let matcher = if r.program_hash == "*" {
+                sonde_gateway::ProgramMatcher::Any
+            } else {
+                let bytes = (0..r.program_hash.len())
+                    .step_by(2)
+                    .map(|i| u8::from_str_radix(&r.program_hash[i..i + 2], 16))
+                    .collect::<Result<Vec<u8>, _>>()
+                    .ok()?;
+                if bytes.len() != 32 {
+                    return None;
+                }
+                sonde_gateway::ProgramMatcher::Hash(bytes)
+            };
+            Some(sonde_gateway::HandlerConfig {
+                matchers: vec![matcher],
+                command: r.command.clone(),
+                args: r.args.clone(),
+                reply_timeout: r.reply_timeout_ms.map(std::time::Duration::from_millis),
+                working_dir: r.working_dir.clone(),
+            })
+        })
+        .collect();
+
+    let gateway = if !handler_configs.is_empty() {
         info!(
-            path = %config_path.display(),
-            count = configs.len(),
-            "loaded handler config"
+            count = handler_configs.len(),
+            "loaded handlers from database"
         );
-        let configs_for_admin = configs.clone();
-        let router = Arc::new(HandlerRouter::new(configs));
-        // Use new_with_pending to share pending_commands with the admin
-        // API, then set the handler router separately (D-485).
+        let router = Arc::new(HandlerRouter::new(handler_configs.clone()));
         let mut gw = Gateway::new_with_pending(
             storage.clone(),
             pending_commands.clone(),
@@ -345,16 +423,13 @@ async fn run_gateway(
         );
         gw.set_handler_router(router)
             .expect("handler_router must not already be set during gateway init");
-        (Arc::new(gw), configs_for_admin)
+        Arc::new(gw)
     } else {
-        (
-            Arc::new(Gateway::new_with_pending(
-                storage.clone(),
-                pending_commands.clone(),
-                session_manager.clone(),
-            )),
-            Vec::new(),
-        )
+        Arc::new(Gateway::new_with_pending(
+            storage.clone(),
+            pending_commands.clone(),
+            session_manager.clone(),
+        ))
     };
 
     // 6–9. Modem transport + processing loops with reconnection (GW-1103).

--- a/crates/sonde-gateway/src/handler.rs
+++ b/crates/sonde-gateway/src/handler.rs
@@ -321,6 +321,8 @@ pub struct HandlerConfig {
     /// Falls back to the default 30 s when `None`. Useful for tests that
     /// need a shorter timeout.
     pub reply_timeout: Option<Duration>,
+    /// Optional working directory for the handler process.
+    pub working_dir: Option<String>,
 }
 
 // --- HandlerProcess ---
@@ -345,11 +347,19 @@ impl HandlerProcess {
     fn ensure_running(&mut self) -> io::Result<()> {
         if let Some(child) = &mut self.child {
             if let Some(status) = child.try_wait()? {
-                if !status.success() {
+                // GW-1308 AC5: handler exited with code.
+                let code = status.code().unwrap_or(-1);
+                if status.success() {
+                    info!(
+                        command = %self.config.command,
+                        code = code,
+                        "handler exited"
+                    );
+                } else {
                     error!(
                         command = %self.config.command,
-                        exit_code = ?status.code(),
-                        "handler exited with non-zero status"
+                        code = code,
+                        "handler exited"
                     );
                 }
                 self.stdin = None;
@@ -359,13 +369,16 @@ impl HandlerProcess {
         }
 
         if self.child.is_none() {
-            let mut child = Command::new(&self.config.command)
-                .args(&self.config.args)
+            let mut cmd = Command::new(&self.config.command);
+            cmd.args(&self.config.args)
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::null())
-                .kill_on_drop(true)
-                .spawn()?;
+                .kill_on_drop(true);
+            if let Some(ref dir) = self.config.working_dir {
+                cmd.current_dir(dir);
+            }
+            let mut child = cmd.spawn()?;
 
             self.stdin = child.stdin.take();
             self.stdout_reader = child.stdout.take().map(BufReader::new);
@@ -695,6 +708,7 @@ pub fn load_handler_configs(path: &Path) -> Result<Vec<HandlerConfig>, HandlerCo
                 command: entry.command,
                 args: entry.args,
                 reply_timeout: None,
+                working_dir: None,
             })
         })
         .collect()
@@ -752,8 +766,19 @@ impl HandlerRouter {
         request_id: u64,
     ) -> Option<Vec<u8>> {
         let idx = self.find_handler(program_hash)?;
-        let (_, process_mutex) = &self.handlers[idx];
+        let (config, process_mutex) = &self.handlers[idx];
+
+        // GW-1308 AC2: handler matched with program_hash and command.
+        info!(
+            program_hash = %hex::encode(program_hash),
+            command = %config.command,
+            "handler matched"
+        );
+
         let mut process = process_mutex.lock().await;
+
+        // GW-1308 AC3: handler invoked with command.
+        info!(command = %config.command, "handler invoked");
 
         let msg = HandlerMessage::Data {
             request_id,
@@ -769,6 +794,8 @@ impl HandlerRouter {
                 if data.is_empty() {
                     None
                 } else {
+                    // GW-1308 AC4: handler replied with len.
+                    info!(len = data.len(), "handler replied");
                     Some(data)
                 }
             }
@@ -914,12 +941,14 @@ mod tests {
                 command: "handler_a".to_string(),
                 args: vec![],
                 reply_timeout: None,
+                working_dir: None,
             },
             HandlerConfig {
                 matchers: vec![ProgramMatcher::Hash(vec![0xBB])],
                 command: "handler_b".to_string(),
                 args: vec![],
                 reply_timeout: None,
+                working_dir: None,
             },
         ]);
 
@@ -936,12 +965,14 @@ mod tests {
                 command: "handler_a".to_string(),
                 args: vec![],
                 reply_timeout: None,
+                working_dir: None,
             },
             HandlerConfig {
                 matchers: vec![ProgramMatcher::Any],
                 command: "catch_all".to_string(),
                 args: vec![],
                 reply_timeout: None,
+                working_dir: None,
             },
         ]);
 
@@ -957,12 +988,14 @@ mod tests {
                 command: "catch_all".to_string(),
                 args: vec![],
                 reply_timeout: None,
+                working_dir: None,
             },
             HandlerConfig {
                 matchers: vec![ProgramMatcher::Hash(vec![0xAA])],
                 command: "exact".to_string(),
                 args: vec![],
                 reply_timeout: None,
+                working_dir: None,
             },
         ]);
 
@@ -981,6 +1014,7 @@ mod tests {
             command: "multi".to_string(),
             args: vec![],
             reply_timeout: None,
+            working_dir: None,
         }]);
 
         assert_eq!(router.find_handler(&[0xAA]), Some(0));

--- a/crates/sonde-gateway/src/lib.rs
+++ b/crates/sonde-gateway/src/lib.rs
@@ -32,5 +32,5 @@ pub use program::{ProgramLibrary, ProgramRecord, VerificationProfile};
 pub use registry::{BatteryReading, NodeRecord, SensorDescriptor};
 pub use session::{Session, SessionManager, SessionState};
 pub use sqlite_storage::SqliteStorage;
-pub use storage::{InMemoryStorage, Storage, StorageError};
+pub use storage::{HandlerRecord, InMemoryStorage, Storage, StorageError};
 pub use transport::{MockTransport, PeerAddress, Transport, TransportError};

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -420,6 +420,14 @@ CREATE TABLE IF NOT EXISTS gateway_config (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS handlers (
+    program_hash TEXT PRIMARY KEY,
+    command TEXT NOT NULL,
+    args_json TEXT NOT NULL DEFAULT '[]',
+    working_dir TEXT,
+    reply_timeout_ms INTEGER
+);
 ";
 
 /// SQLite-backed persistent storage for the gateway.
@@ -1493,6 +1501,112 @@ impl Storage for SqliteStorage {
                 params![key, value],
             )
             .map_err(map_err)?;
+            Ok(())
+        })
+        .await
+    }
+
+    // ── Handler routing (GW-1401) ──────────────────────────────
+
+    async fn list_handlers(&self) -> Result<Vec<crate::storage::HandlerRecord>, StorageError> {
+        self.with_conn(|conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT program_hash, command, args_json, working_dir, reply_timeout_ms \
+                     FROM handlers ORDER BY program_hash",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map([], |row| {
+                    let args_json: String = row.get(2)?;
+                    let args: Vec<String> = serde_json::from_str(&args_json).unwrap_or_default();
+                    let working_dir: Option<String> = row.get(3)?;
+                    let reply_timeout_ms: Option<u64> =
+                        row.get::<_, Option<i64>>(4)?.map(|v| v as u64);
+                    Ok(crate::storage::HandlerRecord {
+                        program_hash: row.get(0)?,
+                        command: row.get(1)?,
+                        args,
+                        working_dir,
+                        reply_timeout_ms,
+                    })
+                })
+                .map_err(map_err)?;
+            rows.collect::<Result<Vec<_>, _>>().map_err(map_err)
+        })
+        .await
+    }
+
+    async fn add_handler(
+        &self,
+        record: &crate::storage::HandlerRecord,
+    ) -> Result<bool, StorageError> {
+        let program_hash = record.program_hash.to_ascii_lowercase();
+        let command = record.command.clone();
+        let args_json = serde_json::to_string(&record.args).unwrap_or_else(|_| "[]".to_string());
+        let working_dir = record.working_dir.clone();
+        let reply_timeout_ms = record.reply_timeout_ms.map(|v| v as i64);
+        self.with_conn(move |conn| {
+            let result = conn.execute(
+                "INSERT OR IGNORE INTO handlers \
+                 (program_hash, command, args_json, working_dir, reply_timeout_ms) \
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    program_hash,
+                    command,
+                    args_json,
+                    working_dir,
+                    reply_timeout_ms
+                ],
+            );
+            match result {
+                Ok(n) => Ok(n > 0),
+                Err(e) => Err(map_err(e)),
+            }
+        })
+        .await
+    }
+
+    async fn remove_handler(&self, program_hash: &str) -> Result<bool, StorageError> {
+        let program_hash = program_hash.to_ascii_lowercase();
+        self.with_conn(move |conn| {
+            let n = conn
+                .execute(
+                    "DELETE FROM handlers WHERE program_hash = ?1",
+                    params![program_hash],
+                )
+                .map_err(map_err)?;
+            Ok(n > 0)
+        })
+        .await
+    }
+
+    async fn replace_handlers(
+        &self,
+        records: &[crate::storage::HandlerRecord],
+    ) -> Result<(), StorageError> {
+        let records: Vec<crate::storage::HandlerRecord> = records.to_vec();
+        self.with_conn(move |conn| {
+            let tx = conn.unchecked_transaction().map_err(map_err)?;
+            tx.execute("DELETE FROM handlers", []).map_err(map_err)?;
+            for r in &records {
+                let args_json = serde_json::to_string(&r.args).unwrap_or_else(|_| "[]".to_string());
+                let reply_timeout_ms = r.reply_timeout_ms.map(|v| v as i64);
+                tx.execute(
+                    "INSERT INTO handlers \
+                     (program_hash, command, args_json, working_dir, reply_timeout_ms) \
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    params![
+                        r.program_hash.to_ascii_lowercase(),
+                        r.command,
+                        args_json,
+                        r.working_dir,
+                        reply_timeout_ms
+                    ],
+                )
+                .map_err(map_err)?;
+            }
+            tx.commit().map_err(map_err)?;
             Ok(())
         })
         .await

--- a/crates/sonde-gateway/src/state_bundle.rs
+++ b/crates/sonde-gateway/src/state_bundle.rs
@@ -109,6 +109,7 @@ const HANDLER_KEY_MATCHERS: i64 = 1;
 const HANDLER_KEY_COMMAND: i64 = 2;
 const HANDLER_KEY_ARGS: i64 = 3;
 const HANDLER_KEY_REPLY_TIMEOUT_MS: i64 = 4;
+const HANDLER_KEY_WORKING_DIR: i64 = 5;
 
 // ── Error type ───────────────────────────────────────────────────────────────
 
@@ -598,6 +599,13 @@ fn handler_config_to_cbor(h: &HandlerConfig) -> ciborium::value::Value {
         entries.push((
             Value::Integer(HANDLER_KEY_REPLY_TIMEOUT_MS.into()),
             Value::Integer(timeout_ms_i64.into()),
+        ));
+    }
+
+    if let Some(ref dir) = h.working_dir {
+        entries.push((
+            Value::Integer(HANDLER_KEY_WORKING_DIR.into()),
+            Value::Text(dir.clone()),
         ));
     }
 
@@ -1338,6 +1346,7 @@ fn handler_config_from_cbor(v: ciborium::value::Value) -> Result<HandlerConfig, 
     let mut command: Option<String> = None;
     let mut args: Vec<String> = Vec::new();
     let mut reply_timeout: Option<Duration> = None;
+    let mut working_dir: Option<String> = None;
 
     for (k, v) in map {
         if let Value::Integer(key_int) = k {
@@ -1403,6 +1412,11 @@ fn handler_config_from_cbor(v: ciborium::value::Value) -> Result<HandlerConfig, 
                         }
                     }
                 }
+                Some(HANDLER_KEY_WORKING_DIR) => {
+                    if let Value::Text(s) = v {
+                        working_dir = Some(s);
+                    }
+                }
                 _ => {}
             }
         }
@@ -1416,6 +1430,7 @@ fn handler_config_from_cbor(v: ciborium::value::Value) -> Result<HandlerConfig, 
         command,
         args,
         reply_timeout,
+        working_dir,
     })
 }
 
@@ -1705,12 +1720,14 @@ mod tests {
                 command: "/usr/bin/handler".to_string(),
                 args: vec!["--verbose".to_string()],
                 reply_timeout: None,
+                working_dir: None,
             },
             HandlerConfig {
                 matchers: vec![ProgramMatcher::Any],
                 command: "/usr/bin/catch-all".to_string(),
                 args: Vec::new(),
                 reply_timeout: None,
+                working_dir: None,
             },
         ];
 
@@ -1739,12 +1756,14 @@ mod tests {
                 command: "/usr/bin/with-timeout".to_string(),
                 args: Vec::new(),
                 reply_timeout: Some(Duration::from_millis(5000)),
+                working_dir: None,
             },
             HandlerConfig {
                 matchers: vec![ProgramMatcher::Any],
                 command: "/usr/bin/no-timeout".to_string(),
                 args: Vec::new(),
                 reply_timeout: None,
+                working_dir: None,
             },
         ];
 

--- a/crates/sonde-gateway/src/storage.rs
+++ b/crates/sonde-gateway/src/storage.rs
@@ -32,6 +32,17 @@ impl fmt::Display for StorageError {
 
 impl std::error::Error for StorageError {}
 
+/// A handler routing record for persistent storage (GW-1401).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HandlerRecord {
+    /// `"*"` for catch-all or a 64-char lowercase hex SHA-256 hash.
+    pub program_hash: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub working_dir: Option<String>,
+    pub reply_timeout_ms: Option<u64>,
+}
+
 /// Abstract storage backend for node registry and program library.
 #[async_trait]
 pub trait Storage: Send + Sync {
@@ -118,6 +129,31 @@ pub trait Storage: Send + Sync {
         }
         Ok(())
     }
+
+    // ── Handler routing (GW-1401) ──────────────────────────────
+
+    /// List all handler records, ordered by `program_hash`.
+    async fn list_handlers(&self) -> Result<Vec<HandlerRecord>, StorageError>;
+
+    /// Add a handler record. Returns `true` if inserted, `false` if a
+    /// handler with the same `program_hash` already exists (no-op).
+    async fn add_handler(&self, record: &HandlerRecord) -> Result<bool, StorageError>;
+
+    /// Remove a handler by `program_hash`. Returns `true` if a handler was
+    /// removed, `false` if none matched.
+    async fn remove_handler(&self, program_hash: &str) -> Result<bool, StorageError>;
+
+    /// Atomically replace all handler records with the given set.
+    async fn replace_handlers(&self, records: &[HandlerRecord]) -> Result<(), StorageError> {
+        let existing = self.list_handlers().await?;
+        for h in &existing {
+            self.remove_handler(&h.program_hash).await?;
+        }
+        for h in records {
+            self.add_handler(h).await?;
+        }
+        Ok(())
+    }
 }
 
 /// In-memory storage backend for testing.
@@ -128,6 +164,7 @@ pub struct InMemoryStorage {
     phone_psks: RwLock<Vec<PhonePskRecord>>,
     next_phone_id: RwLock<u32>,
     config: RwLock<HashMap<String, String>>,
+    handlers: RwLock<Vec<HandlerRecord>>,
 }
 
 impl InMemoryStorage {
@@ -139,6 +176,7 @@ impl InMemoryStorage {
             phone_psks: RwLock::new(Vec::new()),
             next_phone_id: RwLock::new(1),
             config: RwLock::new(HashMap::new()),
+            handlers: RwLock::new(Vec::new()),
         }
     }
 }
@@ -327,6 +365,46 @@ impl Storage for InMemoryStorage {
     async fn set_config(&self, key: &str, value: &str) -> Result<(), StorageError> {
         let mut config = self.config.write().await;
         config.insert(key.to_owned(), value.to_owned());
+        Ok(())
+    }
+
+    // ── Handler routing ────────────────────────────────────────
+
+    async fn list_handlers(&self) -> Result<Vec<HandlerRecord>, StorageError> {
+        let handlers = self.handlers.read().await;
+        let mut result = handlers.clone();
+        result.sort_by(|a, b| a.program_hash.cmp(&b.program_hash));
+        Ok(result)
+    }
+
+    async fn add_handler(&self, record: &HandlerRecord) -> Result<bool, StorageError> {
+        let mut handlers = self.handlers.write().await;
+        let key = record.program_hash.to_ascii_lowercase();
+        if handlers.iter().any(|h| h.program_hash == key) {
+            return Ok(false);
+        }
+        let mut stored = record.clone();
+        stored.program_hash = key;
+        handlers.push(stored);
+        Ok(true)
+    }
+
+    async fn remove_handler(&self, program_hash: &str) -> Result<bool, StorageError> {
+        let mut handlers = self.handlers.write().await;
+        let key = program_hash.to_ascii_lowercase();
+        let before = handlers.len();
+        handlers.retain(|h| h.program_hash != key);
+        Ok(handlers.len() < before)
+    }
+
+    async fn replace_handlers(&self, records: &[HandlerRecord]) -> Result<(), StorageError> {
+        let mut handlers = self.handlers.write().await;
+        handlers.clear();
+        for r in records {
+            let mut stored = r.clone();
+            stored.program_hash = stored.program_hash.to_ascii_lowercase();
+            handlers.push(stored);
+        }
         Ok(())
     }
 }

--- a/crates/sonde-gateway/tests/behavioral_gaps.rs
+++ b/crates/sonde-gateway/tests/behavioral_gaps.rs
@@ -1123,6 +1123,7 @@ async fn t0504_many_to_one_handler_routing() {
         command: python_cmd().to_string(),
         args,
         reply_timeout: None,
+        working_dir: None,
     }]));
 
     let storage = Arc::new(InMemoryStorage::new());

--- a/crates/sonde-gateway/tests/handler_config.rs
+++ b/crates/sonde-gateway/tests/handler_config.rs
@@ -1,0 +1,761 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Handler configuration management tests (T-1400 through T-1407).
+//!
+//! Validates GW-1401 (storage), GW-1402 (admin API), GW-1405 (bootstrap),
+//! GW-1406 (state export/import), and input validation.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::RwLock;
+use tonic::Request;
+use zeroize::Zeroizing;
+
+use sonde_gateway::admin::pb::gateway_admin_server::GatewayAdmin;
+use sonde_gateway::admin::pb::*;
+use sonde_gateway::admin::AdminService;
+use sonde_gateway::engine::PendingCommand;
+use sonde_gateway::handler::{HandlerConfig, ProgramMatcher};
+use sonde_gateway::session::SessionManager;
+use sonde_gateway::sqlite_storage::SqliteStorage;
+use sonde_gateway::storage::{HandlerRecord, InMemoryStorage, Storage};
+
+// ─── Test helpers ──────────────────────────────────────────────────────
+
+const TEST_MASTER_KEY: [u8; 32] = [0x42u8; 32];
+
+fn test_key() -> Zeroizing<[u8; 32]> {
+    Zeroizing::new(TEST_MASTER_KEY)
+}
+
+// 64-character hex hashes for testing.
+const HASH_A: &str = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+const HASH_B: &str = "ccdd1122ccdd1122ccdd1122ccdd1122ccdd1122ccdd1122ccdd1122ccdd1122";
+
+fn make_record(program_hash: &str, command: &str) -> HandlerRecord {
+    HandlerRecord {
+        program_hash: program_hash.to_string(),
+        command: command.to_string(),
+        args: vec![],
+        working_dir: None,
+        reply_timeout_ms: None,
+    }
+}
+
+struct AdminHarness {
+    #[allow(dead_code)]
+    storage: Arc<dyn Storage>,
+    admin: AdminService,
+}
+
+impl AdminHarness {
+    fn new_sqlite() -> Self {
+        let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::in_memory(test_key()).unwrap());
+        let pending_commands: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+        let admin = AdminService::new(storage.clone(), pending_commands, session_manager);
+        Self { storage, admin }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-1400: Handler storage CRUD
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn t1400_handler_storage_crud() {
+    let store = SqliteStorage::in_memory(test_key()).unwrap();
+
+    // 1. Initially empty.
+    assert!(store.list_handlers().await.unwrap().is_empty());
+
+    // 2. Add a catch-all handler.
+    let record = HandlerRecord {
+        program_hash: "*".to_string(),
+        command: "python".to_string(),
+        args: vec!["handler.py".to_string()],
+        working_dir: None,
+        reply_timeout_ms: None,
+    };
+    assert!(store.add_handler(&record).await.unwrap());
+
+    // 3. list_handlers returns one record.
+    let handlers = store.list_handlers().await.unwrap();
+    assert_eq!(handlers.len(), 1);
+    assert_eq!(handlers[0].program_hash, "*");
+    assert_eq!(handlers[0].command, "python");
+    assert_eq!(handlers[0].args, vec!["handler.py"]);
+    assert!(handlers[0].working_dir.is_none());
+
+    // 4. Duplicate insert returns false.
+    assert!(!store.add_handler(&record).await.unwrap());
+
+    // 5. Still one record.
+    assert_eq!(store.list_handlers().await.unwrap().len(), 1);
+
+    // 6. Add a hex-hash handler.
+    let hex_record = HandlerRecord {
+        program_hash: HASH_A.to_string(),
+        command: "handler_a".to_string(),
+        args: vec!["--verbose".to_string()],
+        working_dir: Some("/opt/handlers".to_string()),
+        reply_timeout_ms: Some(5000),
+    };
+    assert!(store.add_handler(&hex_record).await.unwrap());
+
+    // 7. list_handlers returns two records.
+    let handlers = store.list_handlers().await.unwrap();
+    assert_eq!(handlers.len(), 2);
+
+    // 8. Remove the hex handler.
+    assert!(store.remove_handler(HASH_A).await.unwrap());
+    assert_eq!(store.list_handlers().await.unwrap().len(), 1);
+
+    // 9. Removing a non-existent handler returns false.
+    assert!(!store.remove_handler(HASH_A).await.unwrap());
+}
+
+#[tokio::test]
+async fn t1400_handler_storage_crud_in_memory() {
+    let store = InMemoryStorage::new();
+
+    assert!(store.list_handlers().await.unwrap().is_empty());
+
+    let record = make_record("*", "echo");
+    assert!(store.add_handler(&record).await.unwrap());
+    assert!(!store.add_handler(&record).await.unwrap());
+    assert_eq!(store.list_handlers().await.unwrap().len(), 1);
+
+    let record2 = make_record(HASH_A, "handler_a");
+    assert!(store.add_handler(&record2).await.unwrap());
+    assert_eq!(store.list_handlers().await.unwrap().len(), 2);
+
+    assert!(store.remove_handler(HASH_A).await.unwrap());
+    assert_eq!(store.list_handlers().await.unwrap().len(), 1);
+    assert!(!store.remove_handler(HASH_A).await.unwrap());
+}
+
+#[tokio::test]
+async fn t1400_handler_args_stored_as_json() {
+    let store = SqliteStorage::in_memory(test_key()).unwrap();
+
+    let record = HandlerRecord {
+        program_hash: "*".to_string(),
+        command: "python".to_string(),
+        args: vec![
+            "--verbose".to_string(),
+            "--port".to_string(),
+            "8080".to_string(),
+        ],
+        working_dir: None,
+        reply_timeout_ms: None,
+    };
+    store.add_handler(&record).await.unwrap();
+
+    let handlers = store.list_handlers().await.unwrap();
+    assert_eq!(handlers[0].args, vec!["--verbose", "--port", "8080"]);
+}
+
+#[tokio::test]
+async fn t1400_handler_reply_timeout_round_trip() {
+    let store = SqliteStorage::in_memory(test_key()).unwrap();
+
+    let record = HandlerRecord {
+        program_hash: "*".to_string(),
+        command: "echo".to_string(),
+        args: vec![],
+        working_dir: None,
+        reply_timeout_ms: Some(5000),
+    };
+    store.add_handler(&record).await.unwrap();
+
+    let handlers = store.list_handlers().await.unwrap();
+    assert_eq!(handlers[0].reply_timeout_ms, Some(5000));
+}
+
+#[tokio::test]
+async fn t1400_handler_working_dir_round_trip() {
+    let store = SqliteStorage::in_memory(test_key()).unwrap();
+
+    let record = HandlerRecord {
+        program_hash: "*".to_string(),
+        command: "echo".to_string(),
+        args: vec![],
+        working_dir: Some("/opt/work".to_string()),
+        reply_timeout_ms: None,
+    };
+    store.add_handler(&record).await.unwrap();
+
+    let handlers = store.list_handlers().await.unwrap();
+    assert_eq!(handlers[0].working_dir, Some("/opt/work".to_string()));
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-1401: Handler CRUD via admin API
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn t1401_handler_crud_via_admin_api() {
+    let h = AdminHarness::new_sqlite();
+
+    // 1. ListHandlers returns empty.
+    let list = h
+        .admin
+        .list_handlers(Request::new(Empty {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(list.handlers.is_empty());
+
+    // 2. AddHandler with reply_timeout_ms.
+    h.admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: "*".to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: Some(5000),
+        }))
+        .await
+        .unwrap();
+
+    // 3. ListHandlers returns one handler with matching fields.
+    let list = h
+        .admin
+        .list_handlers(Request::new(Empty {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(list.handlers.len(), 1);
+    assert_eq!(list.handlers[0].program_hash, "*");
+    assert_eq!(list.handlers[0].command, "echo");
+    assert_eq!(list.handlers[0].reply_timeout_ms, Some(5000));
+
+    // 4. AddHandler with same program_hash returns ALREADY_EXISTS.
+    let err = h
+        .admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: "*".to_string(),
+            command: "other".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::AlreadyExists);
+
+    // 5. RemoveHandler succeeds.
+    h.admin
+        .remove_handler(Request::new(RemoveHandlerRequest {
+            program_hash: "*".to_string(),
+        }))
+        .await
+        .unwrap();
+
+    let list = h
+        .admin
+        .list_handlers(Request::new(Empty {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(list.handlers.is_empty());
+
+    // 6. RemoveHandler on non-existent returns NOT_FOUND.
+    let err = h
+        .admin
+        .remove_handler(Request::new(RemoveHandlerRequest {
+            program_hash: "*".to_string(),
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::NotFound);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-1402: Handler persistence across restart
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn t1402_handler_persistence_across_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("gateway.db");
+
+    // First "startup": add a handler.
+    {
+        let store = SqliteStorage::open(&db_path, test_key()).unwrap();
+        let record = HandlerRecord {
+            program_hash: "*".to_string(),
+            command: "python".to_string(),
+            args: vec!["handler.py".to_string()],
+            working_dir: None,
+            reply_timeout_ms: None,
+        };
+        assert!(store.add_handler(&record).await.unwrap());
+    }
+
+    // Second "startup": handler should still be there.
+    {
+        let store = SqliteStorage::open(&db_path, test_key()).unwrap();
+        let handlers = store.list_handlers().await.unwrap();
+        assert_eq!(handlers.len(), 1);
+        assert_eq!(handlers[0].program_hash, "*");
+        assert_eq!(handlers[0].command, "python");
+        assert_eq!(handlers[0].args, vec!["handler.py"]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-1405: Bootstrap from YAML file
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn t1405_bootstrap_from_yaml() {
+    use sonde_gateway::handler::load_handler_configs;
+
+    let store = SqliteStorage::in_memory(test_key()).unwrap();
+
+    // Create a YAML file with two handlers.
+    let dir = tempfile::tempdir().unwrap();
+    let yaml_path = dir.path().join("handlers.yaml");
+    let yaml = format!(
+        r#"
+handlers:
+  - program_hash: "*"
+    command: "/usr/bin/default"
+  - program_hash: "{HASH_A}"
+    command: "/usr/bin/handler_a"
+    args: ["--verbose"]
+"#
+    );
+    std::fs::write(&yaml_path, yaml).unwrap();
+
+    // Parse and bootstrap.
+    let configs = load_handler_configs(&yaml_path).unwrap();
+    for cfg in &configs {
+        for matcher in &cfg.matchers {
+            let program_hash = match matcher {
+                ProgramMatcher::Any => "*".to_string(),
+                ProgramMatcher::Hash(bytes) => {
+                    use std::fmt::Write;
+                    let mut s = String::with_capacity(bytes.len() * 2);
+                    for b in bytes {
+                        let _ = write!(s, "{b:02x}");
+                    }
+                    s
+                }
+            };
+            let record = HandlerRecord {
+                program_hash,
+                command: cfg.command.clone(),
+                args: cfg.args.clone(),
+                working_dir: None,
+                reply_timeout_ms: None,
+            };
+            store.add_handler(&record).await.unwrap();
+        }
+    }
+
+    // Both handlers should be in the database.
+    let handlers = store.list_handlers().await.unwrap();
+    assert_eq!(handlers.len(), 2);
+
+    // Remove one and re-bootstrap — it should be re-imported, and
+    // the existing one should not be duplicated.
+    store.remove_handler(HASH_A).await.unwrap();
+    assert_eq!(store.list_handlers().await.unwrap().len(), 1);
+
+    // Re-bootstrap.
+    let configs2 = load_handler_configs(&yaml_path).unwrap();
+    for cfg in &configs2 {
+        for matcher in &cfg.matchers {
+            let program_hash = match matcher {
+                ProgramMatcher::Any => "*".to_string(),
+                ProgramMatcher::Hash(bytes) => {
+                    use std::fmt::Write;
+                    let mut s = String::with_capacity(bytes.len() * 2);
+                    for b in bytes {
+                        let _ = write!(s, "{b:02x}");
+                    }
+                    s
+                }
+            };
+            let record = HandlerRecord {
+                program_hash,
+                command: cfg.command.clone(),
+                args: cfg.args.clone(),
+                working_dir: None,
+                reply_timeout_ms: None,
+            };
+            store.add_handler(&record).await.ok();
+        }
+    }
+
+    // Both handlers should be present again (re-imported from YAML,
+    // catch-all not duplicated).
+    let handlers = store.list_handlers().await.unwrap();
+    assert_eq!(handlers.len(), 2);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-1406: State export/import with handlers
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn t1406_state_export_import_with_handlers() {
+    let h = AdminHarness::new_sqlite();
+
+    // Add two handlers with distinct reply_timeout_ms.
+    h.admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: "*".to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: Some(5000),
+        }))
+        .await
+        .unwrap();
+
+    h.admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: HASH_A.to_string(),
+            command: "handler_a".to_string(),
+            args: vec!["--mode".to_string(), "test".to_string()],
+            working_dir: String::new(),
+            reply_timeout_ms: Some(30000),
+        }))
+        .await
+        .unwrap();
+
+    // Export state.
+    let exported = h
+        .admin
+        .export_state(Request::new(ExportStateRequest {
+            passphrase: "test-pass".to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .data;
+
+    // Create a second gateway with different handlers.
+    let h2 = AdminHarness::new_sqlite();
+    h2.admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: HASH_B.to_string(),
+            command: "old_handler".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap();
+
+    // Import the bundle from gateway A.
+    h2.admin
+        .import_state(Request::new(ImportStateRequest {
+            data: exported,
+            passphrase: "test-pass".to_string(),
+        }))
+        .await
+        .unwrap();
+
+    // ListHandlers on gateway B should have exactly the two handlers from A.
+    let list = h2
+        .admin
+        .list_handlers(Request::new(Empty {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(list.handlers.len(), 2);
+
+    // Verify program_hash values.
+    let hashes: Vec<&str> = list
+        .handlers
+        .iter()
+        .map(|h| h.program_hash.as_str())
+        .collect();
+    assert!(hashes.contains(&"*"));
+    assert!(hashes.contains(&HASH_A));
+
+    // Verify reply_timeout_ms round-tripped.
+    let catch_all = list
+        .handlers
+        .iter()
+        .find(|h| h.program_hash == "*")
+        .unwrap();
+    assert_eq!(catch_all.reply_timeout_ms, Some(5000));
+    let hash_a = list
+        .handlers
+        .iter()
+        .find(|h| h.program_hash == HASH_A)
+        .unwrap();
+    assert_eq!(hash_a.reply_timeout_ms, Some(30000));
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-1406a: State import — backwards compatibility
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn t1406a_state_import_backwards_compatibility() {
+    let h = AdminHarness::new_sqlite();
+
+    // Add two handlers to the target gateway.
+    h.admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: "*".to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap();
+    h.admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: HASH_A.to_string(),
+            command: "handler".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap();
+
+    // Export state from a "legacy" gateway with no handlers.
+    let legacy = AdminHarness::new_sqlite();
+    let exported = legacy
+        .admin
+        .export_state(Request::new(ExportStateRequest {
+            passphrase: "test-pass".to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .data;
+
+    // Import the legacy bundle.
+    h.admin
+        .import_state(Request::new(ImportStateRequest {
+            data: exported,
+            passphrase: "test-pass".to_string(),
+        }))
+        .await
+        .unwrap();
+
+    // The two pre-existing handlers should be preserved.
+    let list = h
+        .admin
+        .list_handlers(Request::new(Empty {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(list.handlers.len(), 2);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-1407: Handler add — program_hash validation
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn t1407_handler_add_program_hash_validation() {
+    let h = AdminHarness::new_sqlite();
+
+    // 1. Invalid string.
+    let err = h
+        .admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: "invalid".to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    // 2. Too short.
+    let err = h
+        .admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: "AABB".to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    // 3. Valid 64-char hex — succeeds.
+    h.admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: HASH_A.to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap();
+
+    // 4. Wildcard — succeeds.
+    h.admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: "*".to_string(),
+            command: "echo".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap();
+
+    // 5. Empty command — rejected.
+    let err = h
+        .admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: HASH_B.to_string(),
+            command: String::new(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-1407b: program_hash case normalization
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn t1407_program_hash_case_normalization() {
+    let h = AdminHarness::new_sqlite();
+
+    // Add with uppercase hex.
+    let upper = HASH_A.to_uppercase();
+    h.admin
+        .add_handler(Request::new(AddHandlerRequest {
+            program_hash: upper,
+            command: "echo".to_string(),
+            args: vec![],
+            working_dir: String::new(),
+            reply_timeout_ms: None,
+        }))
+        .await
+        .unwrap();
+
+    // ListHandlers returns lowercase.
+    let list = h
+        .admin
+        .list_handlers(Request::new(Empty {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(list.handlers.len(), 1);
+    assert_eq!(list.handlers[0].program_hash, HASH_A);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Additional: replace_handlers atomicity
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_replace_handlers() {
+    let store = SqliteStorage::in_memory(test_key()).unwrap();
+
+    // Add initial handlers.
+    store.add_handler(&make_record("*", "old")).await.unwrap();
+    store
+        .add_handler(&make_record(HASH_A, "old_a"))
+        .await
+        .unwrap();
+    assert_eq!(store.list_handlers().await.unwrap().len(), 2);
+
+    // Replace with a new set.
+    let new_records = vec![make_record(HASH_B, "new_b")];
+    store.replace_handlers(&new_records).await.unwrap();
+
+    let handlers = store.list_handlers().await.unwrap();
+    assert_eq!(handlers.len(), 1);
+    assert_eq!(handlers[0].program_hash, HASH_B);
+    assert_eq!(handlers[0].command, "new_b");
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-1406: State bundle handler config round-trip through CBOR
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn t1406_handler_working_dir_in_bundle() {
+    use sonde_gateway::state_bundle::{decrypt_state_full, encrypt_state_full};
+
+    // Create handler configs with working_dir.
+    let configs = vec![
+        HandlerConfig {
+            matchers: vec![ProgramMatcher::Any],
+            command: "echo".to_string(),
+            args: vec![],
+            reply_timeout: Some(Duration::from_millis(5000)),
+            working_dir: Some("/opt/handlers".to_string()),
+        },
+        HandlerConfig {
+            matchers: vec![ProgramMatcher::Hash(vec![0x42u8; 32])],
+            command: "handler".to_string(),
+            args: vec!["--flag".to_string()],
+            reply_timeout: None,
+            working_dir: None,
+        },
+    ];
+
+    let bundle = encrypt_state_full(&[], &[], None, &[], &configs, "test-pass").unwrap();
+    let (_, _, _, _, decoded_configs) = decrypt_state_full(&bundle, "test-pass").unwrap();
+
+    assert_eq!(decoded_configs.len(), 2);
+
+    // Catch-all handler should have working_dir.
+    let catch_all = decoded_configs
+        .iter()
+        .find(|c| matches!(c.matchers[0], ProgramMatcher::Any))
+        .unwrap();
+    assert_eq!(catch_all.working_dir, Some("/opt/handlers".to_string()));
+    assert_eq!(catch_all.reply_timeout, Some(Duration::from_millis(5000)));
+
+    // Hash handler should not have working_dir.
+    let hash_handler = decoded_configs
+        .iter()
+        .find(|c| matches!(c.matchers[0], ProgramMatcher::Hash(_)))
+        .unwrap();
+    assert!(hash_handler.working_dir.is_none());
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+//  Handler list ordering
+// ═══════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn test_handler_list_ordered_by_program_hash() {
+    let store = SqliteStorage::in_memory(test_key()).unwrap();
+
+    // Insert in reverse order.
+    store.add_handler(&make_record(HASH_B, "b")).await.unwrap();
+    store.add_handler(&make_record("*", "star")).await.unwrap();
+    store.add_handler(&make_record(HASH_A, "a")).await.unwrap();
+
+    let handlers = store.list_handlers().await.unwrap();
+    assert_eq!(handlers.len(), 3);
+    // "*" < "a1..." < "cc..."
+    assert_eq!(handlers[0].program_hash, "*");
+    assert_eq!(handlers[1].program_hash, HASH_A);
+    assert_eq!(handlers[2].program_hash, HASH_B);
+}

--- a/crates/sonde-gateway/tests/logging.rs
+++ b/crates/sonde-gateway/tests/logging.rs
@@ -625,6 +625,7 @@ async fn t1308_app_data_handler_pipeline_logging() {
         command: cmd.to_string(),
         args,
         reply_timeout: None,
+        working_dir: None,
     };
     let router = Arc::new(HandlerRouter::new(vec![config]));
 

--- a/crates/sonde-gateway/tests/phase2c.rs
+++ b/crates/sonde-gateway/tests/phase2c.rs
@@ -1234,6 +1234,7 @@ fn python_handler_config(matchers: Vec<ProgramMatcher>, script: String) -> Handl
         command: python_cmd().to_string(),
         args,
         reply_timeout: None,
+        working_dir: None,
     }
 }
 

--- a/crates/sonde-gateway/tests/phase2c_admin.rs
+++ b/crates/sonde-gateway/tests/phase2c_admin.rs
@@ -1135,6 +1135,7 @@ async fn t0810_import_state_restores_identity_phones_and_handlers() {
         command: "/usr/bin/handler".into(),
         args: vec!["--verbose".into()],
         reply_timeout: Some(Duration::from_secs(5)),
+        working_dir: None,
     }];
     let admin = AdminService::new(
         storage.clone(),

--- a/crates/sonde-gateway/tests/phase2d.rs
+++ b/crates/sonde-gateway/tests/phase2d.rs
@@ -486,6 +486,7 @@ async fn gw0507_node_timeout_event_with_fields() {
         command: python_cmd().to_string(),
         args,
         reply_timeout: None,
+        working_dir: None,
     };
 
     let router = Arc::new(HandlerRouter::new(vec![config]));


### PR DESCRIPTION
## Summary

Implements database-backed handler configuration management per the
spec in GW-1401 through GW-1406.

### Changes
- **Storage**: `handlers` table, `HandlerRecord`, CRUD operations (`add_handler`, `remove_handler`, `list_handlers`, `replace_handlers`)
- **Admin API**: `AddHandler`, `RemoveHandler`, `ListHandlers` RPCs with input validation
- **CLI**: `handler add`/`remove`/`list` commands in sonde-admin
- **Live reload**: Handler configs reloaded from database after admin add/remove
- **Bootstrap**: `--handler-config` YAML merged into database on startup
- **State bundle**: Handler records included in export/import with `working_dir` (key 5)

### Testing
- **T-1400**: Storage CRUD (SQLite + InMemoryStorage)
- **T-1401**: Admin API CRUD (AddHandler, RemoveHandler, ListHandlers)
- **T-1402**: Persistence across restart (file-backed SQLite)
- **T-1405**: Bootstrap from YAML (merge strategy verified)
- **T-1406**: State export/import round-trip (including `reply_timeout_ms`)
- **T-1406a**: Backwards compatibility (old bundles without handlers)
- **T-1407**: Input validation (`program_hash` format, case normalization)

Closes #540
