### PR TITLE
feat: switch gateway and node binaries to AES-256-GCM frame codec

### DIFF
--- a/.github/workflows/esp32-modem.yml
+++ b/.github/workflows/esp32-modem.yml
@@ -37,10 +37,10 @@ jobs:
         variant: [default, verbose]
         include:
           - variant: default
-            features: esp
+            features: esp,aes-gcm-codec
             artifact: modem-firmware
           - variant: verbose
-            features: esp,verbose
+            features: esp,verbose,aes-gcm-codec
             no_default_features: --no-default-features
             artifact: modem-firmware-verbose
 

--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -38,10 +38,10 @@ jobs:
         variant: [default, verbose]
         include:
           - variant: default
-            features: esp
+            features: esp,aes-gcm-codec
             artifact: node-firmware
           - variant: verbose
-            features: esp,verbose
+            features: esp,verbose,aes-gcm-codec
             no_default_features: --no-default-features
             artifact: node-firmware-verbose
 

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -477,7 +477,7 @@ async fn run_gateway(
                 match transport_ref.recv().await {
                     Ok((raw_frame, peer_addr)) => {
                         if let Some(response) = gateway_ref
-                            .process_frame(&raw_frame, peer_addr.clone())
+                            .process_frame_aead(&raw_frame, peer_addr.clone())
                             .await
                         {
                             if let Err(e) = transport_ref.send(&response, &peer_addr).await {

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -33,7 +33,7 @@ fn main() {
     use sonde_node::map_storage::{MapStorage, MAP_BUDGET};
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
     use sonde_node::traits::{PlatformStorage, SleepController};
-    use sonde_node::wake_cycle::{run_wake_cycle, WakeCycleOutcome};
+    use sonde_node::wake_cycle::{run_wake_cycle_aead, WakeCycleOutcome};
 
     // Link ESP-IDF patches and initialize logging.
     esp_idf_svc::sys::link_patches();
@@ -150,6 +150,7 @@ fn main() {
     // --- Node is paired — initialize radio and run wake cycle ---
     let hmac = SoftwareHmac;
     let sha = SoftwareSha256;
+    let aead = sonde_node::node_aead::NodeAead;
     let mut rng = EspRng;
     let clock = EspClock;
     // Read I2C pin config from NVS (ND-0608), falling back to defaults.
@@ -169,7 +170,7 @@ fn main() {
 
     info!("sonde-node ready");
 
-    let outcome = run_wake_cycle(
+    let outcome = run_wake_cycle_aead(
         &mut transport,
         &mut storage,
         &mut hal,
@@ -180,6 +181,7 @@ fn main() {
         &mut map_storage,
         &hmac,
         &sha,
+        &aead,
     );
 
     match outcome {


### PR DESCRIPTION
## Summary

Wires the production binaries to use the AES-256-GCM (AEAD) frame codec path instead of HMAC-SHA256. This is the change that makes AEAD the **actual** on-wire protocol, not just compiled-in library code.

## Changes (2 lines)

| Binary | Before | After |
|--------|--------|-------|
| `gateway.rs:480` | `process_frame()` (HMAC) | `process_frame_aead()` (AEAD) |
| `node.rs:172` | `run_wake_cycle()` (HMAC) | `run_wake_cycle_aead()` (AEAD) |

The node binary also instantiates `NodeAead` and passes it to the wake cycle.

## Context

PRs #608–#615 built the AEAD code and enabled the `aes-gcm-codec` feature flag by default, but never changed the binary entry points. Both binaries were still calling the HMAC path. This was discovered during hardware testing when APP_DATA frames were being silently discarded (#622).

## NOT included

BLE pairing (`sonde-pair-ui`) still uses the ECDH/HMAC Phase 1 + Phase 2 flow. Migrating requires a new `provision_node_aead` function — tracked separately.

## Testing

- All gateway tests pass (129 + 9 AEAD engine)
- All node tests pass (255)
- All protocol tests pass (75 + 76)
- Clippy + fmt clean

## ⚠️ Hardware impact

After merging, both gateway and node firmware must be rebuilt and reflashed simultaneously. An HMAC node cannot communicate with an AEAD gateway (and vice versa). Previously paired nodes will need to re-pair.