### PR TITLE
docs: minimal ESP32-C3 schematic design with Qwiic

### DIFF
--- a/docs/audits/hw-spec-invariant-audit.md
+++ b/docs/audits/hw-spec-invariant-audit.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
 # Sonde Sensor Node Hardware Specification Invariant Audit — Investigation Report
 
 > **Audit date:** 2026-03-29

--- a/docs/hw-schematic-design.md
+++ b/docs/hw-schematic-design.md
@@ -36,7 +36,7 @@ This design addresses the following requirements from
 |-------------|-------|----------|
 | HW-0100 | Microcontroller | ESP32-C3-MINI-1, 4 MB flash, all GPIOs routed |
 | HW-0101 | USB-C connector | USB-C receptacle → native USB (GPIO18/19) |
-| HW-0102 | Voltage regulator | MCP1700-3302E/TT, 1.6 µA Iq, 3.0–6 V input |
+| HW-0102 | Voltage regulator | MCP1700-3302E/TT, 1.6 µA Iq, 2.3–6.0 V input (3.3 V regulation down to ~3.5 V battery after Schottky) |
 | HW-0103 | Battery input | JST-PH 2-pin, high-Z divider, Schottky protection |
 | HW-0200 | I2C bus (Qwiic) | 2× Qwiic connectors, 4.7 kΩ pull-ups on gated rail |
 | HW-0203 | GPIO breakout | 2.54 mm header with remaining GPIOs |
@@ -91,11 +91,19 @@ HW-0201 (SPI bus), HW-0202 (1-Wire), HW-0300/HW-0301 (on-board sensors).
 #### U1 — ESP32-C3-MINI-1 Module
 
 - **Responsibility:** MCU, WiFi/BLE radio, program execution.
-- **Interfaces:** USB (GPIO18/19), I2C (GPIO4/5), ADC (GPIO0), power gate
-  control (GPIO3), BOOT button (GPIO9), all remaining GPIOs to header.
+- **Interfaces:** USB (GPIO18/19), I2C (GPIO4 = SDA, GPIO5 = SCL), ADC (GPIO0),
+  power gate control (GPIO3), BOOT button (GPIO9), all remaining GPIOs to header.
 - **Dependencies:** 3V3 rail, GND.
 - **Constraints:** Antenna keepout zone per datasheet (HW-0502).
-  Operating voltage 3.0–3.6 V. Deep sleep ≈ 5 µA typical.
+  Operating voltage 3.0–3.6 V. Deep sleep ≈ 5 µA typical. Firmware /
+  provisioning note: current `sonde-node` firmware defaults I2C to
+  SDA = GPIO0 / SCL = GPIO1 unless an NVS pin-config map is present. Because
+  this board routes I2C to GPIO4/5, production units MUST either be
+  factory-programmed with the appropriate NVS pin map for SDA=4/SCL=5, or
+  use a future `sonde-pair` release that appends the optional pin-config
+  CBOR map during pairing. Until one of these provisioning paths is in
+  place, the Qwiic I2C connectors on this board will not function with
+  stock firmware.
 
 #### U2 — MCP1700-3302E/TT (LDO Regulator)
 

--- a/hw/configs/minimal-qwiic.yaml
+++ b/hw/configs/minimal-qwiic.yaml
@@ -41,7 +41,11 @@ board:
   fab: jlcpcb         # JLCPCB manufacturing rules
 
 # --- Pin assignments ---
-# These match the firmware defaults (ND-0608 NVS config).
+# Board I2C is wired to SDA=GPIO4 / SCL=GPIO5 for Qwiic.
+# NOTE: Node firmware defaults to i2c0_sda=0 / i2c0_scl=1 when NVS is unset.
+#       ND-0608 NVS config (or equivalent provisioning) MUST set i2c0_sda=4
+#       and i2c0_scl=5 for this board, or the firmware defaults must be
+#       changed to match the pinout.
 pins:
   i2c0_sda: 4         # GPIO4
   i2c0_scl: 5         # GPIO5


### PR DESCRIPTION
## Summary

Schematic design document and board configuration YAML for the **minimal-qwiic** sonde sensor node variant.

## Board Features

- **ESP32-C3-MINI-1** (4 MB flash, integrated antenna)
- **USB-C** connector for programming and power (GPIO18/19)
- **MCP1700-3302E/TT** LDO — 1.6 uA quiescent current (SOT-23-3)
- **2x Qwiic/STEMMA QT** connectors (JST-SH 4-pin, daisy-chain)
- **Si2301 P-FET** sensor power gating on \SENSOR_3V3\ rail
- **JST-PH 2-pin** battery input with Schottky OR-ing
- **High-Z voltage divider** (2x 10 MOhm, 0.19 uA leakage) for battery monitoring
- **BOOT + RESET** buttons per audit finding F-001
- **I2C pull-ups on gated rail** per audit finding F-002
- **GPIO breakout** header (2x5, 2.54 mm)
- **Solder jumper** bypass for always-on sensor power

## Deep Sleep Current Budget

| Component | Current |
|-----------|---------|
| ESP32-C3 deep sleep | 5.0 uA typ |
| MCP1700 quiescent | 1.6 uA typ / 4.0 uA max |
| VBAT divider (20 MOhm) | 0.19 uA |
| USBLC6-2SC6 leakage | 0.15 uA max |
| I2C pull-ups (gated OFF) | 0.0 uA |
| **Total** | **~7.0 uA typ / ~9.4 uA max** |

Well within HW-0400 requirement of <= 20 uA.

## BOM

Estimated total: **~\.65** (meets HW-0601 target of <= \ USD). All parts have LCSC part numbers for JLCPCB assembly.

## Files

- \docs/hw-schematic-design.md\ — Full schematic design document with circuit details, tradeoff analysis, BOM, and net list
- \hw/configs/minimal-qwiic.yaml\ — Board configuration for the \sonde-hw\ generation tool

## Requirements Addressed

HW-0100, HW-0101, HW-0102, HW-0103, HW-0200, HW-0203, HW-0204, HW-0400, HW-0401, HW-0500, HW-0501, HW-0502

