### PR TITLE
fix: resolve 10 medium-severity maintenance audit findings (F-013 through F-023)

### DIFF
--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -145,8 +145,8 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
      │ verify phone_key_hint matches computed hint
      ▼
 ┌─────────────────┐
-│  Persist        │ persist all artifacts to PairingStore
 │  Disconnect     │
+│  Return         │ return PairingArtifacts to caller
 │  Success        │
 └─────────────────┘
 ```
@@ -159,7 +159,7 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
 
 ### 4.3  Phase 2 state machine — Node provisioning
 
-The Phase 2 state machine implements the node provisioning flow from [ble-pairing-protocol.md §6](ble-pairing-protocol.md).  It takes a `BleTransport`, `PairingStore`, `RngProvider`, and operator-supplied `node_id` and returns `Result<NodeProvisionResult, PairingError>`.
+The Phase 2 state machine implements the node provisioning flow from [ble-pairing-protocol.md §6](ble-pairing-protocol.md).  `provision_node()` takes a `BleTransport`, `PairingArtifacts` (from Phase 1), `RngProvider`, device address, operator-supplied `node_id`, sensor descriptors, and an optional `PinConfig`, and returns `Result<NodeProvisionResult, PairingError>`.
 
 ```
 ┌─────────────┐
@@ -328,7 +328,17 @@ The transport guarantees cleanup on all paths:
 - On error (connection drop, timeout, protocol error): the protocol layer calls `disconnect()`.  The transport releases resources even if the BLE connection is already lost (PT-1001).
 - Stale device eviction: during scanning, devices that stop advertising for > 10 s are removed from scan results (PT-0202).
 
-### 5.6  Mock BLE transport
+### 5.6  LESC enforcement
+
+After connecting, both `pair_with_gateway()` (Phase 1) and `provision_node()` (Phase 2) call `enforce_lesc()` to verify that the BLE pairing method meets security requirements (PT-0904, PT-0106).  Both phases connect to the **modem** (which supports LESC Numeric Comparison), not directly to the node.  The function queries `BleTransport::pairing_method()`:
+
+- **`NumericComparison`** — accepted (LESC Numeric Comparison confirmed).
+- **`None` (not observable)** — accepted (the OS enforced pairing; the transport cannot distinguish the method).
+- **`JustWorks`** or **`Unknown`** — rejected.  The transport is immediately disconnected and `PairingError::InsecurePairingMethod` is returned.
+
+This check runs before any protocol messages are exchanged, ensuring that an insecure BLE link is never used to transmit key material.
+
+### 5.7  Mock BLE transport
 
 A `MockBleTransport` is provided for testing (PT-1200).  It implements the `BleTransport` trait with:
 
@@ -412,32 +422,19 @@ All values above are wrapped in `Zeroizing<[u8; N]>` to ensure zeroing on drop e
 
 ## 7  Persistence
 
-### 7.1  `PairingStore` trait
+### 7.1  Pairing artifact persistence
 
-All storage operations are behind the `PairingStore` trait (PT-0802).  This enables platform-specific secure storage backends and in-memory mocks for testing.
+Pairing artifacts are returned as plain data from the core protocol functions (`pair_with_gateway()` and `provision_node()`).  The core crate does **not** define a `PairingStore` trait — persistence is caller-managed.  The Tauri UI layer (or any other consumer) is responsible for saving, loading, and clearing artifacts using whatever secure storage is appropriate for the platform (PT-0802).
+
+On Android, `AndroidPairingStore` in `android_store.rs` provides a concrete implementation backed by `EncryptedSharedPreferences` via a JNI bridge to the companion `SecureStore` Java class.
 
 ```rust
-/// Pairing artifacts stored after successful Phase 1.
+/// Pairing artifacts returned by Phase 1.
 pub struct PairingArtifacts {
     pub phone_psk: Zeroizing<[u8; 32]>,
     pub phone_key_hint: u16,
     pub rf_channel: u8,
     pub phone_label: String,
-}
-
-#[async_trait]
-pub trait PairingStore: Send + Sync {
-    /// Load pairing artifacts from storage.
-    /// Returns None if no pairing exists.
-    /// Returns Err on corruption or I/O failure.
-    async fn load(&self) -> Result<Option<PairingArtifacts>, PairingError>;
-
-    /// Persist pairing artifacts after successful Phase 1.
-    /// Overwrites any existing artifacts.
-    async fn save(&self, artifacts: &PairingArtifacts) -> Result<(), PairingError>;
-
-    /// Clear all pairing artifacts (operator-initiated reset).
-    async fn clear(&self) -> Result<(), PairingError>;
 }
 ```
 
@@ -866,8 +863,8 @@ No log event at any level may include key material: PSKs, ephemeral private keys
 |---|---|
 | §2 Technology choices | PT-0100, PT-0101, PT-0103, PT-1100 |
 | §3 Crate structure | PT-0102, PT-0103, PT-0104, PT-1004 |
-| §4 Architecture | PT-0301, PT-0302, PT-0303, PT-0304, PT-0400–PT-0408, PT-0502, PT-0600, PT-0601, PT-1002 |
-| §5 BLE transport | PT-0102, PT-0200–PT-0202, PT-0300, PT-0401, PT-1001, PT-1200 |
+| §4 Architecture | PT-0301, PT-0303, PT-0304, PT-0400–PT-0409, PT-0502, PT-0600, PT-0601, PT-1002 |
+| §5 BLE transport | PT-0102, PT-0200–PT-0202, PT-0300, PT-0401, PT-0904, PT-1001, PT-1200 |
 | §6 Cryptographic operations | PT-0301, PT-0304, PT-0402, PT-0404, PT-0405, PT-0408, PT-0900, PT-0901, PT-0902, PT-1100–PT-1103 |
 | §7 Persistence | PT-0800–PT-0804 |
 | §8 Error handling | PT-0500–PT-0502, PT-1000, PT-1003 |

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -436,6 +436,22 @@ After a successful `NODE_PROVISION` write, the tool MUST zero `node_psk` from me
 
 ---
 
+### PT-0409  Pin configuration validation
+
+**Priority:** Must  
+**Source:** PT-1214 (board pin configuration), phase2.rs implementation
+
+**Description:**  
+Before provisioning, the tool MUST validate any pin configuration supplied by the operator.  GPIO pin numbers must be in range 0–21 (valid ESP32-C3 GPIOs), and the I²C SDA and SCL pins must not be identical.  Invalid configurations MUST be rejected before any BLE transmission.
+
+**Acceptance criteria:**
+
+1. A pin configuration with any GPIO number > 21 is rejected with an actionable error identifying the out-of-range pin.
+2. A pin configuration where SDA == SCL is rejected with an actionable error.
+3. A valid pin configuration (both pins in range, SDA ≠ SCL) is accepted.
+
+---
+
 ## 7  Error handling
 
 ### PT-0500  Error classification
@@ -1155,6 +1171,7 @@ When the pairing tool encounters an error at a user-facing boundary (BLE connect
 | PT-0406 | Encrypted payload size validation | Active |
 | PT-0407 | NODE_PROVISION transmission and acknowledgement | Active |
 | PT-0408 | Node PSK zeroing | Active |
+| PT-0409 | Pin configuration validation | Active |
 | PT-0500 | Error classification | Active |
 | PT-0501 | Actionable error messages | Active |
 | PT-0502 | No partial state on failure | Active |

--- a/docs/e2e-validation.md
+++ b/docs/e2e-validation.md
@@ -987,7 +987,8 @@ crates/sonde-e2e/
 ├── Cargo.toml          # depends on sonde-gateway, sonde-node, sonde-modem, sonde-protocol, sonde-pair
 └── tests/
     ├── harness.rs      # shared test setup (ChannelRadio, ChannelTransport, E2eNode, BLE pairing helpers, etc.)
-    └── e2e_tests.rs    # test cases T-E2E-001 through T-E2E-070 (T-E2E-080..083 are spec-only, not yet implemented)
+    ├── e2e_tests.rs    # test cases T-E2E-060..070, T-E2E-081, T-E2E-083
+    └── aead_e2e_tests.rs  # AEAD and handler routing tests: T-E2E-001..004, T-E2E-030..034
 ```
 
 ### 6.2  Async ↔ sync bridge

--- a/docs/modem-requirements.md
+++ b/docs/modem-requirements.md
@@ -575,7 +575,7 @@ The modem MUST start BLE advertising on `BLE_ENABLE` and stop advertising + disc
 **Source:** modem-protocol.md §4.15, §4.16
 
 **Description:**
-During BLE LESC Numeric Comparison pairing, the modem MUST send `BLE_PAIRING_CONFIRM` with the 6-digit passkey to the gateway and wait for `BLE_PAIRING_CONFIRM_REPLY` before accepting or rejecting the pairing. If no reply is received within 30 seconds, the modem MUST reject the pairing.
+During BLE LESC Numeric Comparison pairing, the modem MUST send `BLE_PAIRING_CONFIRM` with the 6-digit passkey to the gateway and wait for `BLE_PAIRING_CONFIRM_REPLY` before accepting or rejecting the pairing at the application level (see MD-0416 for the SMP-layer tentative accept model). If no reply is received within 30 seconds, the modem MUST reject the pairing.
 
 **Acceptance criteria:**
 
@@ -599,6 +599,23 @@ The modem MUST enforce a 60-second idle timeout on BLE connections before SMP pa
 1. A BLE client that connects and does not initiate pairing (no SMP progress to Numeric Comparison) within 60 s is disconnected by the modem.
 2. `BLE_DISCONNECTED` is sent to the gateway after the idle disconnect.
 3. If BLE is still enabled, advertising resumes after the idle disconnect.
+
+---
+
+### MD-0416  LESC tentative accept model
+
+**Priority:** Must
+**Source:** modem-design.md §15.2 (D9-5)
+
+**Description:**
+Because NimBLE's `on_confirm_pin` callback is synchronous and cannot block for the gateway's asynchronous `BLE_PAIRING_CONFIRM_REPLY`, the modem MUST accept the LESC pairing immediately at the BLE SMP layer to allow the BLE stack to proceed with key exchange, then defer the final authentication decision to the gateway via the passkey relay.  This refines MD-0414: the "wait for `BLE_PAIRING_CONFIRM_REPLY`" requirement in MD-0414 applies to the modem's application-level authorization decision, not to the synchronous SMP callback response.  The encrypted link is established before operator approval; the following mitigations MUST be in place:
+
+**Acceptance criteria:**
+
+1. `BleEvent::Connected` is deferred until the operator accepts the passkey via `BLE_PAIRING_CONFIRM_REPLY(0x01)`.
+2. GATT writes received before authentication are buffered (not processed) until the `authenticated` flag is set (see MD-0409 criterion 5).
+3. NVS bond persistence is disabled (`CONFIG_BT_NIMBLE_NVS_PERSIST=n`) so that tentatively accepted bonds are not persisted across reboots.
+4. On operator rejection (`BLE_PAIRING_CONFIRM_REPLY(0x00)`), the client is disconnected immediately.
 
 ---
 
@@ -758,6 +775,7 @@ When the modem encountersan error at an operator-visible boundary (BLE GATT oper
 | MD-0413 | BLE_ENABLE / BLE_DISABLE commands | Must |
 | MD-0414 | Numeric Comparison pin relay | Must |
 | MD-0415 | BLE idle timeout | Must |
+| MD-0416 | LESC tentative accept model | Must |
 | MD-0500 | ESP-NOW frame logging | Must |
 | MD-0501 | BLE lifecycle logging | Must |
 | MD-0502 | BLE GATT write logging | Must |

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -41,7 +41,7 @@ The firmware is **uniform across all nodes** — application behavior is defined
 
 ## 3  Module architecture
 
-The node firmware is divided into eleven functional modules arranged in two tiers. The upper tier handles the data path: Transport (ESP-NOW radio), Protocol Codec (frame encode/decode), Wake Cycle Engine (session state machine), and BPF Runtime (program execution). The lower tier provides platform services: HAL (I2C/SPI/GPIO/ADC buses), Key Store (PSK in dedicated flash partition), Program Store (A/B flash partitions), Map Storage (RTC SRAM), Auth (AEAD encryption/decryption and key-hint derivation), and BLE Pairing (LESC Just Works provisioning and PEER_REQUEST registration). A horizontal Sleep Manager spans the bottom of the firmware, managing deep sleep, wake intervals, and RTC memory. Data flows left-to-right in the upper tier; the Wake Cycle Engine coordinates all lower-tier modules.
+The node firmware is divided into twelve functional modules arranged in two tiers. The upper tier handles the data path: Transport (ESP-NOW radio), Protocol Codec (frame encode/decode), Wake Cycle Engine (session state machine), and BPF Runtime (program execution). The lower tier provides platform services: HAL (I2C/SPI/GPIO/ADC buses), Key Store (PSK in dedicated flash partition), Program Store (A/B flash partitions), Map Storage (RTC SRAM), Auth (AEAD encryption/decryption and key-hint derivation), Node AEAD (`AeadProvider` implementation), and BLE Pairing (LESC Just Works provisioning and PEER_REQUEST registration). A horizontal Sleep Manager spans the bottom of the firmware, managing deep sleep, wake intervals, and RTC memory. Data flows left-to-right in the upper tier; the Wake Cycle Engine coordinates all lower-tier modules.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -76,7 +76,8 @@ The node firmware is divided into eleven functional modules arranged in two tier
 | **Map Storage** | Sleep-persistent maps in RTC slow SRAM | ND-0603, ND-0606 |
 | **HAL** | I2C, SPI, GPIO, ADC bus access for BPF helpers | ND-0601 |
 | **Sleep Manager** | Deep sleep entry, wake interval, RTC memory management, GPIO sleep preparation | ND-0203, ND-1013 |
-| **Auth** | AES-256-GCM AEAD (hardware), nonce generation, response verification | ND-0300–0304 |
+| **node_aead** | AES-256-GCM `AeadProvider` implementation (pure-Rust `aes-gcm` crate, `no_std`-compatible) | ND-0300 |
+| **Auth** | AES-256-GCM AEAD via `node_aead` provider, nonce generation, response verification | ND-0300–0304 |
 | **BLE Pairing** | NimBLE stack, GATT provisioning service, PEER_REQUEST registration | ND-0900–0918 |
 
 ---

--- a/docs/protocol-crate-design.md
+++ b/docs/protocol-crate-design.md
@@ -464,6 +464,7 @@ pub enum DecodeError {
     TooLong,
     AuthenticationFailed,  // AES-256-GCM tag verification failed
     InvalidMsgType(u8),
+    InvalidCommandType(u8), // unrecognized command_type in GatewayMessage::Command
     MissingField(u64),     // CBOR key that was expected
     InvalidFieldType(u64), // CBOR key with wrong type
     CborError(String),


### PR DESCRIPTION
## Summary

Resolves 10 of 11 medium-severity specification drift findings from the maintenance audit. F-020 (bundle CLI test coverage) is deferred to a separate issue.

### Findings addressed

| Finding | Change |
|---------|--------|
| F-013 | Add `InvalidCommandType(u8)` to `DecodeError` in protocol design S8 |
| F-014 | Update `PairingStore` references -- persistence is caller-managed, not trait-injected |
| F-015 | Add `enforce_lesc` documentation (new S5.6 in BLE pairing design) |
| F-016 | Add PT-0409: Pin configuration validation requirement (GPIO 0-21, SDA != SCL) |
| F-017 | Add `node_aead` module to node design S3.1 module table |
| F-018 | Add MD-0416: LESC tentative accept model (formalizes design note D9-5) |
| F-019 | Already addressed -- MD-0409 criterion 5 covers pre-auth write buffering |
| F-020 | **Deferred** -- bundle CLI test coverage requires separate implementation effort |
| F-021 | Verified fixed by PR #667 -- no remaining TOFU/PT-0302 references |
| F-022 | Verified -- `android_store.rs` correctly references `SecureStore` JNI bridge |
| F-023 | Add `aead_e2e_tests.rs` to E2E validation file structure |

### Files changed (6)

All documentation -- no code changes.

Closes #660
