### PR TITLE
feat: switch BLE pairing UI to simplified AEAD flow

### DIFF
--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -471,13 +471,8 @@ impl NodeTransport for BridgeTransport {
 // BridgeTransportAead — AEAD variant for AES-256-GCM E2E tests
 // ---------------------------------------------------------------------------
 
-/// In-memory frame relay that routes frames through the gateway's AEAD path.
-///
-/// WAKE, GET_CHUNK, and PROGRAM_ACK frames are processed via
-/// `process_frame_aead` (AES-256-GCM). APP_DATA and PEER_REQUEST frames
-/// are routed through `process_frame` (HMAC) — APP_DATA because the BPF
-/// dispatch helpers still use the HMAC codec, and PEER_REQUEST because the
-/// AEAD handler rejects it (the node is not yet registered at that point).
+/// In-memory frame relay that routes all frames through the gateway's
+/// `process_frame_aead` path (AES-256-GCM), including PEER_REQUEST.
 #[cfg(feature = "aes-gcm-codec")]
 struct BridgeTransportAead {
     gateway: Arc<Gateway>,
@@ -544,31 +539,17 @@ impl NodeTransport for BridgeTransportAead {
 
         let gateway = self.gateway.clone();
         let peer = self.peer.clone();
-        let msg_type = if frame.len() > sonde_protocol::OFFSET_MSG_TYPE {
-            frame[sonde_protocol::OFFSET_MSG_TYPE]
-        } else {
-            0
-        };
 
-        // PEER_REQUEST uses the HMAC path because the gateway's AEAD
-        // handler requires a registered phone PSK. All other frames
-        // (including APP_DATA) use the AEAD codec.
-        let response = if msg_type == sonde_protocol::MSG_PEER_REQUEST {
-            let frame_vec = frame.to_vec();
-            tokio::task::block_in_place(|| {
-                self.rt.block_on(gateway.process_frame(&frame_vec, peer))
-            })
-        } else {
-            let mut frame_vec = frame.to_vec();
-            if self.tamper_outgoing && frame_vec.len() > sonde_protocol::HEADER_SIZE {
-                // Flip a bit in the first ciphertext byte to trigger GCM auth failure.
-                frame_vec[sonde_protocol::HEADER_SIZE] ^= 0x01;
-            }
-            tokio::task::block_in_place(|| {
-                self.rt
-                    .block_on(gateway.process_frame_aead(&frame_vec, peer))
-            })
-        };
+        // All frames (including PEER_REQUEST) use the AEAD codec.
+        let mut frame_vec = frame.to_vec();
+        if self.tamper_outgoing && frame_vec.len() > sonde_protocol::HEADER_SIZE {
+            // Flip a bit in the first ciphertext byte to trigger GCM auth failure.
+            frame_vec[sonde_protocol::HEADER_SIZE] ^= 0x01;
+        }
+        let response = tokio::task::block_in_place(|| {
+            self.rt
+                .block_on(gateway.process_frame_aead(&frame_vec, peer))
+        });
 
         if response.is_some() {
             self.response_count += 1;
@@ -1438,15 +1419,11 @@ pub async fn simulate_phone_registration(
     rf_channel: u8,
 ) -> (Zeroizing<[u8; 32]>, u16) {
     use sonde_gateway::ble_pairing::{handle_ble_recv, RegistrationWindow};
-    use sonde_pair::crypto::{
-        aes256gcm_decrypt, ed25519_to_x25519_public, generate_x25519_keypair, hkdf_sha256,
-        verify_ed25519_signature, x25519_ecdh,
-    };
-    use sonde_pair::envelope::{
-        build_envelope, parse_envelope, parse_gw_info_response, parse_phone_registered,
-    };
+    use sonde_pair::crypto::verify_ed25519_signature;
+    use sonde_pair::envelope::{build_envelope, parse_envelope, parse_gw_info_response};
     use sonde_pair::rng::{OsRng, RngProvider};
     use sonde_pair::types;
+    use std::sync::Arc;
 
     let mut window = RegistrationWindow::new();
     window.open(120);
@@ -1490,11 +1467,12 @@ pub async fn simulate_phone_registration(
         "response gateway_id must match gateway identity"
     );
 
-    // Phase 1b: REGISTER_PHONE
-    let (eph_secret, eph_public) = generate_x25519_keypair(&rng).unwrap();
+    // Phase 1b: REGISTER_PHONE (AEAD — phone sends PSK directly)
+    let mut phone_psk = Zeroizing::new([0u8; 32]);
+    rng.fill_bytes(&mut *phone_psk).unwrap();
     let label = b"e2e-test-phone";
     let mut register_body = Vec::with_capacity(32 + 1 + label.len());
-    register_body.extend_from_slice(&eph_public);
+    register_body.extend_from_slice(&*phone_psk);
     register_body.push(label.len() as u8);
     register_body.extend_from_slice(label);
     let register_request = build_envelope(types::REGISTER_PHONE, &register_body).unwrap();
@@ -1510,49 +1488,27 @@ pub async fn simulate_phone_registration(
     .await
     .expect("PHONE_REGISTERED must be returned");
 
-    // Decrypt PHONE_REGISTERED
+    // Parse PHONE_REGISTERED (AEAD): status(1) + rf_channel(1) + phone_key_hint(2 BE)
     let (msg_type, body) = parse_envelope(&register_response).unwrap();
     assert_eq!(msg_type, types::PHONE_REGISTERED);
-    let registered = parse_phone_registered(body).unwrap();
-
-    // Decrypt using fields from the GW_INFO_RESPONSE (not the caller's
-    // identity) so the helper validates the response like a real phone.
-    let gw_x25519 = ed25519_to_x25519_public(&gw_info.gw_public_key).unwrap();
-    let shared_secret = x25519_ecdh(&eph_secret, &gw_x25519);
-    let aes_key = hkdf_sha256(&shared_secret, &gw_info.gateway_id, b"sonde-phone-reg-v1");
-    let plaintext = aes256gcm_decrypt(
-        &aes_key,
-        &registered.nonce,
-        &registered.ciphertext,
-        &gw_info.gateway_id,
-    )
-    .unwrap();
-
-    // Inner: status(1) + phone_psk(32) + phone_key_hint(2) + rf_channel(1)
-    assert_eq!(
-        plaintext.len(),
-        36,
-        "PHONE_REGISTERED inner must be 36 bytes"
-    );
-    assert_eq!(plaintext[0], 0x00, "status must be success");
-    let mut phone_psk = Zeroizing::new([0u8; 32]);
-    phone_psk.copy_from_slice(&plaintext[1..33]);
-    let phone_key_hint = u16::from_be_bytes([plaintext[33], plaintext[34]]);
-    assert_eq!(plaintext[35], rf_channel, "rf_channel must match");
+    assert_eq!(body.len(), 4, "PHONE_REGISTERED body must be 4 bytes");
+    assert_eq!(body[0], 0x00, "status must be success");
+    assert_eq!(body[1], rf_channel, "rf_channel must match");
+    let phone_key_hint = u16::from_be_bytes([body[2], body[3]]);
 
     (phone_psk, phone_key_hint)
 }
 
-/// Build the encrypted_payload for NODE_PROVISION and PEER_REQUEST.
+/// Build the complete ESP-NOW PEER_REQUEST frame for NODE_PROVISION.
 ///
-/// Mirrors the payload construction from `sonde_pair::phase2::provision_node`
-/// using the public crypto and CBOR building blocks.
+/// Uses `encrypt_pairing_request_aead` to build a frame the node relays
+/// verbatim during the PEER_REQUEST exchange.
 #[allow(clippy::too_many_arguments)]
 pub fn build_encrypted_payload(
-    gw_public_key: &[u8; 32],
-    gw_gateway_id: &[u8; 16],
+    _gw_public_key: &[u8; 32],
+    _gw_gateway_id: &[u8; 16],
     phone_psk: &[u8; 32],
-    phone_key_hint: u16,
+    _phone_key_hint: u16,
     node_id: &str,
     node_psk: &[u8; 32],
     rf_channel: u8,
@@ -1564,10 +1520,10 @@ pub fn build_encrypted_payload(
         .as_secs() as i64;
 
     build_encrypted_payload_with_timestamp(
-        gw_public_key,
-        gw_gateway_id,
+        _gw_public_key,
+        _gw_gateway_id,
         phone_psk,
-        phone_key_hint,
+        _phone_key_hint,
         node_id,
         node_psk,
         rf_channel,
@@ -1576,16 +1532,16 @@ pub fn build_encrypted_payload(
     )
 }
 
-/// Build the encrypted_payload with a caller-supplied timestamp.
+/// Build the complete ESP-NOW PEER_REQUEST frame with a caller-supplied timestamp.
 ///
 /// Same as [`build_encrypted_payload`] but accepts an explicit timestamp
 /// for negative testing (e.g. stale timestamps outside the ±86400 s window).
 #[allow(clippy::too_many_arguments)]
 pub fn build_encrypted_payload_with_timestamp(
-    gw_public_key: &[u8; 32],
-    gw_gateway_id: &[u8; 16],
+    _gw_public_key: &[u8; 32],
+    _gw_gateway_id: &[u8; 16],
     phone_psk: &[u8; 32],
-    phone_key_hint: u16,
+    _phone_key_hint: u16,
     node_id: &str,
     node_psk: &[u8; 32],
     rf_channel: u8,
@@ -1593,41 +1549,11 @@ pub fn build_encrypted_payload_with_timestamp(
     timestamp: i64,
 ) -> Vec<u8> {
     use sonde_pair::cbor::encode_pairing_request;
-    use sonde_pair::crypto::{
-        aes256gcm_encrypt, ed25519_to_x25519_public, generate_x25519_keypair, hkdf_sha256,
-        hmac_sha256, x25519_ecdh,
-    };
-    use sonde_pair::rng::{OsRng, RngProvider};
+    use sonde_pair::crypto::encrypt_pairing_request_aead;
 
-    // Step 1: Encode PairingRequest as CBOR
     let cbor = encode_pairing_request(node_id, node_psk, rf_channel, sensors, timestamp).unwrap();
-
-    // Step 2: authenticated_request = phone_key_hint(2) + cbor + hmac(32)
-    let phone_hmac = hmac_sha256(phone_psk, &cbor);
-    let mut auth_request = Vec::with_capacity(2 + cbor.len() + 32);
-    auth_request.extend_from_slice(&phone_key_hint.to_be_bytes());
-    auth_request.extend_from_slice(&cbor);
-    auth_request.extend_from_slice(&phone_hmac);
-
-    // Step 3: ECDH with gateway
-    let gw_x25519 = ed25519_to_x25519_public(gw_public_key).unwrap();
-    let rng = OsRng;
-    let (eph_secret, eph_public) = generate_x25519_keypair(&rng).unwrap();
-    let shared_secret = x25519_ecdh(&eph_secret, &gw_x25519);
-    let aes_key = hkdf_sha256(&shared_secret, gw_gateway_id, b"sonde-node-pair-v1");
-
-    // Step 4: Encrypt
-    let mut nonce = [0u8; 12];
-    rng.fill_bytes(&mut nonce).unwrap();
-    let ciphertext = aes256gcm_encrypt(&aes_key, &nonce, &auth_request, gw_gateway_id).unwrap();
-
-    // Step 5: encrypted_payload = eph_public(32) + nonce(12) + ciphertext
-    let mut payload = Vec::with_capacity(32 + 12 + ciphertext.len());
-    payload.extend_from_slice(&eph_public);
-    payload.extend_from_slice(&nonce);
-    payload.extend_from_slice(&ciphertext);
-
-    payload
+    encrypt_pairing_request_aead(phone_psk, &cbor)
+        .expect("encrypt_pairing_request_aead must succeed in test")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sonde-e2e/tests/ble_loopback_tests.rs
+++ b/crates/sonde-e2e/tests/ble_loopback_tests.rs
@@ -11,15 +11,13 @@
 //!
 //! - BleTransport initialization crashes
 //! - BLE envelope encoding/decoding mismatches between `sonde-pair` and `sonde-gateway`
-//! - Phase 1 flow issues through the real transport layer
-//! - Cryptographic handshake regressions (ECDH, HKDF, AES-GCM)
-//! - TOFU identity pinning via the store
+//! - Phase 1 AEAD flow through the real transport layer
+//! - PSK registration and artifact construction
 
 use sonde_e2e::fake_peripheral::{self, FakePeripheralConfig};
 use sonde_pair::loopback_transport::LoopbackBleTransport;
 use sonde_pair::phase1;
 use sonde_pair::rng::OsRng;
-use sonde_pair::store::{MemoryPairingStore, PairingStore};
 use sonde_pair::transport::BleTransport;
 
 /// Start a fake peripheral and return (transport, peripheral) pair.
@@ -36,11 +34,10 @@ async fn setup() -> (LoopbackBleTransport, fake_peripheral::FakePeripheral) {
     (transport, peripheral)
 }
 
-/// Phase 1 happy path: scan → connect → pair with gateway → verify artifacts.
+/// Phase 1 AEAD happy path: scan → connect → register phone → verify artifacts.
 #[tokio::test]
 async fn phase1_loopback_happy_path() {
     let (mut transport, peripheral) = setup().await;
-    let mut store = MemoryPairingStore::new();
     let rng = OsRng;
     let device_addr = [0x10, 0x0B, 0xAC, 0x00, 0x00, 0x01];
 
@@ -49,23 +46,20 @@ async fn phase1_loopback_happy_path() {
     assert_eq!(devices.len(), 1);
     assert_eq!(devices[0].name, "Sonde-GW-Loopback");
 
-    // Phase 1: pair with the fake gateway
-    let artifacts = phase1::pair_with_gateway(
+    // Phase 1: pair with the fake gateway (AEAD)
+    let artifacts = phase1::pair_with_gateway_aead(
         &mut transport,
-        &mut store,
         &rng,
         &device_addr,
         "integration-test-phone",
         None,
     )
     .await
-    .expect("Phase 1 pairing should succeed");
+    .expect("Phase 1 AEAD pairing should succeed");
 
     // Verify artifacts
     assert_eq!(artifacts.rf_channel, 6);
     assert_eq!(artifacts.phone_label, "integration-test-phone");
-    assert_eq!(artifacts.gateway_identity.public_key.len(), 32);
-    assert_eq!(artifacts.gateway_identity.gateway_id.len(), 16);
 
     // PSK should not be all-zeros
     assert_ne!(&*artifacts.phone_psk, &[0u8; 32]);
@@ -74,115 +68,47 @@ async fn phase1_loopback_happy_path() {
     let expected_hint = sonde_pair::validation::compute_key_hint(&artifacts.phone_psk);
     assert_eq!(artifacts.phone_key_hint, expected_hint);
 
-    // Artifacts should be persisted in the store
-    let loaded = store
-        .load_artifacts()
-        .unwrap()
-        .expect("artifacts should be saved");
-    assert_eq!(
-        loaded.gateway_identity.public_key,
-        artifacts.gateway_identity.public_key
-    );
-    assert_eq!(loaded.rf_channel, artifacts.rf_channel);
-
     peripheral.cancel();
 }
 
-/// Phase 1 with re-pairing: running Phase 1 twice should succeed and
-/// overwrite the previous artifacts cleanly (PT-0600 / PT-0601).
+/// Phase 1 AEAD re-pairing: running Phase 1 twice should succeed each time.
 #[tokio::test]
 async fn phase1_loopback_re_pair() {
     let (mut transport, peripheral) = setup().await;
-    let mut store = MemoryPairingStore::new();
     let rng = OsRng;
     let device_addr = [0x10, 0x0B, 0xAC, 0x00, 0x00, 0x01];
 
     // First pairing
-    let first = phase1::pair_with_gateway(
-        &mut transport,
-        &mut store,
-        &rng,
-        &device_addr,
-        "first-phone",
-        None,
-    )
-    .await
-    .expect("first pairing should succeed");
+    let first =
+        phase1::pair_with_gateway_aead(&mut transport, &rng, &device_addr, "first-phone", None)
+            .await
+            .expect("first pairing should succeed");
 
-    // Second pairing — same gateway, new label
-    let second = phase1::pair_with_gateway(
-        &mut transport,
-        &mut store,
-        &rng,
-        &device_addr,
-        "second-phone",
-        None,
-    )
-    .await
-    .expect("re-pairing should succeed");
+    // Second pairing — new PSK generated each time
+    let second =
+        phase1::pair_with_gateway_aead(&mut transport, &rng, &device_addr, "second-phone", None)
+            .await
+            .expect("re-pairing should succeed");
 
-    // Gateway identity should be the same (same fake peripheral)
-    assert_eq!(
-        first.gateway_identity.public_key,
-        second.gateway_identity.public_key
-    );
-
-    // But artifacts should differ (new PSK issued each time)
+    // PSKs should differ (fresh random each time)
     assert_ne!(*first.phone_psk, *second.phone_psk);
     assert_eq!(second.phone_label, "second-phone");
 
-    // Store should have the latest artifacts
-    let loaded = store.load_artifacts().unwrap().unwrap();
-    assert_eq!(loaded.phone_label, "second-phone");
-
     peripheral.cancel();
 }
 
-/// Phase 1 with empty phone label (allowed by spec: 0–64 bytes).
+/// Phase 1 AEAD with empty phone label (allowed by spec: 0–64 bytes).
 #[tokio::test]
 async fn phase1_loopback_empty_label() {
     let (mut transport, peripheral) = setup().await;
-    let mut store = MemoryPairingStore::new();
     let rng = OsRng;
     let device_addr = [0x10, 0x0B, 0xAC, 0x00, 0x00, 0x01];
 
-    let artifacts =
-        phase1::pair_with_gateway(&mut transport, &mut store, &rng, &device_addr, "", None)
-            .await
-            .expect("pairing with empty label should succeed");
+    let artifacts = phase1::pair_with_gateway_aead(&mut transport, &rng, &device_addr, "", None)
+        .await
+        .expect("pairing with empty label should succeed");
 
     assert_eq!(artifacts.phone_label, "");
-
-    peripheral.cancel();
-}
-
-/// TOFU violation: if the store already has a different gateway identity,
-/// Phase 1 should fail with `PublicKeyMismatch`.
-#[tokio::test]
-async fn phase1_loopback_tofu_violation() {
-    let (mut transport, peripheral) = setup().await;
-    let rng = OsRng;
-    let device_addr = [0x10, 0x0B, 0xAC, 0x00, 0x00, 0x01];
-
-    // Pre-seed the store with a different gateway identity
-    let mut store = MemoryPairingStore::new();
-    let fake_identity = sonde_pair::types::GatewayIdentity {
-        public_key: [0x99u8; 32], // different from the real peripheral's key
-        gateway_id: [0x01u8; 16],
-    };
-    store.save_gateway_identity(&fake_identity).unwrap();
-
-    let result =
-        phase1::pair_with_gateway(&mut transport, &mut store, &rng, &device_addr, "test", None)
-            .await;
-
-    assert!(
-        matches!(
-            result,
-            Err(sonde_pair::error::PairingError::PublicKeyMismatch)
-        ),
-        "expected PublicKeyMismatch, got {result:?}"
-    );
 
     peripheral.cancel();
 }

--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -3,7 +3,7 @@
 
 //! End-to-end integration tests exercising the full gateway ↔ node protocol.
 
-use sonde_e2e::harness::{E2eTestEnv, NodeProxy, TestHmac, TestSha256};
+use sonde_e2e::harness::{E2eTestEnv, NodeProxy, TestSha256};
 use sonde_gateway::engine::PendingCommand;
 use sonde_gateway::{ProgramRecord, VerificationProfile};
 use sonde_node::traits::PlatformStorage;
@@ -919,9 +919,8 @@ async fn t_e2e_060_gateway_identity_persistence() {
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_061_phone_registration() {
     use sonde_gateway::ble_pairing::{handle_ble_recv, RegistrationWindow};
-    use sonde_pair::crypto::generate_x25519_keypair;
     use sonde_pair::envelope::{build_envelope, parse_envelope, parse_error_body};
-    use sonde_pair::rng::OsRng;
+    use sonde_pair::rng::{OsRng, RngProvider};
     use sonde_pair::types;
     use std::sync::Arc;
 
@@ -944,10 +943,11 @@ async fn t_e2e_061_phone_registration() {
     let dyn_storage: Arc<dyn Storage> = env.storage.clone();
 
     let rng = OsRng;
-    let (_, eph_public) = generate_x25519_keypair(&rng).unwrap();
+    let mut test_psk = [0u8; 32];
+    rng.fill_bytes(&mut test_psk).unwrap();
     let label = b"test";
     let mut body = Vec::with_capacity(32 + 1 + label.len());
-    body.extend_from_slice(&eph_public);
+    body.extend_from_slice(&test_psk);
     body.push(label.len() as u8);
     body.extend_from_slice(label);
     let register_request = build_envelope(types::REGISTER_PHONE, &body).unwrap();
@@ -1071,7 +1071,7 @@ async fn t_e2e_063_peer_request_ack() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // Run wake cycle — node sends PEER_REQUEST, gateway processes + WAKE.
-    let stats = node.run_wake_cycle(&env);
+    let stats = node.run_wake_cycle_aead(&env);
 
     // PEER_REQUEST succeeded: node should complete a normal WAKE cycle.
     assert_eq!(
@@ -1141,7 +1141,7 @@ async fn t_e2e_064_onboarding_to_wake() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // First cycle: PEER_REQUEST + WAKE.
-    let stats = node.run_wake_cycle(&env);
+    let stats = node.run_wake_cycle_aead(&env);
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
     // Verify steady-state: peer_payload erased (ND-0914), reg_complete set.
@@ -1152,7 +1152,7 @@ async fn t_e2e_064_onboarding_to_wake() {
     );
 
     // Second cycle: pure WAKE (no PEER_REQUEST).
-    let stats2 = node.run_wake_cycle(&env);
+    let stats2 = node.run_wake_cycle_aead(&env);
     assert_eq!(
         stats2.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -1212,7 +1212,7 @@ async fn t_e2e_065_deferred_erasure() {
     assert!(!node.storage.read_reg_complete());
 
     // Run cycle: PEER_REQUEST + WAKE succeeds → payload erased.
-    let stats = node.run_wake_cycle(&env);
+    let stats = node.run_wake_cycle_aead(&env);
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
     // After WAKE success: reg_complete set, peer_payload erased.
@@ -1270,7 +1270,7 @@ async fn t_e2e_066_self_healing() {
 
     // Cycle 1: reg_complete=true → skip PEER_REQUEST → WAKE fails
     // (gateway doesn't recognize key_hint) → self-healing clears reg_complete.
-    let stats1 = node.run_wake_cycle(&env);
+    let stats1 = node.run_wake_cycle_aead(&env);
     assert_eq!(
         stats1.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -1287,7 +1287,7 @@ async fn t_e2e_066_self_healing() {
 
     // Cycle 2: reg_complete=false, payload present → PEER_REQUEST →
     // gateway registers → PEER_ACK → WAKE → success.
-    let stats2 = node.run_wake_cycle(&env);
+    let stats2 = node.run_wake_cycle_aead(&env);
     assert_eq!(
         stats2.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -1338,7 +1338,7 @@ async fn t_e2e_067_agent_revocation() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // PEER_REQUEST should be silently discarded (revoked phone) → timeout → Sleep.
-    let stats = node.run_wake_cycle(&env);
+    let stats = node.run_wake_cycle_aead(&env);
     assert_eq!(
         stats.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -1399,7 +1399,7 @@ async fn t_e2e_068_factory_reset_reprovision() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // Run initial cycle to register the node.
-    let stats = node.run_wake_cycle(&env);
+    let stats = node.run_wake_cycle_aead(&env);
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(node.storage.read_reg_complete());
 
@@ -1449,7 +1449,7 @@ async fn t_e2e_068_factory_reset_reprovision() {
     assert_eq!(status, NODE_ACK_SUCCESS);
 
     // Run PEER_REQUEST + WAKE with new identity.
-    let stats2 = node.run_wake_cycle(&env);
+    let stats2 = node.run_wake_cycle_aead(&env);
     assert_eq!(
         stats2.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -1515,12 +1515,12 @@ async fn t_e2e_069_multi_node() {
     let mut node_b = NodeProxy::new_ble_provisioned(hint_b, psk_b, rf_channel, payload_b);
 
     // Onboard node A.
-    let stats_a = node_a.run_wake_cycle(&env);
+    let stats_a = node_a.run_wake_cycle_aead(&env);
     assert_eq!(stats_a.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(node_a.storage.read_reg_complete());
 
     // Onboard node B.
-    let stats_b = node_b.run_wake_cycle(&env);
+    let stats_b = node_b.run_wake_cycle_aead(&env);
     assert_eq!(stats_b.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(node_b.storage.read_reg_complete());
 
@@ -1539,8 +1539,8 @@ async fn t_e2e_069_multi_node() {
         .is_some());
 
     // Both operate in steady-state.
-    let stats_a2 = node_a.run_wake_cycle(&env);
-    let stats_b2 = node_b.run_wake_cycle(&env);
+    let stats_a2 = node_a.run_wake_cycle_aead(&env);
+    let stats_b2 = node_b.run_wake_cycle_aead(&env);
     assert_eq!(stats_a2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert_eq!(stats_b2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
@@ -1610,7 +1610,7 @@ async fn t_e2e_070_full_use_case() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // 4. PEER_REQUEST/PEER_ACK + first WAKE.
-    let stats = node.run_wake_cycle(&env);
+    let stats = node.run_wake_cycle_aead(&env);
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(node.storage.read_reg_complete());
     assert!(node.storage.read_peer_payload().is_none());
@@ -1625,7 +1625,7 @@ async fn t_e2e_070_full_use_case() {
 
     // 6. Run with real BPF — program calls send() helper.
     let mut interpreter = SondeBpfInterpreter::new();
-    let stats2 = node.run_wake_cycle_with(&env, &mut interpreter);
+    let stats2 = node.run_wake_cycle_aead_with(&env, &mut interpreter);
     assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
     // Verify APP_DATA was sent (msg_type 0x04).
@@ -1652,8 +1652,6 @@ async fn t_e2e_070_full_use_case() {
 /// Covers: GW-1215
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_063a_stale_timestamp_discarded() {
-    use sonde_protocol::{encode_frame, FrameHeader, MSG_PEER_REQUEST};
-
     let env = E2eTestEnv::new();
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
@@ -1661,7 +1659,6 @@ async fn t_e2e_063a_stale_timestamp_discarded() {
         simulate_phone_registration(&identity, &env.storage, rf_channel).await;
 
     let node_psk = [0xBBu8; 32];
-    let node_key_hint = compute_key_hint(&node_psk);
     let node_id = "stale-ts-node";
 
     // Build payload with timestamp 86401 seconds in the past (1 second beyond window).
@@ -1674,7 +1671,8 @@ async fn t_e2e_063a_stale_timestamp_discarded() {
         .expect("system time must be at least 86401s after UNIX_EPOCH for this test")
         as i64;
 
-    let encrypted_payload = build_encrypted_payload_with_timestamp(
+    // build_encrypted_payload_with_timestamp returns a complete AEAD PEER_REQUEST frame.
+    let stale_frame = build_encrypted_payload_with_timestamp(
         identity.public_key(),
         identity.gateway_id(),
         &phone_psk,
@@ -1686,25 +1684,9 @@ async fn t_e2e_063a_stale_timestamp_discarded() {
         stale_timestamp,
     );
 
-    // Build PEER_REQUEST frame manually and send to gateway.
-    let cbor_map = ciborium::Value::Map(vec![(
-        ciborium::Value::Integer(sonde_protocol::PEER_REQ_KEY_PAYLOAD.into()),
-        ciborium::Value::Bytes(encrypted_payload),
-    )]);
-    let mut cbor_buf = Vec::new();
-    ciborium::into_writer(&cbor_map, &mut cbor_buf).unwrap();
-
-    let hmac = TestHmac;
-    let header = FrameHeader {
-        key_hint: node_key_hint,
-        msg_type: MSG_PEER_REQUEST,
-        nonce: 0x1234_5678_9ABC_DEF0,
-    };
-    let frame = encode_frame(&header, &cbor_buf, &node_psk, &hmac).unwrap();
-
     let result = env
         .gateway
-        .process_frame(&frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame_aead(&stale_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await;
 
     assert!(
@@ -1719,7 +1701,7 @@ async fn t_e2e_063a_stale_timestamp_discarded() {
     // Positive control: same setup with a fresh timestamp MUST succeed,
     // proving the discard above was specifically due to the stale timestamp.
     let fresh_node_id = "fresh-ts-node";
-    let fresh_payload = build_encrypted_payload(
+    let fresh_frame = build_encrypted_payload(
         identity.public_key(),
         identity.gateway_id(),
         &phone_psk,
@@ -1729,21 +1711,9 @@ async fn t_e2e_063a_stale_timestamp_discarded() {
         rf_channel,
         &[],
     );
-    let fresh_cbor_map = ciborium::Value::Map(vec![(
-        ciborium::Value::Integer(sonde_protocol::PEER_REQ_KEY_PAYLOAD.into()),
-        ciborium::Value::Bytes(fresh_payload),
-    )]);
-    let mut fresh_cbor_buf = Vec::new();
-    ciborium::into_writer(&fresh_cbor_map, &mut fresh_cbor_buf).unwrap();
-    let fresh_header = FrameHeader {
-        key_hint: node_key_hint,
-        msg_type: MSG_PEER_REQUEST,
-        nonce: 0x1234_5678_9ABC_DEF1,
-    };
-    let fresh_frame = encode_frame(&fresh_header, &fresh_cbor_buf, &node_psk, &hmac).unwrap();
     let fresh_result = env
         .gateway
-        .process_frame(&fresh_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame_aead(&fresh_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await;
     assert!(
         fresh_result.is_some(),
@@ -1755,15 +1725,18 @@ async fn t_e2e_063a_stale_timestamp_discarded() {
     );
 }
 
-/// T-E2E-063b — Frame key_hint / CBOR node_key_hint mismatch → silent discard.
+/// T-E2E-063b — Frame phone_key_hint mismatch → gateway silent discard.
 ///
-/// §7.3 step 11: Frame key_hint MUST match CBOR node_key_hint; discard on
-/// mismatch. This consistency check prevents cross-key confusion attacks.
+/// In the AEAD flow, the frame header key_hint identifies the phone PSK.
+/// A wrong phone_key_hint yields no matching candidates → silent discard.
 ///
 /// Covers: GW-1217
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_063b_key_hint_mismatch_discarded() {
-    use sonde_protocol::{encode_frame, FrameHeader, MSG_PEER_REQUEST};
+    use sonde_pair::cbor::encode_pairing_request;
+    use sonde_pair::crypto::{aes256gcm_encrypt, PAIRING_REQUEST_AAD};
+    use sonde_pair::rng::{OsRng, RngProvider};
+    use sonde_protocol::{encode_frame_aead, FrameHeader, MSG_PEER_REQUEST};
 
     let env = E2eTestEnv::new();
     let identity = setup_gateway_identity(&env.storage).await;
@@ -1772,23 +1745,26 @@ async fn t_e2e_063b_key_hint_mismatch_discarded() {
         simulate_phone_registration(&identity, &env.storage, rf_channel).await;
 
     let node_psk = [0xCDu8; 32];
-    let node_key_hint = compute_key_hint(&node_psk);
     let node_id = "keyhint-mismatch-node";
 
-    // Build a valid encrypted payload (CBOR inside contains correct node_key_hint).
-    let encrypted_payload = build_encrypted_payload(
-        identity.public_key(),
-        identity.gateway_id(),
-        &phone_psk,
-        phone_key_hint,
-        node_id,
-        &node_psk,
-        rf_channel,
-        &[],
-    );
+    // Build inner PairingRequest CBOR and encrypt with phone_psk.
+    let cbor = encode_pairing_request(node_id, &node_psk, rf_channel, &[], {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    })
+    .unwrap();
 
-    // Build PEER_REQUEST with a WRONG key_hint in the frame header.
-    let wrong_key_hint = node_key_hint.wrapping_add(1);
+    let rng = OsRng;
+    let mut inner_nonce = [0u8; 12];
+    rng.fill_bytes(&mut inner_nonce).unwrap();
+    let inner_ct = aes256gcm_encrypt(&phone_psk, &inner_nonce, &cbor, PAIRING_REQUEST_AAD).unwrap();
+
+    let mut encrypted_payload = Vec::with_capacity(12 + inner_ct.len());
+    encrypted_payload.extend_from_slice(&inner_nonce);
+    encrypted_payload.extend_from_slice(&inner_ct);
+
     let cbor_map = ciborium::Value::Map(vec![(
         ciborium::Value::Integer(sonde_protocol::PEER_REQ_KEY_PAYLOAD.into()),
         ciborium::Value::Bytes(encrypted_payload),
@@ -1796,69 +1772,54 @@ async fn t_e2e_063b_key_hint_mismatch_discarded() {
     let mut cbor_buf = Vec::new();
     ciborium::into_writer(&cbor_map, &mut cbor_buf).unwrap();
 
-    // HMAC is computed over (header with wrong_key_hint + payload) using node_psk.
-    // The gateway will verify HMAC with the extracted node_psk → passes.
-    // Then check header.key_hint vs CBOR node_key_hint → mismatch → discard.
-    let hmac = TestHmac;
+    // Build PEER_REQUEST with a WRONG phone_key_hint in the frame header.
+    let wrong_key_hint = phone_key_hint.wrapping_add(1);
+    let sha = TestSha256;
+    let aead = sonde_gateway::GatewayAead;
     let header = FrameHeader {
         key_hint: wrong_key_hint,
         msg_type: MSG_PEER_REQUEST,
         nonce: 0xAAAA_BBBB_CCCC_DDDD,
     };
-    let frame = encode_frame(&header, &cbor_buf, &node_psk, &hmac).unwrap();
+    let frame = encode_frame_aead(&header, &cbor_buf, &phone_psk, &aead, &sha).unwrap();
 
     let result = env
         .gateway
-        .process_frame(&frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame_aead(&frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await;
 
     assert!(
         result.is_none(),
-        "key_hint mismatch must cause silent discard (no PEER_ACK)"
+        "wrong phone_key_hint must cause silent discard (no PEER_ACK)"
     );
     assert!(
         env.storage.get_node(node_id).await.unwrap().is_none(),
-        "node must NOT be registered with mismatched key_hint"
+        "node must NOT be registered with mismatched phone_key_hint"
     );
 
-    // Positive control: same payload with the CORRECT key_hint MUST succeed,
-    // proving the discard above was specifically due to the key_hint mismatch.
+    // Positive control: correct phone_key_hint MUST succeed.
     let good_node_id = "keyhint-good-node";
-    let good_node_psk = [0xCEu8; 32];
-    let good_key_hint = compute_key_hint(&good_node_psk);
-    let good_payload = build_encrypted_payload(
+    let good_frame = build_encrypted_payload(
         identity.public_key(),
         identity.gateway_id(),
         &phone_psk,
         phone_key_hint,
         good_node_id,
-        &good_node_psk,
+        &node_psk,
         rf_channel,
         &[],
     );
-    let good_cbor_map = ciborium::Value::Map(vec![(
-        ciborium::Value::Integer(sonde_protocol::PEER_REQ_KEY_PAYLOAD.into()),
-        ciborium::Value::Bytes(good_payload),
-    )]);
-    let mut good_cbor_buf = Vec::new();
-    ciborium::into_writer(&good_cbor_map, &mut good_cbor_buf).unwrap();
-    let good_header = FrameHeader {
-        key_hint: good_key_hint,
-        msg_type: MSG_PEER_REQUEST,
-        nonce: 0xAAAA_BBBB_CCCC_DDDE,
-    };
-    let good_frame = encode_frame(&good_header, &good_cbor_buf, &good_node_psk, &hmac).unwrap();
     let good_result = env
         .gateway
-        .process_frame(&good_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame_aead(&good_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await;
     assert!(
         good_result.is_some(),
-        "positive control: matching key_hint must produce PEER_ACK"
+        "positive control: matching phone_key_hint must produce PEER_ACK"
     );
     assert!(
         env.storage.get_node(good_node_id).await.unwrap().is_some(),
-        "positive control: node must be registered with matching key_hint"
+        "positive control: node must be registered with matching phone_key_hint"
     );
 }
 
@@ -1898,7 +1859,7 @@ async fn t_e2e_063c_duplicate_node_id_discarded() {
         rf_channel,
         encrypted_payload_1,
     );
-    let stats1 = node1.run_wake_cycle(&env);
+    let stats1 = node1.run_wake_cycle_aead(&env);
     assert!(
         matches!(stats1.outcome, WakeCycleOutcome::Sleep { .. }),
         "first registration must succeed (got {:?})",
@@ -1937,7 +1898,7 @@ async fn t_e2e_063c_duplicate_node_id_discarded() {
     );
 
     // The second PEER_REQUEST should be silently discarded → timeout → Sleep.
-    let stats2 = node2.run_wake_cycle(&env);
+    let stats2 = node2.run_wake_cycle_aead(&env);
     assert!(
         matches!(stats2.outcome, WakeCycleOutcome::Sleep { .. }),
         "duplicate node_id PEER_REQUEST must result in Sleep (timeout) (got {:?})",
@@ -1974,7 +1935,9 @@ async fn t_e2e_063c_duplicate_node_id_discarded() {
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
     use sonde_node::key_store::NodeIdentity;
-    use sonde_node::peer_request::{build_peer_request_frame, verify_peer_ack};
+    use sonde_node::node_aead::NodeAead;
+    use sonde_node::peer_request::verify_peer_ack_aead;
+    use sonde_protocol::decode_frame_aead;
 
     let env = E2eTestEnv::new();
     let identity = setup_gateway_identity(&env.storage).await;
@@ -1986,7 +1949,8 @@ async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
     let node_key_hint = compute_key_hint(&node_psk);
     let node_id = "nonce-test-node";
 
-    let encrypted_payload = build_encrypted_payload(
+    // build_encrypted_payload returns a complete AEAD PEER_REQUEST frame.
+    let complete_frame = build_encrypted_payload(
         identity.public_key(),
         identity.gateway_id(),
         &phone_psk,
@@ -1997,45 +1961,33 @@ async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
         &[],
     );
 
-    // Build a PEER_REQUEST with a known nonce.
-    let hmac = TestHmac;
-    let request_nonce: u64 = 0x1111_2222_3333_4444;
+    // Extract the nonce from the frame header.
+    let decoded = decode_frame_aead(&complete_frame).expect("frame must decode");
+    let request_nonce = decoded.header.nonce;
+
     let node_identity = NodeIdentity {
         key_hint: node_key_hint,
         psk: node_psk,
     };
-    let frame =
-        build_peer_request_frame(&node_identity, &encrypted_payload, request_nonce, &hmac).unwrap();
 
     // Send to gateway and get the PEER_ACK back.
     let ack_frame = env
         .gateway
-        .process_frame(&frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame_aead(&complete_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await
         .expect("gateway must return PEER_ACK for valid PEER_REQUEST");
 
     // Verify node accepts the real PEER_ACK with correct expected nonce.
+    let aead = NodeAead;
+    let sha = TestSha256;
     assert!(
-        verify_peer_ack(
-            &ack_frame,
-            &node_identity,
-            request_nonce,
-            &encrypted_payload,
-            &hmac
-        )
-        .is_ok(),
+        verify_peer_ack_aead(&ack_frame, &node_identity, request_nonce, &aead, &sha).is_ok(),
         "node must accept PEER_ACK with correct nonce"
     );
 
     // Verify node REJECTS the same PEER_ACK when expected nonce differs.
     let wrong_nonce: u64 = 0x5555_6666_7777_8888;
-    let result = verify_peer_ack(
-        &ack_frame,
-        &node_identity,
-        wrong_nonce,
-        &encrypted_payload,
-        &hmac,
-    );
+    let result = verify_peer_ack_aead(&ack_frame, &node_identity, wrong_nonce, &aead, &sha);
     assert!(
         result.is_err(),
         "node must reject PEER_ACK when nonce does not match PEER_REQUEST"
@@ -2051,49 +2003,42 @@ async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
 
 /// T-E2E-063e — sonde-pair → gateway end-to-end integration.
 ///
-/// Wires the actual `sonde_pair::phase1::pair_with_gateway` state machine to
-/// the gateway's `handle_ble_recv` via a `GatewayBleAdapter`, proving that
-/// sonde-pair's Phase 1 output is compatible with the gateway. The resulting
-/// `PairingArtifacts` are then used (via sonde-pair's crypto/CBOR functions)
-/// to build the encrypted payload for Phase 3, which flows through a NodeProxy
-/// to the gateway via PEER_REQUEST/PEER_ACK.
+/// Wires the actual `sonde_pair::phase1::pair_with_gateway_aead` state machine
+/// to the gateway's `handle_ble_recv` via a `GatewayBleAdapter`, proving that
+/// sonde-pair's Phase 1 AEAD output is compatible with the gateway. The
+/// resulting `PairingArtifactsAead` are used to build the encrypted payload
+/// for Phase 3 via `encrypt_pairing_request_aead`, which flows through a
+/// NodeProxy to the gateway via PEER_REQUEST/PEER_ACK.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_063e_sonde_pair_gateway_integration() {
     use sonde_pair::cbor::encode_pairing_request;
-    use sonde_pair::crypto::{
-        aes256gcm_encrypt, ed25519_to_x25519_public, generate_x25519_keypair, hkdf_sha256,
-        hmac_sha256, x25519_ecdh,
-    };
+    use sonde_pair::crypto::encrypt_pairing_request_aead;
     use sonde_pair::phase1;
-    use sonde_pair::rng::{OsRng, RngProvider};
-    use sonde_pair::store::MemoryPairingStore;
+    use sonde_pair::rng::OsRng;
     use std::sync::Arc;
 
     let env = E2eTestEnv::new();
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
 
-    // Phase 1: use sonde-pair's actual state machine against the gateway.
+    // Phase 1: use sonde-pair's actual AEAD state machine against the gateway.
     let dyn_storage: Arc<dyn sonde_gateway::storage::Storage> = env.storage.clone();
     let mut transport = GatewayBleAdapter::new(identity.clone(), dyn_storage, rf_channel);
-    let mut store = MemoryPairingStore::new();
     let rng = OsRng;
     let device_addr = [0x10, 0x0B, 0xAC, 0x00, 0x00, 0x01];
 
-    let artifacts = phase1::pair_with_gateway(
+    let artifacts = phase1::pair_with_gateway_aead(
         &mut transport,
-        &mut store,
         &rng,
         &device_addr,
         "e2e-integration-phone",
         None,
     )
     .await
-    .expect("Phase 1 pairing via GatewayBleAdapter must succeed");
+    .expect("Phase 1 AEAD pairing via GatewayBleAdapter must succeed");
 
     // Verify artifacts
     assert_eq!(artifacts.rf_channel, rf_channel);
-    // PSK validity is covered by the key_hint round-trip check below.
     let expected_hint = compute_key_hint(&artifacts.phone_psk);
     assert_eq!(artifacts.phone_key_hint, expected_hint);
 
@@ -2101,7 +2046,7 @@ async fn t_e2e_063e_sonde_pair_gateway_integration() {
     let psks = Storage::list_phone_psks(&*env.storage).await.unwrap();
     assert_eq!(psks.len(), 1, "exactly one phone PSK should be stored");
 
-    // Phase 3: build encrypted payload using sonde-pair's actual crypto,
+    // Phase 3: build encrypted payload using sonde-pair's AEAD crypto,
     // then wire through a NodeProxy to the gateway.
     let node_psk = [0xF0u8; 32];
     let node_key_hint = compute_key_hint(&node_psk);
@@ -2112,39 +2057,13 @@ async fn t_e2e_063e_sonde_pair_gateway_integration() {
         .unwrap_or_default()
         .as_secs() as i64;
     let cbor = encode_pairing_request(node_id, &node_psk, rf_channel, &[], timestamp).unwrap();
-    let phone_hmac = hmac_sha256(&*artifacts.phone_psk, &cbor);
-    let mut auth_request = Vec::with_capacity(2 + cbor.len() + 32);
-    auth_request.extend_from_slice(&artifacts.phone_key_hint.to_be_bytes());
-    auth_request.extend_from_slice(&cbor);
-    auth_request.extend_from_slice(&phone_hmac);
-
-    let gw_x25519 = ed25519_to_x25519_public(&artifacts.gateway_identity.public_key).unwrap();
-    let (eph_secret, eph_public) = generate_x25519_keypair(&rng).unwrap();
-    let shared_secret = x25519_ecdh(&eph_secret, &gw_x25519);
-    let aes_key = hkdf_sha256(
-        &shared_secret,
-        &artifacts.gateway_identity.gateway_id,
-        b"sonde-node-pair-v1",
-    );
-    let mut nonce = [0u8; 12];
-    rng.fill_bytes(&mut nonce).unwrap();
-    let ciphertext = aes256gcm_encrypt(
-        &aes_key,
-        &nonce,
-        &auth_request,
-        &artifacts.gateway_identity.gateway_id,
-    )
-    .unwrap();
-
-    let mut encrypted_payload = Vec::with_capacity(32 + 12 + ciphertext.len());
-    encrypted_payload.extend_from_slice(&eph_public);
-    encrypted_payload.extend_from_slice(&nonce);
-    encrypted_payload.extend_from_slice(&ciphertext);
+    let encrypted_payload = encrypt_pairing_request_aead(&artifacts.phone_psk, &cbor)
+        .expect("encrypt_pairing_request_aead must succeed");
 
     // Wire the payload through a NodeProxy to the gateway.
     let mut node =
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
-    let stats = node.run_wake_cycle(&env);
+    let stats = node.run_wake_cycle_aead(&env);
 
     assert_eq!(
         stats.outcome,

--- a/crates/sonde-gateway/src/ble_pairing.rs
+++ b/crates/sonde-gateway/src/ble_pairing.rs
@@ -226,7 +226,7 @@ pub async fn handle_ble_recv(
     match msg_type {
         BLE_MSG_REQUEST_GW_INFO => handle_request_gw_info(body, identity),
         BLE_MSG_REGISTER_PHONE => {
-            handle_register_phone(body, identity, storage, window, rf_channel, controller).await
+            handle_register_phone_aead(body, storage, window, rf_channel, controller).await
         }
         _ => {
             debug!(msg_type, "ignoring unknown BLE message type");
@@ -279,6 +279,7 @@ fn handle_request_gw_info(body: &[u8], identity: &GatewayIdentity) -> Option<Vec
 /// REGISTER_PHONE body: ephemeral_pubkey(32) + label_len(1) + label(label_len).
 /// PHONE_REGISTERED body: nonce(12) + ciphertext (AES-256-GCM encrypted inner).
 /// Inner plaintext: status(1) + phone_psk(32) + phone_key_hint(2) + rf_channel(1) = 36 bytes.
+#[allow(dead_code)] // Retained for ECDH/HMAC fallback; will be removed with full HMAC cleanup.
 async fn handle_register_phone(
     body: &[u8],
     identity: &GatewayIdentity,
@@ -440,6 +441,102 @@ async fn handle_register_phone(
         });
     }
 
+    encode_ble_envelope(BLE_MSG_PHONE_REGISTERED, &response)
+}
+
+// ---------------------------------------------------------------------------
+// REGISTER_PHONE — AEAD variant (simplified, phone generates PSK)
+// ---------------------------------------------------------------------------
+
+/// Handle REGISTER_PHONE (AEAD): phone sends its PSK, gateway stores it.
+///
+/// REGISTER_PHONE body: phone_psk(32) + label_len(1) + label(label_len).
+/// PHONE_REGISTERED body: status(1) + rf_channel(1) + phone_key_hint(2 BE).
+async fn handle_register_phone_aead(
+    body: &[u8],
+    storage: &Arc<dyn Storage>,
+    window: &mut RegistrationWindow,
+    rf_channel: u8,
+    controller: Option<&BlePairingController>,
+) -> Option<Vec<u8>> {
+    const ERROR_GENERIC: u8 = 0x01;
+
+    if !window.is_open() {
+        info!("REGISTER_PHONE (AEAD) rejected: registration window closed");
+        return encode_ble_envelope(BLE_MSG_ERROR, &[ERROR_WINDOW_CLOSED]);
+    }
+
+    if body.len() < 33 {
+        warn!(
+            len = body.len(),
+            "REGISTER_PHONE (AEAD): body too short (min 33 bytes)"
+        );
+        return encode_ble_envelope(BLE_MSG_ERROR, &[ERROR_GENERIC]);
+    }
+
+    let mut phone_psk = Zeroizing::new([0u8; 32]);
+    phone_psk.copy_from_slice(&body[..32]);
+    let label_len = body[32] as usize;
+
+    if label_len > PHONE_LABEL_MAX_BYTES {
+        warn!(
+            label_len,
+            "REGISTER_PHONE (AEAD): label too long (max 64 bytes)"
+        );
+        return encode_ble_envelope(BLE_MSG_ERROR, &[ERROR_GENERIC]);
+    }
+
+    if body.len() != 33 + label_len {
+        warn!(
+            expected = 33 + label_len,
+            actual = body.len(),
+            "REGISTER_PHONE (AEAD): body length mismatch"
+        );
+        return encode_ble_envelope(BLE_MSG_ERROR, &[ERROR_GENERIC]);
+    }
+
+    let label = match std::str::from_utf8(&body[33..33 + label_len]) {
+        Ok(s) => s.to_owned(),
+        Err(_) => {
+            warn!("REGISTER_PHONE (AEAD): label is not valid UTF-8");
+            return encode_ble_envelope(BLE_MSG_ERROR, &[ERROR_GENERIC]);
+        }
+    };
+
+    // Derive phone_key_hint = SHA-256(psk)[30..32] as BE u16
+    let psk_hash = Sha256::digest(phone_psk.as_slice());
+    let phone_key_hint = u16::from_be_bytes([psk_hash[30], psk_hash[31]]);
+
+    // Store phone PSK
+    let record = PhonePskRecord {
+        phone_id: 0,
+        phone_key_hint,
+        psk: phone_psk,
+        label: label.clone(),
+        issued_at: SystemTime::now(),
+        status: PhonePskStatus::Active,
+    };
+
+    if let Err(e) = storage.store_phone_psk(&record).await {
+        warn!(?e, "REGISTER_PHONE (AEAD): failed to store phone PSK");
+        return None;
+    }
+
+    info!(
+        phone_key_hint,
+        label = record.label,
+        "phone registered successfully (AEAD)"
+    );
+
+    if let Some(ctrl) = controller {
+        ctrl.broadcast_event(BlePairingEventKind::PhoneRegistered {
+            label,
+            phone_key_hint,
+        });
+    }
+
+    // Build PHONE_REGISTERED response: status(1) + rf_channel(1) + phone_key_hint(2 BE)
+    let response = [0x00, rf_channel, psk_hash[30], psk_hash[31]];
     encode_ble_envelope(BLE_MSG_PHONE_REGISTERED, &response)
 }
 

--- a/crates/sonde-gateway/tests/ble_pairing.rs
+++ b/crates/sonde-gateway/tests/ble_pairing.rs
@@ -7,10 +7,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use aes_gcm::aead::{Aead, KeyInit};
-use aes_gcm::{Aes256Gcm, Nonce as GcmNonce};
 use ed25519_dalek::{Signature, VerifyingKey};
-use hkdf::Hkdf;
 use sha2::Sha256;
 use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret as X25519StaticSecret};
 
@@ -29,8 +26,6 @@ const BLE_MSG_PHONE_REGISTERED: u8 = 0x82;
 const BLE_MSG_ERROR: u8 = 0xFF;
 
 const ERROR_WINDOW_CLOSED: u8 = 0x02;
-
-const HKDF_INFO: &[u8] = b"sonde-phone-reg-v1";
 
 // ── T-1200: Ed25519 keypair generation ──────────────────────────────────────
 
@@ -252,7 +247,7 @@ async fn t1206_registration_window_auto_close() {
 
 // ── T-1207: REGISTER_PHONE happy path ───────────────────────────────────────
 
-/// T-1207  REGISTER_PHONE happy path — full ECDH key exchange.
+/// T-1207  REGISTER_PHONE happy path — AEAD (phone sends PSK directly).
 #[tokio::test]
 async fn t1207_register_phone_happy_path() {
     let storage: Arc<dyn Storage> = Arc::new(InMemoryStorage::new());
@@ -260,15 +255,13 @@ async fn t1207_register_phone_happy_path() {
     let mut window = RegistrationWindow::new();
     window.open(60);
 
-    // Generate ephemeral X25519 keypair on the "phone" side.
-    let mut phone_scalar = [0u8; 32];
-    getrandom::fill(&mut phone_scalar).unwrap();
-    let phone_secret = X25519StaticSecret::from(phone_scalar);
-    let phone_pub = X25519PublicKey::from(&phone_secret);
+    // Phone generates PSK and sends it directly.
+    let mut phone_psk = [0x42u8; 32];
+    getrandom::fill(&mut phone_psk).unwrap();
 
     let label = b"test-phone";
     let mut body = Vec::with_capacity(33 + label.len());
-    body.extend_from_slice(phone_pub.as_bytes());
+    body.extend_from_slice(&phone_psk);
     body.push(label.len() as u8);
     body.extend_from_slice(label);
 
@@ -280,50 +273,22 @@ async fn t1207_register_phone_happy_path() {
     let (msg_type, resp_body) = parse_ble_envelope(&resp_bytes).unwrap();
     assert_eq!(msg_type, BLE_MSG_PHONE_REGISTERED);
 
-    // Decrypt: resp_body = nonce(12) + ciphertext(36 + 16 tag)
-    assert!(
-        resp_body.len() >= 12 + 36 + 16,
-        "PHONE_REGISTERED body too short: {}",
-        resp_body.len()
-    );
-    let nonce: &[u8; 12] = resp_body[..12].try_into().unwrap();
-    let ciphertext = &resp_body[12..];
-
-    // Derive AES key via ECDH + HKDF.
-    // Phone computes: shared_secret = phone_secret * gw_x25519_pub
-    let (_, gw_x25519_pub) = identity.to_x25519().unwrap();
-    let shared_secret = phone_secret.diffie_hellman(&gw_x25519_pub);
-
-    let gateway_id = identity.gateway_id();
-    let hkdf = Hkdf::<Sha256>::new(Some(gateway_id), shared_secret.as_bytes());
-    let mut aes_key = [0u8; 32];
-    hkdf.expand(HKDF_INFO, &mut aes_key).unwrap();
-
-    let cipher = Aes256Gcm::new_from_slice(&aes_key).unwrap();
-    let gcm_nonce = GcmNonce::from_slice(nonce);
-    let plaintext = cipher
-        .decrypt(
-            gcm_nonce,
-            aes_gcm::aead::Payload {
-                msg: ciphertext,
-                aad: gateway_id,
-            },
-        )
-        .expect("AES-GCM decryption must succeed");
-
-    // Plaintext: status(1) + phone_psk(32) + phone_key_hint(2) + rf_channel(1) = 36
-    assert_eq!(plaintext.len(), 36);
-    assert_eq!(plaintext[0], 0x00, "status must be 0 (accepted)");
-    let phone_psk = &plaintext[1..33];
-    assert_ne!(phone_psk, &[0u8; 32], "phone PSK must not be all-zero");
-    let phone_key_hint = u16::from_be_bytes([plaintext[33], plaintext[34]]);
-    assert_eq!(plaintext[35], 7, "rf_channel must match");
+    // AEAD response: status(1) + rf_channel(1) + phone_key_hint(2 BE) = 4 bytes
+    assert_eq!(resp_body.len(), 4, "PHONE_REGISTERED body must be 4 bytes");
+    assert_eq!(resp_body[0], 0x00, "status must be 0 (accepted)");
+    assert_eq!(resp_body[1], 7, "rf_channel must match");
+    let phone_key_hint = u16::from_be_bytes([resp_body[2], resp_body[3]]);
 
     // Verify phone_key_hint = SHA-256(psk)[30..32].
     use sha2::Digest;
     let psk_hash = Sha256::digest(phone_psk);
     let expected_hint = u16::from_be_bytes([psk_hash[30], psk_hash[31]]);
     assert_eq!(phone_key_hint, expected_hint);
+
+    // Verify phone PSK was stored with the value we sent.
+    let phones = storage.list_phone_psks().await.unwrap();
+    assert_eq!(phones.len(), 1);
+    assert_eq!(&*phones[0].psk, &phone_psk);
 }
 
 // ── T-1208: Phone PSK storage, labelling, and revocation ────────────────────
@@ -336,14 +301,12 @@ async fn t1208_phone_psk_storage_and_revocation() {
     let mut window = RegistrationWindow::new();
     window.open(60);
 
-    // Register a phone.
-    let mut phone_scalar = [0u8; 32];
-    getrandom::fill(&mut phone_scalar).unwrap();
-    let phone_secret = X25519StaticSecret::from(phone_scalar);
-    let phone_pub = X25519PublicKey::from(&phone_secret);
+    // Register a phone (AEAD: send PSK directly).
+    let mut phone_psk = [0x55u8; 32];
+    getrandom::fill(&mut phone_psk).unwrap();
     let label = b"my-phone";
     let mut body = Vec::with_capacity(33 + label.len());
-    body.extend_from_slice(phone_pub.as_bytes());
+    body.extend_from_slice(&phone_psk);
     body.push(label.len() as u8);
     body.extend_from_slice(label);
 

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -3,9 +3,13 @@
 
 //! Tauri v2 backend for the Sonde BLE pairing tool.
 //!
-//! On desktop, BLE operations use [`BtleplugTransport`] and [`FilePairingStore`].
-//! On Android, BLE operations use [`AndroidBleTransport`] and [`AndroidPairingStore`],
-//! initialized from the Tauri Android activity via JNI.
+//! On desktop, BLE operations use [`BtleplugTransport`].
+//! On Android, BLE operations use [`AndroidBleTransport`].
+//!
+//! Pairing artifacts (phone PSK) are held in memory during the session
+//! and persisted to `pairing-aead.json` via [`FilePairingStore`] on
+//! desktop. The simplified AEAD flow does not use ECDH or gateway
+//! identity TOFU.
 //!
 //! All BLE operations use `spawn_blocking` + `Handle::block_on` so that
 //! non-Send futures from [`sonde_pair::transport::BleTransport`] work on
@@ -17,7 +21,6 @@ use serde::Serialize;
 use sonde_pair::discovery::{service_type, DeviceScanner, ServiceType};
 use sonde_pair::phase1::PairingProgress;
 use sonde_pair::rng::OsRng;
-use sonde_pair::store::PairingStore;
 use sonde_pair::types::ScannedDevice;
 use sonde_pair::{phase1, phase2};
 
@@ -40,10 +43,10 @@ struct AppState {
     scanner: Mutex<Option<DeviceScanner<BtleplugTransport>>>,
     #[cfg(target_os = "android")]
     scanner: Mutex<Option<DeviceScanner<AndroidBleTransport>>>,
-    #[cfg(target_os = "android")]
-    store: Mutex<Option<AndroidPairingStore>>,
     phase: Arc<Mutex<String>>,
     logs: Arc<Mutex<Vec<String>>>,
+    /// Phase 1 AEAD artifacts, held in memory for Phase 2 provisioning.
+    pairing_artifacts: Mutex<Option<Arc<phase1::PairingArtifactsAead>>>,
 }
 
 /// Reports Phase 1 sub-phase transitions to the UI via the shared `phase` mutex.
@@ -192,30 +195,9 @@ async fn pair_gateway(
     state: tauri::State<'_, AppState>,
     address: String,
     phone_label: String,
-    force: Option<bool>,
+    _force: Option<bool>,
 ) -> Result<(), String> {
     *state.scanner.lock().unwrap() = None;
-
-    // PT-0601: check for existing pairing and require explicit confirmation.
-    if !force.unwrap_or(false) {
-        let existing_identity = tokio::task::spawn_blocking(|| {
-            let store = FilePairingStore::new()?;
-            store.load_gateway_identity()
-        })
-        .await
-        .map_err(|e| format!("task panicked: {e}"))?
-        .map_err(|e| e.to_string())?;
-
-        if let Some(identity) = existing_identity {
-            let gw_hex = hex::encode(identity.gateway_id);
-            *state.phase.lock().unwrap() = format!(
-                "Error: Gateway already paired with ID {gw_hex}. To re-pair, clear the existing pairing in the app, then retry."
-            );
-            return Err(format!(
-                "Gateway already paired with ID {gw_hex}. To re-pair, clear the existing pairing in the app, then retry."
-            ));
-        }
-    }
 
     let addr = match parse_address(&address) {
         Ok(a) => a,
@@ -235,11 +217,9 @@ async fn pair_gateway(
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = BtleplugTransport::new().await?;
-            let mut store = FilePairingStore::new()?;
             let rng = OsRng;
-            phase1::pair_with_gateway(
+            phase1::pair_with_gateway_aead(
                 &mut transport,
-                &mut store,
                 &rng,
                 &addr,
                 &phone_label,
@@ -252,7 +232,13 @@ async fn pair_gateway(
     .map_err(|e| format!("task panicked: {e}"))?;
 
     match result {
-        Ok(_) => {
+        Ok(artifacts) => {
+            // Persist to file store so provisioning works across app restarts.
+            let store = FilePairingStore::new().map_err(|e| e.to_string())?;
+            store
+                .save_artifacts_aead(&artifacts)
+                .map_err(|e| e.to_string())?;
+            *state.pairing_artifacts.lock().unwrap() = Some(Arc::new(artifacts));
             *state.phase.lock().unwrap() = "Complete".into();
             Ok(())
         }
@@ -281,14 +267,32 @@ async fn provision_node(
         }
     };
 
+    // Load artifacts from in-memory cache, falling back to file store.
+    let artifacts = {
+        let mut guard = state.pairing_artifacts.lock().unwrap();
+        if guard.is_none() {
+            let store = FilePairingStore::new().map_err(|e| e.to_string())?;
+            match store.load_artifacts_aead() {
+                Ok(Some(loaded)) => {
+                    *guard = Some(Arc::new(loaded));
+                }
+                Ok(None) => {}
+                Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
+            }
+        }
+        guard
+            .clone()
+            .ok_or_else(|| "Not paired — run pair_gateway first".to_string())?
+    };
+
     *state.phase.lock().unwrap() = "Provisioning".into();
 
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = BtleplugTransport::new().await?;
-            let store = FilePairingStore::new()?;
             let rng = OsRng;
-            phase2::provision_node(&mut transport, &store, &rng, &addr, &node_id, &[]).await
+            phase2::provision_node_aead(&mut transport, &artifacts, &rng, &addr, &node_id, &[])
+                .await
         })
     })
     .await
@@ -309,20 +313,28 @@ async fn provision_node(
 
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
-fn get_pairing_status() -> Result<PairingStatus, String> {
-    let store = FilePairingStore::new().map_err(|e| e.to_string())?;
-    let identity = store.load_gateway_identity().map_err(|e| e.to_string())?;
+fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus, String> {
+    let mut paired = state.pairing_artifacts.lock().unwrap().is_some();
+    if !paired {
+        let store = FilePairingStore::new().map_err(|e| e.to_string())?;
+        match store.load_artifacts_aead() {
+            Ok(Some(_)) => paired = true,
+            Ok(None) => {}
+            Err(e) => return Err(format!("failed to check pairing status: {e}")),
+        }
+    }
     Ok(PairingStatus {
-        paired: identity.is_some(),
-        gateway_id: identity.map(|id| hex::encode(id.gateway_id)),
+        paired,
+        gateway_id: None,
     })
 }
 
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
 fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
-    let mut store = FilePairingStore::new().map_err(|e| e.to_string())?;
-    store.clear().map_err(|e| e.to_string())?;
+    *state.pairing_artifacts.lock().unwrap() = None;
+    let store = FilePairingStore::new().map_err(|e| e.to_string())?;
+    store.clear_aead().map_err(|e| e.to_string())?;
     *state.phase.lock().unwrap() = "Idle".into();
     Ok(())
 }
@@ -406,24 +418,9 @@ async fn pair_gateway(
     state: tauri::State<'_, AppState>,
     address: String,
     phone_label: String,
-    force: Option<bool>,
+    _force: Option<bool>,
 ) -> Result<(), String> {
     *state.scanner.lock().unwrap() = None;
-
-    // PT-0601: check for existing pairing and require explicit confirmation.
-    if !force.unwrap_or(false) {
-        let guard = get_or_init_store(&state.store)?;
-        let store = guard.as_ref().unwrap();
-        if let Some(identity) = store.load_gateway_identity().map_err(|e| e.to_string())? {
-            let gw_hex = hex::encode(identity.gateway_id);
-            *state.phase.lock().unwrap() = format!(
-                "Error: Gateway already paired with ID {gw_hex}. To re-pair, clear the existing pairing in the app, then retry."
-            );
-            return Err(format!(
-                "Gateway already paired with ID {gw_hex}. To re-pair, clear the existing pairing in the app, then retry."
-            ));
-        }
-    }
 
     let addr = match parse_address(&address) {
         Ok(a) => a,
@@ -433,8 +430,6 @@ async fn pair_gateway(
         }
     };
 
-    // Set an immediate initial phase so the UI doesn't show stale state
-    // while the blocking task is being spawned.
     *state.phase.lock().unwrap() = "Connecting".into();
 
     let phase = state.phase.clone();
@@ -443,11 +438,9 @@ async fn pair_gateway(
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = AndroidBleTransport::from_cached_vm()?;
-            let mut store = AndroidPairingStore::from_cached_vm()?;
             let rng = OsRng;
-            phase1::pair_with_gateway(
+            phase1::pair_with_gateway_aead(
                 &mut transport,
-                &mut store,
                 &rng,
                 &addr,
                 &phone_label,
@@ -460,7 +453,8 @@ async fn pair_gateway(
     .map_err(|e| format!("task panicked: {e}"))?;
 
     match result {
-        Ok(_) => {
+        Ok(artifacts) => {
+            *state.pairing_artifacts.lock().unwrap() = Some(Arc::new(artifacts));
             *state.phase.lock().unwrap() = "Complete".into();
             Ok(())
         }
@@ -489,14 +483,21 @@ async fn provision_node(
         }
     };
 
+    let artifacts = state
+        .pairing_artifacts
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| "Not paired — run pair_gateway first".to_string())?;
+
     *state.phase.lock().unwrap() = "Provisioning".into();
 
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = AndroidBleTransport::from_cached_vm()?;
-            let store = AndroidPairingStore::from_cached_vm()?;
             let rng = OsRng;
-            phase2::provision_node(&mut transport, &store, &rng, &addr, &node_id, &[]).await
+            phase2::provision_node_aead(&mut transport, &artifacts, &rng, &addr, &node_id, &[])
+                .await
         })
     })
     .await
@@ -516,34 +517,19 @@ async fn provision_node(
 }
 
 #[cfg(target_os = "android")]
-fn get_or_init_store(
-    store_lock: &Mutex<Option<AndroidPairingStore>>,
-) -> Result<std::sync::MutexGuard<'_, Option<AndroidPairingStore>>, String> {
-    let mut guard = store_lock.lock().unwrap();
-    if guard.is_none() {
-        *guard = Some(AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?);
-    }
-    Ok(guard)
-}
-
-#[cfg(target_os = "android")]
 #[tauri::command]
 fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus, String> {
-    let guard = get_or_init_store(&state.store)?;
-    let store = guard.as_ref().unwrap();
-    let identity = store.load_gateway_identity().map_err(|e| e.to_string())?;
+    let paired = state.pairing_artifacts.lock().unwrap().is_some();
     Ok(PairingStatus {
-        paired: identity.is_some(),
-        gateway_id: identity.map(|id| hex::encode(id.gateway_id)),
+        paired,
+        gateway_id: None,
     })
 }
 
 #[cfg(target_os = "android")]
 #[tauri::command]
 fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
-    let mut guard = get_or_init_store(&state.store)?;
-    let store = guard.as_mut().unwrap();
-    store.clear().map_err(|e| e.to_string())?;
+    *state.pairing_artifacts.lock().unwrap() = None;
     *state.phase.lock().unwrap() = "Idle".into();
     Ok(())
 }
@@ -609,12 +595,6 @@ mod log_capture {
                 }
             }
         }
-    }
-}
-
-mod hex {
-    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
-        bytes.as_ref().iter().map(|b| format!("{b:02x}")).collect()
     }
 }
 
@@ -705,10 +685,9 @@ pub fn run() {
 
     let state = AppState {
         scanner: Mutex::new(None),
-        #[cfg(target_os = "android")]
-        store: Mutex::new(None),
         phase: Arc::new(Mutex::new("Idle".into())),
         logs,
+        pairing_artifacts: Mutex::new(None),
     };
 
     tauri::Builder::default()

--- a/crates/sonde-pair/src/error.rs
+++ b/crates/sonde-pair/src/error.rs
@@ -139,6 +139,9 @@ pub enum PairingError {
     #[error("scan is already active")]
     ScanAlreadyActive,
 
+    #[error("system clock error — check that the system time is set correctly")]
+    TimestampUnavailable,
+
     // Platform / JNI errors (Android)
     #[cfg(feature = "android")]
     #[error("JNI error: {0}")]

--- a/crates/sonde-pair/src/file_store.rs
+++ b/crates/sonde-pair/src/file_store.rs
@@ -293,6 +293,108 @@ impl FilePairingStore {
             phone_label: s.phone_label.clone(),
         })
     }
+
+    /// Save AEAD pairing artifacts to a companion file (`pairing-aead.json`).
+    #[cfg(feature = "aes-gcm-codec")]
+    pub fn save_artifacts_aead(
+        &self,
+        artifacts: &crate::phase1::PairingArtifactsAead,
+    ) -> Result<(), PairingError> {
+        let aead_path = self.aead_path();
+        if let Some(parent) = aead_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| PairingError::StoreSaveFailed(e.to_string()))?;
+        }
+
+        let stored = StoredAeadArtifacts {
+            phone_psk: to_hex(&*artifacts.phone_psk),
+            phone_key_hint: artifacts.phone_key_hint,
+            rf_channel: artifacts.rf_channel,
+            phone_label: artifacts.phone_label.clone(),
+        };
+
+        let json = serde_json::to_string_pretty(&stored)
+            .map_err(|e| PairingError::StoreSaveFailed(e.to_string()))?;
+
+        let tmp = aead_path.with_extension("tmp");
+        let mut file =
+            fs::File::create(&tmp).map_err(|e| PairingError::StoreSaveFailed(e.to_string()))?;
+        file.write_all(json.as_bytes())
+            .map_err(|e| PairingError::StoreSaveFailed(e.to_string()))?;
+        file.sync_all()
+            .map_err(|e| PairingError::StoreSaveFailed(e.to_string()))?;
+        drop(file);
+        fs::rename(&tmp, &aead_path).map_err(|e| PairingError::StoreSaveFailed(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Load AEAD pairing artifacts from the companion file.
+    #[cfg(feature = "aes-gcm-codec")]
+    pub fn load_artifacts_aead(
+        &self,
+    ) -> Result<Option<crate::phase1::PairingArtifactsAead>, PairingError> {
+        let aead_path = self.aead_path();
+        let bytes = match fs::read(&aead_path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(PairingError::StoreLoadFailed(e.to_string())),
+        };
+
+        let stored: StoredAeadArtifacts = serde_json::from_slice(&bytes).map_err(|e| {
+            PairingError::StoreCorrupted(format!("{e}: delete or fix {}", aead_path.display()))
+        })?;
+
+        let mut psk_bytes = from_hex(&stored.phone_psk, 32)?;
+        let mut psk = Zeroizing::new([0u8; 32]);
+        psk.copy_from_slice(&psk_bytes);
+        psk_bytes.zeroize();
+
+        // Recompute key_hint from PSK to detect corruption.
+        let expected_hint = crate::validation::compute_key_hint(&psk);
+        if stored.phone_key_hint != expected_hint {
+            return Err(PairingError::StoreCorrupted(
+                "phone_key_hint does not match phone_psk".into(),
+            ));
+        }
+
+        Ok(Some(crate::phase1::PairingArtifactsAead {
+            phone_psk: psk,
+            phone_key_hint: expected_hint,
+            rf_channel: stored.rf_channel,
+            phone_label: stored.phone_label,
+        }))
+    }
+
+    /// Clear AEAD artifacts file (`pairing-aead.json`).
+    ///
+    /// This only removes the AEAD file; the legacy `pairing.json` is
+    /// managed separately by the [`PairingStore::clear`] implementation.
+    #[cfg(feature = "aes-gcm-codec")]
+    pub fn clear_aead(&self) -> Result<(), PairingError> {
+        let aead_path = self.aead_path();
+        // Also remove any leftover temp file from a crashed save.
+        let tmp_path = aead_path.with_extension("tmp");
+        let _ = fs::remove_file(&tmp_path);
+        match fs::remove_file(&aead_path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(PairingError::StoreSaveFailed(e.to_string())),
+        }
+    }
+
+    #[cfg(feature = "aes-gcm-codec")]
+    fn aead_path(&self) -> PathBuf {
+        self.path.with_file_name("pairing-aead.json")
+    }
+}
+
+#[cfg(feature = "aes-gcm-codec")]
+#[derive(Serialize, Deserialize)]
+struct StoredAeadArtifacts {
+    phone_psk: String,
+    phone_key_hint: u16,
+    rf_channel: u8,
+    phone_label: String,
 }
 
 impl PairingStore for FilePairingStore {

--- a/crates/sonde-pair/src/phase1.rs
+++ b/crates/sonde-pair/src/phase1.rs
@@ -520,6 +520,7 @@ async fn do_pair_with_gateway_aead(
 /// (no Ed25519 keypair or `gateway_id`). Gateway authority derives
 /// solely from possession of the phone PSK.
 #[cfg(feature = "aes-gcm-codec")]
+#[derive(Clone)]
 pub struct PairingArtifactsAead {
     pub phone_psk: Zeroizing<[u8; 32]>,
     pub phone_key_hint: u16,

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -238,6 +238,175 @@ async fn do_provision_node(
     Ok(NodeProvisionResult { status })
 }
 
+/// Phase 2 (AEAD): Provision a node via BLE using simplified AEAD flow.
+///
+/// Unlike [`provision_node`], this does not require gateway identity or ECDH.
+/// The phone generates the node PSK, builds a PairingRequest CBOR, encrypts
+/// it with `phone_psk` via AES-256-GCM, and wraps it in a complete ESP-NOW
+/// PEER_REQUEST frame using [`crypto::encrypt_pairing_request_aead`].
+///
+/// The node stores the frame verbatim and relays it to the gateway on its
+/// next wake cycle.
+#[cfg(feature = "aes-gcm-codec")]
+pub async fn provision_node_aead(
+    transport: &mut dyn BleTransport,
+    artifacts: &crate::phase1::PairingArtifactsAead,
+    rng: &dyn RngProvider,
+    device_address: &[u8; 6],
+    node_id: &str,
+    sensors: &[crate::types::SensorDescriptor],
+) -> Result<NodeProvisionResult, PairingError> {
+    // Step 1: Validate node_id
+    validate_node_id(node_id)?;
+
+    // Step 2: Generate node PSK
+    let mut node_psk = Zeroizing::new([0u8; 32]);
+    rng.fill_bytes(&mut *node_psk)?;
+    trace!("generated 32-byte node PSK");
+
+    // Step 3: Compute node_key_hint
+    let node_key_hint = compute_key_hint(&node_psk);
+
+    // Step 4: Build PairingRequest CBOR
+    let timestamp = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|_| PairingError::TimestampUnavailable)?
+            .as_secs(),
+    )
+    .map_err(|_| PairingError::TimestampUnavailable)?;
+    let cbor =
+        encode_pairing_request(node_id, &node_psk, artifacts.rf_channel, sensors, timestamp)?;
+
+    // Step 5: Encrypt with phone_psk and wrap in ESP-NOW AEAD PEER_REQUEST frame.
+    let encrypted_frame = crypto::encrypt_pairing_request_aead(&artifacts.phone_psk, &cbor)?;
+
+    // Step 6: Connect to node
+    debug!(address = ?device_address, "connecting to node (AEAD provision)");
+    let mtu = transport.connect(device_address).await?;
+    if mtu < BLE_MTU_MIN {
+        transport.disconnect().await.ok();
+        return Err(PairingError::MtuTooLow {
+            negotiated: mtu,
+            required: BLE_MTU_MIN,
+        });
+    }
+    debug!(address = ?device_address, mtu, "connected to node");
+
+    enforce_lesc(transport).await?;
+
+    // Step 7: Build NODE_PROVISION payload (AEAD format per spec §6.6):
+    // node_key_hint(2) ‖ node_psk(32) ‖ rf_channel(1) ‖ payload_len(2) ‖ encrypted_payload
+    let result = do_provision_node_aead(
+        transport,
+        node_key_hint,
+        &node_psk,
+        artifacts.rf_channel,
+        &encrypted_frame,
+    )
+    .await;
+
+    transport.disconnect().await.ok();
+    result
+}
+
+/// Inner implementation for AEAD node provisioning.
+#[cfg(feature = "aes-gcm-codec")]
+async fn do_provision_node_aead(
+    transport: &mut dyn BleTransport,
+    node_key_hint: u16,
+    node_psk: &[u8; 32],
+    rf_channel: u8,
+    encrypted_frame: &[u8],
+) -> Result<NodeProvisionResult, PairingError> {
+    if encrypted_frame.len() > PEER_PAYLOAD_MAX_LEN {
+        return Err(PairingError::PayloadTooLarge {
+            size: encrypted_frame.len(),
+            max: PEER_PAYLOAD_MAX_LEN,
+        });
+    }
+    let payload_len = encrypted_frame.len() as u16;
+
+    let mut provision_payload =
+        Zeroizing::new(Vec::with_capacity(2 + 32 + 1 + 2 + encrypted_frame.len()));
+    provision_payload.extend_from_slice(&node_key_hint.to_be_bytes());
+    provision_payload.extend_from_slice(node_psk);
+    provision_payload.push(rf_channel);
+    provision_payload.extend_from_slice(&payload_len.to_be_bytes());
+    provision_payload.extend_from_slice(encrypted_frame);
+
+    let message = Zeroizing::new(build_envelope(NODE_PROVISION, &provision_payload).ok_or(
+        PairingError::PayloadTooLarge {
+            size: provision_payload.len(),
+            max: u16::MAX as usize,
+        },
+    )?);
+
+    trace!(
+        msg = "NODE_PROVISION",
+        len = message.len(),
+        "BLE write (AEAD)"
+    );
+    transport
+        .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &message)
+        .await?;
+
+    trace!("waiting for NODE_ACK indication (5 s timeout)");
+    let response = transport
+        .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, 5000)
+        .await?;
+    let (msg_type, payload) = parse_envelope(&response)?;
+    trace!(
+        msg_type = format_args!("0x{msg_type:02x}"),
+        msg_name = msg_type_name(msg_type),
+        len = payload.len(),
+        "BLE indication received (AEAD provision)"
+    );
+
+    if msg_type == MSG_ERROR {
+        let (status, message) = parse_error_body(payload);
+        const MAX_DIAGNOSTIC_LEN: usize = 256;
+        let diagnostic: String = message
+            .chars()
+            .filter(|c| !c.is_control() || *c == '\n' || *c == '\r' || *c == '\t')
+            .take(MAX_DIAGNOSTIC_LEN)
+            .collect();
+        debug!(
+            status = format_args!("0x{status:02x}"),
+            diagnostic = %diagnostic,
+            "node returned error response (AEAD provision)"
+        );
+        return Err(PairingError::NodeErrorResponse {
+            status,
+            message: diagnostic,
+        });
+    }
+    if msg_type != NODE_ACK {
+        return Err(PairingError::InvalidResponse {
+            msg_type,
+            reason: format!(
+                "expected NODE_ACK (0x{:02x}), got 0x{msg_type:02x}",
+                NODE_ACK
+            ),
+        });
+    }
+
+    let status_byte = parse_node_ack(payload)?;
+    let status = NodeAckStatus::from_byte(status_byte);
+
+    match status {
+        NodeAckStatus::Success => {
+            info!("Phase 2 (AEAD) complete — node provisioned");
+        }
+        _ => {
+            debug!(status = ?status, "node provision failed (AEAD)");
+            return Err(PairingError::NodeProvisionFailed(status));
+        }
+    }
+
+    Ok(NodeProvisionResult { status })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1310,5 +1479,118 @@ mod tests {
                 "no writes should occur when MTU is too low"
             );
         });
+    }
+
+    #[cfg(feature = "aes-gcm-codec")]
+    #[tokio::test]
+    async fn provision_node_aead_happy_path() {
+        use crate::phase1::PairingArtifactsAead;
+
+        let artifacts = PairingArtifactsAead {
+            phone_psk: Zeroizing::new([0x55u8; 32]),
+            phone_key_hint: compute_key_hint(&[0x55u8; 32]),
+            rf_channel: 6,
+            phone_label: "test".into(),
+        };
+
+        let rng = MockRng::new([0x42u8; 32]);
+
+        // NODE_ACK(0x00 = success) wrapped in envelope
+        let ack_body = [0x00u8];
+        let mut ack_envelope = Vec::new();
+        ack_envelope.push(NODE_ACK);
+        ack_envelope.extend_from_slice(&(ack_body.len() as u16).to_be_bytes());
+        ack_envelope.extend_from_slice(&ack_body);
+
+        let mut transport = MockBleTransport::new(247);
+        transport.queue_response(Ok(ack_envelope));
+
+        let result = provision_node_aead(
+            &mut transport,
+            &artifacts,
+            &rng,
+            &[0xAA; 6],
+            "test-node",
+            &[],
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "provision_node_aead should succeed: {result:?}"
+        );
+        assert_eq!(result.unwrap().status, NodeAckStatus::Success);
+
+        // Verify NODE_PROVISION was written
+        assert_eq!(transport.written.len(), 1);
+        let (_svc, _chr, data) = &transport.written[0];
+        // First byte of envelope is NODE_PROVISION msg type
+        assert_eq!(data[0], NODE_PROVISION);
+    }
+
+    #[cfg(feature = "aes-gcm-codec")]
+    #[tokio::test]
+    async fn provision_node_aead_mtu_too_low() {
+        use crate::phase1::PairingArtifactsAead;
+
+        let artifacts = PairingArtifactsAead {
+            phone_psk: Zeroizing::new([0x55u8; 32]),
+            phone_key_hint: compute_key_hint(&[0x55u8; 32]),
+            rf_channel: 6,
+            phone_label: "test".into(),
+        };
+
+        let rng = MockRng::new([0x42u8; 32]);
+        let mut transport = MockBleTransport::new(100); // below BLE_MTU_MIN
+
+        let result = provision_node_aead(
+            &mut transport,
+            &artifacts,
+            &rng,
+            &[0xAA; 6],
+            "test-node",
+            &[],
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(PairingError::MtuTooLow { .. })),
+            "expected MtuTooLow, got {result:?}"
+        );
+        assert!(
+            transport.written.is_empty(),
+            "no writes should occur when MTU is too low"
+        );
+    }
+
+    #[cfg(feature = "aes-gcm-codec")]
+    #[tokio::test]
+    async fn provision_node_aead_invalid_node_id() {
+        use crate::phase1::PairingArtifactsAead;
+
+        let artifacts = PairingArtifactsAead {
+            phone_psk: Zeroizing::new([0x55u8; 32]),
+            phone_key_hint: compute_key_hint(&[0x55u8; 32]),
+            rf_channel: 6,
+            phone_label: "test".into(),
+        };
+
+        let rng = MockRng::new([0x42u8; 32]);
+        let mut transport = MockBleTransport::new(247);
+
+        let result = provision_node_aead(
+            &mut transport,
+            &artifacts,
+            &rng,
+            &[0xAA; 6],
+            "", // empty node_id
+            &[],
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(PairingError::InvalidNodeId(_))),
+            "expected InvalidNodeId, got {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Migrates the BLE pairing tool from the ECDH/HMAC model to the simplified AEAD flow, completing the full AES-256-GCM switchover across all components.

## Changes

### Phase 1 (phone ↔ gateway over BLE)
- \pair_with_gateway()\ → \pair_with_gateway_aead()\
- Phone generates PSK, sends over BLE LESC — no ECDH, no TOFU
- Artifacts held in \AppState\ (via \Arc\) and persisted to \pairing-aead.json\ on desktop

### Phase 2 (phone → node over BLE) — **new function**
- \provision_node()\ → \provision_node_aead()\
- Encrypts PairingRequest with \phone_psk\ via AES-256-GCM
- Builds complete ESP-NOW PEER_REQUEST frame for node relay
- Payload buffers wrapped in \Zeroizing\

### Gateway BLE handler
- New \handle_register_phone_aead()\ — receives phone-generated PSK directly (no ECDH)

### Cleanup
- Removed: TOFU pre-check, \get_or_init_store\, \hex\ module
- Both desktop + Android paths updated
- \clear_pairing\ propagates errors from file deletion

## Testing
- 159 sonde-pair tests pass (includes \provision_node_aead_happy_path\)
- Clippy clean, fmt clean