### PR TITLE
Revert "fix(gateway): set named pipe ACL so non-elevated admins can connect"

### DIFF
--- a/crates/sonde-gateway/Cargo.toml
+++ b/crates/sonde-gateway/Cargo.toml
@@ -46,11 +46,8 @@ tonic-prost-build = "0.14"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_Security_Cryptography",
-    "Win32_Security",
-    "Win32_Security_Authorization",
     "Win32_Foundation",
     "Win32_System_Memory",
-    "Win32_System_Pipes",
 ] }
 windows-service = "0.8.0"
 tracing-etw = "0.2.3"

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -1419,13 +1419,13 @@ pub async fn serve_admin(
     use std::pin::Pin;
     use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-    use tokio::net::windows::named_pipe::NamedPipeServer;
+    use tokio::net::windows::named_pipe::ServerOptions;
     use tonic::transport::server::Connected;
     use tracing::info;
 
     /// Wraps a Windows named pipe server connection so it satisfies tonic's
     /// `Connected + AsyncRead + AsyncWrite + Unpin` bound.
-    struct NamedPipeConn(NamedPipeServer);
+    struct NamedPipeConn(tokio::net::windows::named_pipe::NamedPipeServer);
 
     impl Connected for NamedPipeConn {
         type ConnectInfo = ();
@@ -1464,22 +1464,19 @@ pub async fn serve_admin(
     let pipe_name = pipe_name.to_owned();
     info!(pipe = %pipe_name, "gRPC admin server listening on named pipe");
 
-    // Build a security descriptor that grants BUILTIN\Administrators
-    // (BA) and SYSTEM (SY) full access.  Without this, a pipe created
-    // by the SYSTEM service account may not be connectable from a
-    // non-elevated Administrator session (#605).
-    let sd = create_pipe_security_descriptor()?;
-
     // Build a stream that accepts connections from the named pipe one at a time.
     // Each iteration creates a new server instance to wait for the next client.
-    let incoming = futures::stream::unfold((true, pipe_name, sd), |(first, name, sd)| async move {
-        let server = match create_named_pipe(&name, first, &sd) {
+    let incoming = futures::stream::unfold((true, pipe_name), |(first, name)| async move {
+        let server = match ServerOptions::new()
+            .first_pipe_instance(first)
+            .create(&name)
+        {
             Ok(s) => s,
-            Err(e) => return Some((Err::<NamedPipeConn, _>(e), (false, name, sd))),
+            Err(e) => return Some((Err::<NamedPipeConn, _>(e), (false, name))),
         };
         match server.connect().await {
-            Ok(()) => Some((Ok(NamedPipeConn(server)), (false, name, sd))),
-            Err(e) => Some((Err(e), (false, name, sd))),
+            Ok(()) => Some((Ok(NamedPipeConn(server)), (false, name))),
+            Err(e) => Some((Err(e), (false, name))),
         }
     });
 
@@ -1488,132 +1485,6 @@ pub async fn serve_admin(
         .serve_with_incoming(incoming)
         .await?;
     Ok(())
-}
-
-/// Security descriptor wrapper that frees the descriptor on drop.
-#[cfg(windows)]
-struct PipeSecurityDescriptor {
-    sd: *mut std::ffi::c_void,
-}
-
-// SAFETY: The security descriptor is a plain data buffer allocated by
-// `ConvertStringSecurityDescriptorToSecurityDescriptorW` and only read
-// (via pointer) by `CreateNamedPipeW`. It has no thread affinity.
-#[cfg(windows)]
-unsafe impl Send for PipeSecurityDescriptor {}
-#[cfg(windows)]
-unsafe impl Sync for PipeSecurityDescriptor {}
-
-#[cfg(windows)]
-impl Drop for PipeSecurityDescriptor {
-    fn drop(&mut self) {
-        if !self.sd.is_null() {
-            // SAFETY: `sd` was allocated by
-            // `ConvertStringSecurityDescriptorToSecurityDescriptorW`
-            // and must be freed with `LocalFree`.
-            unsafe {
-                windows_sys::Win32::Foundation::LocalFree(self.sd as _);
-            }
-        }
-    }
-}
-
-/// Parse a SDDL string into a security descriptor for the admin pipe.
-///
-/// Grants BUILTIN\Administrators (BA) and SYSTEM (SY) full access.
-/// Non-elevated admin users belong to the BA SID and can open the pipe
-/// without running an elevated prompt.
-#[cfg(windows)]
-fn create_pipe_security_descriptor() -> Result<PipeSecurityDescriptor, Box<dyn std::error::Error>> {
-    use windows_sys::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
-
-    // D:  — DACL
-    // (A;;GA;;;SY) — Allow SYSTEM Generic All
-    // (A;;GA;;;BA) — Allow BUILTIN\Administrators Generic All
-    let sddl: Vec<u16> = "D:(A;;GA;;;SY)(A;;GA;;;BA)\0".encode_utf16().collect();
-
-    let mut sd: *mut std::ffi::c_void = std::ptr::null_mut();
-    // SDDL_REVISION_1 = 1
-    let ok = unsafe {
-        ConvertStringSecurityDescriptorToSecurityDescriptorW(
-            sddl.as_ptr(),
-            1, // SDDL_REVISION_1
-            &mut sd,
-            std::ptr::null_mut(),
-        )
-    };
-    if ok == 0 {
-        return Err(format!(
-            "ConvertStringSecurityDescriptorToSecurityDescriptorW failed: {}",
-            std::io::Error::last_os_error()
-        )
-        .into());
-    }
-    Ok(PipeSecurityDescriptor { sd })
-}
-
-/// Create a named pipe with the given security descriptor.
-///
-/// Returns a tokio `NamedPipeServer` ready for `connect().await`.
-#[cfg(windows)]
-fn create_named_pipe(
-    name: &str,
-    first: bool,
-    sd: &PipeSecurityDescriptor,
-) -> std::io::Result<tokio::net::windows::named_pipe::NamedPipeServer> {
-    use std::os::windows::io::{FromRawHandle, OwnedHandle};
-    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
-    use windows_sys::Win32::System::Pipes::CreateNamedPipeW;
-
-    // Well-known constants for CreateNamedPipeW.
-    const PIPE_ACCESS_DUPLEX: u32 = 0x0000_0003;
-    const FILE_FLAG_OVERLAPPED: u32 = 0x4000_0000;
-    const FILE_FLAG_FIRST_PIPE_INSTANCE: u32 = 0x0008_0000;
-    const PIPE_TYPE_BYTE: u32 = 0x0000_0000;
-    const PIPE_WAIT: u32 = 0x0000_0000;
-    const PIPE_REJECT_REMOTE_CLIENTS: u32 = 0x0000_0008;
-
-    let wide_name: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
-
-    let mut open_mode = PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED;
-    if first {
-        open_mode |= FILE_FLAG_FIRST_PIPE_INSTANCE;
-    }
-
-    let security_attributes = windows_sys::Win32::Security::SECURITY_ATTRIBUTES {
-        nLength: std::mem::size_of::<windows_sys::Win32::Security::SECURITY_ATTRIBUTES>() as u32,
-        lpSecurityDescriptor: sd.sd,
-        bInheritHandle: 0,
-    };
-
-    // SAFETY: We pass valid pointers and the handle is checked below.
-    let handle = unsafe {
-        CreateNamedPipeW(
-            wide_name.as_ptr(),
-            open_mode,
-            PIPE_TYPE_BYTE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
-            255,  // max instances
-            4096, // out buffer
-            4096, // in buffer
-            0,    // default timeout
-            &security_attributes,
-        )
-    };
-
-    if handle == INVALID_HANDLE_VALUE {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    // SAFETY: handle is valid (not INVALID_HANDLE_VALUE) and we own it.
-    let owned = unsafe { OwnedHandle::from_raw_handle(handle as _) };
-
-    // SAFETY: The handle is a valid named pipe handle created with
-    // FILE_FLAG_OVERLAPPED, which tokio requires.
-    unsafe {
-        tokio::net::windows::named_pipe::NamedPipeServer::from_raw_handle(
-            std::os::windows::io::IntoRawHandle::into_raw_handle(owned),
-        )
-    }
 }
 
 #[cfg(not(any(unix, windows)))]


### PR DESCRIPTION
Reverts Alan-Jowett/sonde#621

This pull request simplifies the Windows named pipe server implementation in the `sonde-gateway` admin server by removing custom security descriptor handling and leveraging the default options provided by Tokio's `ServerOptions`. The code is now more maintainable and less error-prone, relying on upstream Tokio features instead of manual Windows API calls.

**Windows named pipe server simplification:**

* Removed custom security descriptor creation and handling (`create_pipe_security_descriptor`, `PipeSecurityDescriptor`, and related code), instead using Tokio's `ServerOptions` for named pipe creation. This eliminates direct Windows API calls and manual memory management.
* Updated the named pipe connection stream to use `ServerOptions::new().first_pipe_instance(first).create(&name)` for pipe creation, removing the need to pass and manage a security descriptor.

**Dependency cleanup:**

* Removed unused Windows dependency features: `"Win32_Security"`, `"Win32_Security_Authorization"`, and `"Win32_System_Pipes"` from `Cargo.toml`, as they are no longer needed after the refactor.

**Minor code adjustments:**

* Updated type references and imports to match the new usage of `ServerOptions` and the removal of direct `NamedPipeServer` construction.