### PR TITLE
refactor: remove _aead suffixes, audit banners, unused deps

### DIFF
--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -4,8 +4,8 @@
 //! Bridge harness that wires gateway and node together via in-memory frame
 //! queues for end-to-end integration testing.
 //!
-//! All frames are routed through the gateway's `process_frame_aead` path
-//! (AES-256-GCM) via `BridgeTransportAead`.
+//! All frames are routed through the gateway's `process_frame` path
+//! (AES-256-GCM) via `BridgeTransport`.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
@@ -117,7 +117,7 @@ impl E2eTestEnv {
 
 /// Statistics captured during a single wake cycle.
 pub struct WakeCycleStats {
-    /// The outcome returned by `run_wake_cycle_aead`.
+    /// The outcome returned by `run_wake_cycle`.
     pub outcome: WakeCycleOutcome,
     /// Number of non-`None` responses the gateway produced.
     pub response_count: usize,
@@ -178,26 +178,26 @@ impl NodeProxy {
     }
 
     /// Run one AEAD wake cycle, relaying frames through the gateway's
-    /// `process_frame_aead` path (AES-256-GCM).
+    /// `process_frame` path (AES-256-GCM).
     ///
     /// Uses `block_in_place` internally, so the caller must be running
     /// inside a multi-thread Tokio runtime. All E2E tests that call this
     /// must use `#[tokio::test(flavor = "multi_thread")]`.
-    pub fn run_wake_cycle_aead(&mut self, env: &E2eTestEnv) -> WakeCycleStats {
+    pub fn run_wake_cycle(&mut self, env: &E2eTestEnv) -> WakeCycleStats {
         let mut interpreter = MockBpfInterpreter::new();
-        self.run_wake_cycle_aead_inner(env, &mut interpreter, false)
+        self.run_wake_cycle_inner(env, &mut interpreter, false)
     }
 
-    /// Like [`run_wake_cycle_aead`] but accepts a caller-supplied BPF
+    /// Like [`run_wake_cycle`] but accepts a caller-supplied BPF
     /// interpreter for tests that require real BPF program execution.
     ///
-    /// Requires a multi-thread Tokio runtime (see [`run_wake_cycle_aead`]).
-    pub fn run_wake_cycle_aead_with(
+    /// Requires a multi-thread Tokio runtime (see [`run_wake_cycle`]).
+    pub fn run_wake_cycle_with(
         &mut self,
         env: &E2eTestEnv,
         interpreter: &mut impl BpfInterpreter,
     ) -> WakeCycleStats {
-        self.run_wake_cycle_aead_inner(env, interpreter, false)
+        self.run_wake_cycle_inner(env, interpreter, false)
     }
 
     /// Run one AEAD wake cycle with outgoing frame tampering.
@@ -206,20 +206,20 @@ impl NodeProxy {
     /// frame before forwarding to the gateway, causing GCM authentication
     /// failure and silent discard.
     ///
-    /// Requires a multi-thread Tokio runtime (see [`run_wake_cycle_aead`]).
-    pub fn run_wake_cycle_aead_tampered(&mut self, env: &E2eTestEnv) -> WakeCycleStats {
+    /// Requires a multi-thread Tokio runtime (see [`run_wake_cycle`]).
+    pub fn run_wake_cycle_tampered(&mut self, env: &E2eTestEnv) -> WakeCycleStats {
         let mut interpreter = MockBpfInterpreter::new();
-        self.run_wake_cycle_aead_inner(env, &mut interpreter, true)
+        self.run_wake_cycle_inner(env, &mut interpreter, true)
     }
 
-    fn run_wake_cycle_aead_inner(
+    fn run_wake_cycle_inner(
         &mut self,
         env: &E2eTestEnv,
         interpreter: &mut impl BpfInterpreter,
         tamper: bool,
     ) -> WakeCycleStats {
         use sonde_node::node_aead::NodeAead;
-        use sonde_node::wake_cycle::run_wake_cycle_aead;
+        use sonde_node::wake_cycle::run_wake_cycle;
 
         let mut hal = MockHal;
         let clock = MockClock::new();
@@ -228,12 +228,12 @@ impl NodeProxy {
         let aead = NodeAead;
 
         let mut transport = if tamper {
-            BridgeTransportAead::new_tampered(env.gateway.clone(), self.mac.clone())
+            BridgeTransport::new_tampered(env.gateway.clone(), self.mac.clone())
         } else {
-            BridgeTransportAead::new(env.gateway.clone(), self.mac.clone())
+            BridgeTransport::new(env.gateway.clone(), self.mac.clone())
         };
 
-        let outcome = run_wake_cycle_aead(
+        let outcome = run_wake_cycle(
             &mut transport,
             &mut self.storage,
             &mut hal,
@@ -255,12 +255,12 @@ impl NodeProxy {
 }
 
 // ---------------------------------------------------------------------------
-// BridgeTransportAead — AEAD frame relay for AES-256-GCM E2E tests
+// BridgeTransport — AEAD frame relay for AES-256-GCM E2E tests
 // ---------------------------------------------------------------------------
 
 /// In-memory frame relay that routes all frames through the gateway's
-/// `process_frame_aead` path (AES-256-GCM), including PEER_REQUEST.
-struct BridgeTransportAead {
+/// `process_frame` path (AES-256-GCM), including PEER_REQUEST.
+struct BridgeTransport {
     gateway: Arc<Gateway>,
     peer: Vec<u8>,
     pending_response: Option<Vec<u8>>,
@@ -271,7 +271,7 @@ struct BridgeTransportAead {
     tamper_outgoing: bool,
 }
 
-impl BridgeTransportAead {
+impl BridgeTransport {
     fn new(gateway: Arc<Gateway>, peer: Vec<u8>) -> Self {
         Self {
             gateway,
@@ -281,7 +281,7 @@ impl BridgeTransportAead {
             wake_nonces: Vec::new(),
             sent_frames: Vec::new(),
             rt: tokio::runtime::Handle::try_current()
-                .expect("BridgeTransportAead must be created inside a Tokio runtime"),
+                .expect("BridgeTransport must be created inside a Tokio runtime"),
             tamper_outgoing: false,
         }
     }
@@ -305,7 +305,7 @@ impl BridgeTransportAead {
     }
 }
 
-impl NodeTransport for BridgeTransportAead {
+impl NodeTransport for BridgeTransport {
     fn send(&mut self, frame: &[u8]) -> NodeResult<()> {
         if frame.len() >= sonde_protocol::HEADER_SIZE {
             let msg_type = frame[sonde_protocol::OFFSET_MSG_TYPE];
@@ -331,8 +331,7 @@ impl NodeTransport for BridgeTransportAead {
             frame_vec[sonde_protocol::HEADER_SIZE] ^= 0x01;
         }
         let response = tokio::task::block_in_place(|| {
-            self.rt
-                .block_on(gateway.process_frame_aead(&frame_vec, peer))
+            self.rt.block_on(gateway.process_frame(&frame_vec, peer))
         });
 
         if response.is_some() {
@@ -752,7 +751,7 @@ pub async fn simulate_phone_registration(
 
 /// Build the complete ESP-NOW PEER_REQUEST frame for NODE_PROVISION.
 ///
-/// Uses `encrypt_pairing_request_aead` to build a frame the node relays
+/// Uses `encrypt_pairing_request` to build a frame the node relays
 /// verbatim during the PEER_REQUEST exchange.
 #[allow(clippy::too_many_arguments)]
 pub fn build_encrypted_payload(
@@ -800,11 +799,10 @@ pub fn build_encrypted_payload_with_timestamp(
     timestamp: i64,
 ) -> Vec<u8> {
     use sonde_pair::cbor::encode_pairing_request;
-    use sonde_pair::crypto::encrypt_pairing_request_aead;
+    use sonde_pair::crypto::encrypt_pairing_request;
 
     let cbor = encode_pairing_request(node_id, node_psk, rf_channel, sensors, timestamp).unwrap();
-    encrypt_pairing_request_aead(phone_psk, &cbor)
-        .expect("encrypt_pairing_request_aead must succeed in test")
+    encrypt_pairing_request(phone_psk, &cbor).expect("encrypt_pairing_request must succeed in test")
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -4,8 +4,8 @@
 //! AES-256-GCM end-to-end integration tests.
 //!
 //! These tests exercise the AEAD frame path: the node uses
-//! `run_wake_cycle_aead` (with `NodeAead`) and the gateway processes
-//! frames via `process_frame_aead` (with `GatewayAead`).
+//! `run_wake_cycle` (with `NodeAead`) and the gateway processes
+//! frames via `process_frame` (with `GatewayAead`).
 
 use sonde_e2e::harness::{E2eTestEnv, NodeProxy, TestSha256};
 use sonde_gateway::storage::Storage;
@@ -74,13 +74,13 @@ fn make_program_from_bytecode(bytecode: &[u8]) -> (ProgramRecord, Vec<u8>) {
 ///   compatible AES-256-GCM frames.
 /// - Gateway updates node telemetry after a successful AEAD exchange.
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_050_aead_nop_wake_cycle() {
+async fn t_e2e_050_nop_wake_cycle() {
     let env = E2eTestEnv::new();
     let psk = [0x50; 32];
     env.register_node("aead-nop", 1, psk).await;
 
     let mut node = NodeProxy::new(1, psk);
-    let stats = node.run_wake_cycle_aead(&env);
+    let stats = node.run_wake_cycle(&env);
 
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
@@ -106,18 +106,18 @@ async fn t_e2e_050_aead_nop_wake_cycle() {
 /// persistent storage and monotonic RNG state work correctly across
 /// multiple AES-256-GCM exchanges.
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_050b_aead_consecutive_wake_cycles() {
+async fn t_e2e_050b_consecutive_wake_cycles() {
     let env = E2eTestEnv::new();
     let psk = [0x55; 32];
     env.register_node("aead-multi", 1, psk).await;
 
     let mut node = NodeProxy::new(1, psk);
 
-    let stats1 = node.run_wake_cycle_aead(&env);
+    let stats1 = node.run_wake_cycle(&env);
     assert_eq!(stats1.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(stats1.response_count > 0);
 
-    let stats2 = node.run_wake_cycle_aead(&env);
+    let stats2 = node.run_wake_cycle(&env);
     assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(stats2.response_count > 0);
 
@@ -139,7 +139,7 @@ async fn t_e2e_050b_aead_consecutive_wake_cycles() {
 /// dispatch sends APP_DATA via the HMAC codec (this is the current design —
 /// BPF helpers have not yet been migrated to AEAD).
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_051_aead_app_data_fire_and_forget() {
+async fn t_e2e_051_app_data_fire_and_forget() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
     let env = E2eTestEnv::new();
@@ -155,7 +155,7 @@ async fn t_e2e_051_aead_app_data_fire_and_forget() {
 
     let mut node = NodeProxy::new(1, psk);
     let mut interpreter = SondeBpfInterpreter::new();
-    let stats = node.run_wake_cycle_aead_with(&env, &mut interpreter);
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
 
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
@@ -176,13 +176,13 @@ async fn t_e2e_051_aead_app_data_fire_and_forget() {
 /// cannot decrypt the AEAD frame and silently discards it. The node
 /// exhausts its retries and sleeps.
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_052_aead_wrong_psk_rejected() {
+async fn t_e2e_052_wrong_psk_rejected() {
     let env = E2eTestEnv::new();
     env.register_node("aead-wrong", 1, [0xAA; 32]).await;
 
     // Node has a different PSK.
     let mut node = NodeProxy::new(1, [0xBB; 32]);
-    let stats = node.run_wake_cycle_aead(&env);
+    let stats = node.run_wake_cycle(&env);
 
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert_eq!(
@@ -208,13 +208,13 @@ async fn t_e2e_052_aead_wrong_psk_rejected() {
 /// The gateway silently discards the corrupted frame and the node receives
 /// no response, eventually exhausting retries.
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_053_aead_tampered_frame_discarded() {
+async fn t_e2e_053_tampered_frame_discarded() {
     let env = E2eTestEnv::new();
     let psk = [0x53; 32];
     env.register_node("aead-tamper", 1, psk).await;
 
     let mut node = NodeProxy::new(1, psk);
-    let stats = node.run_wake_cycle_aead_tampered(&env);
+    let stats = node.run_wake_cycle_tampered(&env);
 
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert_eq!(

--- a/crates/sonde-e2e/tests/ble_loopback_tests.rs
+++ b/crates/sonde-e2e/tests/ble_loopback_tests.rs
@@ -47,7 +47,7 @@ async fn phase1_loopback_happy_path() {
     assert_eq!(devices[0].name, "Sonde-GW-Loopback");
 
     // Phase 1: pair with the fake gateway (AEAD)
-    let artifacts = phase1::pair_with_gateway_aead(
+    let artifacts = phase1::pair_with_gateway(
         &mut transport,
         &rng,
         &device_addr,
@@ -79,14 +79,13 @@ async fn phase1_loopback_re_pair() {
     let device_addr = [0x10, 0x0B, 0xAC, 0x00, 0x00, 0x01];
 
     // First pairing
-    let first =
-        phase1::pair_with_gateway_aead(&mut transport, &rng, &device_addr, "first-phone", None)
-            .await
-            .expect("first pairing should succeed");
+    let first = phase1::pair_with_gateway(&mut transport, &rng, &device_addr, "first-phone", None)
+        .await
+        .expect("first pairing should succeed");
 
     // Second pairing — new PSK generated each time
     let second =
-        phase1::pair_with_gateway_aead(&mut transport, &rng, &device_addr, "second-phone", None)
+        phase1::pair_with_gateway(&mut transport, &rng, &device_addr, "second-phone", None)
             .await
             .expect("re-pairing should succeed");
 
@@ -104,7 +103,7 @@ async fn phase1_loopback_empty_label() {
     let rng = OsRng;
     let device_addr = [0x10, 0x0B, 0xAC, 0x00, 0x00, 0x01];
 
-    let artifacts = phase1::pair_with_gateway_aead(&mut transport, &rng, &device_addr, "", None)
+    let artifacts = phase1::pair_with_gateway(&mut transport, &rng, &device_addr, "", None)
         .await
         .expect("pairing with empty label should succeed");
 

--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -248,7 +248,7 @@ async fn t_e2e_063_peer_request_ack() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // Run wake cycle — node sends PEER_REQUEST, gateway processes + WAKE.
-    let stats = node.run_wake_cycle_aead(&env);
+    let stats = node.run_wake_cycle(&env);
 
     // PEER_REQUEST succeeded: node should complete a normal WAKE cycle.
     assert_eq!(
@@ -318,7 +318,7 @@ async fn t_e2e_064_onboarding_to_wake() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // First cycle: PEER_REQUEST + WAKE.
-    let stats = node.run_wake_cycle_aead(&env);
+    let stats = node.run_wake_cycle(&env);
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
     // Verify steady-state: peer_payload erased (ND-0914), reg_complete set.
@@ -329,7 +329,7 @@ async fn t_e2e_064_onboarding_to_wake() {
     );
 
     // Second cycle: pure WAKE (no PEER_REQUEST).
-    let stats2 = node.run_wake_cycle_aead(&env);
+    let stats2 = node.run_wake_cycle(&env);
     assert_eq!(
         stats2.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -389,7 +389,7 @@ async fn t_e2e_065_deferred_erasure() {
     assert!(!node.storage.read_reg_complete());
 
     // Run cycle: PEER_REQUEST + WAKE succeeds → payload erased.
-    let stats = node.run_wake_cycle_aead(&env);
+    let stats = node.run_wake_cycle(&env);
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
     // After WAKE success: reg_complete set, peer_payload erased.
@@ -447,7 +447,7 @@ async fn t_e2e_066_self_healing() {
 
     // Cycle 1: reg_complete=true → skip PEER_REQUEST → WAKE fails
     // (gateway doesn't recognize key_hint) → self-healing clears reg_complete.
-    let stats1 = node.run_wake_cycle_aead(&env);
+    let stats1 = node.run_wake_cycle(&env);
     assert_eq!(
         stats1.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -464,7 +464,7 @@ async fn t_e2e_066_self_healing() {
 
     // Cycle 2: reg_complete=false, payload present → PEER_REQUEST →
     // gateway registers → PEER_ACK → WAKE → success.
-    let stats2 = node.run_wake_cycle_aead(&env);
+    let stats2 = node.run_wake_cycle(&env);
     assert_eq!(
         stats2.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -515,7 +515,7 @@ async fn t_e2e_067_agent_revocation() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // PEER_REQUEST should be silently discarded (revoked phone) → timeout → Sleep.
-    let stats = node.run_wake_cycle_aead(&env);
+    let stats = node.run_wake_cycle(&env);
     assert_eq!(
         stats.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -576,7 +576,7 @@ async fn t_e2e_068_factory_reset_reprovision() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // Run initial cycle to register the node.
-    let stats = node.run_wake_cycle_aead(&env);
+    let stats = node.run_wake_cycle(&env);
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(node.storage.read_reg_complete());
 
@@ -626,7 +626,7 @@ async fn t_e2e_068_factory_reset_reprovision() {
     assert_eq!(status, NODE_ACK_SUCCESS);
 
     // Run PEER_REQUEST + WAKE with new identity.
-    let stats2 = node.run_wake_cycle_aead(&env);
+    let stats2 = node.run_wake_cycle(&env);
     assert_eq!(
         stats2.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -692,12 +692,12 @@ async fn t_e2e_069_multi_node() {
     let mut node_b = NodeProxy::new_ble_provisioned(hint_b, psk_b, rf_channel, payload_b);
 
     // Onboard node A.
-    let stats_a = node_a.run_wake_cycle_aead(&env);
+    let stats_a = node_a.run_wake_cycle(&env);
     assert_eq!(stats_a.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(node_a.storage.read_reg_complete());
 
     // Onboard node B.
-    let stats_b = node_b.run_wake_cycle_aead(&env);
+    let stats_b = node_b.run_wake_cycle(&env);
     assert_eq!(stats_b.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(node_b.storage.read_reg_complete());
 
@@ -716,8 +716,8 @@ async fn t_e2e_069_multi_node() {
         .is_some());
 
     // Both operate in steady-state.
-    let stats_a2 = node_a.run_wake_cycle_aead(&env);
-    let stats_b2 = node_b.run_wake_cycle_aead(&env);
+    let stats_a2 = node_a.run_wake_cycle(&env);
+    let stats_b2 = node_b.run_wake_cycle(&env);
     assert_eq!(stats_a2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert_eq!(stats_b2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
@@ -787,7 +787,7 @@ async fn t_e2e_070_full_use_case() {
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
 
     // 4. PEER_REQUEST/PEER_ACK + first WAKE.
-    let stats = node.run_wake_cycle_aead(&env);
+    let stats = node.run_wake_cycle(&env);
     assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(node.storage.read_reg_complete());
     assert!(node.storage.read_peer_payload().is_none());
@@ -802,7 +802,7 @@ async fn t_e2e_070_full_use_case() {
 
     // 6. Run with real BPF — program calls send() helper.
     let mut interpreter = SondeBpfInterpreter::new();
-    let stats2 = node.run_wake_cycle_aead_with(&env, &mut interpreter);
+    let stats2 = node.run_wake_cycle_with(&env, &mut interpreter);
     assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
 
     // Verify APP_DATA was sent (msg_type 0x04).
@@ -863,7 +863,7 @@ async fn t_e2e_063a_stale_timestamp_discarded() {
 
     let result = env
         .gateway
-        .process_frame_aead(&stale_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame(&stale_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await;
 
     assert!(
@@ -890,7 +890,7 @@ async fn t_e2e_063a_stale_timestamp_discarded() {
     );
     let fresh_result = env
         .gateway
-        .process_frame_aead(&fresh_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame(&fresh_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await;
     assert!(
         fresh_result.is_some(),
@@ -913,7 +913,7 @@ async fn t_e2e_063b_key_hint_mismatch_discarded() {
     use sonde_pair::cbor::encode_pairing_request;
     use sonde_pair::crypto::{aes256gcm_encrypt, PAIRING_REQUEST_AAD};
     use sonde_pair::rng::{OsRng, RngProvider};
-    use sonde_protocol::{encode_frame_aead, FrameHeader, MSG_PEER_REQUEST};
+    use sonde_protocol::{encode_frame, FrameHeader, MSG_PEER_REQUEST};
 
     let env = E2eTestEnv::new();
     let identity = setup_gateway_identity(&env.storage).await;
@@ -958,11 +958,11 @@ async fn t_e2e_063b_key_hint_mismatch_discarded() {
         msg_type: MSG_PEER_REQUEST,
         nonce: 0xAAAA_BBBB_CCCC_DDDD,
     };
-    let frame = encode_frame_aead(&header, &cbor_buf, &phone_psk, &aead, &sha).unwrap();
+    let frame = encode_frame(&header, &cbor_buf, &phone_psk, &aead, &sha).unwrap();
 
     let result = env
         .gateway
-        .process_frame_aead(&frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame(&frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await;
 
     assert!(
@@ -988,7 +988,7 @@ async fn t_e2e_063b_key_hint_mismatch_discarded() {
     );
     let good_result = env
         .gateway
-        .process_frame_aead(&good_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame(&good_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await;
     assert!(
         good_result.is_some(),
@@ -1036,7 +1036,7 @@ async fn t_e2e_063c_duplicate_node_id_discarded() {
         rf_channel,
         encrypted_payload_1,
     );
-    let stats1 = node1.run_wake_cycle_aead(&env);
+    let stats1 = node1.run_wake_cycle(&env);
     assert!(
         matches!(stats1.outcome, WakeCycleOutcome::Sleep { .. }),
         "first registration must succeed (got {:?})",
@@ -1075,7 +1075,7 @@ async fn t_e2e_063c_duplicate_node_id_discarded() {
     );
 
     // The second PEER_REQUEST should be silently discarded → timeout → Sleep.
-    let stats2 = node2.run_wake_cycle_aead(&env);
+    let stats2 = node2.run_wake_cycle(&env);
     assert!(
         matches!(stats2.outcome, WakeCycleOutcome::Sleep { .. }),
         "duplicate node_id PEER_REQUEST must result in Sleep (timeout) (got {:?})",
@@ -1113,8 +1113,8 @@ async fn t_e2e_063c_duplicate_node_id_discarded() {
 async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
     use sonde_node::key_store::NodeIdentity;
     use sonde_node::node_aead::NodeAead;
-    use sonde_node::peer_request::verify_peer_ack_aead;
-    use sonde_protocol::decode_frame_aead;
+    use sonde_node::peer_request::verify_peer_ack;
+    use sonde_protocol::decode_frame;
 
     let env = E2eTestEnv::new();
     let identity = setup_gateway_identity(&env.storage).await;
@@ -1139,7 +1139,7 @@ async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
     );
 
     // Extract the nonce from the frame header.
-    let decoded = decode_frame_aead(&complete_frame).expect("frame must decode");
+    let decoded = decode_frame(&complete_frame).expect("frame must decode");
     let request_nonce = decoded.header.nonce;
 
     let node_identity = NodeIdentity {
@@ -1150,7 +1150,7 @@ async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
     // Send to gateway and get the PEER_ACK back.
     let ack_frame = env
         .gateway
-        .process_frame_aead(&complete_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        .process_frame(&complete_frame, vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
         .await
         .expect("gateway must return PEER_ACK for valid PEER_REQUEST");
 
@@ -1158,13 +1158,13 @@ async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
     let aead = NodeAead;
     let sha = TestSha256;
     assert!(
-        verify_peer_ack_aead(&ack_frame, &node_identity, request_nonce, &aead, &sha).is_ok(),
+        verify_peer_ack(&ack_frame, &node_identity, request_nonce, &aead, &sha).is_ok(),
         "node must accept PEER_ACK with correct nonce"
     );
 
     // Verify node REJECTS the same PEER_ACK when expected nonce differs.
     let wrong_nonce: u64 = 0x5555_6666_7777_8888;
-    let result = verify_peer_ack_aead(&ack_frame, &node_identity, wrong_nonce, &aead, &sha);
+    let result = verify_peer_ack(&ack_frame, &node_identity, wrong_nonce, &aead, &sha);
     assert!(
         result.is_err(),
         "node must reject PEER_ACK when nonce does not match PEER_REQUEST"
@@ -1180,16 +1180,16 @@ async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
 
 /// T-E2E-063e — sonde-pair → gateway end-to-end integration.
 ///
-/// Wires the actual `sonde_pair::phase1::pair_with_gateway_aead` state machine
+/// Wires the actual `sonde_pair::phase1::pair_with_gateway` state machine
 /// to the gateway's `handle_ble_recv` via a `GatewayBleAdapter`, proving that
 /// sonde-pair's Phase 1 AEAD output is compatible with the gateway. The
-/// resulting `PairingArtifactsAead` are used to build the encrypted payload
-/// for Phase 3 via `encrypt_pairing_request_aead`, which flows through a
+/// resulting `PairingArtifacts` are used to build the encrypted payload
+/// for Phase 3 via `encrypt_pairing_request`, which flows through a
 /// NodeProxy to the gateway via PEER_REQUEST/PEER_ACK.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_063e_sonde_pair_gateway_integration() {
     use sonde_pair::cbor::encode_pairing_request;
-    use sonde_pair::crypto::encrypt_pairing_request_aead;
+    use sonde_pair::crypto::encrypt_pairing_request;
     use sonde_pair::phase1;
     use sonde_pair::rng::OsRng;
     use std::sync::Arc;
@@ -1204,7 +1204,7 @@ async fn t_e2e_063e_sonde_pair_gateway_integration() {
     let rng = OsRng;
     let device_addr = [0x10, 0x0B, 0xAC, 0x00, 0x00, 0x01];
 
-    let artifacts = phase1::pair_with_gateway_aead(
+    let artifacts = phase1::pair_with_gateway(
         &mut transport,
         &rng,
         &device_addr,
@@ -1234,13 +1234,13 @@ async fn t_e2e_063e_sonde_pair_gateway_integration() {
         .unwrap_or_default()
         .as_secs() as i64;
     let cbor = encode_pairing_request(node_id, &node_psk, rf_channel, &[], timestamp).unwrap();
-    let encrypted_payload = encrypt_pairing_request_aead(&artifacts.phone_psk, &cbor)
-        .expect("encrypt_pairing_request_aead must succeed");
+    let encrypted_payload = encrypt_pairing_request(&artifacts.phone_psk, &cbor)
+        .expect("encrypt_pairing_request must succeed");
 
     // Wire the payload through a NodeProxy to the gateway.
     let mut node =
         NodeProxy::new_ble_provisioned(node_key_hint, node_psk, rf_channel, encrypted_payload);
-    let stats = node.run_wake_cycle_aead(&env);
+    let stats = node.run_wake_cycle(&env);
 
     assert_eq!(
         stats.outcome,
@@ -1312,7 +1312,7 @@ async fn t_e2e_083_instruction_budget_enforcement() {
 
     let mut node = NodeProxy::new(1, psk);
     let mut interpreter = SondeBpfInterpreter::new();
-    let stats = node.run_wake_cycle_aead_with(&env, &mut interpreter);
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
 
     // Verify the program was actually installed (PROGRAM_ACK sent).
     let ack_count = stats
@@ -1395,7 +1395,7 @@ async fn t_e2e_081_ephemeral_restrictions() {
 
     let mut node = NodeProxy::new(1, psk);
     let mut interpreter = SondeBpfInterpreter::new();
-    let stats = node.run_wake_cycle_aead_with(&env, &mut interpreter);
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
     assert_eq!(
         stats.outcome,
         WakeCycleOutcome::Sleep { seconds: 60 },
@@ -1450,7 +1450,7 @@ async fn t_e2e_081_ephemeral_restrictions() {
         )
         .await;
 
-    let stats = node.run_wake_cycle_aead_with(&env, &mut interpreter);
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
 
     // Verify the ephemeral program was downloaded (GET_CHUNK sent).
     let get_chunk_count = stats

--- a/crates/sonde-gateway/src/aead.rs
+++ b/crates/sonde-gateway/src/aead.rs
@@ -56,7 +56,7 @@ mod inner {
 mod tests {
     use super::GatewayAead;
     use sonde_protocol::{
-        decode_frame_aead, encode_frame_aead, open_frame, AeadProvider, FrameHeader, MSG_WAKE,
+        decode_frame, encode_frame, open_frame, AeadProvider, FrameHeader, MSG_WAKE,
     };
 
     use crate::crypto::RustCryptoSha256;
@@ -74,10 +74,10 @@ mod tests {
         };
         let payload = vec![0xA1, 0x01, 0x02];
 
-        let raw = encode_frame_aead(&header, &payload, &psk, &aead, &sha)
-            .expect("encoding should succeed");
+        let raw =
+            encode_frame(&header, &payload, &psk, &aead, &sha).expect("encoding should succeed");
 
-        let decoded = decode_frame_aead(&raw).expect("decoding should succeed");
+        let decoded = decode_frame(&raw).expect("decoding should succeed");
         assert_eq!(decoded.header.key_hint, 1);
         assert_eq!(decoded.header.msg_type, MSG_WAKE);
         assert_eq!(decoded.header.nonce, 100);
@@ -100,10 +100,10 @@ mod tests {
         };
         let payload = vec![0xA0];
 
-        let raw = encode_frame_aead(&header, &payload, &psk, &aead, &sha)
-            .expect("encoding should succeed");
+        let raw =
+            encode_frame(&header, &payload, &psk, &aead, &sha).expect("encoding should succeed");
 
-        let decoded = decode_frame_aead(&raw).expect("decoding should succeed");
+        let decoded = decode_frame(&raw).expect("decoding should succeed");
 
         // Attempting to open with a different PSK must fail.
         let result = open_frame(&decoded, &wrong_psk, &aead, &sha);
@@ -153,10 +153,10 @@ mod tests {
             nonce: 0,
         };
 
-        let raw = encode_frame_aead(&header, &[], &psk, &aead, &sha)
+        let raw = encode_frame(&header, &[], &psk, &aead, &sha)
             .expect("encoding empty payload should succeed");
 
-        let decoded = decode_frame_aead(&raw).expect("decoding should succeed");
+        let decoded = decode_frame(&raw).expect("decoding should succeed");
         let plaintext = open_frame(&decoded, &psk, &aead, &sha).expect("open should succeed");
         assert!(plaintext.is_empty());
     }

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -477,7 +477,7 @@ async fn run_gateway(
                 match transport_ref.recv().await {
                     Ok((raw_frame, peer_addr)) => {
                         if let Some(response) = gateway_ref
-                            .process_frame_aead(&raw_frame, peer_addr.clone())
+                            .process_frame(&raw_frame, peer_addr.clone())
                             .await
                         {
                             if let Err(e) = transport_ref.send(&response, &peer_addr).await {

--- a/crates/sonde-gateway/src/ble_pairing.rs
+++ b/crates/sonde-gateway/src/ble_pairing.rs
@@ -219,7 +219,7 @@ pub async fn handle_ble_recv(
     match msg_type {
         BLE_MSG_REQUEST_GW_INFO => handle_request_gw_info(body, identity),
         BLE_MSG_REGISTER_PHONE => {
-            handle_register_phone_aead(body, storage, window, rf_channel, controller).await
+            handle_register_phone(body, storage, window, rf_channel, controller).await
         }
         _ => {
             debug!(msg_type, "ignoring unknown BLE message type");
@@ -264,14 +264,14 @@ fn handle_request_gw_info(body: &[u8], identity: &GatewayIdentity) -> Option<Vec
 }
 
 // ---------------------------------------------------------------------------
-// REGISTER_PHONE — AEAD variant (simplified, phone generates PSK)
+// REGISTER_PHONE — phone generates PSK
 // ---------------------------------------------------------------------------
 
 /// Handle REGISTER_PHONE (AEAD): phone sends its PSK, gateway stores it.
 ///
 /// REGISTER_PHONE body: phone_psk(32) + label_len(1) + label(label_len).
 /// PHONE_REGISTERED body: status(1) + rf_channel(1) + phone_key_hint(2 BE).
-async fn handle_register_phone_aead(
+async fn handle_register_phone(
     body: &[u8],
     storage: &Arc<dyn Storage>,
     window: &mut RegistrationWindow,

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -9,7 +9,7 @@ use tokio::sync::RwLock;
 use tracing::{info, warn};
 
 use sonde_protocol::{
-    decode_frame_aead, encode_frame_aead, open_frame, CommandPayload, FrameHeader, GatewayMessage,
+    decode_frame, encode_frame, open_frame, CommandPayload, FrameHeader, GatewayMessage,
     NodeMessage, MSG_APP_DATA, MSG_APP_DATA_REPLY, MSG_CHUNK, MSG_COMMAND, MSG_GET_CHUNK,
     MSG_PEER_ACK, MSG_PEER_REQUEST, MSG_PROGRAM_ACK, MSG_WAKE, PEER_ACK_KEY_STATUS,
     PEER_REQ_KEY_PAYLOAD,
@@ -273,21 +273,21 @@ impl Gateway {
 
     /// Process a raw frame using AES-256-GCM authenticated encryption.
     ///
-    /// This is the AEAD counterpart of [`process_frame`]. It decodes the
+    /// Decodes the
     /// frame header, looks up candidate PSKs by `key_hint`, then tries
     /// each candidate with [`open_frame`] (AES-256-GCM decrypt + auth).
     ///
     /// For `PEER_REQUEST` frames, the `key_hint` identifies a phone PSK
     /// (not a node PSK).  The outer frame is decrypted with `phone_psk`,
     /// and the inner payload is also decrypted with `phone_psk`.
-    pub async fn process_frame_aead(&self, raw: &[u8], peer: PeerAddress) -> Option<Vec<u8>> {
+    pub async fn process_frame(&self, raw: &[u8], peer: PeerAddress) -> Option<Vec<u8>> {
         use crate::aead::GatewayAead;
 
-        let decoded = decode_frame_aead(raw).ok()?;
+        let decoded = decode_frame(raw).ok()?;
 
         // PEER_REQUEST: key_hint identifies a phone PSK, not a node.
         if decoded.header.msg_type == MSG_PEER_REQUEST {
-            return self.handle_peer_request_aead(&decoded).await;
+            return self.handle_peer_request(&decoded).await;
         }
 
         let key_hint = decoded.header.key_hint;
@@ -315,11 +315,11 @@ impl Gateway {
 
         match decoded.header.msg_type {
             MSG_WAKE => {
-                self.handle_wake_aead(&node, &decoded.header, &payload, peer)
+                self.handle_wake(&node, &decoded.header, &payload, peer)
                     .await
             }
             MSG_GET_CHUNK | MSG_PROGRAM_ACK | MSG_APP_DATA => {
-                self.handle_post_wake_aead(&node, &decoded.header, &payload)
+                self.handle_post_wake(&node, &decoded.header, &payload)
                     .await
             }
             _ => None,
@@ -327,14 +327,14 @@ impl Gateway {
     }
 
     /// Encode a response frame using AES-256-GCM.
-    fn encode_response_aead(
+    fn encode_response(
         &self,
         header: &FrameHeader,
         cbor: &[u8],
         psk: &[u8; 32],
     ) -> Option<Vec<u8>> {
         use crate::aead::GatewayAead;
-        encode_frame_aead(header, cbor, psk, &GatewayAead, &self.crypto_sha).ok()
+        encode_frame(header, cbor, psk, &GatewayAead, &self.crypto_sha).ok()
     }
     #[allow(dead_code)]
     async fn get_identity(&self) -> Option<Arc<GatewayIdentity>> {
@@ -363,9 +363,9 @@ impl Gateway {
     /// 4. Decrypts the inner payload with `phone_psk` (AAD = `"sonde-pairing-v2"`).
     /// 5. Parses the PairingRequest CBOR and registers the node.
     /// 6. Sends PEER_ACK encrypted with `node_psk`.
-    async fn handle_peer_request_aead(
+    async fn handle_peer_request(
         &self,
-        decoded: &sonde_protocol::DecodedFrameAead<'_>,
+        decoded: &sonde_protocol::DecodedFrame<'_>,
     ) -> Option<Vec<u8>> {
         use aes_gcm::aead::{Aead, KeyInit};
         use aes_gcm::{Aes256Gcm, Nonce};
@@ -497,7 +497,7 @@ impl Gateway {
             nonce: decoded.header.nonce,
         };
 
-        let frame = encode_frame_aead(
+        let frame = encode_frame(
             &ack_header,
             &ack_cbor_buf,
             &record.psk,
@@ -728,8 +728,8 @@ impl Gateway {
         Some((response_header, response_cbor))
     }
 
-    /// AEAD variant of [`handle_wake_aead`] — same business logic, AES-256-GCM encoding.
-    async fn handle_wake_aead(
+    /// Handle a WAKE frame — business logic + AES-256-GCM response encoding.
+    async fn handle_wake(
         &self,
         node: &NodeRecord,
         header: &FrameHeader,
@@ -738,11 +738,11 @@ impl Gateway {
     ) -> Option<Vec<u8>> {
         let (response_header, response_cbor) =
             self.handle_wake_core(node, header, payload, peer).await?;
-        self.encode_response_aead(&response_header, &response_cbor, &node.psk)
+        self.encode_response(&response_header, &response_cbor, &node.psk)
     }
 
-    /// AEAD variant of [`handle_post_wake_aead`] — same dispatch, AES-256-GCM encoding.
-    async fn handle_post_wake_aead(
+    /// Handle a post-WAKE message — dispatch + AES-256-GCM encoding.
+    async fn handle_post_wake(
         &self,
         node: &NodeRecord,
         header: &FrameHeader,
@@ -769,19 +769,19 @@ impl Gateway {
 
         match msg {
             NodeMessage::GetChunk { chunk_index } => {
-                self.handle_get_chunk_aead(node, header, chunk_index).await
+                self.handle_get_chunk(node, header, chunk_index).await
             }
             NodeMessage::ProgramAck { program_hash } => {
                 self.handle_program_ack(node, program_hash).await;
                 None
             }
-            NodeMessage::AppData { blob } => self.handle_app_data_aead(node, header, blob).await,
+            NodeMessage::AppData { blob } => self.handle_app_data(node, header, blob).await,
             _ => None,
         }
     }
 
-    /// AEAD variant of [`handle_get_chunk_aead`] — AES-256-GCM response encoding.
-    async fn handle_get_chunk_aead(
+    /// Handle a GET_CHUNK request — AES-256-GCM response encoding.
+    async fn handle_get_chunk(
         &self,
         node: &NodeRecord,
         header: &FrameHeader,
@@ -790,11 +790,11 @@ impl Gateway {
         let (response_header, response_cbor) = self
             .handle_get_chunk_core(node, header, chunk_index)
             .await?;
-        self.encode_response_aead(&response_header, &response_cbor, &node.psk)
+        self.encode_response(&response_header, &response_cbor, &node.psk)
     }
 
-    /// AEAD variant of [`handle_app_data_aead`] — AES-256-GCM response encoding.
-    async fn handle_app_data_aead(
+    /// Handle an APP_DATA message — AES-256-GCM response encoding.
+    async fn handle_app_data(
         &self,
         node: &NodeRecord,
         header: &FrameHeader,
@@ -802,7 +802,7 @@ impl Gateway {
     ) -> Option<Vec<u8>> {
         let (response_header, response_cbor) =
             self.handle_app_data_core(node, header, blob).await?;
-        self.encode_response_aead(&response_header, &response_cbor, &node.psk)
+        self.encode_response(&response_header, &response_cbor, &node.psk)
     }
 
     /// Shared GET_CHUNK business logic: look up session/program, serve chunk.

--- a/crates/sonde-gateway/tests/aead_engine.rs
+++ b/crates/sonde-gateway/tests/aead_engine.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 sonde contributors
 
-//! Integration tests for the AES-256-GCM `process_frame_aead` engine path.
+//! Integration tests for the AES-256-GCM `process_frame` engine path.
 //!
 //! These tests mirror the HMAC engine tests (phase2b) but exercise the AEAD
 //! codec.
@@ -17,9 +17,9 @@ use sonde_gateway::transport::PeerAddress;
 use sonde_gateway::GatewayAead;
 
 use sonde_protocol::{
-    decode_frame_aead, encode_frame_aead, open_frame, FrameHeader, GatewayMessage, NodeMessage,
-    MSG_APP_DATA, MSG_GET_CHUNK, MSG_PEER_ACK, MSG_PEER_REQUEST, MSG_PROGRAM_ACK, MSG_WAKE,
-    PEER_ACK_KEY_STATUS, PEER_REQ_KEY_PAYLOAD,
+    decode_frame, encode_frame, open_frame, FrameHeader, GatewayMessage, NodeMessage, MSG_APP_DATA,
+    MSG_GET_CHUNK, MSG_PEER_ACK, MSG_PEER_REQUEST, MSG_PROGRAM_ACK, MSG_WAKE, PEER_ACK_KEY_STATUS,
+    PEER_REQ_KEY_PAYLOAD,
 };
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -47,7 +47,7 @@ impl TestNode {
         self.node_id.as_bytes().to_vec()
     }
 
-    fn build_wake_aead(
+    fn build_wake(
         &self,
         nonce: u64,
         firmware_abi_version: u32,
@@ -65,11 +65,11 @@ impl TestNode {
             battery_mv,
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 
     #[allow(dead_code)]
-    fn build_get_chunk_aead(&self, seq: u64, chunk_index: u32) -> Vec<u8> {
+    fn build_get_chunk(&self, seq: u64, chunk_index: u32) -> Vec<u8> {
         let header = FrameHeader {
             key_hint: self.key_hint,
             msg_type: MSG_GET_CHUNK,
@@ -77,11 +77,11 @@ impl TestNode {
         };
         let msg = NodeMessage::GetChunk { chunk_index };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 
     #[allow(dead_code)]
-    fn build_program_ack_aead(&self, seq: u64, program_hash: &[u8]) -> Vec<u8> {
+    fn build_program_ack(&self, seq: u64, program_hash: &[u8]) -> Vec<u8> {
         let header = FrameHeader {
             key_hint: self.key_hint,
             msg_type: MSG_PROGRAM_ACK,
@@ -91,10 +91,10 @@ impl TestNode {
             program_hash: program_hash.to_vec(),
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 
-    fn build_app_data_aead(&self, seq: u64, blob: &[u8]) -> Vec<u8> {
+    fn build_app_data(&self, seq: u64, blob: &[u8]) -> Vec<u8> {
         let header = FrameHeader {
             key_hint: self.key_hint,
             msg_type: MSG_APP_DATA,
@@ -104,7 +104,7 @@ impl TestNode {
             blob: blob.to_vec(),
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 }
 
@@ -124,14 +124,14 @@ async fn aead_wake_round_trip() {
     let node = TestNode::new("node-aead-01", 0x0001, [0xBBu8; 32]);
     storage.upsert_node(&node.to_record()).await.unwrap();
 
-    let frame = node.build_wake_aead(42, 1, &[0u8; 32], 3300);
+    let frame = node.build_wake(42, 1, &[0u8; 32], 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("AEAD WAKE must produce a COMMAND response");
 
     // The response must be a valid AEAD frame decodable with the node's PSK.
-    let decoded = decode_frame_aead(&resp).expect("response must decode as AEAD frame");
+    let decoded = decode_frame(&resp).expect("response must decode as AEAD frame");
     let plaintext = open_frame(&decoded, &node.psk, &GatewayAead, &RustCryptoSha256)
         .expect("open must succeed with correct PSK");
 
@@ -154,9 +154,9 @@ async fn aead_wrong_psk_discarded() {
 
     // Build a WAKE frame using the wrong PSK.
     let imposter = TestNode::new("node-aead-wrong", 0x0002, wrong_psk);
-    let frame = imposter.build_wake_aead(10, 1, &[0u8; 32], 3000);
+    let frame = imposter.build_wake(10, 1, &[0u8; 32], 3000);
 
-    let resp = gw.process_frame_aead(&frame, b"imposter".to_vec()).await;
+    let resp = gw.process_frame(&frame, b"imposter".to_vec()).await;
     assert!(resp.is_none(), "wrong-PSK frame must be silently discarded");
 }
 
@@ -170,13 +170,13 @@ async fn aead_tampered_frame_discarded() {
     let node = TestNode::new("node-aead-tamper", 0x0003, [0xEEu8; 32]);
     storage.upsert_node(&node.to_record()).await.unwrap();
 
-    let mut frame = node.build_wake_aead(99, 1, &[0u8; 32], 3300);
+    let mut frame = node.build_wake(99, 1, &[0u8; 32], 3300);
     // Flip a bit in the ciphertext region (past the 11-byte header).
     if frame.len() > 12 {
         frame[12] ^= 0x01;
     }
 
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_none(), "tampered frame must be silently discarded");
 }
 
@@ -199,10 +199,9 @@ async fn aead_peer_request_no_phone_psk_discarded() {
         nonce: 1,
     };
     let payload = vec![0xA0]; // minimal CBOR map
-    let frame =
-        encode_frame_aead(&header, &payload, &psk, &GatewayAead, &RustCryptoSha256).unwrap();
+    let frame = encode_frame(&header, &payload, &psk, &GatewayAead, &RustCryptoSha256).unwrap();
 
-    let resp = gw.process_frame_aead(&frame, b"phone".to_vec()).await;
+    let resp = gw.process_frame(&frame, b"phone".to_vec()).await;
     assert!(
         resp.is_none(),
         "PEER_REQUEST with no matching phone PSK must be discarded"
@@ -217,9 +216,9 @@ async fn aead_unknown_key_hint_discarded() {
     // Don't register any node.
 
     let node = TestNode::new("ghost", 0xFFFF, [0x11u8; 32]);
-    let frame = node.build_wake_aead(1, 1, &[0u8; 32], 3000);
+    let frame = node.build_wake(1, 1, &[0u8; 32], 3000);
 
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(
         resp.is_none(),
         "unknown key_hint must be silently discarded"
@@ -326,7 +325,7 @@ async fn aead_peer_request_happy_path() {
         msg_type: MSG_PEER_REQUEST,
         nonce: frame_nonce,
     };
-    let frame = encode_frame_aead(
+    let frame = encode_frame(
         &outer_header,
         &outer_cbor_bytes,
         &phone_psk,
@@ -337,12 +336,12 @@ async fn aead_peer_request_happy_path() {
 
     // --- Send to gateway ---
     let resp = gw
-        .process_frame_aead(&frame, b"phone-peer".to_vec())
+        .process_frame(&frame, b"phone-peer".to_vec())
         .await
         .expect("AEAD PEER_REQUEST must produce a PEER_ACK");
 
     // --- Verify response is a PEER_ACK decryptable with node_psk ---
-    let decoded = decode_frame_aead(&resp).expect("response must decode as AEAD frame");
+    let decoded = decode_frame(&resp).expect("response must decode as AEAD frame");
     assert_eq!(
         decoded.header.msg_type, MSG_PEER_ACK,
         "response must be PEER_ACK"
@@ -382,12 +381,12 @@ async fn aead_peer_request_happy_path() {
 
 /// Helper: do WAKE handshake and extract starting_seq from COMMAND response.
 async fn wake_and_get_seq(gw: &Gateway, node: &TestNode, nonce: u64, program_hash: &[u8]) -> u64 {
-    let frame = node.build_wake_aead(nonce, 1, program_hash, 3300);
+    let frame = node.build_wake(nonce, 1, program_hash, 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("WAKE must produce COMMAND");
-    let decoded = decode_frame_aead(&resp).unwrap();
+    let decoded = decode_frame(&resp).unwrap();
     let plaintext = open_frame(&decoded, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
     match msg {
@@ -405,7 +404,7 @@ async fn wake_and_get_seq(gw: &Gateway, node: &TestNode, nonce: u64, program_has
 /// configured) — see T-E2E-032 / T-E2E-051 for the full end-to-end
 /// handler delivery path.
 #[tokio::test]
-async fn t0503a_app_data_valid_aead_accepted() {
+async fn t0503a_app_data_valid_accepted() {
     let storage = Arc::new(InMemoryStorage::new());
     let gw = make_gateway(storage.clone());
 
@@ -423,8 +422,8 @@ async fn t0503a_app_data_valid_aead_accepted() {
     let expected_before = session_before.unwrap().next_expected_seq;
 
     // Send APP_DATA with valid AEAD.
-    let frame = node.build_app_data_aead(seq, &[0xDE, 0xAD]);
-    let _resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let frame = node.build_app_data(seq, &[0xDE, 0xAD]);
+    let _resp = gw.process_frame(&frame, node.peer_address()).await;
 
     // Assert the session sequence advanced — proves the frame was authenticated
     // and processed (not silently discarded).
@@ -452,12 +451,12 @@ async fn t0503b_app_data_invalid_gcm_tag_rejected() {
     let seq = wake_and_get_seq(&gw, &node, 2000, &program_hash).await;
 
     // Build valid APP_DATA then corrupt GCM tag.
-    let mut frame = node.build_app_data_aead(seq, &[0xBE, 0xEF]);
+    let mut frame = node.build_app_data(seq, &[0xBE, 0xEF]);
     // Flip a bit in the GCM tag (last 16 bytes).
     let tag_offset = frame.len() - 1;
     frame[tag_offset] ^= 0x01;
 
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(
         resp.is_none(),
         "APP_DATA with corrupted GCM tag must be silently discarded"

--- a/crates/sonde-gateway/tests/behavioral_gaps.rs
+++ b/crates/sonde-gateway/tests/behavioral_gaps.rs
@@ -50,8 +50,8 @@ use sonde_gateway::transport::PeerAddress;
 use sonde_gateway::GatewayAead;
 
 use sonde_protocol::{
-    decode_frame_aead, encode_frame_aead, open_frame, CommandPayload, FrameHeader, GatewayMessage,
-    MapDef, NodeMessage, ProgramImage, MAX_FRAME_SIZE, MSG_COMMAND, MSG_WAKE,
+    decode_frame, encode_frame, open_frame, CommandPayload, FrameHeader, GatewayMessage, MapDef,
+    NodeMessage, ProgramImage, MAX_FRAME_SIZE, MSG_COMMAND, MSG_WAKE,
 };
 
 // ─── Test helpers ──────────────────────────────────────────────────────
@@ -97,7 +97,7 @@ impl TestNode {
             battery_mv,
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 }
 
@@ -150,7 +150,7 @@ fn make_cbor_image(bytecode: &[u8]) -> Vec<u8> {
 }
 
 fn decode_response(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
-    let decoded = decode_frame_aead(raw).unwrap();
+    let decoded = decode_frame(raw).unwrap();
     let plaintext = open_frame(&decoded, psk, &GatewayAead, &RustCryptoSha256).unwrap();
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
     (decoded.header, msg)
@@ -164,7 +164,7 @@ async fn do_wake(
 ) -> (u64, u64, CommandPayload) {
     let frame = node.build_wake(nonce, 1, program_hash, 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected COMMAND response");
     let (_hdr, msg) = decode_response(&resp, &node.psk);
@@ -587,7 +587,7 @@ async fn t0600_hmac_failure_state_unchanged() {
     // Establish a valid session.
     let frame_ok = node.build_wake(1, 1, &[0u8; 32], 3300);
     let resp = gw
-        .process_frame_aead(&frame_ok, node.peer_address())
+        .process_frame(&frame_ok, node.peer_address())
         .await
         .expect("valid WAKE must produce a response");
     let (_, msg) = decode_response(&resp, &node.psk);
@@ -609,7 +609,7 @@ async fn t0600_hmac_failure_state_unchanged() {
     let last = bad_frame.len() - 1;
     bad_frame[last] ^= 0xFF;
 
-    let resp = gw.process_frame_aead(&bad_frame, node.peer_address()).await;
+    let resp = gw.process_frame(&bad_frame, node.peer_address()).await;
     assert!(
         resp.is_none(),
         "corrupted AEAD frame must be silently discarded"
@@ -700,7 +700,7 @@ async fn t0705_factory_reset_wake_discarded() {
 
     // Verify: WAKE from the removed node is silently discarded.
     let frame = node.build_wake(2, 1, &[0u8; 32], 3300);
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(
         resp.is_none(),
         "WAKE from removed node must be silently discarded"
@@ -750,7 +750,7 @@ async fn t0103_starting_seq_not_zero_or_constant() {
 
         let frame = node.build_wake(i, 1, &[0u8; 32], 3300);
         let resp = gw
-            .process_frame_aead(&frame, node.peer_address())
+            .process_frame(&frame, node.peer_address())
             .await
             .expect("expected COMMAND response");
         let (_, msg) = decode_response(&resp, &node.psk);
@@ -798,7 +798,7 @@ async fn t0104_command_frame_size_within_limit() {
     // WAKE with a different hash → triggers UPDATE_PROGRAM (larger COMMAND payload).
     let frame = node.build_wake(1, 1, &[0u8; 32], 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected COMMAND response");
 
@@ -826,10 +826,7 @@ async fn t0104_all_command_types_within_limit() {
 
     // NOP
     let frame = node.build_wake(1, 1, &[0u8; 32], 3300);
-    let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
-        .await
-        .unwrap();
+    let resp = gw.process_frame(&frame, node.peer_address()).await.unwrap();
     assert!(resp.len() <= MAX_FRAME_SIZE, "NOP frame too large");
 
     // UpdateSchedule
@@ -839,10 +836,7 @@ async fn t0104_all_command_types_within_limit() {
     )
     .await;
     let frame = node.build_wake(2, 1, &[0u8; 32], 3300);
-    let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
-        .await
-        .unwrap();
+    let resp = gw.process_frame(&frame, node.peer_address()).await.unwrap();
     assert!(
         resp.len() <= MAX_FRAME_SIZE,
         "UpdateSchedule frame too large"
@@ -852,10 +846,7 @@ async fn t0104_all_command_types_within_limit() {
     gw.queue_command("node-allcmd", PendingCommand::Reboot)
         .await;
     let frame = node.build_wake(3, 1, &[0u8; 32], 3300);
-    let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
-        .await
-        .unwrap();
+    let resp = gw.process_frame(&frame, node.peer_address()).await.unwrap();
     assert!(resp.len() <= MAX_FRAME_SIZE, "Reboot frame too large");
 }
 
@@ -1174,7 +1165,7 @@ async fn t0504_many_to_one_handler_routing() {
         blob: vec![0x01, 0x02],
     };
     let cbor_a = msg_a.encode().unwrap();
-    let frame_a = encode_frame_aead(
+    let frame_a = encode_frame(
         &header_a,
         &cbor_a,
         &node_a.psk,
@@ -1184,7 +1175,7 @@ async fn t0504_many_to_one_handler_routing() {
     .unwrap();
     let resp_a = tokio::time::timeout(
         Duration::from_secs(5),
-        gw.process_frame_aead(&frame_a, node_a.peer_address()),
+        gw.process_frame(&frame_a, node_a.peer_address()),
     )
     .await
     .expect("handler did not respond for node A within timeout; routing must be enforced");
@@ -1208,7 +1199,7 @@ async fn t0504_many_to_one_handler_routing() {
         blob: vec![0x03, 0x04],
     };
     let cbor_b = msg_b.encode().unwrap();
-    let frame_b = encode_frame_aead(
+    let frame_b = encode_frame(
         &header_b,
         &cbor_b,
         &node_b.psk,
@@ -1218,7 +1209,7 @@ async fn t0504_many_to_one_handler_routing() {
     .unwrap();
     let resp_b = tokio::time::timeout(
         Duration::from_secs(5),
-        gw.process_frame_aead(&frame_b, node_b.peer_address()),
+        gw.process_frame(&frame_b, node_b.peer_address()),
     )
     .await
     .expect("handler did not respond for node B within timeout; routing must be enforced");
@@ -1258,7 +1249,7 @@ async fn t0700_registry_entry_all_fields_present() {
     // WAKE to populate telemetry fields.
     let frame = node.build_wake(42, 5, &program_hash, 3700);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected response");
 

--- a/crates/sonde-gateway/tests/ble_pairing.rs
+++ b/crates/sonde-gateway/tests/ble_pairing.rs
@@ -363,7 +363,7 @@ async fn t1209_peer_request_bypasses_key_hint() {
     // immediately reject based on key_hint miss.
     let payload = vec![0xA0]; // empty CBOR map
     let psk = [0x42u8; 32];
-    let frame = sonde_protocol::encode_frame_aead(
+    let frame = sonde_protocol::encode_frame(
         &header,
         &payload,
         &psk,
@@ -374,7 +374,7 @@ async fn t1209_peer_request_bypasses_key_hint() {
 
     // The gateway should attempt to process this (eventually failing at
     // CBOR parsing or HMAC, but NOT at key-hint lookup).
-    let resp = gateway.process_frame_aead(&frame, vec![]).await;
+    let resp = gateway.process_frame(&frame, vec![]).await;
     // PEER_REQUEST with bad content: silent discard (no response).
     // The important assertion is that this doesn't panic and doesn't
     // produce a response (which would mean it was processed as a normal
@@ -413,7 +413,7 @@ async fn t1220_peer_request_random_nonces() {
     };
     let payload = vec![0xA0];
     let psk = [0x42u8; 32];
-    let frame = sonde_protocol::encode_frame_aead(
+    let frame = sonde_protocol::encode_frame(
         &header,
         &payload,
         &psk,
@@ -425,7 +425,7 @@ async fn t1220_peer_request_random_nonces() {
     // Should not panic; the gateway processes it (and silently discards
     // because the content is invalid, but importantly NOT because the
     // nonce is "wrong").
-    let _ = gateway.process_frame_aead(&frame, vec![]).await;
+    let _ = gateway.process_frame(&frame, vec![]).await;
 }
 
 // ── T-1221: Admin BLE pairing session ──────────────────────────────────────

--- a/crates/sonde-gateway/tests/handler_config.rs
+++ b/crates/sonde-gateway/tests/handler_config.rs
@@ -29,8 +29,8 @@ use sonde_gateway::storage::{HandlerRecord, InMemoryStorage, Storage};
 use sonde_gateway::GatewayAead;
 
 use sonde_protocol::{
-    decode_frame_aead, encode_frame_aead, open_frame, FrameHeader, GatewayMessage, NodeMessage,
-    MSG_APP_DATA, MSG_APP_DATA_REPLY, MSG_WAKE,
+    decode_frame, encode_frame, open_frame, FrameHeader, GatewayMessage, NodeMessage, MSG_APP_DATA,
+    MSG_APP_DATA_REPLY, MSG_WAKE,
 };
 
 // ─── Test helpers ──────────────────────────────────────────────────────
@@ -115,7 +115,7 @@ impl TestNode {
             battery_mv,
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 
     fn build_app_data(&self, seq: u64, blob: &[u8]) -> Vec<u8> {
@@ -128,12 +128,12 @@ impl TestNode {
             blob: blob.to_vec(),
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 }
 
 fn decode_response(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
-    let decoded = decode_frame_aead(raw).unwrap();
+    let decoded = decode_frame(raw).unwrap();
     let plaintext = open_frame(&decoded, psk, &GatewayAead, &RustCryptoSha256).unwrap();
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
     (decoded.header, msg)
@@ -143,7 +143,7 @@ fn decode_response(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) 
 async fn do_wake(gw: &Gateway, node: &TestNode, nonce: u64, program_hash: &[u8]) -> u64 {
     let frame = node.build_wake(nonce, 1, program_hash, 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected COMMAND response");
     let (_hdr, msg) = decode_response(&resp, &node.psk);
@@ -1117,7 +1117,7 @@ async fn t1403_handler_live_reload_add() {
     // 1. No handler router → APP_DATA produces no reply.
     let seq = do_wake(&gw, &node, 1000, &program_hash).await;
     let resp = gw
-        .process_frame_aead(
+        .process_frame(
             &node.build_app_data(seq, &[0x01, 0x02, 0x03]),
             node.peer_address(),
         )
@@ -1164,7 +1164,7 @@ async fn t1403_handler_live_reload_add() {
     let seq2 = do_wake(&gw, &node, 2000, &program_hash).await;
     let blob = vec![0x01, 0x02, 0x03];
     let resp2 = gw
-        .process_frame_aead(&node.build_app_data(seq2, &blob), node.peer_address())
+        .process_frame(&node.build_app_data(seq2, &blob), node.peer_address())
         .await
         .expect("handler added → APP_DATA_REPLY expected");
 
@@ -1233,7 +1233,7 @@ async fn t1404_handler_live_reload_remove() {
     let seq = do_wake(&gw, &node, 3000, &program_hash).await;
     let blob = vec![0xAA, 0xBB];
     let resp = gw
-        .process_frame_aead(&node.build_app_data(seq, &blob), node.peer_address())
+        .process_frame(&node.build_app_data(seq, &blob), node.peer_address())
         .await
         .expect("catch-all handler → APP_DATA_REPLY expected");
 
@@ -1284,7 +1284,7 @@ async fn t1404_handler_live_reload_remove() {
     gw2.set_handler_router(empty_router).unwrap();
     let seq2 = do_wake(&gw2, &node, 4000, &program_hash).await;
     let resp2 = gw2
-        .process_frame_aead(&node.build_app_data(seq2, &[0xCC]), node.peer_address())
+        .process_frame(&node.build_app_data(seq2, &[0xCC]), node.peer_address())
         .await;
     assert!(resp2.is_none(), "handler removed → no APP_DATA_REPLY");
 }

--- a/crates/sonde-gateway/tests/logging.rs
+++ b/crates/sonde-gateway/tests/logging.rs
@@ -33,7 +33,7 @@ use sonde_gateway::GatewayAead;
 #[cfg(debug_assertions)]
 use sonde_protocol::modem::{encode_modem_frame, FrameDecoder, ModemMessage, RecvFrame};
 use sonde_protocol::{
-    encode_frame_aead, FrameHeader, GatewayMessage, NodeMessage, Sha256Provider, MSG_APP_DATA,
+    encode_frame, FrameHeader, GatewayMessage, NodeMessage, Sha256Provider, MSG_APP_DATA,
     MSG_PEER_REQUEST, MSG_WAKE, PEER_REQ_KEY_PAYLOAD,
 };
 
@@ -114,7 +114,7 @@ impl TestNode {
             battery_mv,
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 
     fn build_app_data(&self, seq: u64, blob: &[u8]) -> Vec<u8> {
@@ -127,7 +127,7 @@ impl TestNode {
             blob: blob.to_vec(),
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 }
 
@@ -217,7 +217,7 @@ fn build_peer_request(
         nonce: 0x1234567890ABCDEF,
     };
 
-    encode_frame_aead(
+    encode_frame(
         &header,
         &outer_buf,
         phone_psk,
@@ -244,7 +244,7 @@ async fn t1300_wake_lifecycle_logging() {
     storage.upsert_node(&record).await.unwrap();
 
     let frame = node.build_wake(100, 1, &program_hash, 3300);
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_some(), "expected COMMAND response");
 
     // GW-1300 AC3: WAKE received with node_id, seq, battery_mv.
@@ -326,7 +326,7 @@ async fn t1302_peer_request_logging() {
     );
     let peer: PeerAddress = b"peer-addr".to_vec();
 
-    let resp = gw.process_frame_aead(&frame, peer).await;
+    let resp = gw.process_frame(&frame, peer).await;
     assert!(resp.is_some(), "expected PEER_ACK response");
 
     // GW-1300 AC1: PEER_REQUEST processed with result "registered" and key_hint.
@@ -660,7 +660,7 @@ async fn t1308_app_data_handler_pipeline_logging() {
 
     // WAKE to establish session.
     let frame = node.build_wake(5000, 1, &program_hash, 3300);
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_some(), "expected COMMAND response");
 
     let (_hdr, msg) = decode_command(&resp.unwrap(), &node.psk);
@@ -673,7 +673,7 @@ async fn t1308_app_data_handler_pipeline_logging() {
     let blob = vec![0x01, 0x02, 0x03];
     let app_frame = node.build_app_data(starting_seq, &blob);
     let resp = gw
-        .process_frame_aead(&app_frame, node.peer_address())
+        .process_frame(&app_frame, node.peer_address())
         .await
         .expect("expected APP_DATA_REPLY");
 
@@ -685,9 +685,7 @@ async fn t1308_app_data_handler_pipeline_logging() {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
         let app_frame2 = node.build_app_data(starting_seq + 1, &blob);
-        let _ = gw
-            .process_frame_aead(&app_frame2, node.peer_address())
-            .await;
+        let _ = gw.process_frame(&app_frame2, node.peer_address()).await;
         if logs_contain("handler exited") {
             break;
         }
@@ -754,7 +752,7 @@ async fn t1308_app_data_handler_pipeline_logging() {
     );
 
     // Verify the reply was correct.
-    let decoded = sonde_protocol::decode_frame_aead(&resp).unwrap();
+    let decoded = sonde_protocol::decode_frame(&resp).unwrap();
     let plaintext =
         sonde_protocol::open_frame(&decoded, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
     let reply_msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
@@ -767,7 +765,7 @@ async fn t1308_app_data_handler_pipeline_logging() {
 }
 
 fn decode_command(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
-    let decoded = sonde_protocol::decode_frame_aead(raw).unwrap();
+    let decoded = sonde_protocol::decode_frame(raw).unwrap();
     let plaintext =
         sonde_protocol::open_frame(&decoded, psk, &GatewayAead, &RustCryptoSha256).unwrap();
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();

--- a/crates/sonde-gateway/tests/modem_transport.rs
+++ b/crates/sonde-gateway/tests/modem_transport.rs
@@ -349,7 +349,7 @@ async fn t1108_e2e_wake_cycle_over_pty() {
     use sonde_gateway::storage::{InMemoryStorage, Storage};
     use sonde_gateway::GatewayAead;
     use sonde_protocol::{
-        decode_frame_aead, encode_frame_aead, open_frame, FrameHeader, GatewayMessage, NodeMessage,
+        decode_frame, encode_frame, open_frame, FrameHeader, GatewayMessage, NodeMessage,
         Sha256Provider, MSG_COMMAND, MSG_WAKE,
     };
 
@@ -377,8 +377,7 @@ async fn t1108_e2e_wake_cycle_over_pty() {
         battery_mv: 3300,
     };
     let cbor = wake_msg.encode().unwrap();
-    let wake_frame =
-        encode_frame_aead(&header, &cbor, &psk, &GatewayAead, &RustCryptoSha256).unwrap();
+    let wake_frame = encode_frame(&header, &cbor, &psk, &GatewayAead, &RustCryptoSha256).unwrap();
 
     // Inject RECV_FRAME carrying the WAKE.
     let recv = ModemMessage::RecvFrame(RecvFrame {
@@ -395,7 +394,7 @@ async fn t1108_e2e_wake_cycle_over_pty() {
     let (frame_data, peer) = transport.recv().await.unwrap();
 
     // Process through gateway.
-    let response = gateway.process_frame_aead(&frame_data, peer).await;
+    let response = gateway.process_frame(&frame_data, peer).await;
     assert!(response.is_some(), "gateway must respond to WAKE");
 
     // Send response back through transport.
@@ -412,7 +411,7 @@ async fn t1108_e2e_wake_cycle_over_pty() {
     match msg {
         ModemMessage::SendFrame(sf) => {
             // Decode the COMMAND response.
-            let decoded = decode_frame_aead(&sf.frame_data).unwrap();
+            let decoded = decode_frame(&sf.frame_data).unwrap();
             assert_eq!(decoded.header.msg_type, MSG_COMMAND);
             let plaintext = open_frame(&decoded, &psk, &GatewayAead, &RustCryptoSha256).unwrap();
             let gw_msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();

--- a/crates/sonde-gateway/tests/peer_request.rs
+++ b/crates/sonde-gateway/tests/peer_request.rs
@@ -24,7 +24,7 @@ use sonde_gateway::transport::PeerAddress;
 
 use sonde_gateway::GatewayAead;
 use sonde_protocol::{
-    decode_frame_aead, encode_frame_aead, open_frame, FrameHeader, Sha256Provider, MSG_PEER_ACK,
+    decode_frame, encode_frame, open_frame, FrameHeader, Sha256Provider, MSG_PEER_ACK,
     MSG_PEER_REQUEST, PEER_ACK_KEY_STATUS, PEER_REQ_KEY_PAYLOAD,
 };
 
@@ -184,7 +184,7 @@ fn build_peer_request_detailed(
         nonce,
     };
 
-    encode_frame_aead(
+    encode_frame(
         &header,
         &outer_buf,
         phone_psk,
@@ -244,14 +244,14 @@ async fn peer_request_happy_path() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_some(),
         "valid PEER_REQUEST must produce a response"
     );
 
     let raw = response.unwrap();
-    let decoded = decode_frame_aead(&raw).unwrap();
+    let decoded = decode_frame(&raw).unwrap();
     let plaintext = open_frame(&decoded, &TEST_NODE_PSK, &GatewayAead, &RustCryptoSha256).unwrap();
     assert_eq!(decoded.header.msg_type, MSG_PEER_ACK);
 
@@ -308,7 +308,7 @@ async fn peer_request_with_sensors() {
         Some(sensors),
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(response.is_some());
 
     let node = env.storage.get_node("node-sensors").await.unwrap().unwrap();
@@ -343,7 +343,7 @@ async fn peer_request_invalid_sensor_type() {
         Some(sensors),
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "invalid sensor_type must cause silent discard"
@@ -370,7 +370,7 @@ async fn peer_request_bad_gcm_tag() {
         frame[20] ^= 0xFF;
     }
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "tampered frame must be silently discarded"
@@ -395,7 +395,7 @@ async fn peer_request_revoked_phone() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "revoked phone must cause silent discard"
@@ -418,7 +418,7 @@ async fn peer_request_bad_phone_hmac() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "wrong phone HMAC must cause silent discard"
@@ -452,7 +452,7 @@ async fn peer_request_bad_frame_hmac() {
 
     // Encrypt the outer frame with a DIFFERENT PSK than the registered phone_psk.
     let wrong_psk = [0xEE; 32];
-    let frame = encode_frame_aead(
+    let frame = encode_frame(
         &header,
         &outer_buf,
         &wrong_psk,
@@ -461,7 +461,7 @@ async fn peer_request_bad_frame_hmac() {
     )
     .unwrap();
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "bad outer frame AEAD must cause silent discard"
@@ -484,7 +484,7 @@ async fn peer_request_timestamp_drift_past() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "old timestamp must cause silent discard"
@@ -507,7 +507,7 @@ async fn peer_request_timestamp_drift_future() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "future timestamp must cause silent discard"
@@ -529,7 +529,7 @@ async fn peer_request_duplicate_node_id() {
         None,
         None,
     );
-    let response1 = env.gateway.process_frame_aead(&frame1, peer()).await;
+    let response1 = env.gateway.process_frame(&frame1, peer()).await;
     assert!(response1.is_some(), "first registration must succeed");
 
     // Second registration with same node_id and matching PSK must still
@@ -543,7 +543,7 @@ async fn peer_request_duplicate_node_id() {
         None,
         None,
     );
-    let response2 = env.gateway.process_frame_aead(&frame2, peer()).await;
+    let response2 = env.gateway.process_frame(&frame2, peer()).await;
     assert!(
         response2.is_some(),
         "duplicate node_id with matching PSK must return PEER_ACK"
@@ -583,7 +583,7 @@ async fn peer_request_key_hint_mismatch() {
         nonce: 0x5678,
     };
 
-    let frame = encode_frame_aead(
+    let frame = encode_frame(
         &header,
         &outer_buf,
         &TEST_PHONE_PSK,
@@ -592,7 +592,7 @@ async fn peer_request_key_hint_mismatch() {
     )
     .unwrap();
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "key_hint mismatch must cause silent discard"
@@ -614,7 +614,7 @@ async fn peer_request_rf_channel_zero() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(response.is_none(), "rf_channel=0 must cause silent discard");
 }
 
@@ -633,7 +633,7 @@ async fn peer_request_rf_channel_14() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "rf_channel=14 must cause silent discard"
@@ -655,7 +655,7 @@ async fn peer_request_rf_channel_13_ok() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(response.is_some(), "rf_channel=13 must be accepted");
 
     let node = env.storage.get_node("node-rf13").await.unwrap().unwrap();
@@ -677,7 +677,7 @@ async fn peer_request_rf_channel_1_ok() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(response.is_some(), "rf_channel=1 must be accepted");
 }
 
@@ -703,7 +703,7 @@ async fn peer_request_node_id_30_ok() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(response.is_some(), "30-byte node_id must be accepted");
 }
 
@@ -722,7 +722,7 @@ async fn peer_request_empty_node_id() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "empty node_id must cause silent discard"
@@ -745,7 +745,7 @@ async fn peer_request_timestamp_boundary_ok() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(response.is_some(), "timestamp at +86400s must be accepted");
 }
 
@@ -766,7 +766,7 @@ async fn peer_request_timestamp_boundary_plus1_rejected() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(response.is_none(), "timestamp at +86410s must be rejected");
 }
 
@@ -796,14 +796,14 @@ async fn t_1210_peer_request_decryption_happy_path() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_some(),
         "correctly encrypted PEER_REQUEST must produce a PEER_ACK"
     );
 
     let raw = response.unwrap();
-    let decoded = decode_frame_aead(&raw).unwrap();
+    let decoded = decode_frame(&raw).unwrap();
     assert_eq!(decoded.header.msg_type, MSG_PEER_ACK);
 }
 
@@ -831,7 +831,7 @@ async fn t_1211_peer_request_bad_gcm_tag() {
         frame[20] ^= 0xFF;
     }
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "bad GCM tag must cause silent discard (no response)"
@@ -887,7 +887,7 @@ async fn t_1212_phone_hmac_multiple_candidates() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_some(),
         "gateway must try both candidates and accept the matching one"
@@ -921,7 +921,7 @@ async fn t_1213_phone_hmac_revoked_psk() {
         None,
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(
         response.is_none(),
         "revoked phone PSK must cause silent discard"
@@ -959,7 +959,7 @@ async fn t_1214_frame_hmac_verification() {
 
     // Encrypt outer frame with a DIFFERENT PSK than the registered phone_psk.
     let wrong_psk = [0xEEu8; 32];
-    let bad_frame = encode_frame_aead(
+    let bad_frame = encode_frame(
         &header,
         &outer_buf,
         &wrong_psk,
@@ -968,14 +968,14 @@ async fn t_1214_frame_hmac_verification() {
     )
     .unwrap();
 
-    let response = env.gateway.process_frame_aead(&bad_frame, peer()).await;
+    let response = env.gateway.process_frame(&bad_frame, peer()).await;
     assert!(
         response.is_none(),
         "outer frame encrypted with wrong PSK must cause silent discard"
     );
 
     // Now submit a valid outer frame AEAD for the same payload.
-    let good_frame = encode_frame_aead(
+    let good_frame = encode_frame(
         &header,
         &outer_buf,
         &TEST_PHONE_PSK,
@@ -983,7 +983,7 @@ async fn t_1214_frame_hmac_verification() {
         &RustCryptoSha256,
     )
     .unwrap();
-    let response = env.gateway.process_frame_aead(&good_frame, peer()).await;
+    let response = env.gateway.process_frame(&good_frame, peer()).await;
     assert!(
         response.is_some(),
         "valid outer frame AEAD must allow processing to continue"
@@ -1013,10 +1013,7 @@ async fn t_1215_timestamp_range_enforcement() {
         None,
     );
     assert!(
-        env.gateway
-            .process_frame_aead(&frame, peer())
-            .await
-            .is_none(),
+        env.gateway.process_frame(&frame, peer()).await.is_none(),
         "timestamp 90000s in the past must be rejected"
     );
 
@@ -1032,10 +1029,7 @@ async fn t_1215_timestamp_range_enforcement() {
         None,
     );
     assert!(
-        env.gateway
-            .process_frame_aead(&frame, peer())
-            .await
-            .is_none(),
+        env.gateway.process_frame(&frame, peer()).await.is_none(),
         "timestamp 90000s in the future must be rejected"
     );
 
@@ -1050,10 +1044,7 @@ async fn t_1215_timestamp_range_enforcement() {
         None,
     );
     assert!(
-        env.gateway
-            .process_frame_aead(&frame, peer())
-            .await
-            .is_some(),
+        env.gateway.process_frame(&frame, peer()).await.is_some(),
         "current timestamp must be accepted"
     );
 }
@@ -1078,10 +1069,7 @@ async fn t_1216_duplicate_node_id_rejected() {
         None,
     );
     assert!(
-        env.gateway
-            .process_frame_aead(&frame1, peer())
-            .await
-            .is_some(),
+        env.gateway.process_frame(&frame1, peer()).await.is_some(),
         "first registration must succeed"
     );
 
@@ -1096,10 +1084,7 @@ async fn t_1216_duplicate_node_id_rejected() {
         None,
     );
     assert!(
-        env.gateway
-            .process_frame_aead(&frame2, peer())
-            .await
-            .is_some(),
+        env.gateway.process_frame(&frame2, peer()).await.is_some(),
         "duplicate node_id with matching PSK must return PEER_ACK"
     );
 }
@@ -1135,7 +1120,7 @@ async fn t_1217_key_hint_mismatch_rejected() {
         nonce: 0xBBBB,
     };
 
-    let frame = encode_frame_aead(
+    let frame = encode_frame(
         &header,
         &outer_buf,
         &TEST_PHONE_PSK,
@@ -1144,10 +1129,7 @@ async fn t_1217_key_hint_mismatch_rejected() {
     )
     .unwrap();
     assert!(
-        env.gateway
-            .process_frame_aead(&frame, peer())
-            .await
-            .is_none(),
+        env.gateway.process_frame(&frame, peer()).await.is_none(),
         "key_hint mismatch must cause silent discard"
     );
 }
@@ -1184,7 +1166,7 @@ async fn t_1218_node_registration_stores_fields() {
         Some(sensors),
     );
 
-    let response = env.gateway.process_frame_aead(&frame, peer()).await;
+    let response = env.gateway.process_frame(&frame, peer()).await;
     assert!(response.is_some(), "PEER_REQUEST must succeed");
 
     let node = env
@@ -1238,12 +1220,12 @@ async fn t_1219_peer_ack_happy_path() {
 
     let response = env
         .gateway
-        .process_frame_aead(&frame, peer())
+        .process_frame(&frame, peer())
         .await
         .expect("valid PEER_REQUEST must produce PEER_ACK");
 
     // Decode and verify the PEER_ACK frame.
-    let decoded = decode_frame_aead(&response).unwrap();
+    let decoded = decode_frame(&response).unwrap();
     assert_eq!(decoded.header.msg_type, MSG_PEER_ACK);
 
     // 3. Nonce must echo the request nonce.

--- a/crates/sonde-gateway/tests/phase2b.rs
+++ b/crates/sonde-gateway/tests/phase2b.rs
@@ -14,7 +14,7 @@ use sonde_gateway::storage::{InMemoryStorage, Storage};
 use sonde_gateway::transport::PeerAddress;
 
 use sonde_protocol::{
-    decode_frame_aead, encode_frame_aead, open_frame, CommandPayload, FrameHeader, GatewayMessage,
+    decode_frame, encode_frame, open_frame, CommandPayload, FrameHeader, GatewayMessage,
     NodeMessage, MAX_FRAME_SIZE, MSG_APP_DATA, MSG_CHUNK, MSG_COMMAND, MSG_GET_CHUNK,
     MSG_PROGRAM_ACK, MSG_WAKE,
 };
@@ -67,7 +67,7 @@ impl TestNode {
             battery_mv,
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 
     /// Build a GET_CHUNK frame with the given sequence number.
@@ -79,7 +79,7 @@ impl TestNode {
         };
         let msg = NodeMessage::GetChunk { chunk_index };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 
     /// Build a PROGRAM_ACK frame with the given sequence number.
@@ -93,7 +93,7 @@ impl TestNode {
             program_hash: program_hash.to_vec(),
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 
     /// Build an APP_DATA frame with the given sequence number.
@@ -108,7 +108,7 @@ impl TestNode {
             blob: blob.to_vec(),
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 }
 
@@ -165,7 +165,7 @@ async fn store_test_program_with_abi(
 
 /// Decode a gateway response frame and return the GatewayMessage.
 fn decode_response(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
-    let decoded = decode_frame_aead(raw).unwrap();
+    let decoded = decode_frame(raw).unwrap();
     let plaintext = open_frame(&decoded, psk, &GatewayAead, &RustCryptoSha256).unwrap();
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
     (decoded.header, msg)
@@ -182,7 +182,7 @@ async fn do_wake_with_abi(
 ) -> (u64, u64, CommandPayload) {
     let frame = node.build_wake(nonce, firmware_abi_version, program_hash, 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected COMMAND response");
     let (_hdr, msg) = decode_response(&resp, &node.psk);
@@ -222,11 +222,11 @@ async fn t0101_valid_cbor_encoding() {
 
     let frame = node.build_wake(42, 1, &[0u8; 32], 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected response");
 
-    let decoded = decode_frame_aead(&resp).unwrap();
+    let decoded = decode_frame(&resp).unwrap();
     let plaintext = open_frame(&decoded, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
     // Payload must be valid CBOR decodable as a GatewayMessage
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext);
@@ -249,10 +249,9 @@ async fn t0102_malformed_cbor_tolerance() {
         nonce: 99,
     };
     let garbage = &[0xFF, 0xFE, 0xFD, 0xFC, 0xFB];
-    let frame =
-        encode_frame_aead(&header, garbage, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
+    let frame = encode_frame(&header, garbage, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
 
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_none(), "garbage CBOR must be silently discarded");
 }
 
@@ -270,7 +269,7 @@ async fn t0103_wake_reception_and_field_extraction() {
 
     let frame = node.build_wake(100, 1, &program_hash, 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected COMMAND response");
 
@@ -317,7 +316,7 @@ async fn t0104_wake_missing_fields_rejected() {
         msg_type: MSG_WAKE,
         nonce: 200,
     };
-    let frame = encode_frame_aead(
+    let frame = encode_frame(
         &header,
         &cbor_buf,
         &node.psk,
@@ -326,7 +325,7 @@ async fn t0104_wake_missing_fields_rejected() {
     )
     .unwrap();
 
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_none(), "WAKE with missing fields must be discarded");
 }
 
@@ -342,7 +341,7 @@ async fn t0105_command_response_structure() {
     let wake_nonce = 12345u64;
     let frame = node.build_wake(wake_nonce, 1, &[0u8; 32], 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected COMMAND response");
 
@@ -402,7 +401,7 @@ async fn t0106_frame_size_constraint() {
         let seq = starting_seq.wrapping_add(i as u64);
         let chunk_frame = node.build_get_chunk(seq, i);
         let resp = gw
-            .process_frame_aead(&chunk_frame, node.peer_address())
+            .process_frame(&chunk_frame, node.peer_address())
             .await
             .expect("expected CHUNK response");
         assert!(
@@ -727,7 +726,7 @@ async fn t0300_complete_chunked_transfer() {
         let seq = starting_seq.wrapping_add(i as u64);
         let chunk_frame = node.build_get_chunk(seq, i);
         let resp = gw
-            .process_frame_aead(&chunk_frame, node.peer_address())
+            .process_frame(&chunk_frame, node.peer_address())
             .await
             .expect("expected CHUNK response");
 
@@ -787,7 +786,7 @@ async fn t0301_transfer_resumption() {
     // Request chunks 0 and 1
     let chunk0_frame = node.build_get_chunk(seq1, 0);
     let resp0 = gw
-        .process_frame_aead(&chunk0_frame, node.peer_address())
+        .process_frame(&chunk0_frame, node.peer_address())
         .await
         .expect("chunk 0");
     let (_, c0) = decode_response(&resp0, &node.psk);
@@ -807,7 +806,7 @@ async fn t0301_transfer_resumption() {
     // Request chunk 0 again from the new session
     let chunk0_frame2 = node.build_get_chunk(seq2, 0);
     let resp0_2 = gw
-        .process_frame_aead(&chunk0_frame2, node.peer_address())
+        .process_frame(&chunk0_frame2, node.peer_address())
         .await
         .expect("chunk 0 re-request");
     let (_, c0_2) = decode_response(&resp0_2, &node.psk);
@@ -846,13 +845,13 @@ async fn t0302_program_ack_updates_registry() {
     for i in 0..chunk_count {
         let seq = starting_seq.wrapping_add(i as u64);
         let f = node.build_get_chunk(seq, i);
-        let _ = gw.process_frame_aead(&f, node.peer_address()).await;
+        let _ = gw.process_frame(&f, node.peer_address()).await;
     }
 
     // Send PROGRAM_ACK
     let ack_seq = starting_seq.wrapping_add(chunk_count as u64);
     let ack_frame = node.build_program_ack(ack_seq, &assigned_hash);
-    let ack_resp = gw.process_frame_aead(&ack_frame, node.peer_address()).await;
+    let ack_resp = gw.process_frame(&ack_frame, node.peer_address()).await;
     assert!(
         ack_resp.is_none(),
         "PROGRAM_ACK should not produce a response frame"
@@ -881,7 +880,7 @@ async fn t0302_program_ack_updates_registry() {
 
 /// T-0600: Valid AEAD frame accepted.
 #[tokio::test]
-async fn t0600_valid_aead_accepted() {
+async fn t0600_valid_accepted() {
     let storage = Arc::new(InMemoryStorage::new());
     let gw = make_gateway(storage.clone());
 
@@ -889,13 +888,13 @@ async fn t0600_valid_aead_accepted() {
     storage.upsert_node(&node.to_record()).await.unwrap();
 
     let frame = node.build_wake(1, 1, &[0u8; 32], 3300);
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_some(), "valid AEAD frame must be accepted");
 }
 
 /// T-0601: Invalid AEAD frame rejected (flipped bit).
 #[tokio::test]
-async fn t0601_invalid_aead_rejected() {
+async fn t0601_invalid_rejected() {
     let storage = Arc::new(InMemoryStorage::new());
     let gw = make_gateway(storage.clone());
 
@@ -907,7 +906,7 @@ async fn t0601_invalid_aead_rejected() {
     let last = frame.len() - 1;
     frame[last] ^= 0x01;
 
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_none(), "flipped GCM tag bit must be rejected");
 }
 
@@ -933,10 +932,9 @@ async fn t0602_wrong_key_rejected() {
         battery_mv: 3300,
     };
     let cbor = msg.encode().unwrap();
-    let frame =
-        encode_frame_aead(&header, &cbor, &wrong_psk, &GatewayAead, &RustCryptoSha256).unwrap();
+    let frame = encode_frame(&header, &cbor, &wrong_psk, &GatewayAead, &RustCryptoSha256).unwrap();
 
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_none(), "wrong PSK must be rejected");
 }
 
@@ -956,7 +954,7 @@ async fn t0603_key_hint_collision() {
     // Send WAKE from node A — gateway must try both PSKs and find A's
     let frame_a = node_a.build_wake(1, 1, &[0u8; 32], 3300);
     let resp_a = gw
-        .process_frame_aead(&frame_a, node_a.peer_address())
+        .process_frame(&frame_a, node_a.peer_address())
         .await
         .expect("node A must be authenticated despite key_hint collision");
 
@@ -971,7 +969,7 @@ async fn t0603_key_hint_collision() {
     // Send WAKE from node B — also must succeed
     let frame_b = node_b.build_wake(2, 1, &[0u8; 32], 3200);
     let resp_b = gw
-        .process_frame_aead(&frame_b, node_b.peer_address())
+        .process_frame(&frame_b, node_b.peer_address())
         .await
         .expect("node B must also be authenticated");
     let (_, msg_b) = decode_response(&resp_b, &node_b.psk);
@@ -991,7 +989,7 @@ async fn t0609_unknown_node_silent_discard() {
     let unknown = TestNode::new("unknown", 0xFFFF, [0x99; 32]);
     let frame = unknown.build_wake(1, 1, &[0u8; 32], 3000);
 
-    let resp = gw.process_frame_aead(&frame, unknown.peer_address()).await;
+    let resp = gw.process_frame(&frame, unknown.peer_address()).await;
     assert!(resp.is_none(), "unknown node must be silently discarded");
 
     // Verify no state changed (no sessions created)
@@ -1176,7 +1174,7 @@ async fn t0607a_wake_retry_preserves_chunked_transfer_end_to_end() {
         let seq = seq2.wrapping_add(i as u64);
         let chunk_frame = node.build_get_chunk(seq, i);
         let resp = gw
-            .process_frame_aead(&chunk_frame, node.peer_address())
+            .process_frame(&chunk_frame, node.peer_address())
             .await
             .unwrap_or_else(|| panic!("chunk {} must succeed after WAKE retry reuse", i));
         let (_, msg) = decode_response(&resp, &node.psk);

--- a/crates/sonde-gateway/tests/phase2c.rs
+++ b/crates/sonde-gateway/tests/phase2c.rs
@@ -17,7 +17,7 @@ use sonde_gateway::transport::PeerAddress;
 use sonde_gateway::GatewayAead;
 
 use sonde_protocol::{
-    decode_frame_aead, encode_frame_aead, open_frame, CommandPayload, FrameHeader, GatewayMessage,
+    decode_frame, encode_frame, open_frame, CommandPayload, FrameHeader, GatewayMessage,
     NodeMessage, MSG_APP_DATA, MSG_APP_DATA_REPLY, MSG_WAKE,
 };
 
@@ -64,7 +64,7 @@ impl TestNode {
             battery_mv,
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 
     fn build_app_data(&self, seq: u64, blob: &[u8]) -> Vec<u8> {
@@ -77,12 +77,12 @@ impl TestNode {
             blob: blob.to_vec(),
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 }
 
 fn decode_response(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
-    let decoded = decode_frame_aead(raw).unwrap();
+    let decoded = decode_frame(raw).unwrap();
     let plaintext = open_frame(&decoded, psk, &GatewayAead, &RustCryptoSha256).unwrap();
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
     (decoded.header, msg)
@@ -97,7 +97,7 @@ async fn do_wake(
 ) -> (u64, u64, CommandPayload) {
     let frame = node.build_wake(nonce, 1, program_hash, 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected COMMAND response");
     let (_hdr, msg) = decode_response(&resp, &node.psk);
@@ -1284,7 +1284,7 @@ async fn t0500_app_data_echo_forwarding() {
     let blob = vec![0x01, 0x02, 0x03];
     let app_frame = node.build_app_data(starting_seq, &blob);
     let resp = gw
-        .process_frame_aead(&app_frame, node.peer_address())
+        .process_frame(&app_frame, node.peer_address())
         .await
         .expect("expected APP_DATA_REPLY");
 
@@ -1323,7 +1323,7 @@ async fn t0501_app_data_reply_fixed_data() {
 
     let app_frame = node.build_app_data(starting_seq, &[0xFF]);
     let resp = gw
-        .process_frame_aead(&app_frame, node.peer_address())
+        .process_frame(&app_frame, node.peer_address())
         .await
         .expect("expected APP_DATA_REPLY");
 
@@ -1359,7 +1359,7 @@ async fn t0502_empty_reply_suppressed() {
     let (starting_seq, _, _) = do_wake(&gw, &node, 3000, &program_hash).await;
 
     let app_frame = node.build_app_data(starting_seq, &[0x01]);
-    let resp = gw.process_frame_aead(&app_frame, node.peer_address()).await;
+    let resp = gw.process_frame(&app_frame, node.peer_address()).await;
     assert!(
         resp.is_none(),
         "empty handler reply must produce no response"
@@ -1393,7 +1393,7 @@ async fn t0503_multiple_app_data_per_wake() {
         let blob = vec![(i + 1) as u8; 4];
         let app_frame = node.build_app_data(seq, &blob);
         let resp = gw
-            .process_frame_aead(&app_frame, node.peer_address())
+            .process_frame(&app_frame, node.peer_address())
             .await
             .unwrap_or_else(|| panic!("expected reply for APP_DATA #{i}"));
 
@@ -1439,7 +1439,7 @@ async fn t0504_handler_transport_framing() {
     let blob = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03];
     let app_frame = node.build_app_data(starting_seq, &blob);
     let resp = gw
-        .process_frame_aead(&app_frame, node.peer_address())
+        .process_frame(&app_frame, node.peer_address())
         .await
         .expect("expected APP_DATA_REPLY");
 
@@ -1479,7 +1479,7 @@ async fn t0505_handler_respawn_on_clean_exit() {
     let blob1 = vec![0x01];
     let app1 = node.build_app_data(starting_seq, &blob1);
     let resp1 = gw
-        .process_frame_aead(&app1, node.peer_address())
+        .process_frame(&app1, node.peer_address())
         .await
         .expect("first APP_DATA must get reply");
     let (_, msg1) = decode_response(&resp1, &node.psk);
@@ -1495,7 +1495,7 @@ async fn t0505_handler_respawn_on_clean_exit() {
     let blob2 = vec![0x02];
     let app2 = node.build_app_data(starting_seq + 1, &blob2);
     let resp2 = gw
-        .process_frame_aead(&app2, node.peer_address())
+        .process_frame(&app2, node.peer_address())
         .await
         .expect("second APP_DATA must get reply (handler respawned)");
     let (_, msg2) = decode_response(&resp2, &node.psk);
@@ -1528,7 +1528,7 @@ async fn t0506_handler_crash_no_reply() {
     let (starting_seq, _, _) = do_wake(&gw, &node, 7000, &program_hash).await;
 
     let app_frame = node.build_app_data(starting_seq, &[0x01]);
-    let resp = gw.process_frame_aead(&app_frame, node.peer_address()).await;
+    let resp = gw.process_frame(&app_frame, node.peer_address()).await;
     assert!(
         resp.is_none(),
         "crashed handler must not produce a response"
@@ -1563,7 +1563,7 @@ async fn t0507_routing_by_program_hash() {
     let blob_a = vec![0xDE, 0xAD];
     let app_a = node_a.build_app_data(seq_a, &blob_a);
     let resp_a = gw
-        .process_frame_aead(&app_a, node_a.peer_address())
+        .process_frame(&app_a, node_a.peer_address())
         .await
         .expect("node A must get echo reply");
     let (_, msg_a) = decode_response(&resp_a, &node_a.psk);
@@ -1581,7 +1581,7 @@ async fn t0507_routing_by_program_hash() {
 
     let app_b = node_b.build_app_data(seq_b, &[0xFF]);
     let resp_b = gw
-        .process_frame_aead(&app_b, node_b.peer_address())
+        .process_frame(&app_b, node_b.peer_address())
         .await
         .expect("node B must get fixed reply");
     let (_, msg_b) = decode_response(&resp_b, &node_b.psk);
@@ -1623,7 +1623,7 @@ async fn t0508_no_handler_match_no_reply() {
     let (starting_seq, _, _) = do_wake(&gw, &node, 10000, &node_hash).await;
 
     let app_frame = node.build_app_data(starting_seq, &[0x01]);
-    let resp = gw.process_frame_aead(&app_frame, node.peer_address()).await;
+    let resp = gw.process_frame(&app_frame, node.peer_address()).await;
     assert!(resp.is_none(), "no matching handler must produce no reply");
 }
 
@@ -1652,7 +1652,7 @@ async fn t0509_catch_all_handler() {
     let blob = vec![0xCA, 0xFE];
     let app_frame = node.build_app_data(starting_seq, &blob);
     let resp = gw
-        .process_frame_aead(&app_frame, node.peer_address())
+        .process_frame(&app_frame, node.peer_address())
         .await
         .expect("catch-all handler must produce reply");
 
@@ -1694,7 +1694,7 @@ async fn t0510_request_id_correlation() {
         let blob = vec![(0x10 + i) as u8];
         let app_frame = node.build_app_data(seq, &blob);
         let resp = gw
-            .process_frame_aead(&app_frame, node.peer_address())
+            .process_frame(&app_frame, node.peer_address())
             .await
             .expect("expected reply");
 
@@ -1729,7 +1729,7 @@ async fn t0511_request_id_mismatch_discarded() {
     let (starting_seq, _, _) = do_wake(&gw, &node, 13000, &program_hash).await;
 
     let app_frame = node.build_app_data(starting_seq, &[0x01]);
-    let resp = gw.process_frame_aead(&app_frame, node.peer_address()).await;
+    let resp = gw.process_frame(&app_frame, node.peer_address()).await;
     assert!(resp.is_none(), "mismatched request_id must suppress reply");
 }
 
@@ -1764,7 +1764,7 @@ async fn t0512_handler_no_crash_on_wake() {
     let blob = vec![0x01];
     let app_frame = node.build_app_data(starting_seq, &blob);
     let resp = gw
-        .process_frame_aead(&app_frame, node.peer_address())
+        .process_frame(&app_frame, node.peer_address())
         .await
         .expect("post-WAKE APP_DATA must still work");
     let (_hdr, msg) = decode_response(&resp, &node.psk);
@@ -1796,7 +1796,7 @@ async fn t0513_log_messages_no_crash() {
     let blob = vec![0xBE, 0xEF];
     let app_frame = node.build_app_data(starting_seq, &blob);
     let resp = gw
-        .process_frame_aead(&app_frame, node.peer_address())
+        .process_frame(&app_frame, node.peer_address())
         .await
         .expect("handler with LOG then DATA_REPLY must produce reply");
 
@@ -1843,7 +1843,7 @@ async fn t0503b_handler_persistence_across_messages() {
         let blob = vec![0xAA];
         let app_frame = node.build_app_data(seq, &blob);
         let resp = gw
-            .process_frame_aead(&app_frame, node.peer_address())
+            .process_frame(&app_frame, node.peer_address())
             .await
             .unwrap_or_else(|| panic!("expected reply for APP_DATA #{i}"));
 
@@ -1894,7 +1894,7 @@ async fn t0503c_handler_reply_timeout() {
     let app_frame = node.build_app_data(starting_seq, &blob);
     let peer = node.peer_address();
 
-    let resp = gw.process_frame_aead(&app_frame, peer).await;
+    let resp = gw.process_frame(&app_frame, peer).await;
 
     assert!(
         resp.is_none(),
@@ -1918,7 +1918,7 @@ async fn t05xx_no_handler_backward_compat() {
     let (starting_seq, _, _) = do_wake(&gw, &node, 99000, &program_hash).await;
 
     let app_frame = node.build_app_data(starting_seq, &[0x01, 0x02]);
-    let resp = gw.process_frame_aead(&app_frame, node.peer_address()).await;
+    let resp = gw.process_frame(&app_frame, node.peer_address()).await;
     assert!(
         resp.is_none(),
         "gateway without handler must silently accept APP_DATA"
@@ -2097,7 +2097,7 @@ async fn gw0503_ac3_persistent_handler_stays_alive() {
         let blob = vec![(i + 1) as u8; 2];
         let app_frame = node.build_app_data(seq, &blob);
         let resp = gw
-            .process_frame_aead(&app_frame, node.peer_address())
+            .process_frame(&app_frame, node.peer_address())
             .await
             .unwrap_or_else(|| panic!("expected reply for APP_DATA #{i}"));
 
@@ -2149,7 +2149,7 @@ async fn gw0501_sequence_number_correctness() {
         let blob = vec![(0x40 + i) as u8; 3];
         let app_frame = node.build_app_data(seq, &blob);
         let resp = gw
-            .process_frame_aead(&app_frame, node.peer_address())
+            .process_frame(&app_frame, node.peer_address())
             .await
             .unwrap_or_else(|| panic!("expected reply for APP_DATA #{i}"));
 
@@ -2204,7 +2204,7 @@ async fn gw0504_many_to_one_routing() {
     let blob_x = vec![0xAA, 0xBB];
     let app_x = node_x.build_app_data(seq_x, &blob_x);
     let resp_x = gw
-        .process_frame_aead(&app_x, node_x.peer_address())
+        .process_frame(&app_x, node_x.peer_address())
         .await
         .expect("node X must get reply from shared handler");
     let (_, msg_x) = decode_response(&resp_x, &node_x.psk);
@@ -2223,7 +2223,7 @@ async fn gw0504_many_to_one_routing() {
     let blob_y = vec![0xCC, 0xDD];
     let app_y = node_y.build_app_data(seq_y, &blob_y);
     let resp_y = gw
-        .process_frame_aead(&app_y, node_y.peer_address())
+        .process_frame(&app_y, node_y.peer_address())
         .await
         .expect("node Y must get reply from shared handler");
     let (_, msg_y) = decode_response(&resp_y, &node_y.psk);

--- a/crates/sonde-gateway/tests/phase2c_admin.rs
+++ b/crates/sonde-gateway/tests/phase2c_admin.rs
@@ -34,7 +34,7 @@ use sonde_gateway::transport::PeerAddress;
 use sonde_gateway::GatewayAead;
 
 use sonde_protocol::{
-    decode_frame_aead, encode_frame_aead, open_frame, CommandPayload, FrameHeader, GatewayMessage,
+    decode_frame, encode_frame, open_frame, CommandPayload, FrameHeader, GatewayMessage,
     NodeMessage, MSG_WAKE,
 };
 
@@ -77,7 +77,7 @@ impl TestNode {
             battery_mv,
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 }
 
@@ -132,7 +132,7 @@ const MINIMAL_BPF: &[u8] = &[
 ];
 
 fn decode_response(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
-    let decoded = decode_frame_aead(raw).unwrap();
+    let decoded = decode_frame(raw).unwrap();
     let plaintext = open_frame(&decoded, psk, &GatewayAead, &RustCryptoSha256).unwrap();
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
     (decoded.header, msg)
@@ -146,7 +146,7 @@ async fn do_wake(
 ) -> (u64, u64, CommandPayload) {
     let frame = node.build_wake(nonce, 1, program_hash, 3300);
     let resp = gw
-        .process_frame_aead(&frame, node.peer_address())
+        .process_frame(&frame, node.peer_address())
         .await
         .expect("expected COMMAND response");
     let (_hdr, msg) = decode_response(&resp, &node.psk);
@@ -318,7 +318,7 @@ async fn t0705_remove_node_wake_rejected() {
     let gw = h.make_gateway();
     let node = TestNode::new("reset-node", 0x0705, psk);
     let frame = node.build_wake(1, 1, &[0u8; 32], 3300);
-    let resp = gw.process_frame_aead(&frame, node.peer_address()).await;
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_some(), "WAKE must succeed while node is registered");
 
     // Remove the node (simulates gateway side of factory reset).
@@ -331,7 +331,7 @@ async fn t0705_remove_node_wake_rejected() {
 
     // Subsequent WAKE must be silently discarded (unknown node).
     let frame2 = node.build_wake(2, 1, &[0u8; 32], 3300);
-    let resp2 = gw.process_frame_aead(&frame2, node.peer_address()).await;
+    let resp2 = gw.process_frame(&frame2, node.peer_address()).await;
     assert!(
         resp2.is_none(),
         "WAKE from removed node must be silently discarded"
@@ -1440,7 +1440,7 @@ async fn t1005_export_plaintext_key_leakage() {
     let gw_fresh = h_fresh.make_gateway();
     let frame_a = node_a.build_wake(5, 1, &[0u8; 32], 3300);
     let resp_a = gw_fresh
-        .process_frame_aead(&frame_a, node_a.peer_address())
+        .process_frame(&frame_a, node_a.peer_address())
         .await;
     assert!(
         resp_a.is_none(),
@@ -1448,7 +1448,7 @@ async fn t1005_export_plaintext_key_leakage() {
     );
     let frame_b = node_b.build_wake(6, 1, &[0u8; 32], 3300);
     let resp_b = gw_fresh
-        .process_frame_aead(&frame_b, node_b.peer_address())
+        .process_frame(&frame_b, node_b.peer_address())
         .await;
     assert!(
         resp_b.is_none(),

--- a/crates/sonde-gateway/tests/phase3.rs
+++ b/crates/sonde-gateway/tests/phase3.rs
@@ -20,7 +20,7 @@ use sonde_gateway::transport::PeerAddress;
 use sonde_gateway::GatewayAead;
 
 use sonde_protocol::{
-    decode_frame_aead, encode_frame_aead, open_frame, CommandPayload, FrameHeader, GatewayMessage,
+    decode_frame, encode_frame, open_frame, CommandPayload, FrameHeader, GatewayMessage,
     NodeMessage, MSG_COMMAND, MSG_WAKE,
 };
 
@@ -61,7 +61,7 @@ impl TestNode {
             battery_mv,
         };
         let cbor = msg.encode().unwrap();
-        encode_frame_aead(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
     }
 }
 
@@ -70,7 +70,7 @@ fn make_gateway(storage: Arc<InMemoryStorage>) -> Gateway {
 }
 
 fn decode_response(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
-    let decoded = decode_frame_aead(raw).unwrap();
+    let decoded = decode_frame(raw).unwrap();
     let plaintext = open_frame(&decoded, psk, &GatewayAead, &RustCryptoSha256).unwrap();
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
     (decoded.header, msg)
@@ -219,7 +219,7 @@ async fn t0608_frame_overhead_budget() {
 
     let wake_frame = node.build_wake(42, 1, &[0u8; 32], 3300);
     let response = gateway
-        .process_frame_aead(&wake_frame, node.peer_address())
+        .process_frame(&wake_frame, node.peer_address())
         .await;
     assert!(response.is_some(), "gateway must respond to WAKE");
 
@@ -227,7 +227,7 @@ async fn t0608_frame_overhead_budget() {
     // Minimum frame: 11 header + at least 1 byte ciphertext + 16 GCM tag = 28
     assert!(raw.len() >= 28, "frame too short: {} bytes", raw.len());
 
-    let decoded = decode_frame_aead(&raw).unwrap();
+    let decoded = decode_frame(&raw).unwrap();
     assert_eq!(decoded.header.msg_type, MSG_COMMAND);
     // Open to verify it's valid
     let _plaintext = open_frame(&decoded, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
@@ -270,7 +270,7 @@ async fn t0701_stale_program_detection() {
     // WAKE with hash_A → should be NOP (program matches).
     let wake = node.build_wake(1, 1, &hash_a, 3300);
     let resp = gateway
-        .process_frame_aead(&wake, node.peer_address())
+        .process_frame(&wake, node.peer_address())
         .await
         .unwrap();
     let (_, msg) = decode_response(&resp, &node.psk);
@@ -292,7 +292,7 @@ async fn t0701_stale_program_detection() {
     // WAKE again with hash_A → should get UPDATE_PROGRAM for B.
     let wake = node.build_wake(2, 1, &hash_a, 3300);
     let resp = gateway
-        .process_frame_aead(&wake, node.peer_address())
+        .process_frame(&wake, node.peer_address())
         .await
         .unwrap();
     let (_, msg) = decode_response(&resp, &node.psk);
@@ -323,9 +323,7 @@ async fn t1000_gateway_failover() {
 
     // Complete a WAKE on gateway A.
     let wake = node.build_wake(1, 1, &[0u8; 32], 3300);
-    let resp_a = gateway_a
-        .process_frame_aead(&wake, node.peer_address())
-        .await;
+    let resp_a = gateway_a.process_frame(&wake, node.peer_address()).await;
     assert!(resp_a.is_some(), "gateway A must respond");
 
     // Export state from A.
@@ -349,9 +347,7 @@ async fn t1000_gateway_failover() {
 
     // WAKE from the same node on B.
     let wake = node.build_wake(10, 1, &[0u8; 32], 3300);
-    let resp_b = gateway_b
-        .process_frame_aead(&wake, node.peer_address())
-        .await;
+    let resp_b = gateway_b.process_frame(&wake, node.peer_address()).await;
     assert!(resp_b.is_some(), "gateway B must respond after import");
 
     // B recognizes the node.
@@ -460,7 +456,7 @@ async fn t1003_concurrent_node_handling() {
         let psk = node.psk;
         let peer = node.peer_address();
         handles.push(tokio::spawn(async move {
-            let resp = gw.process_frame_aead(&wake, peer).await;
+            let resp = gw.process_frame(&wake, peer).await;
             (i, resp, psk)
         }));
     }
@@ -470,7 +466,7 @@ async fn t1003_concurrent_node_handling() {
         let (i, resp, psk) = handle.await.unwrap();
         assert!(resp.is_some(), "node {i} must receive a response");
         let raw = resp.unwrap();
-        let decoded = decode_frame_aead(&raw).unwrap();
+        let decoded = decode_frame(&raw).unwrap();
         assert!(
             open_frame(&decoded, &psk, &GatewayAead, &RustCryptoSha256).is_ok(),
             "node {i} response must be authenticated with its own PSK"

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -33,7 +33,7 @@ fn main() {
     use sonde_node::map_storage::{MapStorage, MAP_BUDGET};
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
     use sonde_node::traits::{PlatformStorage, SleepController};
-    use sonde_node::wake_cycle::{run_wake_cycle_aead, WakeCycleOutcome};
+    use sonde_node::wake_cycle::{run_wake_cycle, WakeCycleOutcome};
 
     // Link ESP-IDF patches and initialize logging.
     esp_idf_svc::sys::link_patches();
@@ -169,7 +169,7 @@ fn main() {
 
     info!("sonde-node ready");
 
-    let outcome = run_wake_cycle_aead(
+    let outcome = run_wake_cycle(
         &mut transport,
         &mut storage,
         &mut hal,

--- a/crates/sonde-node/src/bpf_dispatch.rs
+++ b/crates/sonde-node/src/bpf_dispatch.rs
@@ -160,11 +160,11 @@ fn with_ctx<R>(f: impl FnOnce(&mut DispatchContext) -> R) -> Option<R> {
 /// # Safety
 ///
 /// All pointers must remain valid until [`clear`] is called.
-/// The caller (`run_wake_cycle_aead`) guarantees this by holding
+/// The caller (`run_wake_cycle`) guarantees this by holding
 /// ownership of every referenced object on its stack.
 /// `aead` and `sha` must also remain valid.
 #[allow(clippy::too_many_arguments)]
-pub unsafe fn install_aead(
+pub unsafe fn install(
     hal: *mut dyn Hal,
     transport: *mut dyn Transport,
     map_storage: *mut MapStorage,
@@ -455,7 +455,7 @@ pub fn helper_send(r1: u64, r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
     let result = with_ctx(|ctx| {
         let blob_ptr = r1 as *const u8;
         let blob_len = r2 as usize;
-        if blob_ptr.is_null() || blob_len > sonde_protocol::MAX_PAYLOAD_SIZE_AEAD {
+        if blob_ptr.is_null() || blob_len > sonde_protocol::MAX_PAYLOAD_SIZE {
             return (-1i64) as u64;
         }
 
@@ -468,7 +468,7 @@ pub fn helper_send(r1: u64, r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
             let (aead_ptr, sha_ptr) = ctx.aead;
             let aead = &*aead_ptr;
             let sha = &*sha_ptr;
-            match crate::wake_cycle::send_app_data_aead(transport, identity, seq, blob, aead, sha) {
+            match crate::wake_cycle::send_app_data(transport, identity, seq, blob, aead, sha) {
                 Ok(()) => 0,
                 Err(_) => (-1i64) as u64,
             }
@@ -489,7 +489,7 @@ pub fn helper_send_recv(r1: u64, r2: u64, r3: u64, r4: u64, r5: u64) -> u64 {
         let reply_ptr = r3 as *mut u8;
         let reply_cap = r4 as usize;
         if blob_ptr.is_null()
-            || blob_len > sonde_protocol::MAX_PAYLOAD_SIZE_AEAD
+            || blob_len > sonde_protocol::MAX_PAYLOAD_SIZE
             || reply_ptr.is_null()
             || reply_cap == 0
         {
@@ -512,7 +512,7 @@ pub fn helper_send_recv(r1: u64, r2: u64, r3: u64, r4: u64, r5: u64) -> u64 {
             let (aead_ptr, sha_ptr) = ctx.aead;
             let aead = &*aead_ptr;
             let sha = &*sha_ptr;
-            let send_result = crate::wake_cycle::send_recv_app_data_aead(
+            let send_result = crate::wake_cycle::send_recv_app_data(
                 transport, identity, seq, blob, timeout_ms, clock, aead, sha,
             );
 
@@ -853,7 +853,7 @@ mod tests {
         let aead = crate::node_aead::NodeAead;
         let sha = crate::crypto::SoftwareSha256;
         unsafe {
-            install_aead(
+            install(
                 hal as *mut TestHal as *mut dyn Hal,
                 transport as *mut TestTransport as *mut dyn Transport,
                 map_storage as *mut MapStorage,
@@ -1226,7 +1226,7 @@ mod tests {
         let aead = crate::node_aead::NodeAead;
         let sha = crate::crypto::SoftwareSha256;
         unsafe {
-            install_aead(
+            install(
                 &mut hal as *mut TestHal as *mut dyn Hal,
                 &mut transport as *mut TestTransport as *mut dyn Transport,
                 &mut maps as *mut MapStorage,
@@ -1310,7 +1310,7 @@ mod tests {
         let aead = crate::node_aead::NodeAead;
         let sha_prov = crate::crypto::SoftwareSha256;
         unsafe {
-            install_aead(
+            install(
                 &mut hal as *mut TestHal as *mut dyn Hal,
                 &mut transport as *mut TestTransport as *mut dyn Transport,
                 &mut maps as *mut MapStorage,
@@ -1458,7 +1458,7 @@ mod tests {
     #[test]
     fn test_helper_send() {
         // T-N604: send() produces an APP_DATA frame on the transport.
-        use sonde_protocol::{decode_frame_aead, open_frame};
+        use sonde_protocol::{decode_frame, open_frame};
 
         let mut hal = TestHal::new();
         let mut transport = TestTransport::new();
@@ -1493,7 +1493,7 @@ mod tests {
         assert_eq!(transport.outbound.len(), 1);
 
         // Decode and verify it's a valid AEAD APP_DATA frame
-        let decoded = decode_frame_aead(&transport.outbound[0]).unwrap();
+        let decoded = decode_frame(&transport.outbound[0]).unwrap();
         assert_eq!(decoded.header.msg_type, MSG_APP_DATA);
         let plaintext =
             open_frame(&decoded, &identity.psk, &aead, &sha).expect("AEAD decrypt should succeed");
@@ -1507,7 +1507,7 @@ mod tests {
     #[test]
     fn test_helper_send_recv() {
         // T-N605: send_recv sends APP_DATA and receives APP_DATA_REPLY.
-        use sonde_protocol::{encode_frame_aead, FrameHeader, GatewayMessage, MSG_APP_DATA_REPLY};
+        use sonde_protocol::{encode_frame, FrameHeader, GatewayMessage, MSG_APP_DATA_REPLY};
 
         let mut hal = TestHal::new();
         let mut transport = TestTransport::new();
@@ -1527,7 +1527,7 @@ mod tests {
             nonce: 100, // must match the seq we'll send with
         };
         let reply_frame =
-            encode_frame_aead(&reply_header, &reply_cbor, &identity.psk, &aead, &sha).unwrap();
+            encode_frame(&reply_header, &reply_cbor, &identity.psk, &aead, &sha).unwrap();
         transport.inbound.push_back(Some(reply_frame));
 
         let mut maps = MapStorage::new(4096);
@@ -2223,159 +2223,5 @@ mod tests {
             "non-I/O helpers must not emit DEBUG 'bpf helper' logs, got: {:?}",
             records
         );
-    }
-
-    // -- AEAD-path tests ------------------------------------
-
-    #[allow(clippy::too_many_arguments)]
-    fn with_test_context_aead<F, R>(
-        hal: &mut TestHal,
-        transport: &mut TestTransport,
-        map_storage: &mut MapStorage,
-        sleep_mgr: &mut SleepManager,
-        clock: &TestClock,
-        identity: &NodeIdentity,
-        seq: &mut u64,
-        program_class: ProgramClass,
-        trace_log: &mut Vec<String>,
-        aead: &(dyn sonde_protocol::AeadProvider + 'static),
-        sha: &(dyn sonde_protocol::Sha256Provider + 'static),
-        f: F,
-    ) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        unsafe {
-            install_aead(
-                hal as *mut TestHal as *mut dyn Hal,
-                transport as *mut TestTransport as *mut dyn Transport,
-                map_storage as *mut MapStorage,
-                sleep_mgr as *mut SleepManager,
-                clock as *const TestClock as *const dyn Clock,
-                identity as *const NodeIdentity,
-                seq as *mut u64,
-                program_class,
-                trace_log as *mut Vec<String>,
-                1_710_000_000_000,
-                100,
-                3300,
-                aead,
-                sha,
-            );
-        }
-        let _guard = DispatchGuard;
-        f()
-    }
-
-    #[test]
-    fn test_helper_send_aead() {
-        use sonde_protocol::{decode_frame_aead, open_frame};
-
-        let mut hal = TestHal::new();
-        let mut transport = TestTransport::new();
-        let mut maps = MapStorage::new(4096);
-        let mut sleep = SleepManager::new(60, WakeReason::Scheduled);
-        let clock = TestClock(0);
-        let identity = default_identity();
-        let mut seq = 100u64;
-        let mut trace = Vec::new();
-        let blob: Vec<u8> = vec![0xAA, 0xBB];
-
-        let aead = crate::node_aead::NodeAead;
-        let sha = crate::crypto::SoftwareSha256;
-
-        with_test_context_aead(
-            &mut hal,
-            &mut transport,
-            &mut maps,
-            &mut sleep,
-            &clock,
-            &identity,
-            &mut seq,
-            ProgramClass::Resident,
-            &mut trace,
-            &aead,
-            &sha,
-            || {
-                let result = helper_send(blob.as_ptr() as u64, blob.len() as u64, 0, 0, 0);
-                assert_eq!(result, 0, "helper_send should succeed");
-            },
-        );
-
-        assert_eq!(seq, 101, "sequence should advance");
-        assert_eq!(transport.outbound.len(), 1);
-
-        // Verify the frame is AEAD-authenticated (not HMAC)
-        let frame = &transport.outbound[0];
-        let decoded = decode_frame_aead(frame).expect("should be valid AEAD frame");
-        assert_eq!(decoded.header.msg_type, MSG_APP_DATA);
-        let plaintext =
-            open_frame(&decoded, &identity.psk, &aead, &sha).expect("AEAD decrypt should succeed");
-        let msg = NodeMessage::decode(MSG_APP_DATA, &plaintext).unwrap();
-        match msg {
-            NodeMessage::AppData { blob: received } => assert_eq!(received, vec![0xAA, 0xBB]),
-            _ => panic!("expected AppData"),
-        }
-    }
-
-    #[test]
-    fn test_helper_send_recv_aead() {
-        use sonde_protocol::{encode_frame_aead, FrameHeader, GatewayMessage, MSG_APP_DATA_REPLY};
-
-        let mut hal = TestHal::new();
-        let mut transport = TestTransport::new();
-        let mut maps = MapStorage::new(4096);
-        let mut sleep = SleepManager::new(60, WakeReason::Scheduled);
-        let clock = TestClock(0);
-        let identity = default_identity();
-        let mut seq = 100u64;
-        let mut trace = Vec::new();
-
-        let aead = crate::node_aead::NodeAead;
-        let sha = crate::crypto::SoftwareSha256;
-
-        // Pre-queue an AEAD APP_DATA_REPLY for the transport to return.
-        let reply_msg = GatewayMessage::AppDataReply {
-            blob: vec![0xCC, 0xDD],
-        };
-        let reply_cbor = reply_msg.encode().unwrap();
-        let reply_header = FrameHeader {
-            key_hint: identity.key_hint,
-            msg_type: MSG_APP_DATA_REPLY,
-            nonce: 100, // must match the seq used for the outbound APP_DATA
-        };
-        let reply_frame =
-            encode_frame_aead(&reply_header, &reply_cbor, &identity.psk, &aead, &sha).unwrap();
-        transport.inbound.push_back(Some(reply_frame));
-
-        let blob: Vec<u8> = vec![0xAA, 0xBB];
-        let mut reply_buf = [0u8; 64];
-
-        with_test_context_aead(
-            &mut hal,
-            &mut transport,
-            &mut maps,
-            &mut sleep,
-            &clock,
-            &identity,
-            &mut seq,
-            ProgramClass::Resident,
-            &mut trace,
-            &aead,
-            &sha,
-            || {
-                let result = helper_send_recv(
-                    blob.as_ptr() as u64,
-                    blob.len() as u64,
-                    reply_buf.as_mut_ptr() as u64,
-                    reply_buf.len() as u64,
-                    1000,
-                );
-                assert_eq!(result, 2, "should return 2 bytes of reply");
-            },
-        );
-
-        assert_eq!(seq, 101);
-        assert_eq!(&reply_buf[..2], &[0xCC, 0xDD]);
     }
 }

--- a/crates/sonde-node/src/node_aead.rs
+++ b/crates/sonde-node/src/node_aead.rs
@@ -55,7 +55,7 @@ impl AeadProvider for NodeAead {
 mod tests {
     use super::*;
     use sonde_protocol::{
-        decode_frame_aead, encode_frame_aead, open_frame, AeadProvider, FrameHeader, MSG_WAKE,
+        decode_frame, encode_frame, open_frame, AeadProvider, FrameHeader, MSG_WAKE,
     };
 
     use crate::crypto::SoftwareSha256;
@@ -73,10 +73,10 @@ mod tests {
         };
         let payload = vec![0xA1, 0x01, 0x02];
 
-        let raw = encode_frame_aead(&header, &payload, &psk, &aead, &sha)
-            .expect("encoding should succeed");
+        let raw =
+            encode_frame(&header, &payload, &psk, &aead, &sha).expect("encoding should succeed");
 
-        let decoded = decode_frame_aead(&raw).expect("decoding should succeed");
+        let decoded = decode_frame(&raw).expect("decoding should succeed");
         assert_eq!(decoded.header.key_hint, 1);
         assert_eq!(decoded.header.msg_type, MSG_WAKE);
         assert_eq!(decoded.header.nonce, 100);
@@ -99,10 +99,10 @@ mod tests {
         };
         let payload = vec![0xA0];
 
-        let raw = encode_frame_aead(&header, &payload, &psk, &aead, &sha)
-            .expect("encoding should succeed");
+        let raw =
+            encode_frame(&header, &payload, &psk, &aead, &sha).expect("encoding should succeed");
 
-        let decoded = decode_frame_aead(&raw).expect("decoding should succeed");
+        let decoded = decode_frame(&raw).expect("decoding should succeed");
 
         let result = open_frame(&decoded, &wrong_psk, &aead, &sha);
         assert!(
@@ -150,10 +150,10 @@ mod tests {
             nonce: 0,
         };
 
-        let raw = encode_frame_aead(&header, &[], &psk, &aead, &sha)
+        let raw = encode_frame(&header, &[], &psk, &aead, &sha)
             .expect("encoding empty payload should succeed");
 
-        let decoded = decode_frame_aead(&raw).expect("decoding should succeed");
+        let decoded = decode_frame(&raw).expect("decoding should succeed");
         let plaintext = open_frame(&decoded, &psk, &aead, &sha).expect("open should succeed");
         assert!(plaintext.is_empty());
     }

--- a/crates/sonde-node/src/peer_request.rs
+++ b/crates/sonde-node/src/peer_request.rs
@@ -49,8 +49,8 @@ const PEER_ACK_STATUS_OK: u64 = 0;
 /// provisioning.  This function validates the stored blob is a
 /// decodable AEAD frame with `msg_type == MSG_PEER_REQUEST` and returns
 /// it as-is for transmission.
-pub fn build_peer_request_frame_aead(complete_frame: &[u8]) -> NodeResult<Vec<u8>> {
-    let decoded = sonde_protocol::decode_frame_aead(complete_frame)
+pub fn build_peer_request_frame(complete_frame: &[u8]) -> NodeResult<Vec<u8>> {
+    let decoded = sonde_protocol::decode_frame(complete_frame)
         .map_err(|_| NodeError::MalformedPayload("PEER_REQUEST frame is not a valid AEAD frame"))?;
 
     if decoded.header.msg_type != MSG_PEER_REQUEST {
@@ -67,14 +67,14 @@ pub fn build_peer_request_frame_aead(complete_frame: &[u8]) -> NodeResult<Vec<u8
 /// `ble-pairing-protocol.md` §7.2, the `registration_proof` field is
 /// retired under AES-256-GCM: successful AEAD open with `node_psk`
 /// constitutes proof that the gateway holds the node's PSK.
-pub fn verify_peer_ack_aead<A: sonde_protocol::AeadProvider, S: sonde_protocol::Sha256Provider>(
+pub fn verify_peer_ack<A: sonde_protocol::AeadProvider, S: sonde_protocol::Sha256Provider>(
     raw: &[u8],
     identity: &NodeIdentity,
     expected_nonce: u64,
     aead: &A,
     sha: &S,
 ) -> NodeResult<()> {
-    let decoded = sonde_protocol::decode_frame_aead(raw)
+    let decoded = sonde_protocol::decode_frame(raw)
         .map_err(|_| NodeError::MalformedPayload("PEER_ACK decode failed"))?;
 
     let header = decoded.header.clone();
@@ -126,7 +126,7 @@ pub fn verify_peer_ack_aead<A: sonde_protocol::AeadProvider, S: sonde_protocol::
 /// (built by the phone during BLE provisioning).  The node transmits
 /// it verbatim and waits for a PEER_ACK encrypted with `node_psk`.
 #[allow(clippy::too_many_arguments)]
-pub fn peer_request_exchange_aead<
+pub fn peer_request_exchange<
     T: Transport,
     S: PlatformStorage,
     A: sonde_protocol::AeadProvider,
@@ -140,10 +140,10 @@ pub fn peer_request_exchange_aead<
     aead: &A,
     sha: &H,
 ) -> NodeResult<bool> {
-    let frame = build_peer_request_frame_aead(complete_frame)?;
+    let frame = build_peer_request_frame(complete_frame)?;
 
-    // Extract nonce via decode (already validated by build_peer_request_frame_aead).
-    let decoded = sonde_protocol::decode_frame_aead(&frame)
+    // Extract nonce via decode (already validated by build_peer_request_frame).
+    let decoded = sonde_protocol::decode_frame(&frame)
         .map_err(|_| NodeError::MalformedPayload("cannot decode validated frame"))?;
     let nonce = decoded.header.nonce;
 
@@ -161,7 +161,7 @@ pub fn peer_request_exchange_aead<
         let recv_timeout = remaining.min(500);
 
         if let Some(raw) = transport.recv(recv_timeout)? {
-            if verify_peer_ack_aead(&raw, identity, nonce, aead, sha).is_ok() {
+            if verify_peer_ack(&raw, identity, nonce, aead, sha).is_ok() {
                 storage.write_reg_complete(true)?;
                 log::info!("PEER_ACK received — registration complete (ND-1005)");
                 return Ok(true);
@@ -341,7 +341,7 @@ mod tests {
     mod aead_tests {
         use super::*;
         use crate::node_aead::NodeAead;
-        use sonde_protocol::{decode_frame_aead, Sha256Provider};
+        use sonde_protocol::{decode_frame, Sha256Provider};
 
         struct TestSha256;
         impl Sha256Provider for TestSha256 {
@@ -376,43 +376,43 @@ mod tests {
                 nonce,
             };
 
-            sonde_protocol::encode_frame_aead(&header, &cbor_buf, phone_psk, &aead, &sha).unwrap()
+            sonde_protocol::encode_frame(&header, &cbor_buf, phone_psk, &aead, &sha).unwrap()
         }
 
         #[test]
-        fn build_peer_request_frame_aead_validates_and_returns() {
+        fn build_peer_request_frame_validates_and_returns() {
             let phone_psk = [0x42u8; 32];
             let inner_payload = vec![0xAAu8; 100];
 
             let frame = build_phone_peer_request_frame(&phone_psk, &inner_payload, 12345);
-            let result = build_peer_request_frame_aead(&frame)
+            let result = build_peer_request_frame(&frame)
                 .expect("AEAD PEER_REQUEST frame validation should succeed");
 
             // Must return the frame unchanged
             assert_eq!(result, frame);
 
             // Verify it's a valid AEAD frame
-            let decoded = decode_frame_aead(&result).unwrap();
+            let decoded = decode_frame(&result).unwrap();
             assert_eq!(decoded.header.msg_type, MSG_PEER_REQUEST);
             assert_eq!(decoded.header.nonce, 12345);
         }
 
         #[test]
-        fn build_peer_request_frame_aead_rejects_too_short() {
-            let too_short = vec![0u8; sonde_protocol::MIN_FRAME_SIZE_AEAD - 1];
-            let result = build_peer_request_frame_aead(&too_short);
+        fn build_peer_request_frame_rejects_too_short() {
+            let too_short = vec![0u8; sonde_protocol::MIN_FRAME_SIZE - 1];
+            let result = build_peer_request_frame(&too_short);
             assert!(result.is_err());
         }
 
         #[test]
-        fn build_peer_request_frame_aead_rejects_oversized() {
+        fn build_peer_request_frame_rejects_oversized() {
             let oversized = vec![0xBBu8; sonde_protocol::MAX_FRAME_SIZE + 1];
-            let result = build_peer_request_frame_aead(&oversized);
+            let result = build_peer_request_frame(&oversized);
             assert!(result.is_err());
         }
 
         #[test]
-        fn build_peer_request_frame_aead_accepts_max_size() {
+        fn build_peer_request_frame_accepts_max_size() {
             // Build a frame of exactly MAX_FRAME_SIZE with a valid header
             // (msg_type = MSG_PEER_REQUEST).
             let mut exact = vec![0xCCu8; sonde_protocol::MAX_FRAME_SIZE];
@@ -423,12 +423,12 @@ mod tests {
             };
             let header_bytes = header.to_bytes();
             exact[..header_bytes.len()].copy_from_slice(&header_bytes);
-            let result = build_peer_request_frame_aead(&exact);
+            let result = build_peer_request_frame(&exact);
             assert!(result.is_ok(), "MAX_FRAME_SIZE must succeed");
         }
 
         #[test]
-        fn build_peer_request_frame_aead_rejects_wrong_msg_type() {
+        fn build_peer_request_frame_rejects_wrong_msg_type() {
             let phone_psk = [0x42u8; 32];
             let sha = TestSha256;
             let aead = NodeAead;
@@ -447,9 +447,8 @@ mod tests {
             ciborium::into_writer(&cbor_map, &mut cbor_buf).unwrap();
 
             let frame =
-                sonde_protocol::encode_frame_aead(&header, &cbor_buf, &phone_psk, &aead, &sha)
-                    .unwrap();
-            let result = build_peer_request_frame_aead(&frame);
+                sonde_protocol::encode_frame(&header, &cbor_buf, &phone_psk, &aead, &sha).unwrap();
+            let result = build_peer_request_frame(&frame);
             assert!(result.is_err(), "wrong msg_type must be rejected");
         }
 
@@ -460,7 +459,7 @@ mod tests {
         /// Per `ble-pairing-protocol.md` §7.2, PEER_ACK payload is
         /// `{ 1: status }` — the `registration_proof` field is retired
         /// under AES-256-GCM.
-        fn build_peer_ack_aead(
+        fn build_peer_ack(
             identity: &NodeIdentity,
             nonce: u64,
             aead: &NodeAead,
@@ -479,10 +478,10 @@ mod tests {
                 nonce,
             };
 
-            sonde_protocol::encode_frame_aead(&header, &cbor_buf, &identity.psk, aead, sha).unwrap()
+            sonde_protocol::encode_frame(&header, &cbor_buf, &identity.psk, aead, sha).unwrap()
         }
 
-        fn test_identity_aead() -> NodeIdentity {
+        fn test_identity() -> NodeIdentity {
             let psk = [0x42u8; 32];
             let sha = TestSha256;
             NodeIdentity {
@@ -492,27 +491,27 @@ mod tests {
         }
 
         #[test]
-        fn verify_peer_ack_aead_valid() {
+        fn verify_peer_ack_valid() {
             let sha = TestSha256;
             let aead = NodeAead;
-            let identity = test_identity_aead();
+            let identity = test_identity();
             let nonce: u64 = 0xAABBCCDDEEFF0011;
 
-            let ack_frame = build_peer_ack_aead(&identity, nonce, &aead, &sha);
-            let result = verify_peer_ack_aead(&ack_frame, &identity, nonce, &aead, &sha);
+            let ack_frame = build_peer_ack(&identity, nonce, &aead, &sha);
+            let result = verify_peer_ack(&ack_frame, &identity, nonce, &aead, &sha);
             assert!(result.is_ok());
         }
 
         #[test]
-        fn verify_peer_ack_aead_wrong_nonce() {
+        fn verify_peer_ack_wrong_nonce() {
             let sha = TestSha256;
             let aead = NodeAead;
-            let identity = test_identity_aead();
+            let identity = test_identity();
             let request_nonce: u64 = 0xAABBCCDDEEFF0011;
             let wrong_nonce: u64 = 0x1111111111111111;
 
-            let ack_frame = build_peer_ack_aead(&identity, wrong_nonce, &aead, &sha);
-            let result = verify_peer_ack_aead(&ack_frame, &identity, request_nonce, &aead, &sha);
+            let ack_frame = build_peer_ack(&identity, wrong_nonce, &aead, &sha);
+            let result = verify_peer_ack(&ack_frame, &identity, request_nonce, &aead, &sha);
             assert!(result.is_err());
         }
 
@@ -520,28 +519,28 @@ mod tests {
         /// AEAD decryption with `node_psk` is sufficient.  This test
         /// verifies that decryption with a wrong key is rejected.
         #[test]
-        fn verify_peer_ack_aead_wrong_key() {
+        fn verify_peer_ack_wrong_key() {
             let sha = TestSha256;
             let aead = NodeAead;
-            let identity = test_identity_aead();
+            let identity = test_identity();
             let nonce: u64 = 0x42;
 
-            let ack_frame = build_peer_ack_aead(&identity, nonce, &aead, &sha);
+            let ack_frame = build_peer_ack(&identity, nonce, &aead, &sha);
 
             // Verify with a different PSK — decryption must fail
             let wrong_identity = NodeIdentity {
                 key_hint: identity.key_hint,
                 psk: [0x99u8; 32],
             };
-            let result = verify_peer_ack_aead(&ack_frame, &wrong_identity, nonce, &aead, &sha);
+            let result = verify_peer_ack(&ack_frame, &wrong_identity, nonce, &aead, &sha);
             assert!(result.is_err());
         }
 
         #[test]
-        fn peer_request_exchange_aead_sets_reg_complete() {
+        fn peer_request_exchange_sets_reg_complete() {
             let sha = TestSha256;
             let aead = NodeAead;
-            let identity = test_identity_aead();
+            let identity = test_identity();
             let phone_psk = [0x55u8; 32];
             let nonce: u64 = 0x1122334455667788;
 
@@ -550,14 +549,14 @@ mod tests {
             let complete_frame = build_phone_peer_request_frame(&phone_psk, &inner_payload, nonce);
 
             // Build PEER_ACK with the nonce from the frame.
-            let ack = build_peer_ack_aead(&identity, nonce, &aead, &sha);
+            let ack = build_peer_ack(&identity, nonce, &aead, &sha);
             let mut transport = MockTransport::with_responses(vec![Some(ack)]);
             let mut storage =
                 MockStorage::with_identity(identity.key_hint, identity.psk, complete_frame.clone());
 
             assert!(!storage.reg_complete);
 
-            let result = peer_request_exchange_aead(
+            let result = peer_request_exchange(
                 &mut transport,
                 &mut storage,
                 &identity,
@@ -574,10 +573,10 @@ mod tests {
         }
 
         #[test]
-        fn peer_request_exchange_aead_timeout() {
+        fn peer_request_exchange_timeout() {
             let sha = TestSha256;
             let aead = NodeAead;
-            let identity = test_identity_aead();
+            let identity = test_identity();
             let phone_psk = [0x55u8; 32];
 
             let complete_frame = build_phone_peer_request_frame(&phone_psk, &[0xDE, 0xAD], 0x42);
@@ -586,7 +585,7 @@ mod tests {
             let mut storage =
                 MockStorage::with_identity(identity.key_hint, identity.psk, complete_frame.clone());
 
-            let result = peer_request_exchange_aead(
+            let result = peer_request_exchange(
                 &mut transport,
                 &mut storage,
                 &identity,

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -18,7 +18,7 @@ use crate::error::{NodeError, NodeResult};
 use crate::hal::{BatteryReader, Hal};
 use crate::key_store::NodeIdentity;
 use crate::map_storage::MapStorage;
-use crate::peer_request::peer_request_exchange_aead;
+use crate::peer_request::peer_request_exchange;
 use crate::program_store::{LoadedProgram, ProgramStore};
 use crate::sleep::{SleepManager, WakeReason};
 use crate::traits::{Clock, PlatformStorage, Rng, Transport};
@@ -151,30 +151,30 @@ fn decode_command_as_nop(payload: &[u8]) -> NodeResult<(u64, u64, CommandPayload
     Ok((starting_seq, timestamp_ms, CommandPayload::Nop))
 }
 
-use sonde_protocol::{decode_frame_aead, encode_frame_aead, open_frame, AeadProvider};
+use sonde_protocol::{decode_frame, encode_frame, open_frame, AeadProvider};
 
 /// Decode and authenticate a raw frame using AES-256-GCM.
 ///
 /// Returns `(header, plaintext_payload)` on success.
-fn decode_verify_frame_aead<A: AeadProvider + ?Sized, S: Sha256Provider + ?Sized>(
+fn decode_verify_frame<A: AeadProvider + ?Sized, S: Sha256Provider + ?Sized>(
     raw: &[u8],
     psk: &[u8; 32],
     aead: &A,
     sha: &S,
 ) -> NodeResult<(FrameHeader, Vec<u8>)> {
     let decoded =
-        decode_frame_aead(raw).map_err(|_| NodeError::MalformedPayload("frame decode failed"))?;
+        decode_frame(raw).map_err(|_| NodeError::MalformedPayload("frame decode failed"))?;
     let header = decoded.header.clone();
     let payload = open_frame(&decoded, psk, aead, sha).map_err(|_| NodeError::AuthFailure)?;
     Ok((header, payload))
 }
 
-/// AES-GCM variant of [`wake_command_exchange`].
+/// Authenticate and decode WAKE → COMMAND exchange.
 ///
 /// Encodes the WAKE frame with AES-256-GCM and decodes the COMMAND
 /// response using AEAD authentication instead of HMAC-SHA256.
 #[allow(clippy::too_many_arguments)]
-pub fn wake_command_exchange_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
+pub fn wake_command_exchange<T: Transport, A: AeadProvider, S: Sha256Provider>(
     transport: &mut T,
     identity: &NodeIdentity,
     wake_nonce: u64,
@@ -199,7 +199,7 @@ pub fn wake_command_exchange_aead<T: Transport, A: AeadProvider, S: Sha256Provid
         nonce: wake_nonce,
     };
 
-    let frame = encode_frame_aead(&header, &payload_cbor, &identity.psk, aead, sha)
+    let frame = encode_frame(&header, &payload_cbor, &identity.psk, aead, sha)
         .map_err(|_| NodeError::MalformedPayload("frame encode failed"))?;
 
     for attempt in 0..=WAKE_MAX_RETRIES {
@@ -217,8 +217,7 @@ pub fn wake_command_exchange_aead<T: Transport, A: AeadProvider, S: Sha256Provid
 
         match transport.recv(RESPONSE_TIMEOUT_MS)? {
             Some(raw_response) => {
-                match verify_and_decode_command_aead(&raw_response, identity, wake_nonce, aead, sha)
-                {
+                match verify_and_decode_command(&raw_response, identity, wake_nonce, aead, sha) {
                     Ok(result) => return Ok(result),
                     Err(e) => {
                         log::warn!("COMMAND verification failed: {} (ND-1009)", e);
@@ -233,15 +232,15 @@ pub fn wake_command_exchange_aead<T: Transport, A: AeadProvider, S: Sha256Provid
     Err(NodeError::WakeRetriesExhausted)
 }
 
-/// AES-GCM variant of [`verify_and_decode_command`].
-fn verify_and_decode_command_aead<A: AeadProvider, S: Sha256Provider>(
+/// Verify and decode a COMMAND frame.
+fn verify_and_decode_command<A: AeadProvider, S: Sha256Provider>(
     raw: &[u8],
     identity: &NodeIdentity,
     expected_nonce: u64,
     aead: &A,
     sha: &S,
 ) -> NodeResult<(u64, u64, CommandPayload)> {
-    let (header, payload) = decode_verify_frame_aead(raw, &identity.psk, aead, sha)?;
+    let (header, payload) = decode_verify_frame(raw, &identity.psk, aead, sha)?;
 
     if header.msg_type != MSG_COMMAND {
         return Err(NodeError::UnexpectedMsgType(header.msg_type));
@@ -269,8 +268,8 @@ fn verify_and_decode_command_aead<A: AeadProvider, S: Sha256Provider>(
     }
 }
 
-/// AES-GCM variant of [`send_app_data`].
-pub fn send_app_data_aead<
+/// Send APP_DATA frame.
+pub fn send_app_data<
     T: Transport + ?Sized,
     A: AeadProvider + ?Sized,
     S: Sha256Provider + ?Sized,
@@ -282,7 +281,7 @@ pub fn send_app_data_aead<
     aead: &A,
     sha: &S,
 ) -> NodeResult<()> {
-    if blob.len() > sonde_protocol::MAX_PAYLOAD_SIZE_AEAD {
+    if blob.len() > sonde_protocol::MAX_PAYLOAD_SIZE {
         return Err(NodeError::MalformedPayload(
             "APP_DATA blob exceeds frame payload budget",
         ));
@@ -297,7 +296,7 @@ pub fn send_app_data_aead<
         .encode()
         .map_err(|_| NodeError::MalformedPayload("APP_DATA message encode failed"))?;
 
-    if payload_cbor.len() > sonde_protocol::MAX_PAYLOAD_SIZE_AEAD {
+    if payload_cbor.len() > sonde_protocol::MAX_PAYLOAD_SIZE {
         return Err(NodeError::MalformedPayload(
             "APP_DATA payload exceeds frame payload budget",
         ));
@@ -309,7 +308,7 @@ pub fn send_app_data_aead<
         nonce: seq,
     };
 
-    let frame = encode_frame_aead(&header, &payload_cbor, &identity.psk, aead, sha)
+    let frame = encode_frame(&header, &payload_cbor, &identity.psk, aead, sha)
         .map_err(|_| NodeError::MalformedPayload("frame encode failed"))?;
 
     transport.send(&frame)?;
@@ -317,9 +316,9 @@ pub fn send_app_data_aead<
     Ok(())
 }
 
-/// AES-GCM variant of [`send_recv_app_data`].
+/// Send APP_DATA and wait for reply.
 #[allow(clippy::too_many_arguments)]
-pub fn send_recv_app_data_aead<
+pub fn send_recv_app_data<
     T: Transport + ?Sized,
     C: Clock + ?Sized,
     A: AeadProvider + ?Sized,
@@ -334,7 +333,7 @@ pub fn send_recv_app_data_aead<
     aead: &A,
     sha: &S,
 ) -> NodeResult<Vec<u8>> {
-    if blob.len() > sonde_protocol::MAX_PAYLOAD_SIZE_AEAD {
+    if blob.len() > sonde_protocol::MAX_PAYLOAD_SIZE {
         return Err(NodeError::MalformedPayload(
             "APP_DATA blob exceeds frame payload budget",
         ));
@@ -349,7 +348,7 @@ pub fn send_recv_app_data_aead<
         .encode()
         .map_err(|_| NodeError::MalformedPayload("APP_DATA message encode failed"))?;
 
-    if payload_cbor.len() > sonde_protocol::MAX_PAYLOAD_SIZE_AEAD {
+    if payload_cbor.len() > sonde_protocol::MAX_PAYLOAD_SIZE {
         return Err(NodeError::MalformedPayload(
             "APP_DATA payload exceeds frame payload budget",
         ));
@@ -361,7 +360,7 @@ pub fn send_recv_app_data_aead<
         nonce: seq,
     };
 
-    let frame = encode_frame_aead(&header, &payload_cbor, &identity.psk, aead, sha)
+    let frame = encode_frame(&header, &payload_cbor, &identity.psk, aead, sha)
         .map_err(|_| NodeError::MalformedPayload("frame encode failed"))?;
 
     transport.send(&frame)?;
@@ -377,7 +376,7 @@ pub fn send_recv_app_data_aead<
         match transport.recv(remaining)? {
             Some(raw_response) => {
                 let (hdr, payload) =
-                    match decode_verify_frame_aead(&raw_response, &identity.psk, aead, sha) {
+                    match decode_verify_frame(&raw_response, &identity.psk, aead, sha) {
                         Ok(result) => result,
                         Err(_) => continue,
                     };
@@ -405,8 +404,8 @@ pub fn send_recv_app_data_aead<
     }
 }
 
-/// AES-GCM variant of [`send_program_ack`].
-fn send_program_ack_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
+/// Send PROGRAM_ACK frame.
+fn send_program_ack<T: Transport, A: AeadProvider, S: Sha256Provider>(
     transport: &mut T,
     identity: &NodeIdentity,
     current_seq: &mut u64,
@@ -429,7 +428,7 @@ fn send_program_ack_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
         nonce: seq,
     };
 
-    let frame = encode_frame_aead(&header, &payload_cbor, &identity.psk, aead, sha)
+    let frame = encode_frame(&header, &payload_cbor, &identity.psk, aead, sha)
         .map_err(|_| NodeError::MalformedPayload("frame encode failed"))?;
 
     transport.send(&frame)?;
@@ -437,8 +436,8 @@ fn send_program_ack_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
     Ok(())
 }
 
-/// AES-GCM variant of [`verify_and_decode_chunk`].
-fn verify_and_decode_chunk_aead<A: AeadProvider, S: Sha256Provider>(
+///
+fn verify_and_decode_chunk<A: AeadProvider, S: Sha256Provider>(
     raw: &[u8],
     identity: &NodeIdentity,
     expected_seq: u64,
@@ -446,7 +445,7 @@ fn verify_and_decode_chunk_aead<A: AeadProvider, S: Sha256Provider>(
     aead: &A,
     sha: &S,
 ) -> NodeResult<Vec<u8>> {
-    let (header, payload) = decode_verify_frame_aead(raw, &identity.psk, aead, sha)?;
+    let (header, payload) = decode_verify_frame(raw, &identity.psk, aead, sha)?;
 
     if header.msg_type != MSG_CHUNK {
         return Err(NodeError::UnexpectedMsgType(header.msg_type));
@@ -476,9 +475,9 @@ fn verify_and_decode_chunk_aead<A: AeadProvider, S: Sha256Provider>(
     }
 }
 
-/// AES-GCM variant of [`get_chunk_with_retry`].
+///
 #[allow(clippy::too_many_arguments)]
-fn get_chunk_with_retry_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
+fn get_chunk_with_retry<T: Transport, A: AeadProvider, S: Sha256Provider>(
     transport: &mut T,
     identity: &NodeIdentity,
     current_seq: &mut u64,
@@ -505,7 +504,7 @@ fn get_chunk_with_retry_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
             nonce: attempt_seq,
         };
 
-        let frame = encode_frame_aead(&header, &payload_cbor, &identity.psk, aead, sha)
+        let frame = encode_frame(&header, &payload_cbor, &identity.psk, aead, sha)
             .map_err(|_| NodeError::MalformedPayload("frame encode failed"))?;
 
         transport.send(&frame)?;
@@ -518,7 +517,7 @@ fn get_chunk_with_retry_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
 
         match transport.recv(RESPONSE_TIMEOUT_MS)? {
             Some(raw_response) => {
-                match verify_and_decode_chunk_aead(
+                match verify_and_decode_chunk(
                     &raw_response,
                     identity,
                     attempt_seq,
@@ -544,9 +543,9 @@ fn get_chunk_with_retry_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
     Err(NodeError::ChunkTransferFailed { chunk_index })
 }
 
-/// AES-GCM variant of [`chunked_transfer`].
+/// Chunked program transfer.
 #[allow(clippy::too_many_arguments)]
-pub fn chunked_transfer_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
+pub fn chunked_transfer<T: Transport, A: AeadProvider, S: Sha256Provider>(
     transport: &mut T,
     identity: &NodeIdentity,
     current_seq: &mut u64,
@@ -582,7 +581,7 @@ pub fn chunked_transfer_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
 
     for ci in 0..chunk_count {
         let chunk_data =
-            get_chunk_with_retry_aead(transport, identity, current_seq, ci, clock, aead, sha)?;
+            get_chunk_with_retry(transport, identity, current_seq, ci, clock, aead, sha)?;
 
         if chunk_data.len() > chunk_size_usize {
             return Err(NodeError::MalformedPayload(
@@ -615,7 +614,7 @@ pub fn chunked_transfer_aead<T: Transport, A: AeadProvider, S: Sha256Provider>(
 /// `send()` / `send_recv()` helpers also produce AEAD-authenticated
 /// APP_DATA frames.
 #[allow(clippy::too_many_arguments)]
-pub fn run_wake_cycle_aead<T, S, I, A, H>(
+pub fn run_wake_cycle<T, S, I, A, H>(
     transport: &mut T,
     storage: &mut S,
     hal: &mut (dyn Hal + 'static),
@@ -673,7 +672,7 @@ where
     // phone — the node transmits it verbatim.
     if !storage.read_reg_complete() {
         if let Some(encrypted_payload) = storage.read_peer_payload() {
-            match peer_request_exchange_aead(
+            match peer_request_exchange(
                 transport,
                 storage,
                 &identity,
@@ -711,7 +710,7 @@ where
     let battery_mv = battery.battery_mv();
 
     // 6. Send WAKE, await COMMAND (with retries) via AEAD
-    let command_result = wake_command_exchange_aead(
+    let command_result = wake_command_exchange(
         transport,
         &identity,
         wake_nonce,
@@ -813,7 +812,7 @@ where
             };
 
             // Chunked transfer via AEAD
-            let transfer_result = chunked_transfer_aead(
+            let transfer_result = chunked_transfer(
                 transport,
                 &identity,
                 &mut current_seq,
@@ -845,7 +844,7 @@ where
                     match install_result {
                         Ok(program) => {
                             // PROGRAM_ACK via AEAD
-                            if send_program_ack_aead(
+                            if send_program_ack(
                                 transport,
                                 &identity,
                                 &mut current_seq,
@@ -925,7 +924,7 @@ where
         // SAFETY: all referenced objects are alive on this stack frame
         // and will not be moved until `_guard` is dropped below.
         unsafe {
-            crate::bpf_dispatch::install_aead(
+            crate::bpf_dispatch::install(
                 hal as *mut dyn crate::hal::Hal,
                 transport as *mut T as *mut dyn crate::traits::Transport,
                 map_storage as *mut MapStorage,
@@ -1278,14 +1277,14 @@ mod tests {
     mod aead_tests {
         use super::*;
         use crate::node_aead::NodeAead;
-        use sonde_protocol::{decode_frame_aead, encode_frame_aead, open_frame};
+        use sonde_protocol::{decode_frame, encode_frame, open_frame};
 
         /// Encode a COMMAND response using AES-GCM for test fixtures.
-        fn make_command_aead(psk: &[u8; 32], nonce: u64, payload: &CommandPayload) -> Vec<u8> {
-            make_command_aead_with_seq(psk, nonce, 1, 1000, payload)
+        fn make_command(psk: &[u8; 32], nonce: u64, payload: &CommandPayload) -> Vec<u8> {
+            make_command_with_seq(psk, nonce, 1, 1000, payload)
         }
 
-        fn make_command_aead_with_seq(
+        fn make_command_with_seq(
             psk: &[u8; 32],
             nonce: u64,
             starting_seq: u64,
@@ -1305,11 +1304,11 @@ mod tests {
                 msg_type: MSG_COMMAND,
                 nonce,
             };
-            encode_frame_aead(&header, &payload_cbor, psk, &aead, &sha).unwrap()
+            encode_frame(&header, &payload_cbor, psk, &aead, &sha).unwrap()
         }
 
         #[test]
-        fn wake_command_exchange_aead_round_trip() {
+        fn wake_command_exchange_round_trip() {
             let psk = [0x42u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
@@ -1318,10 +1317,10 @@ mod tests {
             let clock = MockClock;
             let mut transport = MockTransport::new();
 
-            let command_frame = make_command_aead(&psk, 42, &CommandPayload::Nop);
+            let command_frame = make_command(&psk, 42, &CommandPayload::Nop);
             transport.queue_response(Some(command_frame));
 
-            let result = wake_command_exchange_aead(
+            let result = wake_command_exchange(
                 &mut transport,
                 &identity,
                 42,
@@ -1340,14 +1339,14 @@ mod tests {
 
             // Verify outbound WAKE frame is AEAD-encoded
             assert_eq!(transport.outbound.len(), 1);
-            let decoded = decode_frame_aead(&transport.outbound[0]).unwrap();
+            let decoded = decode_frame(&transport.outbound[0]).unwrap();
             assert_eq!(decoded.header.msg_type, MSG_WAKE);
             let wake_payload = open_frame(&decoded, &psk, &aead, &sha).unwrap();
             assert!(!wake_payload.is_empty());
         }
 
         #[test]
-        fn send_app_data_aead_round_trip() {
+        fn send_app_data_round_trip() {
             let psk = [0x42u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
@@ -1357,21 +1356,21 @@ mod tests {
             let mut seq = 0u64;
 
             let blob = b"hello";
-            let result = send_app_data_aead(&mut transport, &identity, &mut seq, blob, &aead, &sha);
+            let result = send_app_data(&mut transport, &identity, &mut seq, blob, &aead, &sha);
 
             assert!(result.is_ok());
             assert_eq!(seq, 1);
             assert_eq!(transport.outbound.len(), 1);
 
             // Verify the outbound frame decrypts correctly
-            let decoded = decode_frame_aead(&transport.outbound[0]).unwrap();
+            let decoded = decode_frame(&transport.outbound[0]).unwrap();
             assert_eq!(decoded.header.msg_type, MSG_APP_DATA);
             let payload = open_frame(&decoded, &psk, &aead, &sha).unwrap();
             assert!(!payload.is_empty());
         }
 
         #[test]
-        fn send_recv_app_data_aead_round_trip() {
+        fn send_recv_app_data_round_trip() {
             let psk = [0x42u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
@@ -1391,11 +1390,10 @@ mod tests {
                 msg_type: MSG_APP_DATA_REPLY,
                 nonce: 0, // echoes the seq we'll send
             };
-            let reply_frame =
-                encode_frame_aead(&reply_header, &reply_cbor, &psk, &aead, &sha).unwrap();
+            let reply_frame = encode_frame(&reply_header, &reply_cbor, &psk, &aead, &sha).unwrap();
             transport.queue_response(Some(reply_frame));
 
-            let result = send_recv_app_data_aead(
+            let result = send_recv_app_data(
                 &mut transport,
                 &identity,
                 &mut seq,
@@ -1412,7 +1410,7 @@ mod tests {
         }
 
         #[test]
-        fn wrong_key_aead_fails() {
+        fn wrong_key_fails() {
             let psk = [0x42u8; 32];
             let wrong_psk = [0x99u8; 32];
             let sha = crate::crypto::SoftwareSha256;
@@ -1426,13 +1424,13 @@ mod tests {
             let mut transport = MockTransport::new();
 
             // Encode with correct PSK, but identity uses wrong PSK
-            let command_frame = make_command_aead(&psk, 42, &CommandPayload::Nop);
+            let command_frame = make_command(&psk, 42, &CommandPayload::Nop);
             transport.queue_response(Some(command_frame.clone()));
             transport.queue_response(Some(command_frame.clone()));
             transport.queue_response(Some(command_frame.clone()));
             transport.queue_response(Some(command_frame));
 
-            let result = wake_command_exchange_aead(
+            let result = wake_command_exchange(
                 &mut transport,
                 &identity,
                 42,
@@ -1450,7 +1448,7 @@ mod tests {
         }
 
         #[test]
-        fn send_program_ack_aead_succeeds() {
+        fn send_program_ack_succeeds() {
             let psk = [0x42u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
@@ -1459,7 +1457,7 @@ mod tests {
             let mut transport = MockTransport::new();
             let mut seq = 5u64;
 
-            let result = send_program_ack_aead(
+            let result = send_program_ack(
                 &mut transport,
                 &identity,
                 &mut seq,
@@ -1472,7 +1470,7 @@ mod tests {
             assert_eq!(seq, 6);
             assert_eq!(transport.outbound.len(), 1);
 
-            let decoded = decode_frame_aead(&transport.outbound[0]).unwrap();
+            let decoded = decode_frame(&transport.outbound[0]).unwrap();
             assert_eq!(decoded.header.msg_type, MSG_PROGRAM_ACK);
             assert_eq!(decoded.header.nonce, 5);
         }
@@ -1480,7 +1478,7 @@ mod tests {
         // --- AEAD chunked transfer tests ---
 
         /// Build a CHUNK response frame using AEAD encryption.
-        fn build_chunk_response_aead(
+        fn build_chunk_response(
             psk: &[u8; 32],
             echo_seq: u64,
             chunk_index: u32,
@@ -1498,11 +1496,11 @@ mod tests {
                 msg_type: MSG_CHUNK,
                 nonce: echo_seq,
             };
-            encode_frame_aead(&header, &payload_cbor, psk, &aead, &sha).unwrap()
+            encode_frame(&header, &payload_cbor, psk, &aead, &sha).unwrap()
         }
 
         #[test]
-        fn chunked_transfer_aead_success() {
+        fn chunked_transfer_success() {
             let psk = [0x22u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
@@ -1530,11 +1528,11 @@ mod tests {
                     .unwrap()
                     .to_vec();
                 let seq = starting_seq + i as u64;
-                let chunk_frame = build_chunk_response_aead(&psk, seq, i, &chunk_data);
+                let chunk_frame = build_chunk_response(&psk, seq, i, &chunk_data);
                 transport.queue_response(Some(chunk_frame));
             }
 
-            let result = chunked_transfer_aead(
+            let result = chunked_transfer(
                 &mut transport,
                 &identity,
                 &mut current_seq,
@@ -1552,7 +1550,7 @@ mod tests {
         }
 
         #[test]
-        fn chunked_transfer_aead_retry_exhausted() {
+        fn chunked_transfer_retry_exhausted() {
             let psk = [0x33u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
@@ -1567,7 +1565,7 @@ mod tests {
                 transport.queue_response(None);
             }
 
-            let result = chunked_transfer_aead(
+            let result = chunked_transfer(
                 &mut transport,
                 &identity,
                 &mut current_seq,
@@ -1584,7 +1582,7 @@ mod tests {
         }
 
         #[test]
-        fn chunked_transfer_aead_wrong_chunk_index() {
+        fn chunked_transfer_wrong_chunk_index() {
             let psk = [0x44u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
@@ -1595,13 +1593,13 @@ mod tests {
             let mut current_seq = 200u64;
 
             // Respond with wrong chunk index (5 instead of 0), then timeouts
-            let bad_chunk = build_chunk_response_aead(&psk, current_seq, 5, &[0u8; 10]);
+            let bad_chunk = build_chunk_response(&psk, current_seq, 5, &[0u8; 10]);
             transport.queue_response(Some(bad_chunk));
             transport.queue_response(None);
             transport.queue_response(None);
             transport.queue_response(None);
 
-            let result = chunked_transfer_aead(
+            let result = chunked_transfer(
                 &mut transport,
                 &identity,
                 &mut current_seq,
@@ -1620,16 +1618,16 @@ mod tests {
             );
         }
 
-        // --- AEAD end-to-end run_wake_cycle_aead tests ---
+        // --- end-to-end run_wake_cycle tests ---
 
         #[test]
-        fn run_wake_cycle_aead_nop() {
+        fn run_wake_cycle_nop() {
             let psk = [0x42u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
             let key_hint = sonde_protocol::key_hint_from_psk(&psk, &sha);
 
-            let command_frame = make_command_aead(&psk, 1, &CommandPayload::Nop);
+            let command_frame = make_command(&psk, 1, &CommandPayload::Nop);
             let mut transport = MockTransport::new();
             transport.queue_response(Some(command_frame));
 
@@ -1640,7 +1638,7 @@ mod tests {
             let mut interp = MockBpfInterpreter::new();
             let mut map_storage = MapStorage::new(DEFAULT_MAP_BUDGET);
 
-            let outcome = run_wake_cycle_aead(
+            let outcome = run_wake_cycle(
                 &mut transport,
                 &mut storage,
                 &mut hal,
@@ -1659,7 +1657,7 @@ mod tests {
         }
 
         #[test]
-        fn run_wake_cycle_aead_update_program() {
+        fn run_wake_cycle_update_program() {
             let psk = [0x22u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
@@ -1679,7 +1677,7 @@ mod tests {
 
             let starting_seq = 5000u64;
 
-            let command_frame = make_command_aead_with_seq(
+            let command_frame = make_command_with_seq(
                 &psk,
                 1, // echoes WAKE nonce (MockRng returns 1)
                 starting_seq,
@@ -1699,7 +1697,7 @@ mod tests {
                     .unwrap()
                     .to_vec();
                 let seq = starting_seq + i as u64;
-                let chunk_frame = build_chunk_response_aead(&psk, seq, i, &chunk_data);
+                let chunk_frame = build_chunk_response(&psk, seq, i, &chunk_data);
                 transport.queue_response(Some(chunk_frame));
             }
 
@@ -1710,7 +1708,7 @@ mod tests {
             let mut interp = MockBpfInterpreter::new();
             let mut map_storage = MapStorage::new(DEFAULT_MAP_BUDGET);
 
-            let outcome = run_wake_cycle_aead(
+            let outcome = run_wake_cycle(
                 &mut transport,
                 &mut storage,
                 &mut hal,
@@ -1733,7 +1731,7 @@ mod tests {
         }
 
         #[test]
-        fn run_wake_cycle_aead_wrong_msg_type_discarded() {
+        fn run_wake_cycle_wrong_msg_type_discarded() {
             let psk = [0x42u8; 32];
             let sha = crate::crypto::SoftwareSha256;
             let aead = NodeAead;
@@ -1750,7 +1748,7 @@ mod tests {
                 msg_type: MSG_CHUNK, // wrong type for COMMAND phase
                 nonce: 1,
             };
-            let wrong_frame = encode_frame_aead(&header, &wrong_cbor, &psk, &aead, &sha).unwrap();
+            let wrong_frame = encode_frame(&header, &wrong_cbor, &psk, &aead, &sha).unwrap();
 
             let mut transport = MockTransport::new();
             // All responses are wrong → retries exhausted → sleep
@@ -1766,7 +1764,7 @@ mod tests {
             let mut interp = MockBpfInterpreter::new();
             let mut map_storage = MapStorage::new(DEFAULT_MAP_BUDGET);
 
-            let outcome = run_wake_cycle_aead(
+            let outcome = run_wake_cycle(
                 &mut transport,
                 &mut storage,
                 &mut hal,

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -46,7 +46,7 @@ struct AppState {
     phase: Arc<Mutex<String>>,
     logs: Arc<Mutex<Vec<String>>>,
     /// Phase 1 AEAD artifacts, held in memory for Phase 2 provisioning.
-    pairing_artifacts: Mutex<Option<Arc<phase1::PairingArtifactsAead>>>,
+    pairing_artifacts: Mutex<Option<Arc<phase1::PairingArtifacts>>>,
 }
 
 /// Reports Phase 1 sub-phase transitions to the UI via the shared `phase` mutex.
@@ -218,14 +218,8 @@ async fn pair_gateway(
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = BtleplugTransport::new().await?;
             let rng = OsRng;
-            phase1::pair_with_gateway_aead(
-                &mut transport,
-                &rng,
-                &addr,
-                &phone_label,
-                Some(&progress),
-            )
-            .await
+            phase1::pair_with_gateway(&mut transport, &rng, &addr, &phone_label, Some(&progress))
+                .await
         })
     })
     .await
@@ -236,7 +230,7 @@ async fn pair_gateway(
             // Persist to file store so provisioning works across app restarts.
             let store = FilePairingStore::new().map_err(|e| e.to_string())?;
             store
-                .save_artifacts_aead(&artifacts)
+                .save_artifacts(&artifacts)
                 .map_err(|e| e.to_string())?;
             *state.pairing_artifacts.lock().unwrap() = Some(Arc::new(artifacts));
             *state.phase.lock().unwrap() = "Complete".into();
@@ -272,7 +266,7 @@ async fn provision_node(
         let mut guard = state.pairing_artifacts.lock().unwrap();
         if guard.is_none() {
             let store = FilePairingStore::new().map_err(|e| e.to_string())?;
-            match store.load_artifacts_aead() {
+            match store.load_artifacts() {
                 Ok(Some(loaded)) => {
                     *guard = Some(Arc::new(loaded));
                 }
@@ -291,8 +285,7 @@ async fn provision_node(
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = BtleplugTransport::new().await?;
             let rng = OsRng;
-            phase2::provision_node_aead(&mut transport, &artifacts, &rng, &addr, &node_id, &[])
-                .await
+            phase2::provision_node(&mut transport, &artifacts, &rng, &addr, &node_id, &[]).await
         })
     })
     .await
@@ -317,7 +310,7 @@ fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus
     let mut paired = state.pairing_artifacts.lock().unwrap().is_some();
     if !paired {
         let store = FilePairingStore::new().map_err(|e| e.to_string())?;
-        match store.load_artifacts_aead() {
+        match store.load_artifacts() {
             Ok(Some(_)) => paired = true,
             Ok(None) => {}
             Err(e) => return Err(format!("failed to check pairing status: {e}")),
@@ -334,7 +327,7 @@ fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus
 fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
     *state.pairing_artifacts.lock().unwrap() = None;
     let store = FilePairingStore::new().map_err(|e| e.to_string())?;
-    store.clear_aead().map_err(|e| e.to_string())?;
+    store.clear().map_err(|e| e.to_string())?;
     *state.phase.lock().unwrap() = "Idle".into();
     Ok(())
 }
@@ -439,14 +432,8 @@ async fn pair_gateway(
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = AndroidBleTransport::from_cached_vm()?;
             let rng = OsRng;
-            phase1::pair_with_gateway_aead(
-                &mut transport,
-                &rng,
-                &addr,
-                &phone_label,
-                Some(&progress),
-            )
-            .await
+            phase1::pair_with_gateway(&mut transport, &rng, &addr, &phone_label, Some(&progress))
+                .await
         })
     })
     .await
@@ -496,8 +483,7 @@ async fn provision_node(
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = AndroidBleTransport::from_cached_vm()?;
             let rng = OsRng;
-            phase2::provision_node_aead(&mut transport, &artifacts, &rng, &addr, &node_id, &[])
-                .await
+            phase2::provision_node(&mut transport, &artifacts, &rng, &addr, &node_id, &[]).await
         })
     })
     .await

--- a/crates/sonde-pair/src/android_store.rs
+++ b/crates/sonde-pair/src/android_store.rs
@@ -158,9 +158,9 @@ impl AndroidPairingStore {
     }
 
     /// Save AEAD pairing artifacts to encrypted SharedPreferences.
-    pub fn save_artifacts_aead(
+    pub fn save_artifacts(
         &mut self,
-        artifacts: &crate::phase1::PairingArtifactsAead,
+        artifacts: &crate::phase1::PairingArtifacts,
     ) -> Result<(), PairingError> {
         self.vm.attach_current_thread(|env| {
             let store = self.store.as_obj();
@@ -181,9 +181,7 @@ impl AndroidPairingStore {
     }
 
     /// Load AEAD pairing artifacts from encrypted SharedPreferences.
-    pub fn load_artifacts_aead(
-        &self,
-    ) -> Result<Option<crate::phase1::PairingArtifactsAead>, PairingError> {
+    pub fn load_artifacts(&self) -> Result<Option<crate::phase1::PairingArtifacts>, PairingError> {
         self.vm
             .attach_current_thread(|env| {
                 let store = self.store.as_obj();
@@ -206,7 +204,7 @@ impl AndroidPairingStore {
                     PairingError::StoreLoadFailed("phone_psk: expected 32 bytes".into())
                 })?;
 
-                Ok(Some(crate::phase1::PairingArtifactsAead {
+                Ok(Some(crate::phase1::PairingArtifacts {
                     phone_psk: Zeroizing::new(psk),
                     phone_key_hint: phone_key_hint as u16,
                     rf_channel: rf_channel as u8,

--- a/crates/sonde-pair/src/crypto.rs
+++ b/crates/sonde-pair/src/crypto.rs
@@ -104,7 +104,7 @@ impl sonde_protocol::AeadProvider for PairAead {
 ///    AES-256-GCM encryption with `phone_psk`).
 ///
 /// The returned blob is what the node stores and forwards verbatim.
-pub fn encrypt_pairing_request_aead(
+pub fn encrypt_pairing_request(
     phone_psk: &[u8; 32],
     pairing_request_cbor: &[u8],
 ) -> Result<Vec<u8>, PairingError> {
@@ -147,7 +147,7 @@ pub fn encrypt_pairing_request_aead(
         nonce: frame_nonce,
     };
 
-    sonde_protocol::encode_frame_aead(&header, &cbor_buf, phone_psk, &aead, &sha)
+    sonde_protocol::encode_frame(&header, &cbor_buf, phone_psk, &aead, &sha)
         .map_err(|_| PairingError::EncryptionFailed("frame encode failed".into()))
 }
 
@@ -158,7 +158,7 @@ pub fn encrypt_pairing_request_aead(
 /// authentication fails.
 ///
 /// The AAD is fixed to `"sonde-pairing-v2"` for domain separation.
-pub fn decrypt_pairing_request_aead(
+pub fn decrypt_pairing_request(
     phone_psk: &[u8; 32],
     encrypted_payload: &[u8],
 ) -> Option<Zeroizing<Vec<u8>>> {
@@ -239,7 +239,7 @@ mod aead_tests {
     fn open_frame_and_extract_inner(phone_psk: &[u8; 32], frame: &[u8]) -> Vec<u8> {
         let sha = PairSha256;
         let aead = PairAead;
-        let decoded = sonde_protocol::decode_frame_aead(frame).expect("decode_frame_aead failed");
+        let decoded = sonde_protocol::decode_frame(frame).expect("decode_frame failed");
         let cbor_payload = sonde_protocol::open_frame(&decoded, phone_psk, &aead, &sha)
             .expect("open_frame failed");
         let cbor: ciborium::Value =
@@ -253,18 +253,18 @@ mod aead_tests {
 
     /// Round-trip: encrypt then decrypt must recover the original plaintext.
     #[test]
-    fn pairing_request_aead_round_trip() {
+    fn pairing_request_round_trip() {
         let psk = [0x42u8; 32];
         let plaintext = b"pairing request CBOR data for node-42";
 
-        let frame = encrypt_pairing_request_aead(&psk, plaintext).unwrap();
+        let frame = encrypt_pairing_request(&psk, plaintext).unwrap();
 
         // Verify it's a valid AEAD frame with PEER_REQUEST msg_type.
-        let decoded = sonde_protocol::decode_frame_aead(&frame).unwrap();
+        let decoded = sonde_protocol::decode_frame(&frame).unwrap();
         assert_eq!(decoded.header.msg_type, sonde_protocol::MSG_PEER_REQUEST);
 
         let inner = open_frame_and_extract_inner(&psk, &frame);
-        let decrypted = decrypt_pairing_request_aead(&psk, &inner);
+        let decrypted = decrypt_pairing_request(&psk, &inner);
         assert_eq!(
             decrypted.as_ref().map(|z| z.as_slice()),
             Some(plaintext.as_slice())
@@ -273,16 +273,16 @@ mod aead_tests {
 
     /// Wrong PSK must fail outer-frame decryption.
     #[test]
-    fn pairing_request_aead_wrong_psk_fails() {
+    fn pairing_request_wrong_psk_fails() {
         let psk = [0x42u8; 32];
         let wrong_psk = [0x43u8; 32];
         let plaintext = b"secret pairing request";
 
-        let frame = encrypt_pairing_request_aead(&psk, plaintext).unwrap();
+        let frame = encrypt_pairing_request(&psk, plaintext).unwrap();
 
         let sha = PairSha256;
         let aead = PairAead;
-        let decoded = sonde_protocol::decode_frame_aead(&frame).unwrap();
+        let decoded = sonde_protocol::decode_frame(&frame).unwrap();
         assert!(
             sonde_protocol::open_frame(&decoded, &wrong_psk, &aead, &sha).is_err(),
             "wrong PSK must fail outer-frame decryption"
@@ -291,18 +291,18 @@ mod aead_tests {
 
     /// Tampered frame must fail authentication.
     #[test]
-    fn pairing_request_aead_tampered_payload_fails() {
+    fn pairing_request_tampered_payload_fails() {
         let psk = [0x42u8; 32];
         let plaintext = b"original pairing request";
 
-        let mut frame = encrypt_pairing_request_aead(&psk, plaintext).unwrap();
+        let mut frame = encrypt_pairing_request(&psk, plaintext).unwrap();
         // Flip a byte in the ciphertext (after the 11-byte header)
         let flip_idx = sonde_protocol::HEADER_SIZE + 1;
         frame[flip_idx] ^= 0xFF;
 
         let sha = PairSha256;
         let aead = PairAead;
-        let decoded = sonde_protocol::decode_frame_aead(&frame).unwrap();
+        let decoded = sonde_protocol::decode_frame(&frame).unwrap();
         assert!(
             sonde_protocol::open_frame(&decoded, &psk, &aead, &sha).is_err(),
             "tampered ciphertext must fail authentication"
@@ -311,11 +311,11 @@ mod aead_tests {
 
     /// AAD binding: decrypting the inner payload with a different AAD must fail.
     #[test]
-    fn pairing_request_aead_wrong_aad_fails() {
+    fn pairing_request_wrong_aad_fails() {
         let psk = [0x42u8; 32];
         let plaintext = b"aad-bound payload";
 
-        let frame = encrypt_pairing_request_aead(&psk, plaintext).unwrap();
+        let frame = encrypt_pairing_request(&psk, plaintext).unwrap();
         let inner = open_frame_and_extract_inner(&psk, &frame);
 
         // Extract nonce and ciphertext_and_tag from inner payload
@@ -337,27 +337,27 @@ mod aead_tests {
 
     /// Payload too short (less than nonce + tag) must return None.
     #[test]
-    fn pairing_request_aead_short_payload_returns_none() {
+    fn pairing_request_short_payload_returns_none() {
         let psk = [0x42u8; 32];
         // 27 bytes < 12 nonce + 16 tag = 28 minimum
         let short = [0u8; 27];
-        assert!(decrypt_pairing_request_aead(&psk, &short).is_none());
+        assert!(decrypt_pairing_request(&psk, &short).is_none());
     }
 
     /// Empty plaintext round-trip: encrypt then decrypt an empty buffer.
     #[test]
-    fn pairing_request_aead_empty_plaintext_round_trip() {
+    fn pairing_request_empty_plaintext_round_trip() {
         let psk = [0x42u8; 32];
-        let frame = encrypt_pairing_request_aead(&psk, b"").unwrap();
+        let frame = encrypt_pairing_request(&psk, b"").unwrap();
 
         // Verify it's a valid frame
-        let decoded = sonde_protocol::decode_frame_aead(&frame).unwrap();
+        let decoded = sonde_protocol::decode_frame(&frame).unwrap();
         assert_eq!(decoded.header.msg_type, sonde_protocol::MSG_PEER_REQUEST);
 
         let inner = open_frame_and_extract_inner(&psk, &frame);
         // inner = nonce(12) + tag(16) = 28 bytes, no ciphertext
         assert_eq!(inner.len(), GCM_NONCE_LEN + GCM_TAG_LEN);
-        let decrypted = decrypt_pairing_request_aead(&psk, &inner);
+        let decrypted = decrypt_pairing_request(&psk, &inner);
         assert_eq!(
             decrypted.as_ref().map(|z| z.as_slice()),
             Some([].as_slice())
@@ -366,8 +366,8 @@ mod aead_tests {
 
     /// Empty payload must return None.
     #[test]
-    fn pairing_request_aead_empty_payload_returns_none() {
+    fn pairing_request_empty_payload_returns_none() {
         let psk = [0x42u8; 32];
-        assert!(decrypt_pairing_request_aead(&psk, &[]).is_none());
+        assert!(decrypt_pairing_request(&psk, &[]).is_none());
     }
 }

--- a/crates/sonde-pair/src/file_store.rs
+++ b/crates/sonde-pair/src/file_store.rs
@@ -47,7 +47,7 @@ pub trait PskProtector: Send + Sync {
 
     /// Remove any externally stored protected material.
     ///
-    /// Called by [`FilePairingStore::clear_aead`] after deleting the JSON file.
+    /// Called by [`FilePairingStore::clear`] after deleting the JSON file.
     /// The default implementation is a no-op, suitable for backends that
     /// store protected data inline (e.g., DPAPI blobs in the JSON file).
     fn clear_protected(&self) -> Result<(), PairingError> {
@@ -81,7 +81,7 @@ pub fn default_protector() -> Option<Box<dyn PskProtector>> {
 // ---------------------------------------------------------------------------
 
 #[derive(Serialize, Deserialize)]
-struct StoredAeadArtifacts {
+struct StoredArtifacts {
     phone_psk: String,
     phone_key_hint: u16,
     rf_channel: u8,
@@ -135,16 +135,16 @@ impl FilePairingStore {
     }
 
     /// Save AEAD pairing artifacts to a companion file (`pairing-aead.json`).
-    pub fn save_artifacts_aead(
+    pub fn save_artifacts(
         &self,
-        artifacts: &crate::phase1::PairingArtifactsAead,
+        artifacts: &crate::phase1::PairingArtifacts,
     ) -> Result<(), PairingError> {
         let aead_path = self.aead_path();
         if let Some(parent) = aead_path.parent() {
             fs::create_dir_all(parent).map_err(|e| PairingError::StoreSaveFailed(e.to_string()))?;
         }
 
-        let stored = StoredAeadArtifacts {
+        let stored = StoredArtifacts {
             phone_psk: to_hex(&*artifacts.phone_psk),
             phone_key_hint: artifacts.phone_key_hint,
             rf_channel: artifacts.rf_channel,
@@ -168,9 +168,7 @@ impl FilePairingStore {
     }
 
     /// Load AEAD pairing artifacts from the companion file.
-    pub fn load_artifacts_aead(
-        &self,
-    ) -> Result<Option<crate::phase1::PairingArtifactsAead>, PairingError> {
+    pub fn load_artifacts(&self) -> Result<Option<crate::phase1::PairingArtifacts>, PairingError> {
         let aead_path = self.aead_path();
         let bytes = match fs::read(&aead_path) {
             Ok(b) => b,
@@ -178,7 +176,7 @@ impl FilePairingStore {
             Err(e) => return Err(PairingError::StoreLoadFailed(e.to_string())),
         };
 
-        let stored: StoredAeadArtifacts = serde_json::from_slice(&bytes).map_err(|e| {
+        let stored: StoredArtifacts = serde_json::from_slice(&bytes).map_err(|e| {
             PairingError::StoreCorrupted(format!("{e}: delete or fix {}", aead_path.display()))
         })?;
 
@@ -195,7 +193,7 @@ impl FilePairingStore {
             ));
         }
 
-        Ok(Some(crate::phase1::PairingArtifactsAead {
+        Ok(Some(crate::phase1::PairingArtifacts {
             phone_psk: psk,
             phone_key_hint: expected_hint,
             rf_channel: stored.rf_channel,
@@ -204,7 +202,7 @@ impl FilePairingStore {
     }
 
     /// Clear AEAD artifacts file (`pairing-aead.json`).
-    pub fn clear_aead(&self) -> Result<(), PairingError> {
+    pub fn clear(&self) -> Result<(), PairingError> {
         let aead_path = self.aead_path();
         // Also remove any leftover temp file from a crashed save.
         let tmp_path = aead_path.with_extension("tmp");
@@ -279,13 +277,13 @@ fn default_path() -> Result<PathBuf, PairingError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::phase1::PairingArtifactsAead;
+    use crate::phase1::PairingArtifacts;
     use crate::validation::compute_key_hint;
     use tempfile::TempDir;
 
-    fn test_aead_artifacts() -> PairingArtifactsAead {
+    fn test_artifacts() -> PairingArtifacts {
         let psk = [0x42u8; 32];
-        PairingArtifactsAead {
+        PairingArtifacts {
             phone_psk: Zeroizing::new(psk),
             phone_key_hint: compute_key_hint(&psk),
             rf_channel: 6,
@@ -302,11 +300,11 @@ mod tests {
     #[test]
     fn aead_save_and_load_round_trip() {
         let (store, _dir) = temp_store();
-        let artifacts = test_aead_artifacts();
-        store.save_artifacts_aead(&artifacts).unwrap();
+        let artifacts = test_artifacts();
+        store.save_artifacts(&artifacts).unwrap();
 
         let loaded = store
-            .load_artifacts_aead()
+            .load_artifacts()
             .unwrap()
             .expect("should have artifacts");
         assert_eq!(*loaded.phone_psk, *artifacts.phone_psk);
@@ -318,24 +316,24 @@ mod tests {
     #[test]
     fn aead_load_missing_file_returns_none() {
         let (store, _dir) = temp_store();
-        assert!(store.load_artifacts_aead().unwrap().is_none());
+        assert!(store.load_artifacts().unwrap().is_none());
     }
 
     #[test]
     fn aead_clear_removes_file() {
         let (store, _dir) = temp_store();
-        store.save_artifacts_aead(&test_aead_artifacts()).unwrap();
+        store.save_artifacts(&test_artifacts()).unwrap();
         assert!(store.aead_path().exists());
 
-        store.clear_aead().unwrap();
+        store.clear().unwrap();
         assert!(!store.aead_path().exists());
-        assert!(store.load_artifacts_aead().unwrap().is_none());
+        assert!(store.load_artifacts().unwrap().is_none());
     }
 
     #[test]
     fn aead_clear_missing_file_is_ok() {
         let (store, _dir) = temp_store();
-        store.clear_aead().unwrap();
+        store.clear().unwrap();
     }
 
     #[test]

--- a/crates/sonde-pair/src/phase1.rs
+++ b/crates/sonde-pair/src/phase1.rs
@@ -12,7 +12,7 @@ use zeroize::Zeroizing;
 
 /// Callback for reporting Phase 1 sub-phase progress (PT-0701).
 ///
-/// ## AEAD flow (`pair_with_gateway_aead`)
+/// ## AEAD flow (`pair_with_gateway`)
 ///
 /// Transitions through these sub-phases in order:
 /// - `"Connecting"` — BLE connection and MTU negotiation
@@ -34,13 +34,13 @@ pub trait PairingProgress: Send + Sync {
 /// REGISTER_PHONE body: `phone_psk(32) ‖ label_len(1) ‖ label(0–64)`
 ///
 /// PHONE_REGISTERED body: `status(1) ‖ rf_channel(1) ‖ phone_key_hint(2 BE)`
-pub async fn pair_with_gateway_aead(
+pub async fn pair_with_gateway(
     transport: &mut dyn BleTransport,
     rng: &dyn RngProvider,
     device_address: &[u8; 6],
     phone_label: &str,
     progress: Option<&dyn PairingProgress>,
-) -> Result<PairingArtifactsAead, PairingError> {
+) -> Result<PairingArtifacts, PairingError> {
     if phone_label.len() > 64 {
         return Err(PairingError::InvalidPhoneLabel(format!(
             "phone label must be at most 64 bytes, got {}",
@@ -65,19 +65,19 @@ pub async fn pair_with_gateway_aead(
 
     enforce_lesc(transport).await?;
 
-    let result = do_pair_with_gateway_aead(transport, rng, phone_label, progress).await;
+    let result = do_pair_with_gateway(transport, rng, phone_label, progress).await;
 
     transport.disconnect().await.ok();
     result
 }
 
 /// Inner implementation for the AEAD Phase 1 flow.
-async fn do_pair_with_gateway_aead(
+async fn do_pair_with_gateway(
     transport: &mut dyn BleTransport,
     rng: &dyn RngProvider,
     phone_label: &str,
     progress: Option<&dyn PairingProgress>,
-) -> Result<PairingArtifactsAead, PairingError> {
+) -> Result<PairingArtifacts, PairingError> {
     // Step 2: Generate phone PSK
     if let Some(cb) = progress {
         cb.on_phase("Registering");
@@ -170,7 +170,7 @@ async fn do_pair_with_gateway_aead(
         return Err(PairingError::InvalidKeyHint);
     }
 
-    let artifacts = PairingArtifactsAead {
+    let artifacts = PairingArtifacts {
         phone_psk,
         phone_key_hint,
         rf_channel,
@@ -189,16 +189,16 @@ async fn do_pair_with_gateway_aead(
 ///
 /// Gateway authority derives solely from possession of the phone PSK.
 #[derive(Clone)]
-pub struct PairingArtifactsAead {
+pub struct PairingArtifacts {
     pub phone_psk: Zeroizing<[u8; 32]>,
     pub phone_key_hint: u16,
     pub rf_channel: u8,
     pub phone_label: String,
 }
 
-impl std::fmt::Debug for PairingArtifactsAead {
+impl std::fmt::Debug for PairingArtifacts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PairingArtifactsAead")
+        f.debug_struct("PairingArtifacts")
             .field("phone_key_hint", &self.phone_key_hint)
             .field("rf_channel", &self.rf_channel)
             .field("phone_label", &self.phone_label)
@@ -218,7 +218,7 @@ mod aead_phase1_tests {
     /// Build a mock PHONE_REGISTERED (AEAD) response.
     ///
     /// Wire format: `status(1) ‖ rf_channel(1) ‖ phone_key_hint(2 BE)`
-    fn build_phone_registered_aead(status: u8, rf_channel: u8, phone_psk: &[u8; 32]) -> Vec<u8> {
+    fn build_phone_registered(status: u8, rf_channel: u8, phone_psk: &[u8; 32]) -> Vec<u8> {
         let phone_key_hint = compute_key_hint(phone_psk);
         let mut body = Vec::with_capacity(4);
         body.push(status);
@@ -241,17 +241,12 @@ mod aead_phase1_tests {
             let rf_channel = 6u8;
 
             let mut transport = MockBleTransport::new(247);
-            transport.queue_response(Ok(build_phone_registered_aead(
-                0x00,
-                rf_channel,
-                &predicted_psk,
-            )));
+            transport.queue_response(Ok(build_phone_registered(0x00, rf_channel, &predicted_psk)));
 
             let device_addr = [0xAA; 6];
 
             let result =
-                pair_with_gateway_aead(&mut transport, &rng, &device_addr, "test-phone", None)
-                    .await;
+                pair_with_gateway(&mut transport, &rng, &device_addr, "test-phone", None).await;
             let artifacts = result.unwrap();
 
             assert_eq!(*artifacts.phone_psk, predicted_psk);
@@ -273,7 +268,7 @@ mod aead_phase1_tests {
             let mut transport = MockBleTransport::new(247);
             transport.queue_response(Ok(build_envelope(MSG_ERROR, &[0x02]).unwrap()));
 
-            let result = pair_with_gateway_aead(&mut transport, &rng, &[0xAA; 6], "", None).await;
+            let result = pair_with_gateway(&mut transport, &rng, &[0xAA; 6], "", None).await;
             assert!(matches!(
                 result,
                 Err(PairingError::RegistrationWindowClosed)
@@ -295,9 +290,9 @@ mod aead_phase1_tests {
             let label = "my-phone";
 
             let mut transport = MockBleTransport::new(247);
-            transport.queue_response(Ok(build_phone_registered_aead(0x00, 6, &predicted_psk)));
+            transport.queue_response(Ok(build_phone_registered(0x00, 6, &predicted_psk)));
 
-            pair_with_gateway_aead(&mut transport, &rng, &[0xAA; 6], label, None)
+            pair_with_gateway(&mut transport, &rng, &[0xAA; 6], label, None)
                 .await
                 .unwrap();
 
@@ -315,10 +310,10 @@ mod aead_phase1_tests {
         });
     }
 
-    /// AEAD Phase 1: `PairingArtifactsAead` Debug redacts PSK.
+    /// AEAD Phase 1: `PairingArtifacts` Debug redacts PSK.
     #[test]
     fn aead_artifacts_debug_redacts_psk() {
-        let artifacts = PairingArtifactsAead {
+        let artifacts = PairingArtifacts {
             phone_psk: Zeroizing::new([0x42u8; 32]),
             phone_key_hint: 0x1234,
             rf_channel: 6,

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -26,13 +26,13 @@ fn msg_type_name(t: u8) -> &'static str {
 ///
 /// The phone generates the node PSK, builds a PairingRequest CBOR, encrypts
 /// it with `phone_psk` via AES-256-GCM, and wraps it in a complete ESP-NOW
-/// PEER_REQUEST frame using [`crypto::encrypt_pairing_request_aead`].
+/// PEER_REQUEST frame using [`crypto::encrypt_pairing_request`].
 ///
 /// The node stores the frame verbatim and relays it to the gateway on its
 /// next wake cycle.
-pub async fn provision_node_aead(
+pub async fn provision_node(
     transport: &mut dyn BleTransport,
-    artifacts: &crate::phase1::PairingArtifactsAead,
+    artifacts: &crate::phase1::PairingArtifacts,
     rng: &dyn RngProvider,
     device_address: &[u8; 6],
     node_id: &str,
@@ -61,7 +61,7 @@ pub async fn provision_node_aead(
         encode_pairing_request(node_id, &node_psk, artifacts.rf_channel, sensors, timestamp)?;
 
     // Step 5: Encrypt with phone_psk and wrap in ESP-NOW AEAD PEER_REQUEST frame.
-    let encrypted_frame = crypto::encrypt_pairing_request_aead(&artifacts.phone_psk, &cbor)?;
+    let encrypted_frame = crypto::encrypt_pairing_request(&artifacts.phone_psk, &cbor)?;
 
     // Step 6: Connect to node
     debug!(address = ?device_address, "connecting to node (AEAD provision)");
@@ -79,7 +79,7 @@ pub async fn provision_node_aead(
 
     // Step 7: Build NODE_PROVISION payload (AEAD format per spec §6.6):
     // node_key_hint(2) || node_psk(32) || rf_channel(1) || payload_len(2) || encrypted_payload
-    let result = do_provision_node_aead(
+    let result = do_provision_node(
         transport,
         node_key_hint,
         &node_psk,
@@ -93,7 +93,7 @@ pub async fn provision_node_aead(
 }
 
 /// Inner implementation for AEAD node provisioning.
-async fn do_provision_node_aead(
+async fn do_provision_node(
     transport: &mut dyn BleTransport,
     node_key_hint: u16,
     node_psk: &[u8; 32],
@@ -195,10 +195,10 @@ mod tests {
     use crate::transport::MockBleTransport;
 
     #[tokio::test]
-    async fn provision_node_aead_happy_path() {
-        use crate::phase1::PairingArtifactsAead;
+    async fn provision_node_happy_path() {
+        use crate::phase1::PairingArtifacts;
 
-        let artifacts = PairingArtifactsAead {
+        let artifacts = PairingArtifacts {
             phone_psk: Zeroizing::new([0x55u8; 32]),
             phone_key_hint: compute_key_hint(&[0x55u8; 32]),
             rf_channel: 6,
@@ -217,7 +217,7 @@ mod tests {
         let mut transport = MockBleTransport::new(247);
         transport.queue_response(Ok(ack_envelope));
 
-        let result = provision_node_aead(
+        let result = provision_node(
             &mut transport,
             &artifacts,
             &rng,
@@ -227,10 +227,7 @@ mod tests {
         )
         .await;
 
-        assert!(
-            result.is_ok(),
-            "provision_node_aead should succeed: {result:?}"
-        );
+        assert!(result.is_ok(), "provision_node should succeed: {result:?}");
         assert_eq!(result.unwrap().status, NodeAckStatus::Success);
 
         // Verify NODE_PROVISION was written
@@ -241,10 +238,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provision_node_aead_mtu_too_low() {
-        use crate::phase1::PairingArtifactsAead;
+    async fn provision_node_mtu_too_low() {
+        use crate::phase1::PairingArtifacts;
 
-        let artifacts = PairingArtifactsAead {
+        let artifacts = PairingArtifacts {
             phone_psk: Zeroizing::new([0x55u8; 32]),
             phone_key_hint: compute_key_hint(&[0x55u8; 32]),
             rf_channel: 6,
@@ -254,7 +251,7 @@ mod tests {
         let rng = MockRng::new([0x42u8; 32]);
         let mut transport = MockBleTransport::new(100); // below BLE_MTU_MIN
 
-        let result = provision_node_aead(
+        let result = provision_node(
             &mut transport,
             &artifacts,
             &rng,
@@ -275,10 +272,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provision_node_aead_invalid_node_id() {
-        use crate::phase1::PairingArtifactsAead;
+    async fn provision_node_invalid_node_id() {
+        use crate::phase1::PairingArtifacts;
 
-        let artifacts = PairingArtifactsAead {
+        let artifacts = PairingArtifacts {
             phone_psk: Zeroizing::new([0x55u8; 32]),
             phone_key_hint: compute_key_hint(&[0x55u8; 32]),
             rf_channel: 6,
@@ -288,7 +285,7 @@ mod tests {
         let rng = MockRng::new([0x42u8; 32]);
         let mut transport = MockBleTransport::new(247);
 
-        let result = provision_node_aead(
+        let result = provision_node(
             &mut transport,
             &artifacts,
             &rng,

--- a/crates/sonde-protocol/fuzz/fuzz_targets/decode_frame.rs
+++ b/crates/sonde-protocol/fuzz/fuzz_targets/decode_frame.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 sonde contributors
 
-//! Fuzz target: decode_frame_aead with arbitrary bytes.
+//! Fuzz target: decode_frame with arbitrary bytes.
 //! The frame parser must never panic on any input.
 
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use sonde_protocol::decode_frame_aead;
+use sonde_protocol::decode_frame;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = decode_frame_aead(data);
+    let _ = decode_frame(data);
 });

--- a/crates/sonde-protocol/src/aead_codec.rs
+++ b/crates/sonde-protocol/src/aead_codec.rs
@@ -18,7 +18,7 @@
 use alloc::vec::Vec;
 
 use crate::constants::{
-    AEAD_TAG_SIZE, GCM_NONCE_SIZE, HEADER_SIZE, MAX_FRAME_SIZE, MIN_FRAME_SIZE_AEAD,
+    AEAD_TAG_SIZE, GCM_NONCE_SIZE, HEADER_SIZE, MAX_FRAME_SIZE, MIN_FRAME_SIZE,
 };
 use crate::error::{DecodeError, EncodeError};
 use crate::header::FrameHeader;
@@ -29,7 +29,7 @@ use crate::traits::{AeadProvider, Sha256Provider};
 /// Borrows the ciphertext+tag region directly from the raw frame to
 /// avoid an extra heap allocation on every received frame.
 #[derive(Debug, Clone)]
-pub struct DecodedFrameAead<'a> {
+pub struct DecodedFrame<'a> {
     pub header: FrameHeader,
     pub ciphertext_and_tag: &'a [u8],
 }
@@ -57,7 +57,7 @@ pub fn build_gcm_nonce(
 ///
 /// Returns `header(11B) ‖ ciphertext ‖ tag(16B)`.
 /// The 11-byte header is used as AAD (authenticated but not encrypted).
-pub fn encode_frame_aead(
+pub fn encode_frame(
     header: &FrameHeader,
     payload_cbor: &[u8],
     psk: &[u8; 32],
@@ -90,11 +90,11 @@ pub fn encode_frame_aead(
 /// Decode a raw AEAD frame into its components without decryption.
 ///
 /// Splits: `header(11B) | ciphertext+tag(rest)`.
-/// The returned [`DecodedFrameAead`] borrows the ciphertext+tag region
+/// The returned [`DecodedFrame`] borrows the ciphertext+tag region
 /// directly from `raw` (zero-copy).
 /// The caller must use [`open_frame`] to decrypt and authenticate.
-pub fn decode_frame_aead(raw: &[u8]) -> Result<DecodedFrameAead<'_>, DecodeError> {
-    if raw.len() < MIN_FRAME_SIZE_AEAD {
+pub fn decode_frame(raw: &[u8]) -> Result<DecodedFrame<'_>, DecodeError> {
+    if raw.len() < MIN_FRAME_SIZE {
         return Err(DecodeError::TooShort);
     }
     if raw.len() > MAX_FRAME_SIZE {
@@ -108,7 +108,7 @@ pub fn decode_frame_aead(raw: &[u8]) -> Result<DecodedFrameAead<'_>, DecodeError
 
     let ciphertext_and_tag = &raw[HEADER_SIZE..];
 
-    Ok(DecodedFrameAead {
+    Ok(DecodedFrame {
         header,
         ciphertext_and_tag,
     })
@@ -119,7 +119,7 @@ pub fn decode_frame_aead(raw: &[u8]) -> Result<DecodedFrameAead<'_>, DecodeError
 /// Returns the plaintext CBOR payload on success, or
 /// `DecodeError::AuthenticationFailed` if the GCM tag check fails.
 pub fn open_frame(
-    frame: &DecodedFrameAead<'_>,
+    frame: &DecodedFrame<'_>,
     psk: &[u8; 32],
     aead: &(impl AeadProvider + ?Sized),
     sha: &(impl Sha256Provider + ?Sized),
@@ -219,8 +219,8 @@ mod tests {
         let payload = vec![0xA1, 0x01, 0x02];
         let psk = [0x42u8; 32];
 
-        let raw = encode_frame_aead(&hdr, &payload, &psk, &StubAead, &StubSha256).unwrap();
-        let decoded = decode_frame_aead(&raw).unwrap();
+        let raw = encode_frame(&hdr, &payload, &psk, &StubAead, &StubSha256).unwrap();
+        let decoded = decode_frame(&raw).unwrap();
         assert_eq!(decoded.header.key_hint, 1);
         assert_eq!(decoded.header.msg_type, MSG_WAKE);
         assert_eq!(decoded.header.nonce, 42);
@@ -237,19 +237,19 @@ mod tests {
             nonce: 1,
         };
         let psk = [0x42u8; 32];
-        let mut raw = encode_frame_aead(&hdr, &[0xA0], &psk, &StubAead, &StubSha256).unwrap();
+        let mut raw = encode_frame(&hdr, &[0xA0], &psk, &StubAead, &StubSha256).unwrap();
         // Flip a bit in the tag (last byte).
         let last = raw.len() - 1;
         raw[last] ^= 0x01;
-        let decoded = decode_frame_aead(&raw).unwrap();
+        let decoded = decode_frame(&raw).unwrap();
         let result = open_frame(&decoded, &psk, &StubAead, &StubSha256);
         assert_eq!(result, Err(DecodeError::AuthenticationFailed));
     }
 
     #[test]
     fn too_short_frame() {
-        let short = vec![0u8; MIN_FRAME_SIZE_AEAD - 1];
-        let err = decode_frame_aead(&short).unwrap_err();
+        let short = vec![0u8; MIN_FRAME_SIZE - 1];
+        let err = decode_frame(&short).unwrap_err();
         assert!(matches!(err, DecodeError::TooShort));
     }
 
@@ -261,8 +261,8 @@ mod tests {
             nonce: 0,
         };
         let psk = [0x42u8; 32];
-        let payload = vec![0u8; MAX_PAYLOAD_SIZE_AEAD]; // 223
-        let raw = encode_frame_aead(&hdr, &payload, &psk, &StubAead, &StubSha256).unwrap();
+        let payload = vec![0u8; MAX_PAYLOAD_SIZE]; // 223
+        let raw = encode_frame(&hdr, &payload, &psk, &StubAead, &StubSha256).unwrap();
         assert_eq!(raw.len(), MAX_FRAME_SIZE);
     }
 
@@ -274,8 +274,8 @@ mod tests {
             nonce: 0,
         };
         let psk = [0x42u8; 32];
-        let big = vec![0u8; MAX_PAYLOAD_SIZE_AEAD + 1];
-        let err = encode_frame_aead(&hdr, &big, &psk, &StubAead, &StubSha256).unwrap_err();
+        let big = vec![0u8; MAX_PAYLOAD_SIZE + 1];
+        let err = encode_frame(&hdr, &big, &psk, &StubAead, &StubSha256).unwrap_err();
         assert!(matches!(err, EncodeError::FrameTooLarge));
     }
 
@@ -287,11 +287,11 @@ mod tests {
             nonce: 0,
         };
         let psk = [0x42u8; 32];
-        let raw = encode_frame_aead(&hdr, &[], &psk, &StubAead, &StubSha256).unwrap();
+        let raw = encode_frame(&hdr, &[], &psk, &StubAead, &StubSha256).unwrap();
         assert_eq!(raw.len(), HEADER_SIZE + AEAD_TAG_SIZE);
-        assert_eq!(raw.len(), MIN_FRAME_SIZE_AEAD);
+        assert_eq!(raw.len(), MIN_FRAME_SIZE);
 
-        let decoded = decode_frame_aead(&raw).unwrap();
+        let decoded = decode_frame(&raw).unwrap();
         let plaintext = open_frame(&decoded, &psk, &StubAead, &StubSha256).unwrap();
         assert!(plaintext.is_empty());
     }

--- a/crates/sonde-protocol/src/constants.rs
+++ b/crates/sonde-protocol/src/constants.rs
@@ -8,8 +8,8 @@ pub const MAX_FRAME_SIZE: usize = 250; // ESP-NOW reference
 // AES-256-GCM constants
 pub const AEAD_TAG_SIZE: usize = 16;
 pub const GCM_NONCE_SIZE: usize = 12;
-pub const MIN_FRAME_SIZE_AEAD: usize = HEADER_SIZE + AEAD_TAG_SIZE; // 27
-pub const MAX_PAYLOAD_SIZE_AEAD: usize = MAX_FRAME_SIZE - HEADER_SIZE - AEAD_TAG_SIZE; // 223
+pub const MIN_FRAME_SIZE: usize = HEADER_SIZE + AEAD_TAG_SIZE; // 27
+pub const MAX_PAYLOAD_SIZE: usize = MAX_FRAME_SIZE - HEADER_SIZE - AEAD_TAG_SIZE; // 223
 
 // Header offsets
 pub const OFFSET_KEY_HINT: usize = 0;

--- a/crates/sonde-protocol/src/lib.rs
+++ b/crates/sonde-protocol/src/lib.rs
@@ -16,9 +16,7 @@ pub mod modem;
 pub mod program_image;
 pub mod traits;
 
-pub use aead_codec::{
-    build_gcm_nonce, decode_frame_aead, encode_frame_aead, open_frame, DecodedFrameAead,
-};
+pub use aead_codec::{build_gcm_nonce, decode_frame, encode_frame, open_frame, DecodedFrame};
 pub use ble_envelope::{encode_ble_envelope, parse_ble_envelope};
 pub use chunk::{chunk_count, get_chunk};
 pub use constants::*;

--- a/crates/sonde-protocol/tests/validation.rs
+++ b/crates/sonde-protocol/tests/validation.rs
@@ -1904,8 +1904,8 @@ mod aead_tests {
         let payload = vec![0xA1, 0x01, 0x02];
         let psk = [0x42u8; 32];
 
-        let raw = encode_frame_aead(&hdr, &payload, &psk, &SoftwareAead, &SoftwareSha256).unwrap();
-        let decoded = decode_frame_aead(&raw).unwrap();
+        let raw = encode_frame(&hdr, &payload, &psk, &SoftwareAead, &SoftwareSha256).unwrap();
+        let decoded = decode_frame(&raw).unwrap();
         assert_eq!(decoded.header.key_hint, 1);
         assert_eq!(decoded.header.msg_type, MSG_WAKE);
         assert_eq!(decoded.header.nonce, 42);
@@ -1923,8 +1923,8 @@ mod aead_tests {
         };
         let psk_a = [0x42u8; 32];
         let psk_b = [0x24u8; 32];
-        let raw = encode_frame_aead(&hdr, &[0xA0], &psk_a, &SoftwareAead, &SoftwareSha256).unwrap();
-        let decoded = decode_frame_aead(&raw).unwrap();
+        let raw = encode_frame(&hdr, &[0xA0], &psk_a, &SoftwareAead, &SoftwareSha256).unwrap();
+        let decoded = decode_frame(&raw).unwrap();
         let result = open_frame(&decoded, &psk_b, &SoftwareAead, &SoftwareSha256);
         assert_eq!(result, Err(DecodeError::AuthenticationFailed));
     }
@@ -1937,7 +1937,7 @@ mod aead_tests {
             nonce: 1,
         };
         let psk = [0x42u8; 32];
-        let mut raw = encode_frame_aead(
+        let mut raw = encode_frame(
             &hdr,
             &[0xA1, 0x01, 0x02],
             &psk,
@@ -1947,7 +1947,7 @@ mod aead_tests {
         .unwrap();
         // Flip one bit in the ciphertext portion (byte right after header).
         raw[HEADER_SIZE] ^= 0x01;
-        let decoded = decode_frame_aead(&raw).unwrap();
+        let decoded = decode_frame(&raw).unwrap();
         let result = open_frame(&decoded, &psk, &SoftwareAead, &SoftwareSha256);
         assert_eq!(result, Err(DecodeError::AuthenticationFailed));
     }
@@ -1960,11 +1960,10 @@ mod aead_tests {
             nonce: 1,
         };
         let psk = [0x42u8; 32];
-        let mut raw =
-            encode_frame_aead(&hdr, &[0xA0], &psk, &SoftwareAead, &SoftwareSha256).unwrap();
+        let mut raw = encode_frame(&hdr, &[0xA0], &psk, &SoftwareAead, &SoftwareSha256).unwrap();
         // Flip one bit in the header (msg_type byte) — header is AAD.
         raw[2] ^= 0x01;
-        let decoded = decode_frame_aead(&raw).unwrap();
+        let decoded = decode_frame(&raw).unwrap();
         let result = open_frame(&decoded, &psk, &SoftwareAead, &SoftwareSha256);
         assert_eq!(result, Err(DecodeError::AuthenticationFailed));
     }
@@ -1977,12 +1976,11 @@ mod aead_tests {
             nonce: 1,
         };
         let psk = [0x42u8; 32];
-        let mut raw =
-            encode_frame_aead(&hdr, &[0xA0], &psk, &SoftwareAead, &SoftwareSha256).unwrap();
+        let mut raw = encode_frame(&hdr, &[0xA0], &psk, &SoftwareAead, &SoftwareSha256).unwrap();
         // Flip one bit in the GCM tag (last byte).
         let last = raw.len() - 1;
         raw[last] ^= 0x01;
-        let decoded = decode_frame_aead(&raw).unwrap();
+        let decoded = decode_frame(&raw).unwrap();
         let result = open_frame(&decoded, &psk, &SoftwareAead, &SoftwareSha256);
         assert_eq!(result, Err(DecodeError::AuthenticationFailed));
     }
@@ -2007,8 +2005,8 @@ mod aead_tests {
 
     #[test]
     fn aead_payload_capacity() {
-        assert_eq!(MAX_PAYLOAD_SIZE_AEAD, 223);
+        assert_eq!(MAX_PAYLOAD_SIZE, 223);
         assert_eq!(AEAD_TAG_SIZE, 16);
-        assert_eq!(MIN_FRAME_SIZE_AEAD, HEADER_SIZE + AEAD_TAG_SIZE);
+        assert_eq!(MIN_FRAME_SIZE, HEADER_SIZE + AEAD_TAG_SIZE);
     }
 }

--- a/docs/audits/aead-migration-maintenance-audit.md
+++ b/docs/audits/aead-migration-maintenance-audit.md
@@ -210,7 +210,7 @@ After removing ~15 000 lines of HMAC/ECDH code across PRs #624–#629, do any ar
 | **Category** | D11 (test-to-validation traceability) |
 | **Location** | `docs/node-validation.md` lines 1843–1845, 1913 |
 | **Description** | The "Implementing Tests" traceability table references test functions that no longer exist: `t_e2e_002_hmac_round_trip`, `test_invalid_hmac_discarded`, `test_outbound_frame_format`, `t_e2e_003_wrong_psk_rejected` (no such e2e test name), `t_e2e_040_unknown_node`, `t_e2e_053_bridged_wrong_psk`, `t_n941_exchange_peer_ack_corrupted_hmac_discarded`, `peer_ack_tampered_hmac`. None of these function names appear in the current codebase. |
-| **Evidence** | `grep -rn "t_e2e_002_hmac\|test_invalid_hmac\|test_outbound_frame_format\|peer_ack_tampered_hmac" crates/` → 0 hits. The AEAD E2E tests use `t_e2e_050_aead_nop_wake_cycle`, `t_e2e_052_aead_wrong_psk_rejected`, etc. Node tests use `wake_command_exchange_aead_round_trip`, `verify_peer_ack_aead_valid`, etc. |
+| **Evidence** | `grep -rn "t_e2e_002_hmac\|test_invalid_hmac\|test_outbound_frame_format\|peer_ack_tampered_hmac" crates/` → 0 hits. The AEAD E2E tests use `t_e2e_050_nop_wake_cycle`, `t_e2e_052_wrong_psk_rejected`, etc. Node tests use `wake_command_exchange_round_trip`, `verify_peer_ack_valid`, etc. |
 | **Root Cause** | Test functions were renamed during AEAD migration but the validation traceability table was not updated. |
 | **Impact** | The traceability table reports false coverage — it claims tests exist that don't. This makes gap analysis unreliable. |
 | **Confidence** | Certain |
@@ -273,8 +273,8 @@ After removing ~15 000 lines of HMAC/ECDH code across PRs #624–#629, do any ar
 | **Severity** | Low |
 | **Category** | D6 (design consistency) |
 | **Location** | `docs/protocol-crate-design.md` lines 148, 174 |
-| **Description** | The design document shows function signatures `pub fn encode_frame(...)` and `pub fn decode_frame(...)`. The actual functions in code are `encode_frame_aead` and `decode_frame_aead`. However, the design doc describes AES-256-GCM semantics correctly (lines 152–159, 171–181), suggesting it was partially updated but the function names were not changed to match the `_aead` suffix in the implementation. |
-| **Evidence** | `protocol-crate-design.md:148` — `pub fn encode_frame(`. Code: `crates/sonde-protocol/src/aead_codec.rs:60` — `pub fn encode_frame_aead(`. |
+| **Description** | The design document shows function signatures `pub fn encode_frame(...)` and `pub fn decode_frame(...)`. The actual functions in code are `encode_frame` and `decode_frame`. However, the design doc describes AES-256-GCM semantics correctly (lines 152–159, 171–181), suggesting it was partially updated but the function names were not changed to match the `_aead` suffix in the implementation. |
+| **Evidence** | `protocol-crate-design.md:148` — `pub fn encode_frame(`. Code: `crates/sonde-protocol/src/aead_codec.rs:60` — `pub fn encode_frame(`. |
 | **Root Cause** | The design doc describes the target API (without `_aead` suffix, as the eventual name post-migration). The code uses `_aead` suffix during the transition period. This is an intentional naming divergence, but creates traceability confusion. |
 | **Impact** | Low — the protocol-crate-validation.md references `encode_frame()` / `decode_frame()` / `open_frame()` consistently with the design, so internal consistency is maintained. The code diverges. |
 | **Confidence** | High |
@@ -306,7 +306,7 @@ After removing ~15 000 lines of HMAC/ECDH code across PRs #624–#629, do any ar
 | **Category** | D5 (cross-document consistency) |
 | **Location** | `docs/audits/round2/gateway-code-compliance.md` line 524 |
 | **Description** | The GW-0603 compliance row says "43-byte overhead (11 header + 32 HMAC)". Post-AEAD, the overhead is 27 bytes (11 header + 16 GCM tag). The requirement itself was updated in `gateway-requirements.md`, but the audit table was not. |
-| **Evidence** | Line 524: `"sonde_protocol — 43-byte overhead (11 header + 32 HMAC)"`. Actual: `MIN_FRAME_SIZE_AEAD = HEADER_SIZE + AEAD_TAG_SIZE = 11 + 16 = 27`. |
+| **Evidence** | Line 524: `"sonde_protocol — 43-byte overhead (11 header + 32 HMAC)"`. Actual: `MIN_FRAME_SIZE = HEADER_SIZE + AEAD_TAG_SIZE = 11 + 16 = 27`. |
 | **Root Cause** | Same as F-007. |
 | **Impact** | Misleading overhead calculation could affect future capacity planning. |
 | **Confidence** | Certain |
@@ -345,7 +345,7 @@ All 16 findings share a common root cause: **the AEAD migration PRs (#624–#629
 |----|---------|--------|--------|
 | R-07 | F-007–F-009, F-013, F-016 | Add "⚠️ Pre-AEAD migration snapshot" banner to all round-1 and round-2 audit docs | Small |
 | R-08 | F-005 | Test removing direct `hmac` dep; remove if `pbkdf2_hmac` still compiles | Trivial |
-| R-09 | F-014 | Rename `encode_frame_aead`/`decode_frame_aead`/`open_frame_aead` → drop `_aead` suffix now that HMAC codec is fully removed | Medium |
+| R-09 | F-014 | Rename `encode_frame`/`decode_frame`/`open_frame` → drop `_aead` suffix now that HMAC codec is fully removed | Medium |
 
 ### Follow-up issue (Phase 2 cleanup)
 
@@ -368,7 +368,7 @@ All 16 findings share a common root cause: **the AEAD migration PRs (#624–#629
 
 1. **Should `GatewayIdentity` be removed now or deferred?** The BLE pairing protocol still uses `REQUEST_GW_INFO`/`GW_INFO_RESPONSE` in the E2E tests even though the protocol doc marks them RETIRED. Is there a production deployment that still relies on Phase 1a? If not, removal should be prioritized.
 
-2. **Should `_aead` function suffixes be dropped?** The design doc uses `encode_frame`/`decode_frame` (no suffix) and the code uses `encode_frame_aead`/`decode_frame_aead`. With HMAC codec fully deleted, there's no ambiguity — the `_aead` suffix is redundant. But renaming touches every call site. Is this worth the churn?
+2. **Should `_aead` function suffixes be dropped?** The design doc uses `encode_frame`/`decode_frame` (no suffix) and the code uses `encode_frame`/`decode_frame`. With HMAC codec fully deleted, there's no ambiguity — the `_aead` suffix is redundant. But renaming touches every call site. Is this worth the churn?
 
 3. **Is the `hmac` crate still needed as a direct dep for `pbkdf2_hmac`?** The `pbkdf2` crate may or may not re-export `hmac`. This needs a compile test.
 

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -30,7 +30,7 @@ sonde/
 │   │       ├── lib.rs
 │   │       ├── constants.rs      # msg_type codes, CBOR keys, frame sizes
 │   │       ├── header.rs         # FrameHeader (de)serialization
-│   │       ├── aead_codec.rs      # encode_frame_aead, decode_frame_aead, open_frame
+│   │       ├── aead_codec.rs      # encode_frame, decode_frame, open_frame
 │   │       ├── messages.rs       # NodeMessage, GatewayMessage enums
 │   │       ├── program_image.rs  # ProgramImage, MapDef, deterministic encoding
 │   │       ├── chunk.rs          # chunk_count, get_chunk
@@ -185,7 +185,7 @@ sonde-protocol  (no_std + alloc, no platform deps)
 | 1.2 | `error.rs` | `EncodeError`, `DecodeError` enums | Compile check |
 | 1.3 | `traits.rs` | `AeadProvider`, `Sha256Provider` traits | Compile check |
 | 1.4 | `header.rs` | `FrameHeader` with `to_bytes`/`from_bytes` | T-P001 to T-P004 |
-| 1.5 | `aead_codec.rs — `encode_frame_aead`, `decode_frame_aead`, `open_frame`` | T-P010 to T-P019 |
+| 1.5 | `aead_codec.rs — `encode_frame`, `decode_frame`, `open_frame`` | T-P010 to T-P019 |
 | 1.6 | `messages.rs` | `NodeMessage`, `GatewayMessage` with CBOR encode/decode | T-P020 to T-P032 |
 | 1.7 | `program_image.rs` | `ProgramImage`, `MapDef`, deterministic encoding, `program_hash` | T-P040 to T-P046 |
 | 1.8 | `chunk.rs` | `chunk_count`, `get_chunk` | T-P050 to T-P053 |

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -175,7 +175,7 @@ The protocol codec is provided by the shared `sonde-protocol` crate (see § Shar
 
 ### 5.1  Frame construction
 
-Uses `sonde_protocol::encode_frame_aead()` with a constructed `FrameHeader`, the node's PSK, and the node's AEAD and SHA-256 implementations:
+Uses `sonde_protocol::encode_frame()` with a constructed `FrameHeader`, the node's PSK, and the node's AEAD and SHA-256 implementations:
 
 ```rust
 let header = sonde_protocol::FrameHeader {
@@ -183,7 +183,7 @@ let header = sonde_protocol::FrameHeader {
     msg_type,
     nonce: nonce_or_seq,
 };
-let frame = sonde_protocol::encode_frame_aead(
+let frame = sonde_protocol::encode_frame(
     &header, &payload_cbor, psk, &aead_impl, &sha_impl,
 );
 ```
@@ -192,7 +192,7 @@ The hardware AES-GCM implementation wraps the ESP-IDF AES peripheral behind the 
 
 ### 5.2  Frame verification (inbound)
 
-Uses `sonde_protocol::decode_frame_aead()` and `sonde_protocol::open_frame()`:
+Uses `sonde_protocol::decode_frame()` and `sonde_protocol::open_frame()`:
 
 1. Attempt AES-256-GCM authenticated decryption using the node's PSK.
 2. If decryption fails (authentication tag mismatch) → discard.
@@ -670,7 +670,7 @@ The `sonde-protocol` crate is a `no_std`-compatible Rust library shared between 
 | Component | Description |
 |---|---|
 | **Constants** | `msg_type` codes, command codes, CBOR key numbers, frame sizes, AEAD tag size |
-| **Frame codec** | `encode_frame_aead()`, `decode_frame_aead()`, `open_frame()`, header parsing at fixed offsets |
+| **Frame codec** | `encode_frame()`, `decode_frame()`, `open_frame()`, header parsing at fixed offsets |
 | **CBOR messages** | `NodeMessage` and `GatewayMessage` enums with typed fields; CBOR encode/decode using integer keys |
 | **Program image** | `ProgramImage` and `MapDef` structs; CBOR deterministic encode/decode |
 | **AEAD trait** | `AeadProvider` trait — platform provides the implementation |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -613,10 +613,10 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 **Procedure:**
 1. Install a program that calls `send([0xAA, 0xBB])`.
-2. Run wake cycle with AEAD providers installed (via `install_aead`).
+2. Run wake cycle with AEAD providers installed (via `install`).
 3. Capture the outbound APP_DATA frame from the transport.
 4. Assert: the frame has the AEAD wire format (11B header + ciphertext + 16B GCM tag), NOT the legacy format (11B header + plaintext + 32B tag).
-5. Assert: `decode_frame_aead()` + `open_frame()` successfully decrypts the frame using the node's PSK.
+5. Assert: `decode_frame()` + `open_frame()` successfully decrypts the frame using the node's PSK.
 6. Assert: the decrypted CBOR contains AppData with blob `[0xAA, 0xBB]`.
 
 ---
@@ -1840,9 +1840,9 @@ Test functions in `crates/sonde-node/src/` are unit tests; those in `crates/sond
 | T-N207 | `test_unknown_command_treated_as_nop` | wake_cycle.rs |
 | T-N208 | `test_set_next_wake_shorter`, `test_set_next_wake_equal` *(partial — unit tests cover SleepManager clamping logic; the full e2e set_next_wake → base-interval-restore cycle is not yet tested)* | sleep.rs |
 | T-N209 | `test_set_next_wake_longer_clamped` | sleep.rs |
-| T-N300 | `wake_command_exchange_aead_round_trip`, `t_e2e_050_aead_nop_wake_cycle` | wake_cycle.rs, aead_e2e_tests.rs |
-| T-N301 | `t_e2e_052_aead_wrong_psk_rejected`, `t_e2e_053_aead_tampered_frame_discarded` | aead_e2e_tests.rs |
-| T-N302 | `wake_command_exchange_aead_round_trip`, `t_e2e_050_aead_nop_wake_cycle` | wake_cycle.rs, aead_e2e_tests.rs |
+| T-N300 | `wake_command_exchange_round_trip`, `t_e2e_050_nop_wake_cycle` | wake_cycle.rs, aead_e2e_tests.rs |
+| T-N301 | `t_e2e_052_wrong_psk_rejected`, `t_e2e_053_tampered_frame_discarded` | aead_e2e_tests.rs |
+| T-N302 | `wake_command_exchange_round_trip`, `t_e2e_050_nop_wake_cycle` | wake_cycle.rs, aead_e2e_tests.rs |
 | T-N303 | `test_wrong_nonce_discarded`, `test_send_recv_app_data_wrong_nonce` | wake_cycle.rs |
 | T-N304 | `test_wrong_seq_on_chunk_discarded` | wake_cycle.rs |
 | T-N305 | `test_sequence_increment_correctness`, `t_e2e_041_sequence_numbers` | wake_cycle.rs, e2e_tests.rs |
@@ -1910,7 +1910,7 @@ Test functions in `crates/sonde-node/src/` are unit tests; those in `crates/sond
 | T-N927 | `t_n927_rng_health_check_failure_aborts` | wake_cycle.rs |
 | T-N929 | `t_n929_write_to_read_only_context_silently_ignored` | sonde_bpf_adapter.rs |
 | T-N940 | `t_n940_payload_len_exceeds_remaining_data`, `t_n940_payload_len_max_u16_rejected` | ble_pairing.rs |
-| T-N941 | `verify_peer_ack_aead_valid`, `verify_peer_ack_aead_wrong_nonce`, `verify_peer_ack_aead_wrong_key` | peer_request.rs |
+| T-N941 | `verify_peer_ack_valid`, `verify_peer_ack_wrong_nonce`, `verify_peer_ack_wrong_key` | peer_request.rs |
 | T-N1016 | *(hardware — validated on target: GPIO state after sleep preparation)* | — |
 
 > **Note:** Spec cases marked *(hardware — validated on target)* require the

--- a/docs/protocol-crate-design.md
+++ b/docs/protocol-crate-design.md
@@ -43,9 +43,9 @@ The crate is `#![no_std]` by default, with `alloc` for heap types (`Vec<u8>`). B
 // Frame structure
 pub const HEADER_SIZE: usize = 11;
 pub const AEAD_TAG_SIZE: usize = 16;
-pub const MIN_FRAME_SIZE_AEAD: usize = HEADER_SIZE + AEAD_TAG_SIZE; // 27
+pub const MIN_FRAME_SIZE: usize = HEADER_SIZE + AEAD_TAG_SIZE; // 27
 pub const MAX_FRAME_SIZE: usize = 250;  // ESP-NOW reference
-pub const MAX_PAYLOAD_SIZE_AEAD: usize = MAX_FRAME_SIZE - HEADER_SIZE - AEAD_TAG_SIZE; // 223
+pub const MAX_PAYLOAD_SIZE: usize = MAX_FRAME_SIZE - HEADER_SIZE - AEAD_TAG_SIZE; // 223
 
 // Header offsets
 pub const OFFSET_KEY_HINT: usize = 0;


### PR DESCRIPTION
Closes #633 #634 #635 #636

Renames all \_aead\-suffixed functions/types now that HMAC is gone, adds pre-AEAD banners to historical audit docs, removes unused \hmac\ dep.

40 files, -226 net lines.