### PR TITLE
test: implement E2E handler routing tests (T-E2E-030 through T-E2E-034)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5304,6 +5304,7 @@ dependencies = [
  "sonde-node",
  "sonde-pair",
  "sonde-protocol",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",

--- a/crates/sonde-e2e/Cargo.toml
+++ b/crates/sonde-e2e/Cargo.toml
@@ -21,6 +21,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 ciborium = "0.2"
+tempfile = "3"
 
 [lib]
 name = "sonde_e2e"

--- a/crates/sonde-e2e/src/bin/stub_handler.rs
+++ b/crates/sonde-e2e/src/bin/stub_handler.rs
@@ -6,11 +6,24 @@
 //! Reads length-prefixed CBOR `HandlerMessage::Data` from stdin, echoes
 //! back a `HandlerMessage::DataReply` with the same `request_id` and a
 //! fixed payload `[0xCC, 0xDD]`.
+//!
+//! Flags:
+//! - `--no-reply`  Return an empty `data` vec (suppresses `APP_DATA_REPLY`).
+//! - `--receipt-dir <DIR>`  Write received blob bytes to `<DIR>/receipt.bin`
+//!   so the test can verify the handler actually received the correct data.
 
 use sonde_gateway::handler::HandlerMessage;
 use std::io::{Read, Write};
+use std::path::PathBuf;
 
 fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let no_reply = args.iter().any(|a| a == "--no-reply");
+    let receipt_dir: Option<PathBuf> = args
+        .windows(2)
+        .find(|w| w[0] == "--receipt-dir")
+        .map(|w| PathBuf::from(&w[1]));
+
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let mut stdin = stdin.lock();
@@ -37,15 +50,22 @@ fn main() {
         };
 
         // Only reply to Data messages.
-        let request_id = match &msg {
-            HandlerMessage::Data { request_id, .. } => *request_id,
+        let (request_id, data_blob) = match &msg {
+            HandlerMessage::Data {
+                request_id, data, ..
+            } => (*request_id, data.clone()),
             _ => continue,
         };
 
-        // Build a DataReply with a fixed echo payload.
+        // Write receipt file so the test can verify handler invocation.
+        if let Some(ref dir) = receipt_dir {
+            let _ = std::fs::write(dir.join("receipt.bin"), &data_blob);
+        }
+
+        // Build a DataReply with a fixed echo payload (or empty for --no-reply).
         let reply = HandlerMessage::DataReply {
             request_id,
-            data: vec![0xCC, 0xDD],
+            data: if no_reply { vec![] } else { vec![0xCC, 0xDD] },
         };
 
         let payload = match reply.encode() {

--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -126,6 +126,10 @@ pub struct WakeCycleStats {
     pub wake_nonces: Vec<u64>,
     /// `(msg_type, nonce)` for every frame the node sent.
     pub sent_frames: Vec<(u8, u64)>,
+    /// Raw bytes of captured outbound APP_DATA frames only.
+    pub sent_raw_frames: Vec<Vec<u8>>,
+    /// `msg_type` for every non-`None` response with a valid protocol header.
+    pub received_msg_types: Vec<u8>,
 }
 
 /// Lightweight handle representing a remote node.
@@ -251,6 +255,8 @@ impl NodeProxy {
             response_count: transport.response_count(),
             wake_nonces: transport.wake_nonces().to_vec(),
             sent_frames: transport.sent_frames().to_vec(),
+            sent_raw_frames: transport.sent_raw_frames().to_vec(),
+            received_msg_types: transport.received_msg_types().to_vec(),
         }
     }
 }
@@ -268,6 +274,8 @@ struct BridgeTransport {
     response_count: usize,
     wake_nonces: Vec<u64>,
     sent_frames: Vec<(u8, u64)>,
+    sent_raw_frames: Vec<Vec<u8>>,
+    received_msg_types: Vec<u8>,
     rt: tokio::runtime::Handle,
     tamper_outgoing: bool,
 }
@@ -281,6 +289,8 @@ impl BridgeTransport {
             response_count: 0,
             wake_nonces: Vec::new(),
             sent_frames: Vec::new(),
+            sent_raw_frames: Vec::new(),
+            received_msg_types: Vec::new(),
             rt: tokio::runtime::Handle::try_current()
                 .expect("BridgeTransport must be created inside a Tokio runtime"),
             tamper_outgoing: false,
@@ -304,6 +314,14 @@ impl BridgeTransport {
     fn sent_frames(&self) -> &[(u8, u64)] {
         &self.sent_frames
     }
+
+    fn received_msg_types(&self) -> &[u8] {
+        &self.received_msg_types
+    }
+
+    fn sent_raw_frames(&self) -> &[Vec<u8>] {
+        &self.sent_raw_frames
+    }
 }
 
 impl NodeTransport for BridgeTransport {
@@ -320,6 +338,11 @@ impl NodeTransport for BridgeTransport {
             if msg_type == sonde_protocol::MSG_WAKE {
                 self.wake_nonces.push(nonce);
             }
+            // Only capture APP_DATA raw frames to avoid copying bulk
+            // CHUNK data during program download.
+            if msg_type == sonde_protocol::MSG_APP_DATA {
+                self.sent_raw_frames.push(frame.to_vec());
+            }
         }
 
         let gateway = self.gateway.clone();
@@ -335,8 +358,12 @@ impl NodeTransport for BridgeTransport {
             self.rt.block_on(gateway.process_frame(&frame_vec, peer))
         });
 
-        if response.is_some() {
+        if let Some(ref resp) = response {
             self.response_count += 1;
+            if resp.len() >= sonde_protocol::HEADER_SIZE {
+                self.received_msg_types
+                    .push(resp[sonde_protocol::OFFSET_MSG_TYPE]);
+            }
         }
         self.pending_response = response;
         Ok(())

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -229,3 +229,451 @@ async fn t_e2e_053_tampered_frame_discarded() {
         "`last_seen` should be None — gateway silently discarded the tampered WAKE"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Helper: send_recv program (helper 9)
+// ---------------------------------------------------------------------------
+
+/// Create a BPF program that calls `send_recv()` (helper 9) with a 2-byte
+/// blob `[0xAA, 0xBB]` and a 16-byte reply buffer on the stack.
+fn make_send_recv_program() -> (ProgramRecord, Vec<u8>) {
+    let bytecode = [
+        // sth [r10-8], 0xBBAA  — store 2-byte blob on stack
+        0x6a, 0x0a, 0xf8, 0xff, 0xAA, 0xBB, 0x00, 0x00,
+        // mov r1, r10          — r1 = frame pointer
+        0xbf, 0xa1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // add r1, -8           — r1 = fp - 8 (pointer to data)
+        0x07, 0x01, 0x00, 0x00, 0xf8, 0xff, 0xff, 0xff,
+        // mov r2, 2            — r2 = blob length
+        0xb7, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        // mov r3, r10          — r3 = frame pointer
+        0xbf, 0xa3, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // add r3, -24          — r3 = fp - 24 (reply buffer)
+        0x07, 0x03, 0x00, 0x00, 0xe8, 0xff, 0xff, 0xff,
+        // mov r4, 16           — r4 = reply buffer capacity
+        0xb7, 0x04, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
+        // mov r5, 0            — r5 = timeout (0 = default)
+        0xb7, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // call 9               — helper_send_recv(r1..r5)
+        0x85, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00,
+        // mov r0, 0            — return 0
+        0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    make_program_from_bytecode(&bytecode)
+}
+
+/// Create a BPF program that calls `send()` (helper 8) with a 2-byte
+/// blob `[0xDE, 0xAD]` on the stack — fire-and-forget APP_DATA.
+fn make_send_program_dead() -> (ProgramRecord, Vec<u8>) {
+    let bytecode = [
+        // sth [r10-8], 0xADDE  — store 2-byte immediate on stack
+        0x6a, 0x0a, 0xf8, 0xff, 0xDE, 0xAD, 0x00, 0x00,
+        // mov r1, r10          — r1 = frame pointer
+        0xbf, 0xa1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // add r1, -8           — r1 = fp - 8 (pointer to data)
+        0x07, 0x01, 0x00, 0x00, 0xf8, 0xff, 0xff, 0xff,
+        // mov r2, 2            — r2 = blob length
+        0xb7, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        // call 8               — helper_send(r1=ptr, r2=len)
+        0x85, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+        // mov r0, 0            — return 0
+        0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    make_program_from_bytecode(&bytecode)
+}
+
+/// Create a BPF program that calls `send()` (helper 8) with a 2-byte
+/// blob `[0x01, 0x02]` on the stack — fire-and-forget APP_DATA (per
+/// T-E2E-031 spec).
+fn make_send_program_0102() -> (ProgramRecord, Vec<u8>) {
+    let bytecode = [
+        // sth [r10-8], 0x0201  — store 2-byte immediate on stack
+        0x6a, 0x0a, 0xf8, 0xff, 0x01, 0x02, 0x00, 0x00,
+        // mov r1, r10          — r1 = frame pointer
+        0xbf, 0xa1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // add r1, -8           — r1 = fp - 8 (pointer to data)
+        0x07, 0x01, 0x00, 0x00, 0xf8, 0xff, 0xff, 0xff,
+        // mov r2, 2            — r2 = blob length
+        0xb7, 0x02, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+        // call 8               — helper_send(r1=ptr, r2=len)
+        0x85, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+        // mov r0, 0            — return 0
+        0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    make_program_from_bytecode(&bytecode)
+}
+
+// ---------------------------------------------------------------------------
+// Handler routing tests (T-E2E-030 through T-E2E-034)
+// ---------------------------------------------------------------------------
+
+/// Helper: register a node with an assigned BPF program in the gateway.
+async fn setup_node_with_program(
+    env: &E2eTestEnv,
+    node_id: &str,
+    key_hint: u16,
+    psk: [u8; 32],
+    program: &ProgramRecord,
+    hash: &[u8],
+) {
+    env.register_node(node_id, key_hint, psk).await;
+    env.storage.store_program(program).await.unwrap();
+    let mut rec = env.storage.get_node(node_id).await.unwrap().unwrap();
+    rec.assigned_program_hash = Some(hash.to_vec());
+    env.storage.upsert_node(&rec).await.unwrap();
+}
+
+/// T-E2E-030 — APP_DATA round-trip with handler.
+///
+/// A BPF program calls `send_recv()` (helper 9) with blob `[0xAA, 0xBB]`.
+/// The gateway routes the APP_DATA to the stub handler, which replies with
+/// `[0xCC, 0xDD]`. The gateway forwards the reply as APP_DATA_REPLY.
+///
+/// Validates: GW-0500, GW-0501, ND-0602.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_030_app_data_round_trip_with_handler() {
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    let receipt_dir = tempfile::tempdir().unwrap();
+    let stub = env!("CARGO_BIN_EXE_stub_handler");
+    let receipt_path = receipt_dir.path().to_str().unwrap();
+    let env = E2eTestEnv::new_with_handler(stub, &["--receipt-dir", receipt_path]);
+
+    let psk = [0x30; 32];
+    let (program, hash) = make_send_recv_program();
+    setup_node_with_program(&env, "handler-rt", 1, psk, &program, &hash).await;
+
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    // The node should have sent exactly one APP_DATA frame.
+    let app_data_count = stats
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_APP_DATA)
+        .count();
+    assert_eq!(
+        app_data_count, 1,
+        "node should send exactly one APP_DATA frame"
+    );
+
+    // Gateway must have replied with an APP_DATA_REPLY.
+    let reply_count = stats
+        .received_msg_types
+        .iter()
+        .filter(|&&t| t == sonde_protocol::MSG_APP_DATA_REPLY)
+        .count();
+    assert_eq!(
+        reply_count, 1,
+        "gateway must produce exactly one APP_DATA_REPLY"
+    );
+
+    // Verify the handler received the correct blob via receipt file.
+    let receipt = std::fs::read(receipt_dir.path().join("receipt.bin")).unwrap();
+    assert_eq!(
+        receipt,
+        [0xAA, 0xBB],
+        "handler must receive the correct APP_DATA blob"
+    );
+}
+
+/// T-E2E-031 — APP_DATA fire-and-forget (send helper).
+///
+/// A BPF program calls `send()` (helper 8) with blob `[0x01, 0x02]`.
+/// The gateway routes the APP_DATA to a handler that returns an empty
+/// reply. No APP_DATA_REPLY is sent back to the node.
+///
+/// Validates: ND-0602 (send, no reply expected).
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_031_app_data_fire_and_forget_with_handler() {
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    let receipt_dir = tempfile::tempdir().unwrap();
+    let stub = env!("CARGO_BIN_EXE_stub_handler");
+    let receipt_path = receipt_dir.path().to_str().unwrap();
+    let env = E2eTestEnv::new_with_handler(stub, &["--no-reply", "--receipt-dir", receipt_path]);
+
+    let psk = [0x31; 32];
+    let (program, hash) = make_send_program_0102();
+    setup_node_with_program(&env, "handler-ff", 1, psk, &program, &hash).await;
+
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    // The node should have sent exactly one APP_DATA frame.
+    let app_data_count = stats
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_APP_DATA)
+        .count();
+    assert_eq!(
+        app_data_count, 1,
+        "node should send exactly one APP_DATA frame"
+    );
+
+    // Handler returned empty reply → gateway must NOT send APP_DATA_REPLY.
+    let reply_count = stats
+        .received_msg_types
+        .iter()
+        .filter(|&&t| t == sonde_protocol::MSG_APP_DATA_REPLY)
+        .count();
+    assert_eq!(
+        reply_count, 0,
+        "gateway must not produce APP_DATA_REPLY for fire-and-forget (handler returned empty)"
+    );
+
+    // Verify the handler was actually invoked and received the correct blob.
+    let receipt = std::fs::read(receipt_dir.path().join("receipt.bin")).unwrap();
+    assert_eq!(
+        receipt,
+        [0x01, 0x02],
+        "handler must receive the correct APP_DATA blob"
+    );
+}
+
+/// T-E2E-032 — APP_DATA AEAD end-to-end.
+///
+/// Verifies that APP_DATA sent by a BPF program through the AEAD frame
+/// path is correctly decrypted by the gateway and delivered to the handler.
+/// The on-wire AEAD format (11-byte header + ciphertext + 16-byte GCM tag)
+/// is validated by the gateway's successful decryption — if the frame
+/// format were wrong, `process_frame` would silently discard it.
+///
+/// Validates: GW-0500, GW-0600, ND-0300, ND-0602.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_032_app_data_aead_end_to_end() {
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    let receipt_dir = tempfile::tempdir().unwrap();
+    let stub = env!("CARGO_BIN_EXE_stub_handler");
+    let receipt_path = receipt_dir.path().to_str().unwrap();
+    let env = E2eTestEnv::new_with_handler(stub, &["--receipt-dir", receipt_path]);
+
+    let psk = [0x32; 32];
+    let (program, hash) = make_send_program_dead();
+    setup_node_with_program(&env, "handler-aead", 1, psk, &program, &hash).await;
+
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    // Verify the AEAD APP_DATA frame was sent by the node.
+    let app_data_count = stats
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_APP_DATA)
+        .count();
+    assert_eq!(
+        app_data_count, 1,
+        "node should send exactly one AEAD APP_DATA frame"
+    );
+
+    // Verify the APP_DATA frame is in AEAD format: 11B header + ciphertext + 16B tag.
+    let app_data_frame = stats
+        .sent_raw_frames
+        .iter()
+        .find(|f| {
+            f.len() >= sonde_protocol::HEADER_SIZE
+                && f[sonde_protocol::OFFSET_MSG_TYPE] == sonde_protocol::MSG_APP_DATA
+        })
+        .expect("APP_DATA raw frame must be captured");
+    assert!(
+        app_data_frame.len() >= sonde_protocol::HEADER_SIZE + 16,
+        "AEAD APP_DATA frame must be at least 11B header + 16B GCM tag, got {} bytes",
+        app_data_frame.len()
+    );
+
+    // Gateway decrypted the AEAD frame and routed to the handler.
+    let reply_count = stats
+        .received_msg_types
+        .iter()
+        .filter(|&&t| t == sonde_protocol::MSG_APP_DATA_REPLY)
+        .count();
+    assert_eq!(
+        reply_count, 1,
+        "gateway must decrypt AEAD APP_DATA, route to handler, and produce APP_DATA_REPLY"
+    );
+
+    // Verify the handler received the decrypted blob [0xDE, 0xAD].
+    let receipt = std::fs::read(receipt_dir.path().join("receipt.bin")).unwrap();
+    assert_eq!(
+        receipt,
+        [0xDE, 0xAD],
+        "handler must receive the decrypted APP_DATA blob"
+    );
+}
+
+/// T-E2E-033 — Live reload: handler add end-to-end.
+///
+/// The gateway starts with no handler configured. APP_DATA is silently
+/// dropped (no handler match). After adding a handler for the specific
+/// program hash via the router, APP_DATA is routed correctly on the
+/// next wake cycle.
+///
+/// Validates: GW-1404, GW-1407.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_033_live_reload_handler_add() {
+    use sonde_gateway::handler::{HandlerConfig, ProgramMatcher};
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    // Start with no handlers.
+    let env = E2eTestEnv::new();
+
+    let psk = [0x33; 32];
+    let (program, hash) = make_send_program();
+    setup_node_with_program(&env, "handler-add", 1, psk, &program, &hash).await;
+
+    // --- Cycle 1: no handler configured → APP_DATA not routed ---
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+    let stats1 = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats1.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+    let app_data_count_1 = stats1
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_APP_DATA)
+        .count();
+    assert_eq!(
+        app_data_count_1, 1,
+        "cycle 1: node must send exactly one APP_DATA frame"
+    );
+    let reply_count_1 = stats1
+        .received_msg_types
+        .iter()
+        .filter(|&&t| t == sonde_protocol::MSG_APP_DATA_REPLY)
+        .count();
+    assert_eq!(
+        reply_count_1, 0,
+        "cycle 1: no APP_DATA_REPLY expected (no handler configured)"
+    );
+
+    // --- Add handler for the specific program hash ---
+    let stub = env!("CARGO_BIN_EXE_stub_handler");
+    let config = HandlerConfig {
+        matchers: vec![ProgramMatcher::Hash(hash.clone())],
+        command: stub.to_string(),
+        args: vec![],
+        reply_timeout: None,
+        working_dir: None,
+    };
+    {
+        let router_arc = env.gateway.handler_router();
+        let mut router = router_arc.write().await;
+        let _removed = router.reload(vec![config]);
+    }
+
+    // --- Cycle 2: handler present → APP_DATA routed and replied ---
+    let stats2 = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+    let app_data_count_2 = stats2
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_APP_DATA)
+        .count();
+    assert_eq!(
+        app_data_count_2, 1,
+        "cycle 2: node must send exactly one APP_DATA frame"
+    );
+    let reply_count_2 = stats2
+        .received_msg_types
+        .iter()
+        .filter(|&&t| t == sonde_protocol::MSG_APP_DATA_REPLY)
+        .count();
+    assert_eq!(
+        reply_count_2, 1,
+        "cycle 2: APP_DATA_REPLY expected (handler was live-added)"
+    );
+}
+
+/// T-E2E-034 — Live reload: handler remove end-to-end.
+///
+/// The gateway starts with a catch-all handler. APP_DATA is routed and
+/// replied. After removing the handler via the router, APP_DATA is
+/// silently dropped on the next wake cycle and the handler process is
+/// shut down.
+///
+/// Validates: GW-1404, GW-1407.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_034_live_reload_handler_remove() {
+    use sonde_gateway::handler::shutdown_removed_handlers;
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    let stub = env!("CARGO_BIN_EXE_stub_handler");
+    let env = E2eTestEnv::new_with_handler(stub, &[]);
+
+    let psk = [0x34; 32];
+    let (program, hash) = make_send_program();
+    setup_node_with_program(&env, "handler-rm", 1, psk, &program, &hash).await;
+
+    // --- Cycle 1: catch-all handler present → APP_DATA routed ---
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+    let stats1 = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats1.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+    let reply_count_1 = stats1
+        .received_msg_types
+        .iter()
+        .filter(|&&t| t == sonde_protocol::MSG_APP_DATA_REPLY)
+        .count();
+    assert_eq!(
+        reply_count_1, 1,
+        "cycle 1: APP_DATA_REPLY expected (catch-all handler matched)"
+    );
+
+    // --- Remove all handlers via HandlerRouter ---
+    let removed = {
+        let router_arc = env.gateway.handler_router();
+        let mut router = router_arc.write().await;
+        router.reload(vec![])
+    };
+    // Shut down the removed handler processes.
+    shutdown_removed_handlers(removed).await;
+
+    // Verify the router has zero handlers after removal.
+    {
+        let router_arc = env.gateway.handler_router();
+        let router = router_arc.read().await;
+        assert_eq!(
+            router.handler_count(),
+            0,
+            "router must have zero handlers after removal"
+        );
+    }
+
+    // --- Cycle 2: no handler → APP_DATA not routed ---
+    let stats2 = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+    let app_data_count_2 = stats2
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_APP_DATA)
+        .count();
+    assert_eq!(
+        app_data_count_2, 1,
+        "cycle 2: node must still send APP_DATA even with no handler"
+    );
+    let reply_count_2 = stats2
+        .received_msg_types
+        .iter()
+        .filter(|&&t| t == sonde_protocol::MSG_APP_DATA_REPLY)
+        .count();
+    assert_eq!(
+        reply_count_2, 0,
+        "cycle 2: no APP_DATA_REPLY expected (handler was live-removed)"
+    );
+}


### PR DESCRIPTION
## Summary

Implements five handler routing E2E tests specified in \docs/e2e-validation.md\ but missing from the test suite. Found during maintenance audit (F-017 through F-021).

| Test | Description | Validates |
|------|------------|-----------|
| T-E2E-030 | APP_DATA round-trip with handler (\send_recv\ helper 9) | GW-0500, GW-0501, ND-0602 |
| T-E2E-031 | APP_DATA fire-and-forget (\send\ helper 8, empty reply) | ND-0602 |
| T-E2E-032 | APP_DATA AEAD end-to-end (decryption + handler routing) | GW-0500, GW-0600, ND-0300, ND-0602 |
| T-E2E-033 | Live reload — handler add mid-session | GW-1404, GW-1407 |
| T-E2E-034 | Live reload — handler remove mid-session | GW-1404, GW-1407 |

## Changes

### Test harness (\harness.rs\)
- Added \eceived_msg_types: Vec<u8>\ to \WakeCycleStats\ — records the \msg_type\ of every gateway response frame. Tests assert on \MSG_APP_DATA_REPLY\ presence/absence rather than total \esponse_count\, avoiding coupling to program-download response counts.

### Stub handler (\stub_handler.rs\)
- Added \--no-reply\ CLI flag that causes the handler to return empty \DataReply\ data, suppressing \APP_DATA_REPLY\ (used by T-E2E-031). Default behavior unchanged.

### New test helpers (\ead_e2e_tests.rs\)
- \make_send_recv_program()\ — BPF bytecode calling helper 9 with blob \[0xAA, 0xBB]\ and 16-byte reply buffer
- \make_send_program_dead()\ — BPF bytecode calling helper 8 with blob \[0xDE, 0xAD]\
- \setup_node_with_program()\ — registers a node and assigns a program in one call

## Test results

All 10 AEAD E2E tests pass (5 existing + 5 new). Full E2E suite (28 tests) passes. Clippy clean.

Closes #647