### PR TITLE
fix: increase BLE connection timeout from 10s to 30s

### DIFF
--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -39,7 +39,7 @@ use crate::types::{PairingMethod, ScannedDevice};
 /// This budget covers GATT connect, LESC Numeric Comparison bonding
 /// (which requires operator confirmation on the gateway side), MTU
 /// negotiation, and service discovery.
-const CONNECT_TIMEOUT_MS: i64 = 10_000;
+const CONNECT_TIMEOUT_MS: i64 = 30_000;
 
 /// Default write-with-response timeout.
 const WRITE_TIMEOUT_MS: i64 = 5_000;

--- a/crates/sonde-pair/src/btleplug_transport.rs
+++ b/crates/sonde-pair/src/btleplug_transport.rs
@@ -40,7 +40,7 @@ use crate::transport::BleTransport;
 use crate::types::{PairingMethod, ScannedDevice, BLE_MTU_MIN};
 
 /// BLE connection timeout (PT-1002).
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Default MTU reported when the platform does not expose the negotiated value.
 ///
@@ -281,7 +281,7 @@ impl BleTransport for BtleplugTransport {
                 .find(|p| p.address() == target_addr)
                 .ok_or(PairingError::DeviceNotFound)?;
 
-            // Connect with a timeout (PT-1002: 10 s).
+            // Connect with a timeout (PT-1002: 30 s).
             tokio::time::timeout(CONNECT_TIMEOUT, peripheral.connect())
                 .await
                 .map_err(|_| PairingError::Timeout {

--- a/docs/audits/ble-pairing-tool-code-compliance.md
+++ b/docs/audits/ble-pairing-tool-code-compliance.md
@@ -120,7 +120,7 @@
 |-----|-------|--------|-------------------|
 | PT-1000 | Transient BLE failure tolerance | ✅ | After any error, phase returns to "Error: …". UI allows restarting scan. Transport always disconnects on error paths. |
 | PT-1001 | No resource leaks on failure | ✅ | `pair_with_gateway` and `provision_node` both call `transport.disconnect().await.ok()` on every exit. `BtleplugTransport::Drop` attempts disconnect. GATT subscriptions cleaned up on disconnect. |
-| PT-1002 | Deterministic timeouts | ⚠️ **D10** | See **D10-003**. `GW_INFO_RESPONSE`: 5 s ✅. `PHONE_REGISTERED`: 30 s ✅. `NODE_ACK`: 5 s ✅. Scan: 30 s ✅. BLE connection: btleplug uses 10 s ✅, but Android uses **30 s** (spec says 10 s). |
+| PT-1002 | Deterministic timeouts | ✅ | **D10-003 RESOLVED** (issue #655). `GW_INFO_RESPONSE`: 45 s ✅. `PHONE_REGISTERED`: 30 s ✅. `NODE_ACK`: 5 s ✅. Scan: 30 s ✅. BLE connection: both platforms use 30 s ✅ (spec updated from 10 s to 30 s). |
 | PT-1003 | No implicit retries | ✅ | No protocol-level retry logic found. All failures are immediately reported. |
 | PT-1004 | Reusable core | ✅ | `sonde-pair` crate has no UI or platform deps. Used by `sonde-pair-ui` (Tauri frontend) and by the built-in test suite (148+ tests across modules). |
 
@@ -307,12 +307,10 @@ Several `PairingError` variants lack actionable guidance:
 
 ### D10-003: Android BLE connection timeout is 30 s, spec says 10 s (PT-1002)
 
-**Severity:** Low
-**Requirement:** PT-1002: "BLE connection establishment 10 s."
+**Severity:** Low — **RESOLVED** (issue #655)
+**Requirement:** PT-1002: "BLE connection establishment 30 s."
 
-`android_transport.rs` uses `CONNECT_TIMEOUT_MS = 30_000` (30 s), documented as including LESC bonding time. The spec says 10 s for connection establishment. The comment explains the 30 s budget covers "GATT connect, LESC Numeric Comparison bonding, MTU negotiation, and service discovery" — which is a reasonable engineering decision, but it deviates from the spec's 10 s value.
-
-**Recommendation:** Either update the spec to allow a longer budget for LESC bonding on Android, or split the timeout into connection (10 s) + bonding (additional 20 s).
+`android_transport.rs` uses `CONNECT_TIMEOUT_MS = 30_000` (30 s), documented as including LESC bonding time. PT-1002 has been updated from 10 s to 30 s to accommodate the LESC Numeric Comparison bonding flow, which requires human confirmation. Both `android_transport.rs` and `btleplug_transport.rs` now use 30 s consistently.
 
 ---
 
@@ -369,7 +367,7 @@ Several `PairingError` variants lack actionable guidance:
 | **P0** | D8-001 (LESC enforcement) | Add `PairingMethod` to `BleTransport` trait; verify on Android; reject Just Works |
 | **P1** | D10-002 (actionable errors) | Add operator guidance to all error message strings |
 | **P1** | D8-004 (verbose toggle) | Add runtime log-level toggle via `tracing_subscriber::reload` |
-| **P2** | D10-003 (Android timeout) | Reconcile spec timeout (10 s) with LESC bonding budget (30 s) |
+| ~~P2~~ | ~~D10-003 (Android timeout)~~ | ~~Reconcile spec timeout (10 s) with LESC bonding budget (30 s)~~ — **RESOLVED** (issue #655) |
 | **P2** | D8-002 (already-paired prompt) | Add `is_paired` check in UI before Phase 1 |
 | **P2** | D8-003 (phase granularity) | Add sub-phase callbacks to protocol functions |
 | **P3** | D8-005 (corruption UX) | Auto-offer store reset on corruption in UI |

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -295,7 +295,7 @@ pub trait BleTransport: Send + Sync {
     /// is required for gateway connections (PT-0300) — a Just Works
     /// fallback MUST be treated as a connection failure.  Just Works
     /// is acceptable only for node provisioning connections.
-    /// Connection establishment MUST time out after 10 seconds (PT-1002).
+    /// Connection establishment MUST time out after 30 seconds (PT-1002).
     async fn connect(&self, device: &DeviceId) -> Result<u16, PairingError>;
 
     /// Disconnect from the currently connected device.

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -756,7 +756,7 @@ BLE connections, GATT subscriptions, and platform BLE resources MUST be released
 **Source:** ble-pairing-protocol.md §3.4, §5, §6
 
 **Description:**  
-All timeouts MUST be deterministic and explicitly configured to the following values: `GW_INFO_RESPONSE` 45 s, `PHONE_REGISTERED` 30 s, `NODE_ACK` 5 s, BLE scan default 30 s, BLE connection establishment 10 s.
+All timeouts MUST be deterministic and explicitly configured to the following values: `GW_INFO_RESPONSE` 45 s, `PHONE_REGISTERED` 30 s, `NODE_ACK` 5 s, BLE scan default 30 s, BLE connection establishment 30 s.
 
 **Acceptance criteria:**
 

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -912,7 +912,7 @@ TestNode {
 2. Assert: `PHONE_REGISTERED` timeout = 30 s.
 3. Assert: `NODE_ACK` timeout = 5 s.
 4. Assert: BLE scan default timeout = 30 s.
-5. Assert: BLE connection establishment timeout = 10 s.
+5. Assert: BLE connection establishment timeout = 30 s.
 
 ---
 


### PR DESCRIPTION
## Summary

The 10-second BLE connection timeout (PT-1002) must cover GATT connect + LESC Numeric Comparison bonding (human confirmation) + MTU negotiation + service discovery. The LESC bonding step alone can exceed 10 seconds on first pairing, causing timeouts before pairing completes.

Increases the timeout to 30 seconds, consistent with the `PHONE_REGISTERED` indication timeout.

## Changes

| File | Change |
|------|--------|
| `ble-pairing-tool-requirements.md` | PT-1002: connection timeout 10s to 30s |
| `ble-pairing-tool-design.md` | S5.1 `connect()` doc comment updated |
| `ble-pairing-tool-validation.md` | T-PT-802 step 5 assertion updated |
| `android_transport.rs` | `CONNECT_TIMEOUT_MS` 10_000 to 30_000 |
| `btleplug_transport.rs` | `CONNECT_TIMEOUT` 10s to 30s |

Both platforms (Android JNI and desktop btleplug) use the same 30s value.

Closes #655
