### PR TITLE
docs: modernise deployment SOP to use platform installers

### DIFF
--- a/docs/deployment-sop.md
+++ b/docs/deployment-sop.md
@@ -171,9 +171,9 @@ SERIAL_PORT=/dev/ttyACM0
 Generate a master key and add it to the service configuration:
 
 ```sh
-sudo openssl rand -hex 32 > /etc/sonde/master-key.hex
-sudo chmod 640 /etc/sonde/master-key.hex
-sudo chown root:sonde /etc/sonde/master-key.hex
+# Atomically create the key file with restrictive permissions so the
+# key material is never world-readable, even transiently.
+sudo sh -c 'openssl rand -hex 32 | install -m 640 -o root -g sonde /dev/stdin /etc/sonde/master-key.hex'
 ```
 
 Create a systemd override to add the master key file:
@@ -486,9 +486,10 @@ journalctl -u sonde-gateway -p err
 To change the level, edit the environment file and restart:
 
 ```sh
-# Remove any existing RUST_LOG line, then set a new one
-sudo sed -i '/^RUST_LOG=/d' /etc/sonde/environment
-echo 'RUST_LOG=sonde_gateway=info' | sudo tee -a /etc/sonde/environment >/dev/null
+# Edit the environment file (preserves ownership/permissions unlike sed -i)
+sudoedit /etc/sonde/environment
+# In the editor: set the RUST_LOG line to the desired level, e.g.:
+#   RUST_LOG=sonde_gateway=info
 sudo systemctl restart sonde-gateway
 ```
 
@@ -526,10 +527,15 @@ The gateway service writes to two log sinks:
 # Set the desired log level at the machine scope (persists across restarts)
 [Environment]::SetEnvironmentVariable("RUST_LOG", "sonde_gateway=debug", "Machine")
 
-# Restart the service to pick up the new environment
+# Restart the service — the gateway reads RUST_LOG at startup, so a
+# restart is required for the new value to take effect.
 sc stop sonde-gateway
 sc start sonde-gateway
 ```
+
+> **Note:** The gateway does not currently support runtime log-level
+> reload via `sc control sonde-gateway paramchange`. Changing
+> `RUST_LOG` always requires a service restart.
 
 Release builds default to `sonde_gateway=warn`. Set
 `RUST_LOG=sonde_gateway=info` for lifecycle events during initial


### PR DESCRIPTION
Rewrite the end-to-end deployment SOP so the gateway is installed and managed as a system service via the \.deb\ / \.msi\ installers rather than run as a foreground console process.

## Key changes

- **Step 1** — Downloads \sonde-installer-linux\ / \sonde-installer-windows\ artifacts instead of raw gateway/admin binaries.
- **Step 4 (new)** — Install the gateway via \dpkg -i\ (Linux) or \msiexec /i\ (Windows). Explains what each installer sets up: systemd unit, Windows service registration, user/group, PATH, data directories.
- **Step 5 (new)** — Configure the gateway: serial-port config in \/etc/sonde/environment\, master-key generation, systemd overrides (Linux). The MSI handles this automatically on Windows.
- **Step 11** — Handler configuration now uses \sonde-admin handler add\ / \emove\ / \list\ instead of editing a YAML file and restarting the gateway (live, no restart required).
- **All steps** — \sonde-admin\ commands drop the \./bin/\ prefix since the installers put the tools on \PATH\.
- **New Monitoring section** — \journalctl\ on Linux; log file + ETW provider \sonde-gateway\ on Windows; runtime log-level reload via \sc control sonde-gateway paramchange\.
- **Troubleshooting** — Updated handler entry to reference \sonde-admin handler list\; added service-specific startup failure rows for both Linux and Windows.