### PR TITLE
feat: produce both debug and release Android APKs

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -41,6 +41,7 @@ jobs:
   android:
     name: Android APK
     uses: ./.github/workflows/tauri-android.yml
+    secrets: inherit
 
   # ── Installer builds (depend on gateway binaries) ───────────────
   installer-linux:
@@ -177,7 +178,10 @@ jobs:
           cp artifacts/modem-firmware/flash_image.bin       release-assets/modem-flash_image.bin
           for f in artifacts/sonde-pair-windows/*; do cp -r "$f" release-assets/; done
           for f in artifacts/sonde-pair-linux/*;   do cp -r "$f" release-assets/; done
-          for f in artifacts/sonde-pair-android/*; do cp -r "$f" release-assets/; done
+          for f in artifacts/sonde-pair-android-debug/*; do cp -r "$f" release-assets/; done
+          if [ -d artifacts/sonde-pair-android-release ]; then
+            for f in artifacts/sonde-pair-android-release/*; do cp -r "$f" release-assets/; done
+          fi
           for f in artifacts/sonde-installer-linux/*;  do cp -r "$f" release-assets/; done
           for f in artifacts/sonde-installer-windows/*; do cp -r "$f" release-assets/; done
 
@@ -195,7 +199,8 @@ jobs:
           | ESP32-S3 Modem firmware | `modem-flash_image.bin` |
           | Desktop — Windows | `*.exe` |
           | Desktop — Linux | `*.deb` |
-          | Android APK | `*.apk` |
+          | Android APK (debug) | `*-debug.apk` |
+          | Android APK (release) | `*-release.apk` (when signing secrets configured) |
           | Installer — Windows | `sonde-x86_64.msi` |
           | Installer — Linux | `sonde_*_amd64.deb` |
 

--- a/.github/workflows/tauri-android.yml
+++ b/.github/workflows/tauri-android.yml
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 sonde contributors
 #
-# Tauri Android APK CI: build sonde-pair-ui for Android (aarch64) and
-# upload the unsigned debug APK as a CI artifact for sideloading/testing.
+# Tauri Android APK CI: build sonde-pair-ui for Android (aarch64).
+# Produces a debug APK (always) and a signed release APK (when
+# signing secrets are configured). See docs/android-signing.md.
 
 name: Tauri Android APK
 
@@ -100,14 +101,62 @@ jobs:
         working-directory: crates/sonde-pair-ui
         run: cargo tauri android build --debug
 
-      # ------------------------------------------------------------------ #
-      # Upload artifact
-      # ------------------------------------------------------------------ #
-
-      - name: Upload APK
+      # Upload debug APK immediately so it's available even if the
+      # optional release build fails.
+      - name: Upload debug APK
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: sonde-pair-android
-          path: crates/sonde-pair-ui/src-tauri/gen/android/**/outputs/**/*.apk
+          name: sonde-pair-android-debug
+          path: crates/sonde-pair-ui/src-tauri/gen/android/**/outputs/**/debug/**/*.apk
+          retention-days: 7
+          if-no-files-found: error
+
+      # ------------------------------------------------------------------ #
+      # Release build (conditional — requires all 4 signing secrets)
+      # ------------------------------------------------------------------ #
+
+      - name: Validate signing secrets
+        id: signing
+        run: |
+          if [ -n "$KEYSTORE" ] && [ -n "$STORE_PASS" ] && [ -n "$KEY_ALIAS" ] && [ -n "$KEY_PASS" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release APK skipped — signing secrets not configured"
+          fi
+        env:
+          KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
+          STORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASS: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+      - name: Decode release keystore
+        if: steps.signing.outputs.available == 'true'
+        env:
+          ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE }}
+        run: |
+          printf '%s' "$ANDROID_KEYSTORE" | base64 --decode > /tmp/sonde-release.jks
+          chmod 600 /tmp/sonde-release.jks
+
+      - name: Build Android APK (release)
+        if: steps.signing.outputs.available == 'true'
+        working-directory: crates/sonde-pair-ui
+        env:
+          ORG_GRADLE_PROJECT_android.injected.signing.store.file: /tmp/sonde-release.jks
+          ORG_GRADLE_PROJECT_android.injected.signing.store.password: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ORG_GRADLE_PROJECT_android.injected.signing.key.alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ORG_GRADLE_PROJECT_android.injected.signing.key.password: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: cargo tauri android build
+
+      - name: Clean up keystore
+        if: always()
+        run: rm -f /tmp/sonde-release.jks
+
+      - name: Upload release APK
+        if: steps.signing.outputs.available == 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: sonde-pair-android-release
+          path: crates/sonde-pair-ui/src-tauri/gen/android/**/outputs/**/release/**/*.apk
           retention-days: 7
           if-no-files-found: error

--- a/docs/android-signing.md
+++ b/docs/android-signing.md
@@ -1,0 +1,69 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright (c) 2026 sonde contributors -->
+
+# Android APK Signing Setup
+
+This guide explains how to configure signed release APK builds in the
+Sonde CI pipeline.  Once configured, the `Tauri Android APK` workflow
+produces both a debug APK (always) and a signed release APK.
+
+## Overview
+
+Android requires all APKs to be signed before installation.  Debug builds
+use a shared debug keystore; release builds need a project-specific
+keystore.  The CI workflow (`tauri-android.yml`) supports both:
+
+- **Debug APK** — built on every push/PR, signed with the Android SDK debug keystore
+- **Release APK** — built only when signing secrets are configured, signed with the project keystore
+
+## Step 1: Generate a keystore
+
+Run once on a trusted machine.  **Back up the `.jks` file securely** —
+losing it means you cannot push updates to any app signed with this key.
+
+```sh
+keytool -genkey -v \
+  -keystore sonde-release.jks \
+  -keyalg RSA -keysize 2048 \
+  -validity 10000 \
+  -alias sonde \
+  -storepass <STORE_PASSWORD> \
+  -keypass <KEY_PASSWORD> \
+  -dname "CN=Sonde, O=sonde contributors"
+```
+
+## Step 2: Add GitHub Actions secrets
+
+Go to **Settings → Secrets and variables → Actions** and add:
+
+| Secret name | Value |
+|-------------|-------|
+| `ANDROID_KEYSTORE` | Base64-encoded keystore: Linux `base64 -w0 sonde-release.jks`; macOS `base64 sonde-release.jks \| tr -d '\n'` |
+| `ANDROID_KEYSTORE_PASSWORD` | The `-storepass` value from Step 1 |
+| `ANDROID_KEY_ALIAS` | `sonde` (or whatever `-alias` you chose) |
+| `ANDROID_KEY_PASSWORD` | The `-keypass` value from Step 1 |
+
+## Step 3: Verify
+
+Push a commit that triggers the `Tauri Android APK` workflow.  Check
+the workflow run:
+
+1. The "Decode release keystore" step should run (not skipped).
+2. The "Build Android APK (release)" step should produce a signed APK.
+3. Two artifacts should appear: `sonde-pair-android-debug` and
+   `sonde-pair-android-release`.
+
+## Notes
+
+- **Secrets on PRs:** GitHub does not expose secrets to pull requests
+  from forks.  Pull requests from branches in the same repository
+  may have access to secrets, subject to repository settings.  When
+  signing secrets are unavailable, the release build step is skipped
+  gracefully — only the debug APK is produced.
+- **Key rotation:** If you need to rotate the signing key, generate
+  a new keystore, update the secrets, and consider using Google Play
+  App Signing (where Google manages the distribution key and the
+  repo key is only an upload key).
+- **The keystore file is never committed to the repository.**  It
+  exists only as a base64-encoded GitHub secret and is decoded to a
+  temporary file during the build, then cleaned up.


### PR DESCRIPTION
## Summary

Add signed release APK builds alongside the existing debug APK in the Android CI workflow.

### Changes

**`tauri-android.yml`:**
- Debug APK build unchanged (always runs)
- New conditional release build: decodes keystore from `ANDROID_KEYSTORE` secret, configures Gradle signing via injected properties, runs `cargo tauri android build` (release mode)
- Keystore is decoded to temp file and cleaned up in an `always()` step
- Separate upload artifacts: `sonde-pair-android-debug` and `sonde-pair-android-release`
- Release build gracefully skips when secrets are not available (forks, PRs)

**`nightly-release.yml`:**
- Copies both debug and release APK artifacts to release assets
- Release APK is optional (`if [ -d ... ]` guard)
- Updated release notes table

**`docs/android-signing.md`** (new):
- Step-by-step guide: keystore generation, GitHub secrets setup, verification
- Notes on fork behavior, key rotation, security

### Prerequisites

To enable signed release builds, add these GitHub Actions secrets (see `docs/android-signing.md`):
- `ANDROID_KEYSTORE` (base64-encoded .jks)
- `ANDROID_KEYSTORE_PASSWORD`
- `ANDROID_KEY_ALIAS`
- `ANDROID_KEY_PASSWORD`

Until secrets are configured, only the debug APK is produced (no regression).

Closes #656
