### PR TITLE
fix(installer): update license copyright to sonde contributors

### DIFF
--- a/installer/windows/license.rtf
+++ b/installer/windows/license.rtf
@@ -3,7 +3,7 @@
 \f0\fs20
 MIT License\par
 \par
-Copyright (c) 2026 Alan Jowett\par
+Copyright (c) 2026 sonde contributors\par
 \par
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The MSI installer license dialog displayed 'Copyright Alan Jowett' instead of 'Copyright sonde contributors', inconsistent with the SPDX headers used across the codebase.

Fixes #604