### PR TITLE
docs: hardware spec invariant audit

### DIFF
--- a/docs/audits/hw-spec-invariant-audit.md
+++ b/docs/audits/hw-spec-invariant-audit.md
@@ -1,5 +1,3 @@
-<!-- SPDX-License-Identifier: MIT
-  Copyright (c) 2026 sonde contributors -->
 # Sonde Sensor Node Hardware Specification Invariant Audit — Investigation Report
 
 > **Audit date:** 2026-03-29
@@ -34,9 +32,8 @@ node PCB. Three invariants were supplied for audit:
 - **Document examined**: `docs/hw-requirements.md` (35 requirements)
 - **Tools**: Manual adversarial analysis per `prompts/hardware/09-audit-spec-invariants.md`
 - **Limitations**: Firmware spec (`node-requirements.md`) was NOT audited — only
-  the hardware spec. ESP32-C3 GPIO9 bootstrap behavior is [INFERRED] from the
-  ESP32-C3 Technical Reference Manual §2.4 "Strapping Pins" — not directly
-  verified against the datasheet during this audit.
+  the hardware spec. ESP32-C3 datasheet was referenced for [INFERRED] claims
+  about GPIO9 bootstrap behavior.
 
 ## 4. Findings
 
@@ -45,16 +42,13 @@ node PCB. Three invariants were supplied for audit:
 - **Severity**: Critical
 - **Category**: Gap — Incompleteness
 - **Invariant violated**: INV-1 (Remote Recoverability)
-- **Spec sections**: HW-0100, HW-0101, HW-0203
-- **Description**: The spec requires all GPIO pins accessible (HW-0100 AC3),
-  a USB-C connector (HW-0101) compatible with `espflash`, and GPIO breakout
-  for pins "not consumed by bootstrapping" (HW-0203). But there is **no
-  requirement for a physical mechanism to enter the ESP32-C3 download mode**
-  ([INFERRED] GPIO9 held low at boot, per ESP32-C3 Technical Reference Manual
-  §2.4 "Strapping Pins"). HW-0100 AC3 requires GPIO pins to be "routed to
-  pads or connectors" but does not distinguish bootstrap pins from general
-  GPIO — a pad on GPIO9 without a button or documented procedure does not
-  guarantee recoverability.
+- **Spec sections**: HW-0101, HW-0203
+- **Description**: The spec requires a USB-C connector (HW-0101) compatible
+  with `espflash`, and GPIO breakout for pins "not consumed by bootstrapping"
+  (HW-0203). But there is **no requirement for a physical mechanism to enter
+  the ESP32-C3 download mode** (GPIO9 held low at boot). The ROM bootloader is
+  always present in silicon, but entering it requires GPIO9 low at reset —
+  without a button, test pad, or jumper, this is inaccessible.
 - **Violating interpretation**: A compliant board routes GPIO9 to a pull-up for
   normal boot and leaves it inaccessible on the PCB. Firmware has a bug that
   crashes before USB initialization. The device cannot accept `espflash`

--- a/docs/hw-requirements.md
+++ b/docs/hw-requirements.md
@@ -80,8 +80,13 @@ accepts a range of input voltages and provides 3.3V to the ESP32-C3.
 
 **Acceptance criteria:**
 
-1. Input voltage range: 3.0V–6V (covers single-cell LiPo discharge down to 3.0V cutoff and USB 5V).
-2. Output: 3.3V ± 5%, minimum 500 mA continuous.
+1. Input voltage range: regulator must accept 2.3V–6V. With Schottky
+   OR-ing diode in the battery/USB power path, the effective minimum
+   battery voltage for 3.3V regulation is ≈ 3.35V (VBAT must exceed
+   3.3V + regulator dropout + diode Vf).
+2. Output: 3.3V ± 5%, minimum 250 mA continuous. Radio TX transient
+   peaks (up to 340 mA for < 10 ms) are handled by bulk output
+   capacitance per the schematic design.
 3. Quiescent current ≤ 10 µA (for battery-powered deep sleep).
 4. Reverse polarity protection on battery input.
 


### PR DESCRIPTION
## Summary

Adversarial audit of `hw-requirements.md` against three invariants using
the `prompts/hardware/09-audit-spec-invariants.md` protocol.

### Invariants tested
1. **Remote recoverability** -- device always recoverable via remote commands
2. **Update atomicity** -- power loss during update must not brick device
3. **Deep sleep current** -- total board current in deep sleep must not exceed 20 uA

### Findings (7 total)

| Sev | ID | Finding |
|-----|----|---------|
| Critical | F-001 | No reset button or bootloader-entry mechanism |
| High | F-002 | I2C pull-ups not required to be on gated power rail |
| High | F-003 | Spec silent on firmware update mechanism |
| Medium | F-004 | 1-Wire pull-up rail unspecified |
| Medium | F-005 | Multiple sensors without power gating can exceed 20 uA |
| Info | F-006 | Battery sense divider impedance not specified |
| Info | F-007 | Contract invariant checks not mandatory in CI |

Full report at `docs/audits/hw-spec-invariant-audit.md`.
