### PR TITLE
Add GHCP CLI support

### DIFF
--- a/.github/prompts/sonde-hw-design.prompt.md
+++ b/.github/prompts/sonde-hw-design.prompt.md
@@ -248,7 +248,12 @@ work on that phase:
 | 8–9. Manufacturing | `.github/prompts/steps/sonde-hw-manufacturing.md` | manufacturing-artifact-generation |
 
 **Loading rules:**
-- Read the methodology file for the current phase BEFORE starting work
+- Read the methodology file for the current phase BEFORE starting work.
+  Use whatever file-reading capability your environment provides:
+  - **Copilot CLI / terminal agent**: use the `view` tool to read the file
+  - **Copilot Chat / IDE agent**: use `#file:` references or workspace
+    file reading tools
+  - The paths above are relative to the repository root
 - Do NOT read all files upfront — load each phase just-in-time
 - Follow the protocol phases in the loaded file IN ORDER
 - Apply the Core Methodology (anti-hallucination + self-verification)


### PR DESCRIPTION
This pull request updates the instructions for reading methodology files in the `.github/prompts/sonde-hw-design.prompt.md` file. The main change is clarifying how to read files depending on the environment, making the instructions more explicit for different Copilot tools.

**Instruction and documentation improvements:**

* Clarified the rule for reading the methodology file by specifying which file-reading method to use based on the environment (Copilot CLI/terminal agent or Copilot Chat/IDE agent), and noted that paths are relative to the repository root.