### PR TITLE
docs: SPICE simulation pipeline specification (#583)

### DIFF
--- a/docs/hw-spice-pipeline-spec.md
+++ b/docs/hw-spice-pipeline-spec.md
@@ -21,14 +21,14 @@ fabrication — turning `prompts/hardware/02-validate-simulation.md` from
 a manual review step into an automated CI check.
 
 ```
-sonde-hw build configs/minimal-qwiic.yaml
+sonde-hw build hw/configs/minimal-qwiic.yaml
    │
    ├── .kicad_sch          (schematic file)
    ├── bom.csv             (bill of materials)
    └── internal net graph  (Python data structure)
           │
           ▼
-   sonde-hw simulate configs/minimal-qwiic.yaml
+   sonde-hw simulate hw/configs/minimal-qwiic.yaml
           │
           ├── Component → SPICE model mapping
           ├── SPICE deck generation (.cir files)
@@ -81,7 +81,7 @@ components to simulation models.
    | Component | Model file | Model type |
    |-----------|-----------|------------|
    | MCP1700 LDO | `mcp1700.sub` | Behavioral subcircuit (Vin, Vout, GND; Iq, dropout, current limit) |
-   | Si2301 P-FET | `si2301.mod` | Level 1 MOSFET (Vth=-1.2V, Rds_on=115mΩ) |
+   | Si2301 P-FET | `si2301.mod` | Level 1 MOSFET tuned for Vth≈-1.2V and ≈115mΩ Rds_on (via VTO/KP/RD/RS) |
    | Schottky diode | `schottky.mod` | Standard diode (Vf=0.3V, Is=1µA) |
    | ESP32-C3 | `esp32c3.sub` | Current source per operating state (5µA sleep, 80mA active, 150mA TX) |
    | USBLC6-2SC6 | `usblc6.sub` | Leakage model (0.15µA per line) |
@@ -303,7 +303,7 @@ analysis:
   type: op       # DC operating point
 
 assertions:
-  - net: VBAT
+  - source: VBAT
     measure: current
     operator: "<="
     threshold: 20e-6
@@ -331,12 +331,13 @@ design validation, not silicon-accurate simulation.
   * Quiescent current
   Iq vin gnd 1.6u
   * Output regulation (behavioral voltage source)
-  Breg vout gnd V = {
+  Breg vout_int gnd V = {
 +   if(V(vin,gnd) > 3.3 + 0.178, 3.3,
 +   if(V(vin,gnd) > 0.5, V(vin,gnd) - 0.178, 0))
 + }
   * Output impedance
   Rout vout_int vout 0.5
+  * Note: Breg drives vout_int; Rout provides series impedance to vout pin
 .ends mcp1700
 ```
 
@@ -374,14 +375,14 @@ Rds(on).
 
 ## 5  MVP scope
 
-The first implementation covers:
+The first implementation is expected to cover:
 
-1. ✅ Netlist JSON export from `sonde-hw build`
-2. ✅ SPICE model files for MCP1700, Si2301, Schottky, ESP32-C3
-3. ✅ SPICE deck generation for 3 tests: `dc-operating-point`,
+1. Netlist JSON export from `sonde-hw build`
+2. SPICE model files for MCP1700, Si2301, Schottky, ESP32-C3
+3. SPICE deck generation for 3 tests: `dc-operating-point`,
    `sleep-current`, `battery-divider`
-4. ✅ ngspice batch runner with assertion evaluation
-5. ✅ `sonde-hw simulate` CLI command
+4. ngspice batch runner with assertion evaluation
+5. `sonde-hw simulate` CLI command
 6. ⬜ Transient tests (`power-on-transient`, `power-gate-on`) — deferred
 7. ⬜ CI integration — deferred
 8. ⬜ kicad-cli netlist cross-check — deferred

--- a/hw/board-erc.rpt
+++ b/hw/board-erc.rpt
@@ -1,0 +1,225 @@
+ERC report (2026-03-30T08:30:48, Encoding UTF8)
+Report includes: Errors, Warnings
+
+***** Sheet /
+[footprint_link_issues]: The current configuration does not include the footprint library 'Diode_SMD'
+    ; warning
+    @(30.48 mm, 10.16 mm): Symbol D2 [D_Schottky]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(30.48 mm, 10.16 mm): Symbol D2 [D_Schottky]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Diode_SMD'
+    ; warning
+    @(30.48 mm, 20.32 mm): Symbol D1 [D_Schottky]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(30.48 mm, 20.32 mm): Symbol D1 [D_Schottky]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Capacitor_SMD'
+    ; warning
+    @(38.10 mm, 22.86 mm): Symbol C3 [C]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(38.10 mm, 22.86 mm): Symbol C3 [C]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'power'
+    ; warning
+    @(38.10 mm, 27.94 mm): Symbol #FLG3 [PWR_FLAG]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Package_TO_SOT_SMD'
+    ; warning
+    @(45.72 mm, 30.48 mm): Symbol U2 [MCP1700-3302E_TT]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Regulator_Linear'
+    ; warning
+    @(45.72 mm, 30.48 mm): Symbol U2 [MCP1700-3302E_TT]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Capacitor_SMD'
+    ; warning
+    @(55.88 mm, 22.86 mm): Symbol C4 [C]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(55.88 mm, 22.86 mm): Symbol C4 [C]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'power'
+    ; warning
+    @(0.00 mm, 60.96 mm): Symbol #FLG2 [PWR_FLAG]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Capacitor_SMD'
+    ; warning
+    @(60.96 mm, 22.86 mm): Symbol C5 [C]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(60.96 mm, 22.86 mm): Symbol C5 [C]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Connector_USB'
+    ; warning
+    @(10.16 mm, 66.04 mm): Symbol J4 [USB_C_Receptacle_USB2.0]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Connector_USB'
+    ; warning
+    @(10.16 mm, 66.04 mm): Symbol J4 [USB_C_Receptacle_USB2.0]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Package_TO_SOT_SMD'
+    ; warning
+    @(45.72 mm, 66.04 mm): Symbol U3 [USBLC6-2SC6]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Power_Protection'
+    ; warning
+    @(45.72 mm, 66.04 mm): Symbol U3 [USBLC6-2SC6]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(15.24 mm, 81.28 mm): Symbol R13 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(15.24 mm, 81.28 mm): Symbol R13 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(25.40 mm, 81.28 mm): Symbol R14 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(25.40 mm, 81.28 mm): Symbol R14 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(76.20 mm, 45.72 mm): Symbol R6 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(76.20 mm, 45.72 mm): Symbol R6 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(66.04 mm, 63.50 mm): Symbol R1 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(66.04 mm, 63.50 mm): Symbol R1 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(66.04 mm, 68.58 mm): Symbol R2 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(66.04 mm, 68.58 mm): Symbol R2 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(86.36 mm, 45.72 mm): Symbol R3 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(86.36 mm, 45.72 mm): Symbol R3 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'power'
+    ; warning
+    @(86.36 mm, 45.72 mm): Symbol #FLG1 [PWR_FLAG]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Capacitor_SMD'
+    ; warning
+    @(91.44 mm, 43.18 mm): Symbol C6 [C]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(91.44 mm, 43.18 mm): Symbol C6 [C]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Button_Switch_SMD'
+    ; warning
+    @(76.20 mm, 81.28 mm): Symbol SW2 [SW_Push]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Switch'
+    ; warning
+    @(76.20 mm, 81.28 mm): Symbol SW2 [SW_Push]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Capacitor_SMD'
+    ; warning
+    @(81.28 mm, 81.28 mm): Symbol C1 [C]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(81.28 mm, 81.28 mm): Symbol C1 [C]
+[footprint_link_issues]: The current configuration does not include the footprint library 'RF_Module'
+    ; warning
+    @(101.60 mm, 60.96 mm): Symbol U1 [ESP32-C3-MINI-1]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'sonde'
+    ; warning
+    @(101.60 mm, 60.96 mm): Symbol U1 [ESP32-C3-MINI-1]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(121.92 mm, 45.72 mm): Symbol R4 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(121.92 mm, 45.72 mm): Symbol R4 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(134.62 mm, 45.72 mm): Symbol R5 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(134.62 mm, 45.72 mm): Symbol R5 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(154.94 mm, 30.48 mm): Symbol R10 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(154.94 mm, 30.48 mm): Symbol R10 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Button_Switch_SMD'
+    ; warning
+    @(139.70 mm, 76.20 mm): Symbol SW1 [SW_Push]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Switch'
+    ; warning
+    @(139.70 mm, 76.20 mm): Symbol SW1 [SW_Push]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(160.02 mm, 25.40 mm): Symbol R9 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(160.02 mm, 25.40 mm): Symbol R9 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Package_TO_SOT_SMD'
+    ; warning
+    @(170.18 mm, 30.48 mm): Symbol Q1 [Q_PMOS_GSD]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(170.18 mm, 30.48 mm): Symbol Q1 [Q_PMOS_GSD]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Connector_JST'
+    ; warning
+    @(170.18 mm, 60.96 mm): Symbol J3 [Conn_01x02]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Connector_Generic'
+    ; warning
+    @(170.18 mm, 60.96 mm): Symbol J3 [Conn_01x02]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Jumper'
+    ; warning
+    @(180.34 mm, 30.48 mm): Symbol JP1 [SolderJumper_2_Open]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Jumper'
+    ; warning
+    @(180.34 mm, 30.48 mm): Symbol JP1 [SolderJumper_2_Open]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Connector_JST'
+    ; warning
+    @(170.18 mm, 91.44 mm): Symbol J1 [Qwiic_Connector]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'sonde'
+    ; warning
+    @(170.18 mm, 91.44 mm): Symbol J1 [Qwiic_Connector]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(185.42 mm, 60.96 mm): Symbol R11 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(185.42 mm, 60.96 mm): Symbol R11 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(185.42 mm, 68.58 mm): Symbol R12 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(185.42 mm, 68.58 mm): Symbol R12 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(185.42 mm, 81.28 mm): Symbol R7 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(185.42 mm, 81.28 mm): Symbol R7 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Capacitor_SMD'
+    ; warning
+    @(193.04 mm, 66.04 mm): Symbol C2 [C]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(193.04 mm, 66.04 mm): Symbol C2 [C]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Connector_JST'
+    ; warning
+    @(170.18 mm, 121.92 mm): Symbol J2 [Qwiic_Connector]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'sonde'
+    ; warning
+    @(170.18 mm, 121.92 mm): Symbol J2 [Qwiic_Connector]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Resistor_SMD'
+    ; warning
+    @(195.58 mm, 81.28 mm): Symbol R8 [R]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Device'
+    ; warning
+    @(195.58 mm, 81.28 mm): Symbol R8 [R]
+[footprint_link_issues]: The current configuration does not include the footprint library 'Connector_PinHeader_2.54mm'
+    ; warning
+    @(170.18 mm, 149.86 mm): Symbol J6 [Conn_02x05_Odd_Even]
+[lib_symbol_issues]: The current configuration does not include the symbol library 'Connector_Generic'
+    ; warning
+    @(170.18 mm, 149.86 mm): Symbol J6 [Conn_02x05_Odd_Even]
+
+ ** ERC messages: 71  Errors 0  Warnings 71
+
+ ** Ignored checks:
+    - Global label only appears once in the schematic
+    - Four connection points are joined together
+    - SPICE model issue
+    - Assigned footprint doesn't match footprint filters


### PR DESCRIPTION
## Summary

Specification for the automated SPICE simulation pipeline (issue #583).

### Pipeline

```
sonde-hw build → netlist.json → SPICE deck → ngspice → assertions
```

### What is specified

- **HW-SIM-001**: Netlist JSON export from build pipeline
- **HW-SIM-002**: SPICE model library (MCP1700 LDO, Si2301 P-FET, ESP32-C3, Schottky, USBLC6)
- **HW-SIM-003**: SPICE deck generation (.cir files)
- **HW-SIM-004**: 6 simulation tests (DC op, sleep current, dropout, transient, power gate, battery divider)
- **HW-SIM-005**: ngspice batch runner with output parsing
- **HW-SIM-006**: CLI integration (`sonde-hw simulate`)
- **HW-SIM-007**: CI integration (Should)

### Key decisions
- **ngspice subprocess** over PySpice/Xyce (simplest, widely available)
- **Internal netlist** over kicad-cli export (data already in memory during build)
- **Behavioral models** not transistor-level (design validation, not silicon accuracy)

### MVP scope
3 tests: `dc-operating-point`, `sleep-current`, `battery-divider`
Transient tests and CI deferred.

Relates-to: #583
