### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "sonde-admin"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -5208,11 +5208,11 @@ dependencies = [
 
 [[package]]
 name = "sonde-bpf"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "sonde-e2e"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ciborium",
  "hmac",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "sonde-gateway"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "sonde-modem"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "embuild",
  "esp-idf-hal",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "sonde-node"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ciborium",
  "embuild",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "sonde-pair"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "btleplug",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "sonde-pair-ui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "jni 0.22.4",
  "serde",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "sonde-protocol"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ciborium",
  "hmac",

--- a/crates/sonde-admin/Cargo.toml
+++ b/crates/sonde-admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonde-admin"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 

--- a/crates/sonde-bpf/Cargo.toml
+++ b/crates/sonde-bpf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonde-bpf"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A simple, zero-allocation BPF interpreter based on RFC 9669"
 license = "MIT"

--- a/crates/sonde-e2e/Cargo.toml
+++ b/crates/sonde-e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonde-e2e"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "End-to-end integration tests for the sonde platform"
 

--- a/crates/sonde-gateway/Cargo.toml
+++ b/crates/sonde-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonde-gateway"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 

--- a/crates/sonde-modem/Cargo.toml
+++ b/crates/sonde-modem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonde-modem"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "ESP32-S3 radio modem firmware — USB-CDC to ESP-NOW bridge"

--- a/crates/sonde-node/Cargo.toml
+++ b/crates/sonde-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonde-node"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Sonde node firmware — wake cycle engine, BPF runtime, and platform abstractions"
 

--- a/crates/sonde-pair-ui/package.json
+++ b/crates/sonde-pair-ui/package.json
@@ -1,5 +1,5 @@
 {
   "name": "sonde-pair-ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true
 }

--- a/crates/sonde-pair-ui/src-tauri/Cargo.toml
+++ b/crates/sonde-pair-ui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonde-pair-ui"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "Tauri v2 BLE pairing tool for sonde sensor nodes"

--- a/crates/sonde-pair-ui/src-tauri/tauri.conf.json
+++ b/crates/sonde-pair-ui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "Sonde Pairing Tool",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "com.sonde.pair",
   "build": {
     "frontendDist": "../src"

--- a/crates/sonde-pair/Cargo.toml
+++ b/crates/sonde-pair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonde-pair"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 

--- a/crates/sonde-protocol/Cargo.toml
+++ b/crates/sonde-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonde-protocol"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Shared protocol crate for the Sonde platform"
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1003,7 +1003,7 @@ The clap `#[command]` attribute uses `concat!()` to build a compile-time version
 #[command(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("SONDE_GIT_COMMIT"), ")"))]
 ```
 
-This produces output like `sonde-gateway 0.2.0 (a1b2c3d)`.
+This produces output like `sonde-gateway 0.3.0 (a1b2c3d)`.
 
 ### 14A.3  Startup log
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -1087,7 +1087,7 @@ The gateway and admin binaries MUST embed the git commit hash (short, 7 characte
 
 **Acceptance criteria:**
 
-1. `sonde-gateway --version` prints the version string in the format `<semver> (<short-hash>)`, e.g., `0.2.0 (a1b2c3d)`.
+1. `sonde-gateway --version` prints the version string in the format `<semver> (<short-hash>)`, e.g., `0.3.0 (a1b2c3d)`.
 2. `sonde-admin --version` prints the same format.
 3. The gateway startup log includes the version string with the embedded commit hash.
 4. When git metadata is unavailable (e.g., building from a tarball), the hash falls back to `unknown`.


### PR DESCRIPTION
Bumps all crate and package versions from 0.2.0 to 0.3.0 following the v0.2.0 release tag.

- All \Cargo.toml\ workspace crates: 0.2.0 → 0.3.0
- \crates/sonde-pair-ui/package.json\: 0.2.0 → 0.3.0
- \crates/sonde-pair-ui/src-tauri/tauri.conf.json\: 0.2.0 → 0.3.0
- \Cargo.lock\ updated accordingly
- Spec example version strings in \docs/gateway-design.md\ and \docs/gateway-requirements.md\ updated