### PR TITLE
ci: trigger nightly release workflow on vx.y.z tags

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -13,7 +13,7 @@ on:
     - cron: '0 6 * * *'
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
 concurrency:
@@ -64,8 +64,9 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
+            BASE=$(grep '^version' crates/sonde-gateway/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
             DATE=$(date -u +%Y%m%d)
-            VERSION="0.1.0+nightly.${DATE}"
+            VERSION="${BASE}+nightly.${DATE}"
           fi
           bash installer/linux/build-deb.sh --version "${VERSION}"
 
@@ -108,7 +109,10 @@ jobs:
           if ($ref -match '^refs/tags/v(\d+\.\d+\.\d+)$') {
             $ver = $Matches[1] + ".0"
           } else {
-            $ver = "0.1.0.${{ github.run_number }}"
+            $base = (Select-String -Path crates\sonde-gateway\Cargo.toml -Pattern '^version\s*=\s*"(.+)"' | Select-Object -First 1).Matches.Groups[1].Value
+            $epoch = [DateTime]::new(2026, 1, 1, 0, 0, 0, [DateTimeKind]::Utc)
+            $revision = [int](New-TimeSpan -Start $epoch -End (Get-Date).ToUniversalTime().Date).TotalDays
+            $ver = "$base.$revision"
           }
           wix build installer\windows\sonde.wxs `
             -d Version="$ver" `
@@ -154,9 +158,11 @@ jobs:
             DATE=$(date -u +%Y-%m-%d)
             TAG="nightly-${DATE}"
             IS_RELEASE=false
+          fi
 
-            # Delete previous release for today (re-runs)
-            gh release delete "$TAG" --yes 2>/dev/null || true
+          # Delete previous release for this tag (idempotent re-runs)
+          gh release delete "$TAG" --yes 2>/dev/null || true
+          if [[ "$IS_RELEASE" != "true" ]]; then
             git push origin ":refs/tags/$TAG" 2>/dev/null || true
           fi
 


### PR DESCRIPTION
When a tag matching \[0-9]+.[0-9]+.[0-9]+\ is pushed, the nightly release workflow now runs a full build and creates a proper GitHub release instead of a pre-release.

### Changes

- **Trigger**: added \push.tags\ for \*.*.*\ patterns
- **Installer versions**: \.deb\ and \.msi\ builds extract the version from the tag (e.g. \1.2.3\ → \1.2.3\) instead of nightly placeholders
- **Release step**: tag-triggered runs create a titled release (\Release v1.2.3\); schedule/dispatch runs keep existing nightly pre-release behavior