### PR TITLE
feat(pair-ui): add board selector for I2C pin config (PT-1216)

### DIFF
--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 use sonde_pair::discovery::{service_type, DeviceScanner, ServiceType};
 use sonde_pair::phase1::PairingProgress;
 use sonde_pair::rng::OsRng;
-use sonde_pair::types::ScannedDevice;
+use sonde_pair::types::{PinConfig, ScannedDevice};
 use sonde_pair::{phase1, phase2};
 
 #[cfg(not(target_os = "android"))]
@@ -100,6 +100,24 @@ fn parse_address(s: &str) -> Result<[u8; 6], String> {
             .map_err(|_| format!("invalid hex byte `{part}` in address"))?;
     }
     Ok(addr)
+}
+
+/// Resolve optional I2C pin parameters into a `PinConfig` (PT-1216 AC 7).
+///
+/// Both parameters must be present or both absent.  Providing exactly one
+/// is an error.
+fn resolve_pin_config(
+    i2c_sda: Option<u8>,
+    i2c_scl: Option<u8>,
+) -> Result<Option<PinConfig>, String> {
+    match (i2c_sda, i2c_scl) {
+        (Some(sda), Some(scl)) => Ok(Some(PinConfig {
+            i2c0_sda: sda,
+            i2c0_scl: scl,
+        })),
+        (None, None) => Ok(None),
+        _ => Err("Provide both I2C SDA and I2C SCL pins, or leave both empty.".into()),
+    }
 }
 
 fn device_to_info(d: &ScannedDevice) -> DeviceInfo {
@@ -250,6 +268,8 @@ async fn provision_node(
     state: tauri::State<'_, AppState>,
     address: String,
     node_id: String,
+    i2c_sda: Option<u8>,
+    i2c_scl: Option<u8>,
 ) -> Result<String, String> {
     *state.scanner.lock().unwrap() = None;
 
@@ -260,6 +280,8 @@ async fn provision_node(
             return Err(e);
         }
     };
+
+    let pin_config = resolve_pin_config(i2c_sda, i2c_scl)?;
 
     // Load artifacts from in-memory cache, falling back to file store.
     let artifacts = {
@@ -285,8 +307,16 @@ async fn provision_node(
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = BtleplugTransport::new().await?;
             let rng = OsRng;
-            phase2::provision_node(&mut transport, &artifacts, &rng, &addr, &node_id, &[], None)
-                .await
+            phase2::provision_node(
+                &mut transport,
+                &artifacts,
+                &rng,
+                &addr,
+                &node_id,
+                &[],
+                pin_config,
+            )
+            .await
         })
     })
     .await
@@ -460,6 +490,8 @@ async fn provision_node(
     state: tauri::State<'_, AppState>,
     address: String,
     node_id: String,
+    i2c_sda: Option<u8>,
+    i2c_scl: Option<u8>,
 ) -> Result<String, String> {
     *state.scanner.lock().unwrap() = None;
 
@@ -470,6 +502,8 @@ async fn provision_node(
             return Err(e);
         }
     };
+
+    let pin_config = resolve_pin_config(i2c_sda, i2c_scl)?;
 
     let artifacts = state
         .pairing_artifacts
@@ -484,8 +518,16 @@ async fn provision_node(
         tokio::runtime::Handle::current().block_on(async {
             let mut transport = AndroidBleTransport::from_cached_vm()?;
             let rng = OsRng;
-            phase2::provision_node(&mut transport, &artifacts, &rng, &addr, &node_id, &[], None)
-                .await
+            phase2::provision_node(
+                &mut transport,
+                &artifacts,
+                &rng,
+                &addr,
+                &node_id,
+                &[],
+                pin_config,
+            )
+            .await
         })
     })
     .await
@@ -693,4 +735,49 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error running Sonde Pairing Tool");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_pin_config_both_present() {
+        let result = resolve_pin_config(Some(5), Some(6)).unwrap();
+        let pc = result.unwrap();
+        assert_eq!(pc.i2c0_sda, 5);
+        assert_eq!(pc.i2c0_scl, 6);
+    }
+
+    #[test]
+    fn resolve_pin_config_both_absent() {
+        let result = resolve_pin_config(None, None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resolve_pin_config_only_sda_rejected() {
+        let result = resolve_pin_config(Some(5), None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("both"));
+    }
+
+    #[test]
+    fn resolve_pin_config_only_scl_rejected() {
+        let result = resolve_pin_config(None, Some(6));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("both"));
+    }
+
+    #[test]
+    fn resolve_pin_config_zero_one_values() {
+        let result = resolve_pin_config(Some(0), Some(1)).unwrap();
+        let pc = result.unwrap();
+        assert_eq!(pc.i2c0_sda, 0);
+        assert_eq!(pc.i2c0_scl, 1);
+    }
 }

--- a/crates/sonde-pair-ui/src/index.html
+++ b/crates/sonde-pair-ui/src/index.html
@@ -38,6 +38,22 @@
       <h2>Phase 2 &mdash; Node Provisioning</h2>
       <label for="node-id">Node ID</label>
       <input id="node-id" type="text" placeholder="sensor-01" maxlength="64" />
+      <label for="board-select">Board</label>
+      <select id="board-select">
+        <option value="custom">Custom</option>
+      </select>
+      <div id="custom-pins" class="custom-pins hidden">
+        <div class="pin-row">
+          <div class="pin-field">
+            <label for="custom-sda">I2C SDA GPIO</label>
+            <input id="custom-sda" type="number" min="0" max="21" placeholder="0" />
+          </div>
+          <div class="pin-field">
+            <label for="custom-scl">I2C SCL GPIO</label>
+            <input id="custom-scl" type="number" min="0" max="21" placeholder="1" />
+          </div>
+        </div>
+      </div>
       <button id="btn-provision" disabled>Provision Node</button>
     </section>
 

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -14,6 +14,10 @@ const deviceList = document.getElementById("device-list");
 const phoneLabel = document.getElementById("phone-label");
 const btnPair = document.getElementById("btn-pair");
 const nodeId = document.getElementById("node-id");
+const boardSelect = document.getElementById("board-select");
+const customPins = document.getElementById("custom-pins");
+const customSda = document.getElementById("custom-sda");
+const customScl = document.getElementById("custom-scl");
 const btnProvision = document.getElementById("btn-provision");
 const pairingStatus = document.getElementById("pairing-status");
 const btnClear = document.getElementById("btn-clear");
@@ -32,6 +36,45 @@ let scanning = false;
 let pollTimer = null;
 let logTimer = null;
 let busy = false;
+
+// ---------------------------------------------------------------------------
+// Board presets (PT-1216)
+// ---------------------------------------------------------------------------
+
+const BOARD_PRESETS = {
+  devkitm1: { label: "Espressif ESP32-C3 DevKitM-1", sda: 0, scl: 1 },
+  sparkfun: { label: "SparkFun ESP32-C3 Pro Micro",   sda: 5, scl: 6 },
+};
+
+/** Populate the board selector from BOARD_PRESETS (single source of truth). */
+function initBoardSelect() {
+  const customOption = boardSelect.querySelector('option[value="custom"]');
+  boardSelect.textContent = "";
+  for (const [value, preset] of Object.entries(BOARD_PRESETS)) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = preset.label;
+    boardSelect.appendChild(option);
+  }
+  if (customOption) boardSelect.appendChild(customOption);
+  customPins.classList.toggle("hidden", boardSelect.value !== "custom");
+}
+
+/** Resolve the current board selection to { sda, scl } or null on error. */
+function resolveI2cPins() {
+  const board = boardSelect.value;
+  if (board === "custom") {
+    const sda = customSda.valueAsNumber;
+    const scl = customScl.valueAsNumber;
+    if (!Number.isInteger(sda) || !Number.isInteger(scl)) { showError("Enter SDA and SCL GPIO numbers"); return null; }
+    if (sda < 0 || sda > 21 || scl < 0 || scl > 21) { showError("GPIO must be 0–21"); return null; }
+    if (sda === scl) { showError("SDA and SCL must be different pins"); return null; }
+    return { sda, scl };
+  }
+  const preset = BOARD_PRESETS[board];
+  if (!preset) { showError("Unknown board selection"); return null; }
+  return { sda: preset.sda, scl: preset.scl };
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -202,6 +245,8 @@ async function provisionNode() {
   if (!selectedAddress) return;
   const nid = nodeId.value.trim();
   if (!nid) { showError("Enter a Node ID"); return; }
+  const pins = resolveI2cPins();
+  if (!pins) return;
   clearError();
   if (scanning) await stopScan();
   setBusy(true);
@@ -210,6 +255,8 @@ async function provisionNode() {
     const status = await invoke("provision_node", {
       address: selectedAddress,
       nodeId: nid,
+      i2cSda: pins.sda,
+      i2cScl: pins.scl,
     });
     setPhase("Complete");
     // status is a human-readable string from NodeAckStatus
@@ -285,6 +332,10 @@ btnPair.addEventListener("click", pairGateway);
 btnProvision.addEventListener("click", provisionNode);
 btnClear.addEventListener("click", clearPairing);
 verboseToggle.addEventListener("change", toggleVerbose);
+boardSelect.addEventListener("change", () => {
+  customPins.classList.toggle("hidden", boardSelect.value !== "custom");
+});
 
 // Initial state
+initBoardSelect();
 refreshPairingStatus();

--- a/crates/sonde-pair-ui/src/styles.css
+++ b/crates/sonde-pair-ui/src/styles.css
@@ -117,6 +117,45 @@ input[type="text"]:focus {
   border-color: var(--accent);
 }
 
+select {
+  width: 100%;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  font-size: 13px;
+  margin: 4px 0 10px;
+  cursor: pointer;
+  appearance: auto;
+}
+
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* Custom pin entry (PT-1216) */
+.custom-pins { margin-bottom: 10px; }
+.custom-pins.hidden { display: none; }
+.pin-row { display: flex; gap: 10px; }
+.pin-field { flex: 1; }
+.pin-field input[type="number"] {
+  width: 100%;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  font-size: 13px;
+  margin: 4px 0 0;
+  -moz-appearance: textfield;
+}
+.pin-field input[type="number"]:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 label {
   font-size: 12px;
   color: var(--text-dim);

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -229,7 +229,7 @@ Offset  Size           Field
 
 The node persists these to NVS. If the map is absent (older pairing tool), the node uses compiled-in defaults. Future keys (SPI pins, pairing button GPIO) may be added without breaking backward compatibility.
 
-**Pin config source:** The pairing tool obtains `i2c0_sda` and `i2c0_scl` values from the bundle manifest's `hardware.pins` section (see [bundle-format.md](bundle-format.md) §4.5).  When the bundle declares I2C sensors for a node, the `pins` section is required and the pairing tool passes the values through to `provision_node` as an optional `PinConfig` parameter.  This keeps the bundle self-contained — no separate board profile management is needed.
+**Pin config source:** The pairing tool obtains `i2c0_sda` and `i2c0_scl` values from the board selector UI (see PT-1216).  The operator selects a named board preset (e.g., "Espressif ESP32-C3 DevKitM-1" or "SparkFun ESP32-C3 Pro Micro") or enters custom GPIO numbers.  The UI layer resolves the selection to a `PinConfig` and passes it to `provision_node()`.  This keeps provisioning simple — no separate board profile files or bundle manifests are required.
 
 ---
 
@@ -728,16 +728,51 @@ The mock RNG for testing returns deterministic bytes, enabling reproducible test
 
 ## 12  Input validation
 
-The `validation.rs` module validates all user inputs before any BLE or cryptographic operation (PT-0403, PT-1205):
+User inputs are validated before any BLE or cryptographic operation (PT-0403, PT-1205).  Validation is split across `validation.rs` (string and range checks for Phase 1/2 fields) and `phase2.rs` (payload size and pin configuration checks):
 
-| Input | Validation rule | Error |
-|-------|----------------|-------|
-| `node_id` | 1–64 bytes UTF-8 | `PairingError::InvalidNodeId` |
-| `rf_channel` | 1–13 inclusive | `PairingError::InvalidRfChannel` |
-| `phone_label` | 0–64 bytes UTF-8 | `PairingError::InvalidLabel` |
-| Encrypted payload | ≤ 202 bytes | `PairingError::PayloadTooLarge` |
+| Input | Validation rule | Validated by | Error |
+|-------|----------------|-------------|-------|
+| `node_id` | 1–64 bytes UTF-8 | `validation.rs` | `PairingError::InvalidNodeId` |
+| `rf_channel` | 1–13 inclusive | `validation.rs` | `PairingError::InvalidRfChannel` |
+| `phone_label` | 0–64 bytes UTF-8 | `validation.rs` | `PairingError::InvalidLabel` |
+| Encrypted payload | ≤ 202 bytes | `phase2.rs` | `PairingError::PayloadTooLarge` |
+| `i2c0_sda` | 0–21, ≠ `i2c0_scl` | `phase2.rs` | `PairingError::InvalidPinConfig` |
+| `i2c0_scl` | 0–21, ≠ `i2c0_sda` | `phase2.rs` | `PairingError::InvalidPinConfig` |
 
 All validation occurs *before* any BLE write, ensuring that invalid inputs never reach the transport layer.
+
+---
+
+## 12.1  Board selector UI (PT-1216)
+
+The Tauri UI includes a board selector dropdown on the Phase 2 (Node Provisioning) card.  The selector is always visible (not collapsed behind an "Advanced" section) and determines the I2C `PinConfig` passed to `provision_node()`.
+
+### Board presets
+
+Board presets are defined as a static table in the frontend JavaScript.  Each preset maps a human-readable board name to its I2C pin assignments:
+
+| Preset label | `i2c0_sda` | `i2c0_scl` |
+|---|---|---|
+| Espressif ESP32-C3 DevKitM-1 | 0 | 1 |
+| SparkFun ESP32-C3 Pro Micro | 5 | 6 |
+| Custom | (user input) | (user input) |
+
+The default selection is "Espressif ESP32-C3 DevKitM-1".  Adding a new board requires only a new entry in the frontend preset table — no backend or protocol changes.
+
+### UI behavior
+
+- **Named preset selected:** The two GPIO values are resolved from the preset table.  No additional input fields are shown.
+- **"Custom" selected:** Two numeric `<input>` fields for SDA and SCL are revealed.  Values are validated client-side per PT-0409 (range 0–21, SDA ≠ SCL) before the Tauri command is invoked.  Validation errors are displayed in the existing error bar.
+
+### Tauri command interface
+
+The `provision_node` Tauri command gains two optional parameters:
+
+```
+provision_node(address, nodeId, i2cSda?, i2cScl?)
+```
+
+When both `i2cSda` and `i2cScl` are provided, the backend constructs `Some(PinConfig { i2c0_sda, i2c0_scl })` and passes it to `phase2::provision_node()`.  When both are omitted, `None` is passed (backward compatible for non-UI callers).  Providing exactly one is an error.
 
 ---
 
@@ -871,6 +906,7 @@ No log event at any level may include key material: PSKs, ephemeral private keys
 | §9 Platform-specific | PT-0100, PT-0105, PT-0106, PT-0107, PT-0108, PT-0300, PT-0801, PT-0904 |
 | §10 BLE message envelope | PT-0301, PT-0303, PT-0407 |
 | §11 RNG provider | PT-0901, PT-0903 |
-| §12 Input validation | PT-0403, PT-0406 |
+| §12 Input validation | PT-0403, PT-0406, PT-0409 |
+| §12.1 Board selector UI | PT-1216, PT-1214, PT-0700 |
 | §13 Implementation order | PT-0700, PT-0701, PT-0702, PT-1200–PT-1206 |
 | §14 Diagnostic logging | PT-0702, PT-0900, PT-1207–PT-1212 |

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -540,7 +540,7 @@ The tool SHOULD check local state before initiating Phase 1 and warn the operato
 **Source:** Product requirements §5.2
 
 **Description:**  
-The UI MUST provide at least: scan toggle (start/stop), device list (with service type and name), device select, pair action, node ID input (Phase 2 only), status area (current phase and progress), and error display (actionable messages).
+The UI MUST provide at least: scan toggle (start/stop), device list (with service type and name), device select, pair action, node ID input (Phase 2 only), board selector (Phase 2 only — see PT-1216), status area (current phase and progress), and error display (actionable messages).
 
 **Acceptance criteria:**
 
@@ -1109,7 +1109,7 @@ The pairing tool MUST apply build-type–aware log-level policies: compile-time 
 **Description:**  
 The pairing tool SHOULD support including optional board-specific pin configuration (I2C SDA/SCL GPIO numbers) in the NODE_PROVISION message body so that a single firmware binary works across different ESP32-C3 boards.
 
-Pin configuration is sourced from the bundle manifest's `hardware.pins` section (see [bundle-format.md](bundle-format.md) §4.5).  When the bundle declares I2C sensors for a node, the `pins` section is required and the pairing tool reads `i2c0_sda` and `i2c0_scl` from it.  The `provision_node` API accepts an optional pin config parameter; callers (e.g., `sonde-pair-ui`) extract pins from the bundle manifest and pass them through.
+Pin configuration is sourced from the board selector UI (see PT-1216).  The operator selects a named board preset or enters custom GPIO pin numbers.  The `provision_node` API accepts an optional pin config parameter; the UI layer extracts the selected board's pin assignments and passes them through.
 
 **Acceptance criteria:**
 
@@ -1138,6 +1138,35 @@ When the pairing tool encounters an error at a user-facing boundary (BLE connect
 2. Where a corrective action is known, the error includes actionable guidance text.
 3. BLE "Not connected" errors include the peer address and a hint about possible stale OS-level Bluetooth pairings.
 4. Serial port errors include the port name, the OS error code, and a hint about possible conflicts (e.g., another application holding the port).
+
+---
+
+### PT-1216  Board selector UI for node provisioning
+
+**Priority:** Must  
+**Source:** PT-1214 (board pin configuration), ND-0608
+
+**Description:**  
+The pairing tool UI MUST present a board selector during Phase 2 (node provisioning) so the operator can specify the target board's I2C pin assignments without entering raw GPIO numbers. The selector is always visible on the provisioning card and determines the `PinConfig` passed to `provision_node()`.
+
+The tool MUST include at least the following named presets:
+
+| Preset | `i2c0_sda` | `i2c0_scl` |
+|--------|-----------|-----------|
+| Espressif ESP32-C3 DevKitM-1 | 0 | 1 |
+| SparkFun ESP32-C3 Pro Micro | 5 | 6 |
+
+A "Custom" option MUST also be available, which reveals two numeric input fields for arbitrary GPIO pin entry (validated per PT-0409).
+
+**Acceptance criteria:**
+
+1. The Phase 2 provisioning card includes a board selector dropdown with the named presets above and a "Custom" option.
+2. The default selection is "Espressif ESP32-C3 DevKitM-1".
+3. Selecting a named preset sets the `PinConfig` to the preset's pin values — no additional input required.
+4. Selecting "Custom" reveals two numeric input fields for SDA and SCL GPIO numbers.
+5. Custom GPIO values are validated per PT-0409 (range 0–21, SDA ≠ SCL) before provisioning.
+6. The selected `PinConfig` is always passed to `provision_node()` — the tool never sends `None` when the UI is used.
+7. The Tauri `provision_node` command accepts optional `i2c_sda` and `i2c_scl` parameters and converts them to a `PinConfig`.
 
 ---
 
@@ -1215,3 +1244,4 @@ When the pairing tool encounters an error at a user-facing boundary (BLE connect
 | PT-1213 | Build-type–aware log levels | Active |
 | PT-1214 | Board pin configuration in NODE_PROVISION | Active |
 | PT-1215 | Error diagnostic observability (extends PT-1212) | Active |
+| PT-1216 | Board selector UI for node provisioning | Active |

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1120,6 +1120,61 @@ TestNode {
 
 ---
 
+### T-PT-1216a  Board preset passes correct pin config
+
+**Validates:** PT-1216 (AC 1, 3, 6), PT-1214 (AC 1, 2)
+
+**Procedure:**
+1. Call `phase2::provision_node(...)` with `MockBleTransport` and pin config `Some(PinConfig { i2c0_sda: 5, i2c0_scl: 6 })` (SparkFun preset values).
+2. Capture the NODE_PROVISION message body written to the mock BLE transport.
+3. Assert: the trailing CBOR map contains integer key 1 = 5 (`i2c0_sda`), integer key 2 = 6 (`i2c0_scl`).
+
+---
+
+### T-PT-1216b  Default preset is Espressif DevKitM-1
+
+**Validates:** PT-1216 (AC 2, 3)
+
+**Procedure:**
+1. Open the provisioning UI and verify the initial board selector value is "Espressif ESP32-C3 DevKitM-1".
+2. Without changing the board selection or manually overriding the I2C pins, trigger provisioning.
+3. Capture the NODE_PROVISION message body written to the mock BLE transport.
+4. Assert: the trailing CBOR map contains integer key 1 = 0 (`i2c0_sda`), integer key 2 = 1 (`i2c0_scl`).
+
+---
+
+### T-PT-1216c  Custom board with valid GPIOs
+
+**Validates:** PT-1216 (AC 4, 5, 6)
+
+**Procedure:**
+1. Call `phase2::provision_node(...)` with `MockBleTransport` and pin config `Some(PinConfig { i2c0_sda: 8, i2c0_scl: 9 })` (custom values).
+2. Capture the NODE_PROVISION message body written to the mock BLE transport.
+3. Assert: the trailing CBOR map contains integer key 1 = 8 (`i2c0_sda`), integer key 2 = 9 (`i2c0_scl`).
+
+---
+
+### T-PT-1216d  Custom board with invalid GPIOs rejected
+
+**Validates:** PT-1216 (AC 5), PT-0409
+
+**Procedure:**
+1. Call `phase2::provision_node(...)` with `MockBleTransport` and pin config `Some(PinConfig { i2c0_sda: 25, i2c0_scl: 6 })`.
+2. Assert: the call returns `Err(PairingError::InvalidPinConfig(_))`.
+3. Assert: no NODE_PROVISION message is written to the mock BLE transport.
+
+---
+
+### T-PT-1216e  Provision with only one pin parameter rejected
+
+**Validates:** PT-1216 (AC 7)
+
+**Procedure:**
+1. Call `resolve_pin_config(Some(5), None)`.
+2. Assert: the call returns an error indicating both pins must be provided.
+
+---
+
 ## Appendix A  Test-to-requirement traceability
 
 | Test ID | Requirement | Title |
@@ -1212,3 +1267,8 @@ TestNode {
 | T-PT-1214b | PT-1214 | No pin config in NODE_PROVISION — backward compatible |
 | T-PT-1214c | PT-1214 | Pin config with out-of-range GPIO rejected |
 | T-PT-1214d | PT-1214 | Pin config with SDA equal to SCL rejected |
+| T-PT-1216a | PT-1216, PT-1214 | Board preset passes correct pin config |
+| T-PT-1216b | PT-1216 | Default preset is Espressif DevKitM-1 |
+| T-PT-1216c | PT-1216 | Custom board with valid GPIOs |
+| T-PT-1216d | PT-1216, PT-0409 | Custom board with invalid GPIOs rejected |
+| T-PT-1216e | PT-1216 | Provision with only one pin parameter rejected |


### PR DESCRIPTION
## Summary

Add a board-selector dropdown to the sonde-pair-ui provisioning screen so operators can specify I2C pin assignments for different ESP32-C3 boards without entering raw GPIO numbers.

## Board presets

| Preset | `i2c0_sda` | `i2c0_scl` |
|--------|-----------|-----------|
| Espressif ESP32-C3 DevKitM-1 (default) | 0 | 1 |
| SparkFun ESP32-C3 Pro Micro | 5 | 6 |
| Custom | user-entered | user-entered |

The selected pin config flows through the Tauri `provision_node` command to `phase2::provision_node()`, which encodes it as trailing CBOR in the NODE_PROVISION message. The node firmware persists pins to NVS at boot (ND-0608). No protocol changes required — the wire format already supports pin config.

## Changes

### Specs
- **Requirements:** new PT-1216 (board selector UI), updated PT-0700 (minimum UI surface) and PT-1214 (pin config source)
- **Design:** new §12.1 (board selector UI design), updated §4.1 (pin config source), updated §12 (validation table), updated traceability
- **Validation:** 5 new test cases (T-PT-1216a through T-PT-1216e), updated traceability table

### Code
- **Backend** (`lib.rs`): `resolve_pin_config()` helper, `i2c_sda`/`i2c_scl` optional params on both desktop and Android `provision_node` commands
- **Frontend** (`index.html`, `main.js`, `styles.css`): board `<select>` dropdown, custom pin input fields, `BOARD_PRESETS` table, client-side validation (0–21, SDA≠SCL)

### Tests
- 5 unit tests for `resolve_pin_config` (both present, both absent, only SDA, only SCL, default preset)
- All 99 existing `sonde-pair` tests pass unchanged

## Verification
- `cargo clippy -p sonde-pair-ui -- -D warnings` — clean
- `cargo test -p sonde-pair-ui --lib` — 5/5 pass
- `cargo test -p sonde-pair` — 99/99 pass
