### PR TITLE
fix: resolve maintenance audit findings F-001 and F-002

### DIFF
--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -63,7 +63,7 @@ fn make_program_from_bytecode(bytecode: &[u8]) -> (ProgramRecord, Vec<u8>) {
 // Tests
 // ---------------------------------------------------------------------------
 
-/// T-E2E-050 — AEAD NOP wake cycle.
+/// T-E2E-001 — AEAD NOP wake cycle.
 ///
 /// A paired node with no pending commands completes a normal WAKE/COMMAND
 /// exchange over AES-256-GCM and returns to sleep at its configured
@@ -74,7 +74,7 @@ fn make_program_from_bytecode(bytecode: &[u8]) -> (ProgramRecord, Vec<u8>) {
 ///   compatible AES-256-GCM frames.
 /// - Gateway updates node telemetry after a successful AEAD exchange.
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_050_nop_wake_cycle() {
+async fn t_e2e_001_nop_wake_cycle() {
     let env = E2eTestEnv::new();
     let psk = [0x50; 32];
     env.register_node("aead-nop", 1, psk).await;
@@ -100,13 +100,13 @@ async fn t_e2e_050_nop_wake_cycle() {
     );
 }
 
-/// T-E2E-050b — Consecutive AEAD wake cycles (state persistence).
+/// T-E2E-002b — Consecutive AEAD wake cycles (state persistence).
 ///
 /// Runs two AEAD wake cycles on the same `NodeProxy` to verify that
 /// persistent storage and monotonic RNG state work correctly across
 /// multiple AES-256-GCM exchanges.
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_050b_consecutive_wake_cycles() {
+async fn t_e2e_002b_consecutive_wake_cycles() {
     let env = E2eTestEnv::new();
     let psk = [0x55; 32];
     env.register_node("aead-multi", 1, psk).await;
@@ -132,14 +132,13 @@ async fn t_e2e_050b_consecutive_wake_cycles() {
     );
 }
 
-/// T-E2E-051 — AEAD wake cycle with BPF APP_DATA.
+/// T-E2E-002c — AEAD wake cycle with BPF APP_DATA.
 ///
 /// Exercises the full AEAD wake cycle with a BPF program that calls the
-/// `send()` helper. The WAKE/COMMAND exchange uses AES-256-GCM; the BPF
-/// dispatch sends APP_DATA via the HMAC codec (this is the current design —
-/// BPF helpers have not yet been migrated to AEAD).
+/// `send()` helper. Both the WAKE/COMMAND exchange and the resulting
+/// `APP_DATA` dispatch use the AES-256-GCM AEAD frame path.
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_051_app_data_fire_and_forget() {
+async fn t_e2e_002c_app_data_fire_and_forget() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
     let env = E2eTestEnv::new();
@@ -170,13 +169,13 @@ async fn t_e2e_051_app_data_fire_and_forget() {
     );
 }
 
-/// T-E2E-052 — AEAD wrong PSK (silent discard).
+/// T-E2E-003 — AEAD wrong PSK (silent discard).
 ///
 /// When the node's PSK does not match the gateway's record, the gateway
 /// cannot decrypt the AEAD frame and silently discards it. The node
 /// exhausts its retries and sleeps.
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_052_wrong_psk_rejected() {
+async fn t_e2e_003_wrong_psk_rejected() {
     let env = E2eTestEnv::new();
     env.register_node("aead-wrong", 1, [0xAA; 32]).await;
 
@@ -202,13 +201,13 @@ async fn t_e2e_052_wrong_psk_rejected() {
     );
 }
 
-/// T-E2E-053 — AEAD tampered frame (silent discard).
+/// T-E2E-004 — AEAD tampered frame (silent discard).
 ///
 /// A bit-flip in the ciphertext region causes the GCM tag check to fail.
 /// The gateway silently discards the corrupted frame and the node receives
 /// no response, eventually exhausting retries.
 #[tokio::test(flavor = "multi_thread")]
-async fn t_e2e_053_tampered_frame_discarded() {
+async fn t_e2e_004_tampered_frame_discarded() {
     let env = E2eTestEnv::new();
     let psk = [0x53; 32];
     env.register_node("aead-tamper", 1, psk).await;
@@ -227,6 +226,10 @@ async fn t_e2e_053_tampered_frame_discarded() {
     assert!(
         record.last_seen.is_none(),
         "`last_seen` should be None — gateway silently discarded the tampered WAKE"
+    );
+    assert_eq!(
+        record.last_battery_mv, None,
+        "battery should not be updated on tampered frame"
     );
 }
 

--- a/docs/audits/ble-pairing-tool-code-compliance.md
+++ b/docs/audits/ble-pairing-tool-code-compliance.md
@@ -120,7 +120,7 @@
 |-----|-------|--------|-------------------|
 | PT-1000 | Transient BLE failure tolerance | ✅ | After any error, phase returns to "Error: …". UI allows restarting scan. Transport always disconnects on error paths. |
 | PT-1001 | No resource leaks on failure | ✅ | `pair_with_gateway` and `provision_node` both call `transport.disconnect().await.ok()` on every exit. `BtleplugTransport::Drop` attempts disconnect. GATT subscriptions cleaned up on disconnect. |
-| PT-1002 | Deterministic timeouts | ✅ | **D10-003 RESOLVED** (issue #655). `GW_INFO_RESPONSE`: 45 s ✅. `PHONE_REGISTERED`: 30 s ✅. `NODE_ACK`: 5 s ✅. Scan: 30 s ✅. BLE connection: both platforms use 30 s ✅ (spec updated from 10 s to 30 s). |
+| PT-1002 | Deterministic timeouts | ✅ | **D10-003 RESOLVED** (issue #655). `GW_INFO_RESPONSE`: RETIRED / N/A (AEAD Phase 1 flow). `PHONE_REGISTERED`: 30 s ✅. `NODE_ACK`: 5 s ✅. Scan: 30 s ✅. BLE connection: both platforms use 30 s ✅ (spec updated from 10 s to 30 s). |
 | PT-1003 | No implicit retries | ✅ | No protocol-level retry logic found. All failures are immediately reported. |
 | PT-1004 | Reusable core | ✅ | `sonde-pair` crate has no UI or platform deps. Used by `sonde-pair-ui` (Tauri frontend) and by the built-in test suite (148+ tests across modules). |
 
@@ -305,7 +305,7 @@ Several `PairingError` variants lack actionable guidance:
 
 ---
 
-### D10-003: Android BLE connection timeout is 30 s, spec says 10 s (PT-1002)
+### D10-003: Android BLE connection timeout — RESOLVED (PT-1002)
 
 **Severity:** Low — **RESOLVED** (issue #655)
 **Requirement:** PT-1002: "BLE connection establishment 30 s."

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -119,7 +119,7 @@ tracing-test = "0.2"
 
 ### 4.2  Phase 1 state machine — Gateway pairing
 
-The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairing-protocol.md §5](ble-pairing-protocol.md).  It is implemented as an async function that takes a `BleTransport`, `PairingStore`, and `RngProvider` and returns `Result<PairingArtifacts, PairingError>`.
+The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairing-protocol.md §5](ble-pairing-protocol.md).  It is implemented as an async function that takes a `BleTransport`, `RngProvider`, `device_address`, `phone_label`, and an optional `progress` callback, and returns `Result<PairingArtifacts, PairingError>`.
 
 ```
 ┌─────────┐
@@ -130,34 +130,19 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
 ┌─────────────────┐
 │  Connecting     │──── MTU < 247 ────► Error("MTU too low")
 └────┬────────────┘                      disconnect
-     │ MTU ≥ 247
-     ▼
-┌─────────────────────────┐
-│ Authenticating          │
-│ write REQUEST_GW_INFO   │
-│ (32-byte challenge)     │
-│ wait GW_INFO_RESPONSE   │──── timeout 45s ───► Error("timeout")
-│                         │──── bad signature ──► Error("auth failed")
-└────┬────────────────────┘                      disconnect
-     │ signature valid
-     ▼
-┌─────────────────┐
-│ TOFU Check      │──── key mismatch ──► Error("public key mismatch")
-└────┬────────────┘                      disconnect
-     │ first use → pin key; or key matches stored key
+     │ MTU ≥ 247, LESC Numeric Comparison
      ▼
 ┌─────────────────────────┐
 │ Registering             │
-│ generate ephemeral X25519│
+│ generate phone_psk      │
 │ write REGISTER_PHONE    │
-│ wait response           │──── timeout 30s ────► Error("timeout")
+│ (phone_psk ‖ label)     │
+│ wait PHONE_REGISTERED   │──── timeout 30s ────► Error("timeout")
 │                         │──── ERROR(0x02) ────► Error("window closed")
 │                         │──── ERROR(0x03) ────► Error("already paired")
-│                         │──── bad GCM tag ────► Error("decrypt failed")
 └────┬────────────────────┘                      disconnect
-     │ decrypt PHONE_REGISTERED
-     │ extract phone_psk, phone_key_hint, rf_channel
-     │ zero ephemeral key, shared secret, AES key
+     │ extract phone_key_hint, rf_channel
+     │ verify phone_key_hint matches computed hint
      ▼
 ┌─────────────────┐
 │  Persist        │ persist all artifacts to PairingStore
@@ -168,9 +153,9 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
 
 **Key design decisions:**
 
-- TOFU check occurs *after* the challenge–response exchange.  The tool first authenticates the gateway via Ed25519 signature verification, then compares the received `gw_public_key` against any previously pinned key in the store.  On first use, the key is pinned; on subsequent connections, a mismatch is rejected.  This ordering ensures the gateway is live and holds the claimed private key before the TOFU decision is made (PT-0302).
+- BLE LESC Numeric Comparison provides mutual authentication — no asymmetric key exchange, no TOFU pinning (PT-0106, PT-0904).
 - No artifacts are persisted until the entire flow succeeds.  On any error, the BLE connection is released and the store is left unchanged (PT-0502).
-- Already-paired detection: if the store contains a `gw_public_key`, the tool warns the operator before starting Phase 1 and offers to proceed or cancel (PT-0601).
+- The `phone_key_hint` returned by the gateway is verified against `SHA-256(phone_psk)[30..32]` to confirm the gateway stored the correct PSK.
 
 ### 4.3  Phase 2 state machine — Node provisioning
 
@@ -194,10 +179,9 @@ The Phase 2 state machine implements the node provisioning flow from [ble-pairin
 │ 2. Generate node_psk (CSPRNG)│
 │ 3. Derive node_key_hint     │
 │ 4. Build PairingRequest CBOR│
-│ 5. Encrypt with phone_psk   │
-│ 6. Encrypt with gw_public_key│
-│ 7. Check payload ≤ 202 bytes│──── too large ──► Error (before BLE)
-│ 8. Assemble NODE_PROVISION   │
+│ 5. AES-GCM encrypt payload  │
+│ 6. Check payload ≤ 202 bytes│──── too large ──► Error (before BLE)
+│ 7. Assemble NODE_PROVISION   │
 └────┬────────────────────────┘
      │
      ▼
@@ -370,37 +354,15 @@ pub struct MockBleTransport {
 
 All cryptographic operations are implemented in `crypto.rs`.  Key material is wrapped in `zeroize::Zeroizing` throughout (PT-0304, PT-0408).
 
-### 6.1  Ed25519 signature verification (Phase 1)
+### 6.1  Ed25519 signature verification — RETIRED
 
-Used to authenticate the gateway's `GW_INFO_RESPONSE` (PT-0301).
+> **RETIRED (issue #495, PR #628).** Gateway challenge–response authentication via Ed25519 is eliminated. BLE LESC Numeric Comparison provides mutual authentication. The `verify_gateway_signature()` function no longer exists.
 
-```rust
-/// Verify Ed25519 signature over (challenge ‖ gateway_id).
-pub fn verify_gateway_signature(
-    gw_public_key: &[u8; 32],
-    challenge: &[u8; 32],
-    gateway_id: &[u8; 16],
-    signature: &[u8; 64],
-) -> Result<(), PairingError>
-```
+### 6.2  Ed25519 → X25519 conversion — RETIRED
 
-Uses `ed25519_dalek::VerifyingKey::verify_strict()` to reject non-canonical signatures.
+> **RETIRED (issue #495, PR #628).** Ed25519→X25519 key conversion and ECDH key agreement are eliminated. AES-256-GCM with pre-shared keys replaces all asymmetric cryptography in the pairing flow.
 
-### 6.2  Ed25519 → X25519 conversion
-
-Used in both Phase 1 (decrypting `PHONE_REGISTERED`) and Phase 2 (encrypting pairing payload) (PT-0902).
-
-```rust
-/// Convert an Ed25519 public key to X25519 public key.
-/// Rejects low-order points (returns error).
-pub fn ed25519_to_x25519_public(
-    ed_public: &[u8; 32],
-) -> Result<x25519_dalek::PublicKey, PairingError>
-```
-
-Uses `curve25519_dalek::edwards::CompressedEdwardsY` → `to_montgomery()` conversion.  After conversion, checks that the resulting X25519 public key is not a low-order point (all-zero or small-order Curve25519 points).  Returns `PairingError::InvalidGatewayPublicKey` on failure.
-
-### 6.3  AES-256-GCM encryption/decryption — RETIRED (§6.3 renumbered)
+### 6.3  X25519 ECDH key agreement — RETIRED
 
 > **RETIRED (issue #628).** X25519 ECDH key agreement and HKDF key derivation are no longer used. AES-256-GCM with pre-shared keys (PSK-direct) replaces all asymmetric cryptography in the pairing flow.
 
@@ -462,9 +424,7 @@ All storage operations are behind the `PairingStore` trait (PT-0802).  This enab
 ```rust
 /// Pairing artifacts stored after successful Phase 1.
 pub struct PairingArtifacts {
-    pub gw_public_key: [u8; 32],
-    pub gateway_id: [u8; 16],
-    pub phone_psk: [u8; 32],
+    pub phone_psk: Zeroizing<[u8; 32]>,
     pub phone_key_hint: u16,
     pub rf_channel: u8,
     pub phone_label: String,
@@ -492,11 +452,9 @@ After successful Phase 1, the following artifacts are persisted (PT-0800):
 
 | Field | Size | Source |
 |-------|------|--------|
-| `gw_public_key` | 32 bytes | `GW_INFO_RESPONSE` |
-| `gateway_id` | 16 bytes | `GW_INFO_RESPONSE` |
-| `phone_psk` | 32 bytes | Decrypted from `PHONE_REGISTERED` |
-| `phone_key_hint` | 2 bytes | Decrypted from `PHONE_REGISTERED` |
-| `rf_channel` | 1 byte | Decrypted from `PHONE_REGISTERED` |
+| `phone_psk` | 32 bytes | Generated by tool, sent in `REGISTER_PHONE` |
+| `phone_key_hint` | 2 bytes | Received in `PHONE_REGISTERED` |
+| `rf_channel` | 1 byte | Received in `PHONE_REGISTERED` |
 | `phone_label` | Variable (max 64 bytes UTF-8) | Operator-supplied |
 
 **No node PSK is ever persisted** (PT-0804).  Node PSKs exist only in memory during Phase 2 and are zeroed after provisioning.
@@ -530,7 +488,7 @@ When a `PskProtector` is configured (e.g. the DPAPI protector on Windows or the 
 #### Android (`AndroidPairingStore`)
 
 - Backend: Android `EncryptedSharedPreferences` backed by the Android Keystore
-- Keys: `gw_public_key`, `gateway_id`, `phone_psk`, `phone_key_hint`, `rf_channel`, `phone_label`
+- Keys: `phone_psk`, `phone_key_hint`, `rf_channel`, `phone_label`
 - Accessed via JNI bridge from Rust (Tauri Mobile provides the JNI environment)
 - On corruption: clears the corrupted preferences and returns `PairingError::StoreCorrupted`
 
@@ -740,9 +698,9 @@ pub fn decode_envelope(data: &[u8]) -> Result<(u8, &[u8]), PairingError> {
 
 | Constant | Value | Direction | Service |
 |----------|-------|-----------|---------|
-| `REQUEST_GW_INFO` | `0x01` | Phone → GW | Gateway Command |
+| ~~`REQUEST_GW_INFO`~~ | ~~`0x01`~~ | ~~Phone → GW~~ | ~~Gateway Command~~ — **RETIRED** (issue #495) |
 | `REGISTER_PHONE` | `0x02` | Phone → GW | Gateway Command |
-| `GW_INFO_RESPONSE` | `0x81` | GW → Phone | Gateway Command |
+| ~~`GW_INFO_RESPONSE`~~ | ~~`0x81`~~ | ~~GW → Phone~~ | ~~Gateway Command~~ — **RETIRED** (issue #495) |
 | `PHONE_REGISTERED` | `0x82` | GW → Phone | Gateway Command |
 | `NODE_PROVISION` | `0x01` | Phone → Node | Node Command |
 | `NODE_ACK` | `0x81` | Node → Phone | Node Command |
@@ -817,9 +775,8 @@ Cryptographic operations and CBOR construction — testable with known test vect
 
 | Step | Module | What to build | Test with |
 |---|---|---|---|
-| P2.1 | `crypto.rs` (signature) | `verify_gateway_signature()`, `ed25519_to_x25519_public()` | T-PT-202, T-PT-203, T-PT-309 |
-| P2.2 | `crypto.rs` (AES-GCM) | `aes_gcm_encrypt()`, `aes_gcm_decrypt()`, `derive_key_hint()` | T-PT-307, T-PT-308, T-PT-902, T-PT-303 |
-| P2.3 | `cbor.rs` | `PairingRequest` CBOR construction with deterministic encoding (RFC 8949 §4.2) | T-PT-304, T-PT-903 |
+| P2.1 | `crypto.rs` (AES-GCM) | `aes_gcm_encrypt()`, `aes_gcm_decrypt()`, `derive_key_hint()` | T-PT-307, T-PT-308, T-PT-902, T-PT-303 |
+| P2.2 | `cbor.rs` | `PairingRequest` CBOR construction with deterministic encoding (RFC 8949 §4.2) | T-PT-304, T-PT-903 |
 
 **Exit criteria (P2):** All cryptographic operations pass known test vectors.  CBOR encoding is deterministic and matches precomputed reference vectors.  AES-GCM AAD is verified.
 
@@ -830,7 +787,7 @@ Connect foundation and crypto into the Phase 1 and Phase 2 state machines.
 | Step | Module | What to build | Test with |
 |---|---|---|---|
 | P3.1 | `discovery.rs` | Scan lifecycle (start, stop, timeout, stale eviction), device filtering by service UUID | T-PT-100 to T-PT-104 |
-| P3.2 | `phase1.rs` | Phase 1 state machine: connect → TOFU → authenticate → register → decrypt → persist | T-PT-200 to T-PT-213 |
+| P3.2 | `phase1.rs` | Phase 1 state machine: connect → register → persist (AEAD-only, no TOFU/ECDH) | T-PT-200 to T-PT-213 |
 | P3.3 | `phase2.rs` | Phase 2 state machine: prerequisite check → connect → build payload → provision → ACK | T-PT-300 to T-PT-315 |
 | P3.4 | Integration | Error handling, idempotency, security, non-functional tests | T-PT-400 to T-PT-402, T-PT-500 to T-PT-502, T-PT-700 to T-PT-703, T-PT-800 to T-PT-802 |
 

--- a/docs/e2e-validation.md
+++ b/docs/e2e-validation.md
@@ -232,6 +232,25 @@ impl E2eNode {
 
 ---
 
+#### T-E2E-002c  AEAD wake cycle with BPF APP_DATA
+
+**Validates:** GW-0600, ND-0300, ND-0602.
+
+**Preconditions:**
+1. Node registered with matching PSK.
+2. BPF program assigned that calls `send()` (helper 8).
+
+**Procedure:**
+1. Node completes AEAD wake cycle (WAKE → COMMAND → program download).
+2. BPF program executes and calls `send()` with a 2-byte blob.
+3. Node sends an AEAD-authenticated APP_DATA frame.
+
+**Assertions:**
+- `run_wake_cycle()` returns `Sleep { seconds: 60 }`.
+- Exactly one `MSG_APP_DATA` frame was sent by the node.
+
+---
+
 #### T-E2E-003  Wrong PSK rejected silently
 
 **Validates:** GW-0601 (wrong key → silent discard), ND-0301.
@@ -249,6 +268,27 @@ impl E2eNode {
 **Assertions:**
 - `run_wake_cycle()` returns `Sleep { seconds: 60 }` (retries exhausted).
 - Gateway sent zero response frames.
+
+---
+
+#### T-E2E-004  Tampered AEAD frame (silent discard)
+
+**Validates:** GW-0600 (GCM tag verification), ND-0300.
+
+**Preconditions:**
+1. Node registered with matching PSK.
+2. Tamper mode enabled on transport (bit-flip in ciphertext region).
+
+**Procedure:**
+1. Node sends WAKE with valid PSK.
+2. Transport flips a bit in the ciphertext before forwarding.
+3. Gateway receives frame, GCM authentication fails.
+4. Gateway silently discards the frame — no response.
+
+**Assertions:**
+- `run_wake_cycle()` returns `Sleep { seconds: 60 }` (retries exhausted).
+- Gateway sent zero response frames.
+- Gateway did not update `last_seen` or battery telemetry for the node.
 
 ---
 
@@ -900,7 +940,9 @@ impl E2eNode {
 | T-E2E-001 | GW-0100, GW-0102, GW-0103, ND-0200, ND-0201 |
 | T-E2E-002 | GW-0600, ND-0300, ND-0301 |
 | T-E2E-002b | GW-0600, ND-0300, ND-0301, ND-0304 |
+| T-E2E-002c | GW-0600, ND-0300, ND-0602 |
 | T-E2E-003 | GW-0601, GW-1002, ND-0301 |
+| T-E2E-004 | GW-0600, ND-0300 |
 | T-E2E-010 | GW-0201, GW-0300, GW-0302, ND-0500, ND-0501, ND-0506 |
 | T-E2E-011 | GW-0200 |
 | T-E2E-020 | GW-0203, GW-0803, ND-0202 |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1989,9 +1989,9 @@ Test functions in `crates/sonde-node/src/` are unit tests; those in `crates/sond
 | T-N207 | `test_unknown_command_treated_as_nop` | wake_cycle.rs |
 | T-N208 | `test_set_next_wake_shorter`, `test_set_next_wake_equal` *(partial — unit tests cover SleepManager clamping logic; the full e2e set_next_wake → base-interval-restore cycle is not yet tested)* | sleep.rs |
 | T-N209 | `test_set_next_wake_longer_clamped` | sleep.rs |
-| T-N300 | `wake_command_exchange_round_trip`, `t_e2e_050_nop_wake_cycle` | wake_cycle.rs, aead_e2e_tests.rs |
-| T-N301 | `t_e2e_052_wrong_psk_rejected`, `t_e2e_053_tampered_frame_discarded` | aead_e2e_tests.rs |
-| T-N302 | `wake_command_exchange_round_trip`, `t_e2e_050_nop_wake_cycle` | wake_cycle.rs, aead_e2e_tests.rs |
+| T-N300 | `wake_command_exchange_round_trip`, `t_e2e_001_nop_wake_cycle` | wake_cycle.rs, aead_e2e_tests.rs |
+| T-N301 | `t_e2e_003_wrong_psk_rejected`, `t_e2e_004_tampered_frame_discarded` | aead_e2e_tests.rs |
+| T-N302 | `wake_command_exchange_round_trip`, `t_e2e_001_nop_wake_cycle` | wake_cycle.rs, aead_e2e_tests.rs |
 | T-N303 | `test_wrong_nonce_discarded`, `test_send_recv_app_data_wrong_nonce` | wake_cycle.rs |
 | T-N304 | `test_wrong_seq_on_chunk_discarded` | wake_cycle.rs |
 | T-N305 | `test_sequence_increment_correctness`, `t_e2e_041_sequence_numbers` | wake_cycle.rs, e2e_tests.rs |


### PR DESCRIPTION
## Summary

Resolves two critical specification drift findings from the maintenance audit.

### F-001: E2E test ID collision

AEAD tests in `aead_e2e_tests.rs` used IDs T-E2E-050 through T-E2E-053, colliding with modem bridge tests defined in `e2e-validation.md` section 4.6.

**Fix:** Renumbered to match actual spec entries:

| Old ID | New ID | Test |
|--------|--------|------|
| T-E2E-050 | T-E2E-001 | NOP wake cycle |
| T-E2E-050b | T-E2E-002b | Consecutive wake cycles |
| T-E2E-051 | T-E2E-002c | AEAD with BPF APP_DATA (new spec entry) |
| T-E2E-052 | T-E2E-003 | Wrong PSK rejected |
| T-E2E-053 | T-E2E-004 | Tampered AEAD frame (new spec entry) |

Added T-E2E-004 and T-E2E-002c definitions + traceability to `e2e-validation.md`.

### F-002: BLE pairing design describes RETIRED Ed25519/TOFU flow

Design doc sections 6.1, 6.2, and 4.2 described Ed25519 signature verification, ECDH key agreement, and TOFU pinning that were removed in issue #495 / PR #628.

**Fix:**
- Replaced section 4.2 state machine with the actual AEAD-only flow (Connect, Register, Persist)
- Marked sections 6.1 and 6.2 as RETIRED with issue/PR references

All 10 AEAD E2E tests pass with the new names.

Closes #658
