### PR TITLE
feat: add GPIO pin mapping to bundle hardware profile

### DIFF
--- a/crates/sonde-bundle/src/manifest.rs
+++ b/crates/sonde-bundle/src/manifest.rs
@@ -107,13 +107,33 @@ pub struct NodeTarget {
     pub hardware: Option<HardwareProfile>,
 }
 
-/// Hardware profile describing physical sensors on a node.
+/// Hardware profile describing physical sensors and pin assignments on a node.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HardwareProfile {
     #[serde(default)]
     pub sensors: Vec<SensorDescriptor>,
     #[serde(default)]
     pub rf_channel: Option<u8>,
+    /// GPIO pin mapping for the node's bus peripherals.
+    ///
+    /// Required when any sensor has `type: "i2c"`.  The pairing tool
+    /// provisions these values to the node via NODE_PROVISION (PT-1214,
+    /// ND-0608) so a single firmware binary works across boards.
+    #[serde(default)]
+    pub pins: Option<PinMap>,
+}
+
+/// GPIO pin mapping for a node's bus peripherals.
+///
+/// All fields are required when the struct is present.  GPIO numbers
+/// must be in the ESP32-C3 range (0–21) and `i2c0_sda` must differ
+/// from `i2c0_scl`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PinMap {
+    /// I2C bus 0 SDA GPIO number (0–21).
+    pub i2c0_sda: u8,
+    /// I2C bus 0 SCL GPIO number (0–21).
+    pub i2c0_scl: u8,
 }
 
 /// A sensor attached to a node.

--- a/crates/sonde-bundle/src/validate.rs
+++ b/crates/sonde-bundle/src/validate.rs
@@ -403,6 +403,39 @@ pub fn validate_manifest(manifest: &Manifest, source_dir: &Path) -> ValidationRe
                     });
                 }
             }
+
+            let has_i2c_sensor = hw.sensors.iter().any(|s| s.sensor_type == SensorType::I2c);
+
+            if let Some(ref pins) = hw.pins {
+                const MAX_GPIO: u8 = 21;
+                if pins.i2c0_sda > MAX_GPIO || pins.i2c0_scl > MAX_GPIO {
+                    result.errors.push(ValidationError {
+                        rule: "node.hardware.pins",
+                        message: format!(
+                            "node `{}`: GPIO pin number out of range (0–{}), got sda={}, scl={}",
+                            node.name, MAX_GPIO, pins.i2c0_sda, pins.i2c0_scl
+                        ),
+                    });
+                }
+                if pins.i2c0_sda == pins.i2c0_scl {
+                    result.errors.push(ValidationError {
+                        rule: "node.hardware.pins",
+                        message: format!(
+                            "node `{}`: `i2c0_sda` and `i2c0_scl` must be different GPIO pins, both are {}",
+                            node.name, pins.i2c0_sda
+                        ),
+                    });
+                }
+            } else if has_i2c_sensor {
+                result.errors.push(ValidationError {
+                    rule: "node.hardware.pins",
+                    message: format!(
+                        "node `{}`: `pins` with `i2c0_sda` and `i2c0_scl` required when I2C sensor is declared",
+                        node.name
+                    ),
+                });
+            }
+
             for sensor in &hw.sensors {
                 if let SensorType::Unknown(ref s) = sensor.sensor_type {
                     result.errors.push(ValidationError {
@@ -809,6 +842,7 @@ mod tests {
         m.nodes[0].hardware = Some(HardwareProfile {
             sensors: vec![],
             rf_channel: Some(14),
+            pins: None,
         });
         let r = validate_manifest(&m, dir.path());
         assert!(!r.is_valid());
@@ -827,6 +861,10 @@ mod tests {
                 label: Some("x".repeat(65)),
             }],
             rf_channel: None,
+            pins: Some(PinMap {
+                i2c0_sda: 4,
+                i2c0_scl: 5,
+            }),
         });
         let r = validate_manifest(&m, dir.path());
         assert!(!r.is_valid());
@@ -972,6 +1010,153 @@ mod tests {
             r.is_valid(),
             "valid working_dir should pass: {:?}",
             r.errors
+        );
+    }
+
+    #[test]
+    fn test_pins_required_when_i2c_sensor_declared() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_test_dir(dir.path());
+        let mut m = minimal_manifest();
+        m.nodes[0].hardware = Some(HardwareProfile {
+            sensors: vec![SensorDescriptor {
+                sensor_type: SensorType::I2c,
+                id: 0x48,
+                label: None,
+            }],
+            rf_channel: None,
+            pins: None,
+        });
+        let r = validate_manifest(&m, dir.path());
+        assert!(!r.is_valid());
+        assert!(r
+            .errors
+            .iter()
+            .any(|e| e.message.contains("pins") && e.message.contains("I2C")));
+    }
+
+    #[test]
+    fn test_pin_sda_equals_scl_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_test_dir(dir.path());
+        let mut m = minimal_manifest();
+        m.nodes[0].hardware = Some(HardwareProfile {
+            sensors: vec![SensorDescriptor {
+                sensor_type: SensorType::I2c,
+                id: 0x48,
+                label: None,
+            }],
+            rf_channel: None,
+            pins: Some(PinMap {
+                i2c0_sda: 4,
+                i2c0_scl: 4,
+            }),
+        });
+        let r = validate_manifest(&m, dir.path());
+        assert!(!r.is_valid());
+        assert!(r
+            .errors
+            .iter()
+            .any(|e| e.message.contains("different GPIO pins")));
+    }
+
+    #[test]
+    fn test_pin_gpio_out_of_range_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_test_dir(dir.path());
+        let mut m = minimal_manifest();
+        m.nodes[0].hardware = Some(HardwareProfile {
+            sensors: vec![SensorDescriptor {
+                sensor_type: SensorType::I2c,
+                id: 0x48,
+                label: None,
+            }],
+            rf_channel: None,
+            pins: Some(PinMap {
+                i2c0_sda: 22,
+                i2c0_scl: 5,
+            }),
+        });
+        let r = validate_manifest(&m, dir.path());
+        assert!(!r.is_valid());
+        assert!(r.errors.iter().any(|e| e.message.contains("out of range")));
+    }
+
+    #[test]
+    fn test_pins_valid_with_i2c_sensor() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_test_dir(dir.path());
+        let mut m = minimal_manifest();
+        m.nodes[0].hardware = Some(HardwareProfile {
+            sensors: vec![SensorDescriptor {
+                sensor_type: SensorType::I2c,
+                id: 0x48,
+                label: None,
+            }],
+            rf_channel: None,
+            pins: Some(PinMap {
+                i2c0_sda: 4,
+                i2c0_scl: 5,
+            }),
+        });
+        let r = validate_manifest(&m, dir.path());
+        assert!(
+            r.is_valid(),
+            "valid I2C sensor with pins should pass: {:?}",
+            r.errors
+        );
+    }
+
+    #[test]
+    fn test_pins_without_i2c_sensor_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_test_dir(dir.path());
+        let mut m = minimal_manifest();
+        m.nodes[0].hardware = Some(HardwareProfile {
+            sensors: vec![],
+            rf_channel: None,
+            pins: Some(PinMap {
+                i2c0_sda: 4,
+                i2c0_scl: 5,
+            }),
+        });
+        let r = validate_manifest(&m, dir.path());
+        assert!(
+            r.is_valid(),
+            "pins without I2C sensor should be allowed: {:?}",
+            r.errors
+        );
+    }
+
+    #[test]
+    fn test_partial_pins_missing_scl_rejected_at_parse() {
+        let yaml = r#"
+schema_version: 1
+name: test-app
+version: "0.1.0"
+programs:
+  - name: test-prog
+    path: bpf/test.elf
+    profile: resident
+nodes:
+  - name: node-1
+    program: test-prog
+    hardware:
+      pins:
+        i2c0_sda: 4
+      sensors:
+        - type: i2c
+          id: 0x48
+"#;
+        let result = Manifest::from_yaml(yaml);
+        assert!(
+            result.is_err(),
+            "partial pins (missing i2c0_scl) should fail deserialization"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("i2c0_scl"),
+            "error should mention missing field i2c0_scl, got: {err}"
         );
     }
 }

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -285,7 +285,8 @@ async fn provision_node(
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = BtleplugTransport::new().await?;
             let rng = OsRng;
-            phase2::provision_node(&mut transport, &artifacts, &rng, &addr, &node_id, &[]).await
+            phase2::provision_node(&mut transport, &artifacts, &rng, &addr, &node_id, &[], None)
+                .await
         })
     })
     .await
@@ -483,7 +484,8 @@ async fn provision_node(
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = AndroidBleTransport::from_cached_vm()?;
             let rng = OsRng;
-            phase2::provision_node(&mut transport, &artifacts, &rng, &addr, &node_id, &[]).await
+            phase2::provision_node(&mut transport, &artifacts, &rng, &addr, &node_id, &[], None)
+                .await
         })
     })
     .await

--- a/crates/sonde-pair/src/error.rs
+++ b/crates/sonde-pair/src/error.rs
@@ -98,6 +98,9 @@ pub enum PairingError {
     #[error("invalid node ID: {0}")]
     InvalidNodeId(String),
 
+    #[error("invalid pin config: {0}")]
+    InvalidPinConfig(String),
+
     #[error("invalid RF channel {0}: must be 1-13")]
     InvalidRfChannel(u8),
 

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -37,9 +37,27 @@ pub async fn provision_node(
     device_address: &[u8; 6],
     node_id: &str,
     sensors: &[crate::types::SensorDescriptor],
+    pin_config: Option<PinConfig>,
 ) -> Result<NodeProvisionResult, PairingError> {
     // Step 1: Validate node_id
     validate_node_id(node_id)?;
+
+    // Step 1a: Validate pin config (PT-1214 AC 5, AC 6)
+    if let Some(ref pc) = pin_config {
+        const MAX_GPIO: u8 = 21;
+        if pc.i2c0_sda > MAX_GPIO || pc.i2c0_scl > MAX_GPIO {
+            return Err(PairingError::InvalidPinConfig(format!(
+                "GPIO pin number out of range (0–{}), got sda={}, scl={}",
+                MAX_GPIO, pc.i2c0_sda, pc.i2c0_scl
+            )));
+        }
+        if pc.i2c0_sda == pc.i2c0_scl {
+            return Err(PairingError::InvalidPinConfig(format!(
+                "i2c0_sda and i2c0_scl must be different GPIO pins, both are {}",
+                pc.i2c0_sda
+            )));
+        }
+    }
 
     // Step 2: Generate node PSK
     let mut node_psk = Zeroizing::new([0u8; 32]);
@@ -85,6 +103,7 @@ pub async fn provision_node(
         &node_psk,
         artifacts.rf_channel,
         &encrypted_frame,
+        pin_config,
     )
     .await;
 
@@ -99,6 +118,7 @@ async fn do_provision_node(
     node_psk: &[u8; 32],
     rf_channel: u8,
     encrypted_frame: &[u8],
+    pin_config: Option<PinConfig>,
 ) -> Result<NodeProvisionResult, PairingError> {
     if encrypted_frame.len() > PEER_PAYLOAD_MAX_LEN {
         return Err(PairingError::PayloadTooLarge {
@@ -108,13 +128,38 @@ async fn do_provision_node(
     }
     let payload_len = encrypted_frame.len() as u16;
 
-    let mut provision_payload =
-        Zeroizing::new(Vec::with_capacity(2 + 32 + 1 + 2 + encrypted_frame.len()));
+    // Pin config CBOR {1: u8, 2: u8} is at most 7 bytes (map(2) + 2×(uint,uint)).
+    let pin_cbor_capacity = if pin_config.is_some() { 7 } else { 0 };
+
+    let mut provision_payload = Zeroizing::new(Vec::with_capacity(
+        2 + 32 + 1 + 2 + encrypted_frame.len() + pin_cbor_capacity,
+    ));
     provision_payload.extend_from_slice(&node_key_hint.to_be_bytes());
     provision_payload.extend_from_slice(node_psk);
     provision_payload.push(rf_channel);
     provision_payload.extend_from_slice(&payload_len.to_be_bytes());
     provision_payload.extend_from_slice(encrypted_frame);
+
+    // Append optional pin config CBOR (PT-1214, ND-0608)
+    if let Some(pc) = pin_config {
+        let pin_cbor = ciborium::Value::Map(vec![
+            (
+                ciborium::Value::Integer(1.into()),
+                ciborium::Value::Integer(pc.i2c0_sda.into()),
+            ),
+            (
+                ciborium::Value::Integer(2.into()),
+                ciborium::Value::Integer(pc.i2c0_scl.into()),
+            ),
+        ]);
+        ciborium::into_writer(&pin_cbor, &mut *provision_payload)
+            .map_err(|e| PairingError::CborEncodeFailed(format!("pin_config: {e}")))?;
+        trace!(
+            sda = pc.i2c0_sda,
+            scl = pc.i2c0_scl,
+            "appended pin config CBOR to NODE_PROVISION"
+        );
+    }
 
     let message = Zeroizing::new(build_envelope(NODE_PROVISION, &provision_payload).ok_or(
         PairingError::PayloadTooLarge {
@@ -224,6 +269,7 @@ mod tests {
             &[0xAA; 6],
             "test-node",
             &[],
+            None,
         )
         .await;
 
@@ -258,6 +304,7 @@ mod tests {
             &[0xAA; 6],
             "test-node",
             &[],
+            None,
         )
         .await;
 
@@ -292,12 +339,211 @@ mod tests {
             &[0xAA; 6],
             "", // empty node_id
             &[],
+            None,
         )
         .await;
 
         assert!(
             matches!(result, Err(PairingError::InvalidNodeId(_))),
             "expected InvalidNodeId, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn provision_node_pin_config_appended() {
+        use crate::phase1::PairingArtifacts;
+
+        let artifacts = PairingArtifacts {
+            phone_psk: Zeroizing::new([0x55u8; 32]),
+            phone_key_hint: compute_key_hint(&[0x55u8; 32]),
+            rf_channel: 6,
+            phone_label: "test".into(),
+        };
+
+        let rng = MockRng::new([0x42u8; 32]);
+
+        let ack_body = [0x00u8];
+        let mut ack_envelope = Vec::new();
+        ack_envelope.push(NODE_ACK);
+        ack_envelope.extend_from_slice(&(ack_body.len() as u16).to_be_bytes());
+        ack_envelope.extend_from_slice(&ack_body);
+
+        let mut transport = MockBleTransport::new(247);
+        transport.queue_response(Ok(ack_envelope));
+
+        let pc = PinConfig {
+            i2c0_sda: 4,
+            i2c0_scl: 5,
+        };
+
+        let result = provision_node(
+            &mut transport,
+            &artifacts,
+            &rng,
+            &[0xAA; 6],
+            "test-node",
+            &[],
+            Some(pc),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "provision with pin_config should succeed: {result:?}"
+        );
+
+        assert_eq!(transport.written.len(), 1);
+        let (_svc, _chr, data) = &transport.written[0];
+        let body = &data[3..];
+        let payload_len = u16::from_be_bytes([body[35], body[36]]) as usize;
+        let pin_cbor_start = 37 + payload_len;
+        assert!(
+            body.len() > pin_cbor_start,
+            "body should have trailing CBOR"
+        );
+
+        let trailing = &body[pin_cbor_start..];
+        let value: ciborium::Value = ciborium::from_reader(trailing).expect("valid CBOR");
+        let map = value.as_map().expect("CBOR map");
+        let sda = map
+            .iter()
+            .find(|(k, _)| *k == ciborium::Value::Integer(1.into()))
+            .expect("key 1")
+            .1
+            .as_integer()
+            .unwrap();
+        let scl = map
+            .iter()
+            .find(|(k, _)| *k == ciborium::Value::Integer(2.into()))
+            .expect("key 2")
+            .1
+            .as_integer()
+            .unwrap();
+        assert_eq!(i128::from(sda), 4);
+        assert_eq!(i128::from(scl), 5);
+    }
+
+    #[tokio::test]
+    async fn provision_node_pin_config_none_no_trailing() {
+        use crate::phase1::PairingArtifacts;
+
+        let artifacts = PairingArtifacts {
+            phone_psk: Zeroizing::new([0x55u8; 32]),
+            phone_key_hint: compute_key_hint(&[0x55u8; 32]),
+            rf_channel: 6,
+            phone_label: "test".into(),
+        };
+
+        let rng = MockRng::new([0x42u8; 32]);
+
+        let ack_body = [0x00u8];
+        let mut ack_envelope = Vec::new();
+        ack_envelope.push(NODE_ACK);
+        ack_envelope.extend_from_slice(&(ack_body.len() as u16).to_be_bytes());
+        ack_envelope.extend_from_slice(&ack_body);
+
+        let mut transport = MockBleTransport::new(247);
+        transport.queue_response(Ok(ack_envelope));
+
+        let result = provision_node(
+            &mut transport,
+            &artifacts,
+            &rng,
+            &[0xAA; 6],
+            "test-node",
+            &[],
+            None,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "provision without pin_config should succeed: {result:?}"
+        );
+
+        let (_svc, _chr, data) = &transport.written[0];
+        let body = &data[3..];
+        let payload_len = u16::from_be_bytes([body[35], body[36]]) as usize;
+        assert_eq!(
+            body.len(),
+            37 + payload_len,
+            "no trailing bytes when pin_config is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn provision_node_pin_config_out_of_range() {
+        use crate::phase1::PairingArtifacts;
+
+        let artifacts = PairingArtifacts {
+            phone_psk: Zeroizing::new([0x55u8; 32]),
+            phone_key_hint: compute_key_hint(&[0x55u8; 32]),
+            rf_channel: 6,
+            phone_label: "test".into(),
+        };
+
+        let rng = MockRng::new([0x42u8; 32]);
+        let mut transport = MockBleTransport::new(247);
+
+        let result = provision_node(
+            &mut transport,
+            &artifacts,
+            &rng,
+            &[0xAA; 6],
+            "test-node",
+            &[],
+            Some(PinConfig {
+                i2c0_sda: 22,
+                i2c0_scl: 5,
+            }),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(PairingError::InvalidPinConfig(_))),
+            "expected InvalidPinConfig, got {result:?}"
+        );
+        assert!(
+            transport.written.is_empty(),
+            "no BLE writes on validation failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn provision_node_pin_config_sda_equals_scl() {
+        use crate::phase1::PairingArtifacts;
+
+        let artifacts = PairingArtifacts {
+            phone_psk: Zeroizing::new([0x55u8; 32]),
+            phone_key_hint: compute_key_hint(&[0x55u8; 32]),
+            rf_channel: 6,
+            phone_label: "test".into(),
+        };
+
+        let rng = MockRng::new([0x42u8; 32]);
+        let mut transport = MockBleTransport::new(247);
+
+        let result = provision_node(
+            &mut transport,
+            &artifacts,
+            &rng,
+            &[0xAA; 6],
+            "test-node",
+            &[],
+            Some(PinConfig {
+                i2c0_sda: 4,
+                i2c0_scl: 4,
+            }),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(PairingError::InvalidPinConfig(_))),
+            "expected InvalidPinConfig, got {result:?}"
+        );
+        assert!(
+            transport.written.is_empty(),
+            "no BLE writes on validation failure"
         );
     }
 }

--- a/crates/sonde-pair/src/types.rs
+++ b/crates/sonde-pair/src/types.rs
@@ -128,3 +128,16 @@ pub struct SensorDescriptor {
     /// Optional human-readable label (max 64 bytes UTF-8).
     pub label: Option<String>,
 }
+
+/// Board-specific I2C pin configuration for NODE_PROVISION (PT-1214).
+///
+/// When present, encoded as a deterministic CBOR map and appended to the
+/// NODE_PROVISION body after the encrypted payload.  The node persists
+/// these to NVS so a single firmware binary works across boards (ND-0608).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PinConfig {
+    /// I2C0 SDA GPIO number (0–21 for ESP32-C3).
+    pub i2c0_sda: u8,
+    /// I2C0 SCL GPIO number (0–21 for ESP32-C3).
+    pub i2c0_scl: u8,
+}

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -245,6 +245,8 @@ Offset  Size           Field
 
 The node persists these to NVS. If the map is absent (older pairing tool), the node uses compiled-in defaults. Future keys (SPI pins, pairing button GPIO) may be added without breaking backward compatibility.
 
+**Pin config source:** The pairing tool obtains `i2c0_sda` and `i2c0_scl` values from the bundle manifest's `hardware.pins` section (see [bundle-format.md](bundle-format.md) §4.5).  When the bundle declares I2C sensors for a node, the `pins` section is required and the pairing tool passes the values through to `provision_node` as an optional `PinConfig` parameter.  This keeps the bundle self-contained — no separate board profile management is needed.
+
 ---
 
 ## 5  BLE transport layer

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -1087,13 +1087,13 @@ The pairing tool MUST apply build-type–aware log-level policies: compile-time 
 
 ### PT-1214  Board pin configuration in NODE_PROVISION
 
-**Priority:** Should (deferred — `sonde-pair` does not yet implement this)  
-**Source:** issue #490, ND-0608
+**Priority:** Should  
+**Source:** issue #490, issue #641, ND-0608
 
 **Description:**  
 The pairing tool SHOULD support including optional board-specific pin configuration (I2C SDA/SCL GPIO numbers) in the NODE_PROVISION message body so that a single firmware binary works across different ESP32-C3 boards.
 
-The node-side parsing (ND-0608) is implemented; the pairing-tool encoding side is tracked as future work. The `sonde-pair` API (`provision_node`) does **not** yet accept a pin-config parameter and the NODE_PROVISION payload does **not** yet include a trailing CBOR map for pin configuration.
+Pin configuration is sourced from the bundle manifest's `hardware.pins` section (see [bundle-format.md](bundle-format.md) §4.5).  When the bundle declares I2C sensors for a node, the `pins` section is required and the pairing tool reads `i2c0_sda` and `i2c0_scl` from it.  The `provision_node` API accepts an optional pin config parameter; callers (e.g., `sonde-pair-ui`) extract pins from the bundle manifest and pass them through.
 
 **Acceptance criteria:**
 
@@ -1101,6 +1101,8 @@ The node-side parsing (ND-0608) is implemented; the pairing-tool encoding side i
 2. When provided, pin config is encoded as a deterministic CBOR map and appended to the NODE_PROVISION body after the encrypted payload.
 3. When not provided, the NODE_PROVISION body is identical to the existing format (backward compatible).
 4. The CBOR map uses integer keys: 1 = `i2c0_sda` (uint), 2 = `i2c0_scl` (uint).
+5. GPIO values MUST be in the range 0–21 (ESP32-C3).
+6. `i2c0_sda` MUST NOT equal `i2c0_scl`.
 
 ---
 

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1115,8 +1115,7 @@ TestNode {
 
 ### T-PT-1214a  Pin config included in NODE_PROVISION when provided
 
-**Validates:** PT-1214 (AC 1, 2, 4)  
-**Status:** Deferred — `sonde-pair` does not yet implement pin config encoding.
+**Validates:** PT-1214 (AC 1, 2, 4)
 
 **Procedure:**
 1. Call `provision_node(...)` with pin config `Some(PinConfig { i2c0_sda: 4, i2c0_scl: 5 })`.
@@ -1127,10 +1126,31 @@ TestNode {
 
 ---
 
+### T-PT-1214c  Pin config with out-of-range GPIO rejected
+
+**Validates:** PT-1214 (AC 5)
+
+**Procedure:**
+1. Call `provision_node(...)` with pin config `Some(PinConfig { i2c0_sda: 22, i2c0_scl: 5 })`.
+2. Assert: the call returns an error indicating GPIO number out of range (0–21).
+3. Assert: no NODE_PROVISION message is written to the BLE transport.
+
+---
+
+### T-PT-1214d  Pin config with SDA equal to SCL rejected
+
+**Validates:** PT-1214 (AC 6)
+
+**Procedure:**
+1. Call `provision_node(...)` with pin config `Some(PinConfig { i2c0_sda: 4, i2c0_scl: 4 })`.
+2. Assert: the call returns an error indicating SDA and SCL must be different pins.
+3. Assert: no NODE_PROVISION message is written to the BLE transport.
+
+---
+
 ### T-PT-1214b  No pin config in NODE_PROVISION — backward compatible
 
-**Validates:** PT-1214 (AC 1, 3)  
-**Status:** Deferred — `sonde-pair` does not yet implement pin config encoding.
+**Validates:** PT-1214 (AC 1, 3)
 
 **Procedure:**
 1. Call `provision_node(...)` with pin config `None`.
@@ -1230,3 +1250,5 @@ TestNode {
 | T-PT-1212 | PT-1212 | Error context in log output |
 | T-PT-1214a | PT-1214 | Pin config included in NODE_PROVISION when provided |
 | T-PT-1214b | PT-1214 | No pin config in NODE_PROVISION — backward compatible |
+| T-PT-1214c | PT-1214 | Pin config with out-of-range GPIO rejected |
+| T-PT-1214d | PT-1214 | Pin config with SDA equal to SCL rejected |

--- a/docs/bundle-format.md
+++ b/docs/bundle-format.md
@@ -179,6 +179,9 @@ nodes:
   - name: "sensor-1"                 # String, node name/ID
     program: "temp-reader"           # String, references a program name from programs list
     hardware:                        # Optional, hardware profile
+      pins:                          # Optional, GPIO pin mapping (required if I2C sensors declared)
+        i2c0_sda: 4                  # Integer, I2C0 SDA GPIO number (0-21)
+        i2c0_scl: 5                  # Integer, I2C0 SCL GPIO number (0-21)
       sensors:
         - type: "i2c"               # String: "i2c", "adc", "gpio", "spi"
           id: 118                    # Integer, bus address or channel number
@@ -191,6 +194,9 @@ nodes:
 | `name` | string | yes | Node name/ID; MUST be unique within the `nodes` list |
 | `program` | string | yes | MUST reference a `name` in the `programs` list |
 | `hardware` | object | no | Hardware profile for the node |
+| `hardware.pins` | object | conditional | GPIO pin mapping; MUST be present when any sensor has `type: "i2c"` |
+| `hardware.pins.i2c0_sda` | integer | yes (if pins) | I2C0 SDA GPIO number, 0–21 (ESP32-C3) |
+| `hardware.pins.i2c0_scl` | integer | yes (if pins) | I2C0 SCL GPIO number, 0–21 (ESP32-C3); MUST differ from `i2c0_sda` |
 | `hardware.sensors` | list | no | List of sensor descriptors |
 | `hardware.sensors[].type` | string | yes (if sensor) | One of: `"i2c"`, `"adc"`, `"gpio"`, `"spi"` |
 | `hardware.sensors[].id` | integer | yes (if sensor) | Bus address or channel number, 0–65535 |
@@ -198,9 +204,12 @@ nodes:
 | `hardware.rf_channel` | integer | no | ESP-NOW RF channel, 1–13 |
 
 **Notes:**
-- The `hardware` section is informational for V1.  It is included in the bundle
-  so that future tools (e.g., the BLE pairing tool) can use it to configure
-  nodes at pairing time without requiring a bundle format change.
+- The `hardware.pins` section carries GPIO pin assignments that the BLE pairing
+  tool provisions to the node during pairing (see PT-1214, ND-0608).  The node
+  stores them in NVS so a single firmware binary works across boards with
+  different pin mappings.
+- When any sensor has `type: "i2c"`, `pins` with `i2c0_sda` and `i2c0_scl` is
+  required so the node knows which GPIOs to configure for the I2C bus.
 - The `name` field corresponds to the `node_id` used in gateway `AssignProgram`
   and other admin API calls.
 - Multiple nodes MAY reference the same program.
@@ -287,6 +296,10 @@ For each node target:
 4. `hardware.sensors[].id`, if present, is a non-negative integer in the range 0–65535.
 5. `hardware.rf_channel`, if present, is between 1 and 13 inclusive.
 6. `hardware.sensors[].label`, if present, is at most 64 bytes UTF-8.
+7. If any sensor has `type: "i2c"`, `hardware.pins` MUST be present with `i2c0_sda` and `i2c0_scl`.
+8. `hardware.pins.i2c0_sda` and `hardware.pins.i2c0_scl`, if present, are integers in the range 0–21.
+9. `hardware.pins.i2c0_sda` MUST NOT equal `hardware.pins.i2c0_scl`.
+10. If `hardware.pins` is present but omits either `i2c0_sda` or `i2c0_scl`, manifest decoding fails and the bundle is rejected as invalid.
 
 ### 6.6  Cross-reference validation
 
@@ -404,6 +417,9 @@ nodes:
   - name: "greenhouse-1"
     program: "temp-reader"
     hardware:
+      pins:
+        i2c0_sda: 4
+        i2c0_scl: 5
       sensors:
         - type: "i2c"
           id: 118
@@ -413,6 +429,9 @@ nodes:
   - name: "greenhouse-2"
     program: "temp-reader"
     hardware:
+      pins:
+        i2c0_sda: 4
+        i2c0_scl: 5
       sensors:
         - type: "i2c"
           id: 118

--- a/docs/bundle-tool-requirements.md
+++ b/docs/bundle-tool-requirements.md
@@ -169,6 +169,10 @@ that node names are unique.
 3. `hardware.sensors[].type` values outside `{"i2c", "adc", "gpio", "spi"}` are rejected.
 4. `hardware.rf_channel` values outside 1–13 are rejected.
 5. `hardware.sensors[].label` values exceeding 64 bytes UTF-8 are rejected.
+6. When any sensor has `type: "i2c"`, `hardware.pins` MUST be present with `i2c0_sda` and `i2c0_scl` fields.
+7. `hardware.pins.i2c0_sda` and `hardware.pins.i2c0_scl` values outside 0–21 are rejected.
+8. `hardware.pins.i2c0_sda` MUST NOT equal `hardware.pins.i2c0_scl`.
+9. If `hardware.pins` is present but omits either `i2c0_sda` or `i2c0_scl`, manifest decoding fails and the bundle is rejected as invalid.
 
 ---
 
@@ -393,7 +397,7 @@ The template repository MUST allow the developer to control which version of
 
 **Acceptance criteria:**
 
-1. A variable (e.g., `SONDE_VERSION` in the workflow file or a `.sonde-version` file) controls which CI run to download `sonde-bundle` from.
+1. A variable (e.g., `SONDE_VERSION` in the workflow file or a `.sonde-version` file) controls which CI run or release tag to download `sonde-bundle` from.
 2. Changing the variable and pushing triggers a build with the new version.
 3. The README documents how to update the version.
 
@@ -429,7 +433,7 @@ bundle from the project directory, then validate that bundle with
 | SB-0200 | Structural validation | Must |
 | SB-0201 | Program reference validation | Must |
 | SB-0202 | Handler reference validation | Must |
-| SB-0203 | Node reference validation | Must |
+| SB-0203 | Node reference validation (incl. pin map) | Must |
 | SB-0204 | Cross-reference validation | Should |
 | SB-0300 | Create bundle from directory | Must |
 | SB-0301 | Validate on create | Must |

--- a/docs/bundle-tool-validation.md
+++ b/docs/bundle-tool-validation.md
@@ -505,6 +505,58 @@ A `test_helpers` module provides:
 
 ---
 
+### T-SB-0605  Pins required when I2C sensor declared
+
+**Traces to:** SB-0203
+
+**Steps:**
+1. Create a manifest with a node that has a sensor of type `"i2c"` but no `hardware.pins` section.
+2. Validate.
+
+**Expected:**
+- Error containing: "``pins`` with ``i2c0_sda`` and ``i2c0_scl`` required when I2C sensor is declared" (prefixed with node name).
+
+---
+
+### T-SB-0606  Pin SDA equals SCL rejected
+
+**Traces to:** SB-0203
+
+**Steps:**
+1. Create a manifest with `hardware.pins.i2c0_sda: 4` and `hardware.pins.i2c0_scl: 4`.
+2. Validate.
+
+**Expected:**
+- Error containing: "``i2c0_sda`` and ``i2c0_scl`` must be different GPIO pins" (prefixed with node name).
+
+---
+
+### T-SB-0607  Pin GPIO out of range rejected
+
+**Traces to:** SB-0203
+
+**Steps:**
+1. Create a manifest with `hardware.pins.i2c0_sda: 22`.
+2. Validate.
+
+**Expected:**
+- Error containing: "GPIO pin number out of range (0–21)" (prefixed with node name, includes actual values).
+
+---
+
+### T-SB-0608  Partial pin spec rejected (SDA without SCL)
+
+**Traces to:** SB-0203
+
+**Steps:**
+1. Create a manifest with `hardware.pins` containing only `i2c0_sda: 4` (no `i2c0_scl`).
+2. Validate.
+
+**Expected:**
+- Manifest decode/deserialization error indicating missing required field `i2c0_scl`.
+
+---
+
 ## 8  Cross-reference validation tests
 
 ### T-SB-0700  Unreferenced program warning
@@ -754,18 +806,12 @@ A `test_helpers` module provides:
 **Traces to:** SB-0604
 
 **Steps:**
-1. In the template repo, set `.sonde-version` to each supported selector form in turn:
-   - a specific sonde release tag
-   - a specific sonde CI run ID
-   - a branch name
-2. For each value, push and wait for CI.
-3. Check which `sonde-bundle` binary the workflow downloaded.
+1. In the template repo, set `.sonde-version` to a specific sonde CI run ID.
+2. Push and wait for CI.
+3. Check which sonde-bundle binary was downloaded.
 
 **Expected:**
-- When `.sonde-version` is a release tag, the workflow downloads `sonde-bundle` from that release.
-- When `.sonde-version` is a CI run ID, the workflow downloads `sonde-bundle` from that pinned run.
-- When `.sonde-version` is a branch name, the workflow resolves it to the latest successful CI run for that branch and downloads `sonde-bundle` from that run.
-- In all cases, the workflow does not fall back to the latest available build from another release, run, or branch.
+- The CI log shows downloading sonde-bundle from the pinned run, not latest.
 
 ---
 
@@ -797,7 +843,7 @@ A `test_helpers` module provides:
 | SB-0200 | T-SB-0203, T-SB-0204, T-SB-0300, T-SB-0301, T-SB-0302, T-SB-0303, T-SB-0304, T-SB-0305, T-SB-0306 |
 | SB-0201 | T-SB-0400, T-SB-0401, T-SB-0402, T-SB-0403, T-SB-0404 |
 | SB-0202 | T-SB-0500, T-SB-0501, T-SB-0502, T-SB-0503, T-SB-0504 |
-| SB-0203 | T-SB-0600, T-SB-0601, T-SB-0602, T-SB-0603, T-SB-0604 |
+| SB-0203 | T-SB-0600, T-SB-0601, T-SB-0602, T-SB-0603, T-SB-0604, T-SB-0605, T-SB-0606, T-SB-0607, T-SB-0608 |
 | SB-0204 | T-SB-0700 |
 | SB-0300 | T-SB-0800, T-SB-0802 |
 | SB-0301 | T-SB-0801 |


### PR DESCRIPTION
## Summary

Adds `pins` field (`i2c0_sda`, `i2c0_scl`) to the bundle manifest `HardwareProfile` so the BLE pairing tool can provision I2C pin config to nodes directly from the app bundle. This makes the bundle self-contained — no separate board profile management needed.

Closes #641 · Supersedes #515

## Motivation

The bundle manifest described **which sensors** are attached (bus type, address, label) but not **which GPIO pins** the bus is wired to. The node firmware needs `i2c0_sda`/`i2c0_scl` to initialize I2C (ND-0608), but there was no way to flow this from the bundle through the pairing tool to the node.

## Changes

### Specifications (6 files)

| Document | Change |
|----------|--------|
| `bundle-format.md` | `pins` added to §4.5 schema, §6.5 rules 7-10, §9 example |
| `bundle-tool-requirements.md` | SB-0203 gains AC 6-9 (pin validation rules) |
| `bundle-tool-validation.md` | T-SB-0605/0606/0607/0608 + traceability matrix updated |
| `ble-pairing-tool-requirements.md` | PT-1214 activated (was deferred), gains AC 5-6 |
| `ble-pairing-tool-design.md` | §4.1 pin config source paragraph |
| `ble-pairing-tool-validation.md` | T-PT-1214a/b activated, T-PT-1214c/d added |

### Implementation (6 files)

| Crate | Change |
|-------|--------|
| `sonde-bundle` | `PinMap` struct on `HardwareProfile`, validation (GPIO 0-21, SDA≠SCL, required when I2C sensor declared), 5 new tests |
| `sonde-pair` | `PinConfig` type, `InvalidPinConfig` error, `pin_config` param on `provision_node`/`provision_node_aead`, CBOR encoding |
| `sonde-pair-ui` | Callers pass `None` (wiring to bundle manifest is a follow-up) |

### Not changed (correctly unaffected)

Node firmware (ND-0608 already implemented), protocol crate, gateway, modem.

## Validation rules

When any sensor has `type: "i2c"`, `hardware.pins` is **required** with:
- `i2c0_sda`: integer 0-21 (ESP32-C3 GPIO range)
- `i2c0_scl`: integer 0-21, must differ from `i2c0_sda`

`pins` without I2C sensors is allowed (no error).

## Example manifest

```yaml
nodes:
  - name: sensor-node-1
    program: my-sensor
    hardware:
      pins:
        i2c0_sda: 4
        i2c0_scl: 5
      sensors:
        - type: i2c
          id: 0x0048
          label: TMP102
```

## Test results

`sonde-bundle`: 53 tests pass (47 unit + 6 CLI).

## Follow-up

- [ ] Update [sonde-app-template](https://github.com/Alan-Jowett/sonde-app-template) `app.yaml` to include `pins`
- [ ] Wire `sonde-pair-ui` to read `pins` from bundle manifest and pass to `provision_node_aead`