### PR TITLE
feat(modem): add `aes-gcm-codec` feature flag propagation (#495)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -1226,6 +1242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +1855,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3451,6 +3482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "normpath"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4169,6 +4206,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -5214,8 +5281,10 @@ version = "0.3.0"
 name = "sonde-bundle"
 version = "0.3.0"
 dependencies = [
+ "assert_cmd",
  "clap",
  "flate2",
+ "predicates",
  "semver",
  "serde",
  "serde_json",
@@ -5915,6 +5984,12 @@ dependencies = [
  "new_debug_unreachable",
  "utf-8",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -6669,6 +6744,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 

--- a/crates/sonde-modem/Cargo.toml
+++ b/crates/sonde-modem/Cargo.toml
@@ -22,6 +22,11 @@ quiet = ["log/release_max_level_warn"]
 # default is INFO. Build with `--features esp,verbose --no-default-features`
 # (MD-0505).
 verbose = ["log/release_max_level_debug"]
+# Forward AES-256-GCM codec support to sonde-protocol.  The modem is a
+# transparent bridge and never decrypts frames, so no additional deps are
+# needed — only the protocol feature flag is propagated so that shared
+# constants and types are available when the workspace is built uniformly.
+aes-gcm-codec = ["sonde-protocol/aes-gcm-codec"]
 
 [dependencies]
 sonde-protocol = { path = "../sonde-protocol", default-features = false }


### PR DESCRIPTION
## Summary

Adds the `aes-gcm-codec` feature flag to `sonde-modem`, forwarding it to `sonde-protocol`.

## Why this is minimal

The modem is a **transparent bridge** — it relays ESP-NOW frames between radio and USB-CDC serial without decrypting or authenticating them (that's the gateway's job). It references only modem serial protocol types (`ModemMessage`, `RecvFrame`, `MAC_SIZE`, etc.) and never touches frame-level crypto constants like `HMAC_SIZE` or `AEAD_TAG_SIZE`.

## Changes

- **`Cargo.toml`**: Added `aes-gcm-codec = ["sonde-protocol/aes-gcm-codec"]` feature — no additional dependencies needed since the modem doesn't perform encryption.
- **`Cargo.lock`**: Updated lockfile.
- **No source code changes** — the modem has zero references to HMAC/AEAD constants or pairing message CBOR encoding.

## Verification

- `cargo fmt --check --all` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅
- `cargo build --workspace` ✅

Implements: #495 (Phase 5, modem layer — additive)
