### PR TITLE
docs(sop): add Windows stale BLE pairing warning before re-provisioning

### DIFF
--- a/docs/deployment-sop.md
+++ b/docs/deployment-sop.md
@@ -332,11 +332,11 @@ individual nodes. Repeat this phase for each new node.
 
 > **Windows re-provisioning:** If you are re-provisioning a node that was
 > previously paired (e.g., after a factory reset or firmware reflash),
-> remove the stale BLE pairing from Windows first:
-> **Settings → Bluetooth & devices → Devices**, find the sonde node/modem
-> entry, click **Remove device**. Without this step, Windows reuses
-> cached pairing keys that no longer match the node and the BLE pairing
-> handshake fails silently.
+> remove the stale BLE pairing for that node from Windows first:
+> **Settings → Bluetooth & devices → Devices**, find the sonde node entry
+> corresponding to the device you're re-provisioning, and click **Remove device**.
+> Without this step, Windows reuses cached pairing keys that no longer match
+> the node and the LESC handshake fails silently.
 
 1. **Launch the pairing tool** (already registered from Phase 1).
 2. The tool scans for sonde nodes advertising the pairing service.


### PR DESCRIPTION
Add a warning box in the BLE provisioning section (Phase 2) instructing users to remove stale Bluetooth pairings from Windows Settings before re-provisioning a node. Without this, Windows reuses cached LESC keys that no longer match after a factory reset or firmware reflash.

The troubleshooting table already covers this symptom, but a proactive warning prevents the issue from occurring in the first place.

Fixes #606