### PR TITLE
Fix git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "prevail-rust"]
+	path = prevail-rust
+	url = https://github.com/elazarg/prevail-rust.git


### PR DESCRIPTION
This pull request adds a new git submodule to the repository. The submodule points to the `prevail-rust` project, which is now included under the `prevail-rust` directory.

- Repository configuration:
  * Added a new git submodule entry for `prevail-rust` in the `.gitmodules` file, specifying its path and remote URL.