### PR TITLE
fix(installer): add CustomAction.config for .NET 4.x CLR activation

### DIFF
--- a/installer/windows/CustomActions/CustomAction.config
+++ b/installer/windows/CustomActions/CustomAction.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0" />
+  </startup>
+</configuration>

--- a/installer/windows/CustomActions/SondeCustomActions.csproj
+++ b/installer/windows/CustomActions/SondeCustomActions.csproj
@@ -16,4 +16,10 @@
   <ItemGroup>
     <Reference Include="System.Management" />
   </ItemGroup>
+
+  <!-- CustomAction.config is packed into the .CA.dll by the WiX DTF
+       PackCustomAction target so the SfxCA stub can locate the CLR. -->
+  <ItemGroup>
+    <Content Include="CustomAction.config" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Problem

The MSI installer fails with error `0x80131700` during the `DetectModemPort` custom action. The WiX DTF SfxCA stub cannot locate the CLR because there is no `CustomAction.config` embedded in the `.CA.dll` cabinet.

## Root Cause

The SfxCA host (the unmanaged stub that loads .NET custom actions) looks for a `CustomAction.config` file inside the self-extracting cabinet to determine which CLR version to load. Without this file, it defaults to looking for CLR 2.0, which is not installed on modern Windows machines that only have .NET Framework 4.x.

## Fix

- Added `CustomAction.config` with `<supportedRuntime version="v4.0" />` and `useLegacyV2RuntimeActivationPolicy="true"`
- Added the file as a `<Content>` item in the `.csproj` so the `PackCustomAction` target includes it in the `.CA.dll` cabinet

## Testing

- Built the DLL and verified via binary inspection that `CustomAction.config` is included in the MakeSfxCA response file
- Loaded the compiled DLL in PowerShell and invoked the detection methods via reflection — all pass correctly