### PR TITLE
docs: store-and-forward radio protocol specification

### DIFF
--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -401,7 +401,7 @@ Queue an opaque data blob for deferred delivery on the next wake cycle. Unlike `
 - The queue is RAM-only; data is lost if the node reboots before the next wake cycle.
 - The queue is cleared after all messages are sent (whether piggybacked or via APP_DATA).
 - The queue is also cleared on program load (UPDATE_PROGRAM or RUN_EPHEMERAL).
-- The handler receives this data as a normal `DATA` message. Handler replies to piggybacked data are always deferred to the next cycle (two-cycle round-trip latency).
+- The handler receives this data as a normal `DATA` message. Non-zero-length replies to piggybacked data are deferred to the next cycle (best-case two-cycle round-trip latency). Zero-length replies produce no deferred delivery.
 - If the queue is full, the BPF program may fall back to `send()` or `send_recv()` for immediate delivery.
 
 **Availability:** Resident and ephemeral.

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -112,7 +112,16 @@ struct sonde_context {
     uint16_t battery_mv;          // battery voltage in millivolts
     uint16_t firmware_abi_version; // firmware ABI version
     uint8_t  wake_reason;         // why the node woke (see below)
+    uint8_t  _padding[3];         // explicit padding; must be zero
+    uint64_t data_start;          // pointer to piggybacked downlink data, or 0
+    uint64_t data_end;            // pointer past end of downlink data, or 0
 };
+/* Total: 32 bytes, 8-byte aligned.
+ * data_start/data_end point to the piggybacked blob from the NOP COMMAND
+ * (see protocol.md §6.7). When no downlink data is present, both are 0.
+ * The BPF program accesses the data via bounded pointer arithmetic,
+ * similar to XDP's data/data_end pattern.
+ * NOTE: pointer width is uint64_t for BPF verifier compatibility. */
 ```
 
 The `timestamp` is derived from the gateway's `timestamp_ms` field in the COMMAND response (see [protocol.md §5.2](protocol.md)). The node has no independent clock source across deep sleep — the gateway is the authoritative time reference. Within a wake cycle, the firmware adds local elapsed time to the gateway-supplied value.
@@ -373,6 +382,30 @@ Send an `APP_DATA` message and block until `APP_DATA_REPLY` arrives or the timeo
 
 **Availability:** Resident and ephemeral.
 
+#### `send_async`
+
+```c
+int send_async(const void *ptr, uint32_t len);
+```
+
+Queue an opaque data blob for deferred delivery on the next wake cycle. Unlike `send()`, which transmits immediately, `send_async()` stores the blob in a RAM queue and returns immediately. The data is transmitted piggybacked on the next WAKE message (if a single message fits within the payload budget) or via APP_DATA (if multiple messages are queued or the blob is oversized). See [protocol.md §6.7](protocol.md) for the full store-and-forward data flow.
+
+| Parameter | Description |
+|---|---|
+| `ptr` | Pointer to the data buffer. |
+| `len` | Length of the data in bytes. |
+
+**Returns:** `0` on success. `-1` if the queue is full (max 10 messages). `-2` if `len` exceeds the maximum blob size.
+
+**Notes:**
+- The queue is RAM-only; data is lost if the node reboots before the next wake cycle.
+- The queue is cleared after all messages are sent (whether piggybacked or via APP_DATA).
+- The queue is also cleared on program load (UPDATE_PROGRAM or RUN_EPHEMERAL).
+- The handler receives this data as a normal `DATA` message. Handler replies to piggybacked data are always deferred to the next cycle (two-cycle round-trip latency).
+- If the queue is full, the BPF program may fall back to `send()` or `send_recv()` for immediate delivery.
+
+**Availability:** Resident and ephemeral.
+
 ---
 
 ### 6.3  Map operations
@@ -493,7 +526,7 @@ All programs are verified by [Prevail](https://github.com/vbpf/ebpf-verifier) on
 | **Loops** | Bounded | None or tightly bounded |
 | **Map access** | Read/write | Read-only |
 | **Instruction budget** | Larger | Small |
-| **Helper set** | Full | Limited (`send`, `send_recv`, `i2c_read`, `i2c_write`, `i2c_write_read`, `spi_transfer`, `gpio_read`, `gpio_write`, `adc_read`, `delay_us`, `map_lookup_elem`, `get_time`, `get_battery_mv`, `bpf_trace_printk`) |
+| **Helper set** | Full | Limited (`send`, `send_recv`, `send_async`, `i2c_read`, `i2c_write`, `i2c_write_read`, `spi_transfer`, `gpio_read`, `gpio_write`, `adc_read`, `delay_us`, `map_lookup_elem`, `get_time`, `get_battery_mv`, `bpf_trace_printk`) |
 | **Side effects** | Allowed | No persistent node state changes (no map writes, no schedule changes) |
 
 A program that fails verification is rejected with a diagnostic explaining why. It never reaches the node.

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -395,7 +395,7 @@ Queue an opaque data blob for deferred delivery on the next wake cycle. Unlike `
 | `ptr` | Pointer to the data buffer. |
 | `len` | Length of the data in bytes. |
 
-**Returns:** `0` on success. `-1` if the queue is full (max 10 messages). `-2` if `len` exceeds the maximum blob size.
+**Returns:** `0` on success. `-1` if the queue is full (max 10 messages). `-2` if `len` exceeds the maximum blob size for APP_DATA (the same limit as `send()`: 223 bytes minus CBOR map overhead, see [protocol.md §3.3](protocol.md)).
 
 **Notes:**
 - The queue is RAM-only; data is lost if the node reboots before the next wake cycle.

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -527,7 +527,7 @@ All programs are verified by [Prevail](https://github.com/vbpf/ebpf-verifier) on
 | **Map access** | Read/write | Read-only |
 | **Instruction budget** | Larger | Small |
 | **Helper set** | Full | Limited (`send`, `send_recv`, `send_async`, `i2c_read`, `i2c_write`, `i2c_write_read`, `spi_transfer`, `gpio_read`, `gpio_write`, `adc_read`, `delay_us`, `map_lookup_elem`, `get_time`, `get_battery_mv`, `bpf_trace_printk`) |
-| **Side effects** | Allowed | No persistent node state changes (no map writes, no schedule changes) |
+| **Side effects** | Allowed | No persistent node state changes under program control (no map writes, no schedule changes); `send_async` may enqueue outbound data for transmission on the next wake cycle |
 
 A program that fails verification is rejected with a diagnostic explaining why. It never reaches the node.
 

--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -127,7 +127,7 @@ The application API has only **4 message types** — two in each direction.
 
 ### 4.1  DATA (Gateway → Handler)
 
-Sent when a node's BPF program calls `send()` or `send_recv()`. The handler processes the data and replies with a `DATA_REPLY`.
+Sent when a node's BPF program calls `send()` or `send_recv()`, or when a node's WAKE message contains a piggybacked `blob` (see [protocol.md §6.7](protocol.md)). The handler processes the data and replies with a `DATA_REPLY`. The handler does not need to distinguish between these sources — the `DATA` message format is identical in both cases.
 
 | Field | CBOR key | Type | Description |
 |---|---|---|---|

--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -150,7 +150,7 @@ Sent when a node's BPF program calls `send()` or `send_recv()`. The handler proc
 
 Response to a `DATA` message. The handler **always** replies:
 
-- **Non-zero-length `data`**: The gateway sends an `APP_DATA_REPLY` to the node (the node's BPF program receives it via `send_recv()`).
+- **Non-zero-length `data`**: The gateway sends an `APP_DATA_REPLY` to the node (the node's BPF program receives it via `send_recv()`), unless `delivery=1` in which case the reply is deferred.
 - **Zero-length `data`**: The gateway does not send anything to the node (used when the BPF program called `send()` fire-and-forget).
 
 The handler and BPF program are written by the same developer — they agree a priori on which messages expect data back.
@@ -160,6 +160,7 @@ The handler and BPF program are written by the same developer — they agree a p
 | `msg_type` | 1 | uint | `0x81` |
 | `request_id` | 2 | uint | Must match the `DATA` message's `request_id`. |
 | `data` | 3 | bstr | Reply blob for the BPF program. Zero-length = no reply to node. |
+| `delivery` | 4 | uint | **Optional.** `0` (or absent) = immediate delivery via `APP_DATA_REPLY`. `1` = deferred delivery, piggybacked on the next NOP COMMAND (see §4.5). Default: `0`. |
 
 ---
 
@@ -194,6 +195,21 @@ Optional: the handler can emit log messages through the gateway's logging system
 | `msg_type` | 1 | uint | `0x82` |
 | `level` | 2 | tstr | `"debug"`, `"info"`, `"warn"`, `"error"` |
 | `message` | 3 | tstr | Log message text. |
+
+---
+
+### 4.5  Deferred delivery
+
+When a handler replies with `delivery=1`, the gateway stores the reply and piggybacks it on the next NOP COMMAND to that node instead of sending an immediate `APP_DATA_REPLY`.
+
+**Rules:**
+
+- At most one deferred reply is stored per node. If a new deferred reply arrives before the previous one is delivered, the new one replaces the old one (latest wins).
+- Storage is RAM-only (lost on gateway restart).
+- Deferred data is delivered only on NOP commands. If the next COMMAND is `UPDATE_PROGRAM`, `UPDATE_SCHEDULE`, `RUN_EPHEMERAL`, or `REBOOT`, the deferred data remains stored until a NOP cycle occurs.
+- For `DATA` messages originating from WAKE piggybacked blobs (see [protocol.md §6.7](protocol.md)), delivery is always deferred — the gateway enforces `delivery=1` regardless of the handler's response.
+
+This mechanism enables bidirectional store-and-forward data exchange piggybacked on the mandatory WAKE↔COMMAND traffic, reducing radio transmissions for the common sensor-read-and-report pattern. See [protocol.md §6.7](protocol.md) for the complete data flow.
 
 ---
 

--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -151,7 +151,7 @@ Sent when a node's BPF program calls `send()` or `send_recv()`. The handler proc
 Response to a `DATA` message. The handler **always** replies:
 
 - **Non-zero-length `data`**: The gateway sends an `APP_DATA_REPLY` to the node (the node's BPF program receives it via `send_recv()`), unless `delivery=1` in which case the reply is deferred.
-- **Zero-length `data`**: The gateway does not send anything to the node (used when the BPF program called `send()` fire-and-forget).
+- **Zero-length `data`**: The gateway does not send anything to the node (used when the BPF program called `send()` fire-and-forget). The `delivery` field is ignored when `data` is zero-length.
 
 The handler and BPF program are written by the same developer — they agree a priori on which messages expect data back.
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -484,10 +484,10 @@ The gateway MUST accept `DATA_REPLY` messages from handlers. The `request_id` MU
 **Acceptance criteria:**
 
 1. A `DATA_REPLY` with a `request_id` that does not match an outstanding request is logged and discarded.
-2. Non-zero-length `data` in the reply triggers an `APP_DATA_REPLY` to the node.
-3. Zero-length `data` results in no `APP_DATA_REPLY` to the node.
-4. `DATA_REPLY` with `delivery=1` causes the data to be stored for deferred delivery, not sent immediately.
-5. `DATA_REPLY` with `delivery=0` or absent `delivery` behaves as before (immediate `APP_DATA_REPLY`).
+2. Non-zero-length `data` in the reply triggers an immediate `APP_DATA_REPLY` to the node unless `delivery=1`.
+3. Zero-length `data` results in no `APP_DATA_REPLY` to the node, regardless of `delivery` value.
+4. `DATA_REPLY` with `delivery=1` and non-zero-length `data` causes the data to be stored for deferred delivery, not sent immediately.
+5. `DATA_REPLY` with `delivery=0` or absent `delivery` uses the default behavior: non-zero-length `data` triggers an immediate `APP_DATA_REPLY`.
 
 ---
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -79,7 +79,7 @@ All control-plane messages produced by the gateway MUST be encoded in CBOR.
 **Source:** README § Wake handshake
 
 **Description:**  
-The gateway MUST accept `WAKE` messages. The `key_hint` and `nonce` are in the fixed binary header; the CBOR payload contains `firmware_abi_version`, `program_hash`, `battery_mv`, and `firmware_version`. The WAKE message MAY also contain an optional `blob` field (CBOR key 10). If present, the gateway MUST route the blob to the handler as a `DATA` message, exactly as it does for APP_DATA blobs. The handler's reply to WAKE-piggybacked data is always deferred (delivery=1 enforced by the gateway).
+The gateway MUST accept `WAKE` messages. The `key_hint` and `nonce` are in the fixed binary header; the CBOR payload contains `firmware_abi_version`, `program_hash`, `battery_mv`, and `firmware_version`. The WAKE message MAY also contain an optional `blob` field (CBOR key 10). If present, the gateway MUST route the blob to the handler as a `DATA` message, exactly as it does for APP_DATA blobs. Any non-zero-length handler reply is stored for deferred delivery regardless of handler-supplied `delivery` value; zero-length replies produce no deferred delivery.
 
 **Acceptance criteria:**
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -79,13 +79,15 @@ All control-plane messages produced by the gateway MUST be encoded in CBOR.
 **Source:** README § Wake handshake
 
 **Description:**  
-The gateway MUST accept `WAKE` messages. The `key_hint` and `nonce` are in the fixed binary header; the CBOR payload contains `firmware_abi_version`, `program_hash`, `battery_mv`, and `firmware_version`.
+The gateway MUST accept `WAKE` messages. The `key_hint` and `nonce` are in the fixed binary header; the CBOR payload contains `firmware_abi_version`, `program_hash`, `battery_mv`, and `firmware_version`. The WAKE message MAY also contain an optional `blob` field (CBOR key 10). If present, the gateway MUST route the blob to the handler as a `DATA` message, exactly as it does for APP_DATA blobs. The handler's reply to WAKE-piggybacked data is always deferred (delivery=1 enforced by the gateway).
 
 **Acceptance criteria:**
 
 1. The gateway extracts `key_hint` and `nonce` from the fixed header and the four CBOR payload fields from a valid `WAKE` message.
 2. The gateway rejects `WAKE` messages missing any required field.
 3. Parsed values are made available for command-selection logic.
+4. If the WAKE contains a `blob` field, the gateway extracts it and routes to the handler.
+5. The handler's `DATA_REPLY` for WAKE-piggybacked data is stored for deferred delivery regardless of the handler's `delivery` field value.
 
 ---
 
@@ -95,7 +97,7 @@ The gateway MUST accept `WAKE` messages. The `key_hint` and `nonce` are in the f
 **Source:** README § Wake handshake
 
 **Description:**  
-The gateway MUST respond to every valid, authenticated `WAKE` message with exactly one `COMMAND` message. The response MUST echo the WAKE nonce in the header's `nonce` field and MUST include `starting_seq` (a random starting sequence number) and `timestamp_ms` (current UTC time in milliseconds since Unix epoch) in the CBOR payload.
+The gateway MUST respond to every valid, authenticated `WAKE` message with exactly one `COMMAND` message. The response MUST echo the WAKE nonce in the header's `nonce` field and MUST include `starting_seq` (a random starting sequence number) and `timestamp_ms` (current UTC time in milliseconds since Unix epoch) in the CBOR payload. When a NOP COMMAND is generated and a deferred reply exists for this node, the gateway MUST include the deferred data as `blob` (CBOR key 10) in the COMMAND response. The `blob` is a top-level COMMAND field, not nested inside `payload` (key 5).
 
 **Acceptance criteria:**
 
@@ -104,6 +106,9 @@ The gateway MUST respond to every valid, authenticated `WAKE` message with exact
 3. The CBOR payload includes `starting_seq` (a random 64-bit value).
 4. The CBOR payload includes `timestamp_ms` (current UTC time in milliseconds since Unix epoch).
 5. The `command_type` field is one of the defined command types (see GW-0200–GW-0205).
+6. When deferred data exists for the node and the command is NOP, the COMMAND includes `blob` (key 10).
+7. When no deferred data exists, `blob` is omitted.
+8. After including deferred data in COMMAND, the stored data is cleared.
 
 ---
 
@@ -474,13 +479,15 @@ When forwarding `APP_DATA` to a handler, the gateway MUST send a `DATA` message 
 **Source:** gateway-api.md §4.2
 
 **Description:**  
-The gateway MUST accept `DATA_REPLY` messages from handlers. The `request_id` MUST match an outstanding `DATA` message. Non-zero-length `data` is forwarded to the node as `APP_DATA_REPLY`; zero-length `data` means no reply is sent to the node.
+The gateway MUST accept `DATA_REPLY` messages from handlers. The `request_id` MUST match an outstanding `DATA` message. Non-zero-length `data` is forwarded to the node as `APP_DATA_REPLY`; zero-length `data` means no reply is sent to the node. The `DATA_REPLY` MAY contain a `delivery` field (CBOR key 4). When `delivery=1`, the gateway stores the reply for deferred delivery on the next NOP COMMAND instead of sending an immediate `APP_DATA_REPLY`. When `delivery` is absent or `0`, existing behavior applies.
 
 **Acceptance criteria:**
 
 1. A `DATA_REPLY` with a `request_id` that does not match an outstanding request is logged and discarded.
 2. Non-zero-length `data` in the reply triggers an `APP_DATA_REPLY` to the node.
 3. Zero-length `data` results in no `APP_DATA_REPLY` to the node.
+4. `DATA_REPLY` with `delivery=1` causes the data to be stored for deferred delivery, not sent immediately.
+5. `DATA_REPLY` with `delivery=0` or absent `delivery` behaves as before (immediate `APP_DATA_REPLY`).
 
 ---
 
@@ -513,6 +520,70 @@ The gateway SHOULD accept `LOG` messages from handlers and route them through th
 
 1. Handler LOG messages appear in the gateway's log output.
 2. The log level from the handler is preserved.
+
+---
+
+### GW-0509  Deferred reply storage
+
+**Priority:** Must  
+**Source:** gateway-api.md §4.2
+
+**Description:**  
+The gateway MUST store at most one deferred reply per node. If a new deferred reply arrives before the previous one is delivered, the new one replaces the old one (latest wins). Storage is RAM-only (lost on gateway restart).
+
+**Acceptance criteria:**
+
+1. At most one deferred reply stored per node.
+2. New deferred reply replaces old.
+3. Storage is RAM-only.
+
+---
+
+### GW-0510  WAKE blob routing
+
+**Priority:** Must  
+**Source:** gateway-api.md §4.2
+
+**Description:**  
+When a WAKE message contains a `blob` field, the gateway MUST route it to the handler as a `DATA` message with the same fields as APP_DATA-originated DATA (`msg_type`, `request_id`, `node_id`, `program_hash`, `data`, `timestamp`). The `delivery` field in the handler's `DATA_REPLY` for WAKE-originated data is overridden to `1` (deferred) by the gateway.
+
+**Acceptance criteria:**
+
+1. WAKE blob routed to handler as `DATA`.
+2. `DATA` message includes all required fields.
+3. Handler reply delivery is forced to deferred.
+
+---
+
+### GW-0511  COMMAND blob injection
+
+**Priority:** Must  
+**Source:** gateway-api.md §4.2
+
+**Description:**  
+When generating a NOP COMMAND for a node that has stored deferred data, the gateway MUST include the deferred data as `blob` (CBOR key 10) in the COMMAND. After including, the stored data MUST be cleared.
+
+**Acceptance criteria:**
+
+1. NOP COMMAND includes `blob` when deferred data exists.
+2. Stored data cleared after inclusion.
+3. `blob` is a top-level COMMAND field, not nested in `payload`.
+
+---
+
+### GW-0512  Deferred delivery only on NOP
+
+**Priority:** Must  
+**Source:** gateway-api.md §4.2
+
+**Description:**  
+Deferred data MUST only be piggybacked on NOP commands. If the next COMMAND is UPDATE_PROGRAM, RUN_EPHEMERAL, UPDATE_SCHEDULE, or REBOOT, the deferred data remains stored until a NOP cycle occurs.
+
+**Acceptance criteria:**
+
+1. Non-NOP commands do not include deferred `blob`.
+2. Deferred data persists across non-NOP cycles.
+3. Deferred data delivered on next NOP.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -741,6 +741,114 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-0518  WAKE with piggybacked blob routed to handler
+
+**Validates:** GW-0510
+
+**Procedure:**
+1. Send WAKE containing `blob` `[0xAA]`.
+2. Assert: handler receives `DATA` message with `data=[0xAA]`, correct `node_id`, `program_hash`, `timestamp`.
+
+---
+
+### T-0519  WAKE blob handler reply is always deferred
+
+**Validates:** GW-0510, GW-0509
+
+**Procedure:**
+1. Send WAKE with `blob`.
+2. Handler replies with `data=[0xBB]`, `delivery=0`.
+3. Assert: no immediate `APP_DATA_REPLY` sent to node.
+4. Assert: deferred reply `[0xBB]` stored for the node.
+
+---
+
+### T-0520  Deferred reply piggybacked on NOP COMMAND
+
+**Validates:** GW-0511
+
+**Procedure:**
+1. Store deferred reply `[0xBB]` for a node.
+2. Node sends next WAKE.
+3. Assert: NOP COMMAND response contains `blob` `[0xBB]` (key 10).
+
+---
+
+### T-0521  Deferred reply cleared after delivery
+
+**Validates:** GW-0511
+
+**Procedure:**
+1. After deferred reply is delivered (per T-0520), node sends another WAKE.
+2. Assert: NOP COMMAND does NOT contain `blob`.
+
+---
+
+### T-0522  Deferred reply latest-wins
+
+**Validates:** GW-0509
+
+**Procedure:**
+1. Store deferred reply `[0x01]` for a node.
+2. Store another deferred reply `[0x02]` before delivery.
+3. Node sends WAKE.
+4. Assert: NOP COMMAND carries `blob` `[0x02]`, not `[0x01]`.
+
+---
+
+### T-0523  Deferred data not delivered on non-NOP command
+
+**Validates:** GW-0512
+
+**Procedure:**
+1. Store deferred reply for a node.
+2. Set pending program update for that node.
+3. Node sends WAKE.
+4. Assert: COMMAND is UPDATE_PROGRAM and does NOT contain `blob`.
+5. Assert: deferred data still stored.
+6. Clear pending update.
+7. Node sends next WAKE.
+8. Assert: NOP COMMAND now contains the deferred `blob`.
+
+---
+
+### T-0524  DATA_REPLY with delivery=1 stores data
+
+**Validates:** GW-0506 (AC4)
+
+**Procedure:**
+1. Complete WAKE handshake.
+2. Send APP_DATA.
+3. Handler replies with `delivery=1`, `data=[0xCC]`.
+4. Assert: no `APP_DATA_REPLY` sent to node.
+5. Assert: deferred data `[0xCC]` stored for the node.
+
+---
+
+### T-0525  DATA_REPLY with delivery=0 sends immediately
+
+**Validates:** GW-0506 (AC5)
+
+**Procedure:**
+1. Complete WAKE handshake.
+2. Send APP_DATA.
+3. Handler replies with `delivery=0`, `data=[0xCC]`.
+4. Assert: `APP_DATA_REPLY` sent to node with blob `[0xCC]` (existing behavior).
+
+---
+
+### T-0526  WAKE without blob — existing behavior preserved
+
+**Validates:** GW-0102
+
+**Procedure:**
+1. Send WAKE without `blob` field (existing format).
+2. Assert: gateway processes it normally.
+3. Assert: no `DATA` message sent to handler for the blob.
+4. Assert: COMMAND response is correct.
+
+---
+
 ## 8  Authentication and security tests
 
 ### T-0600  Valid AEAD accepted

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -510,7 +510,7 @@ The firmware MUST provide `send()` (fire-and-forget `APP_DATA`) and `send_recv()
 1. `send()` initiates transmission of an `APP_DATA` frame as a fire-and-forget operation and MUST NOT wait for any `APP_DATA_REPLY` before returning (it may still block briefly while queuing or transmitting the frame).
 2. `send_recv()` transmits an `APP_DATA` frame and blocks until `APP_DATA_REPLY` or timeout.
 3. Each call increments the session sequence number.
-4. `send_async()` returns 0 on success, -1 when the queue is full (max 10 messages), or -2 when the blob exceeds the maximum size.
+4. `send_async()` returns 0 on success, -1 when the queue is full (max 10 messages), or -2 when the blob exceeds the maximum APP_DATA blob size (same limit as `send()`: 223 bytes minus CBOR map overhead, see protocol.md §3.3).
 5. `send_async()` does not transmit immediately; queued data is sent on the next wake cycle.
 6. `send_async()` is available to both resident and ephemeral programs.
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -126,7 +126,7 @@ Each wake cycle MUST follow this structure: wake → send one or more `WAKE` mes
 **Source:** protocol.md §5.1
 
 **Description:**  
-The `WAKE` message MUST include `firmware_abi_version`, `program_hash` (SHA-256 of the resident program, or zero-length if none installed), `battery_mv`, and `firmware_version` (semantic version string derived from `CARGO_PKG_VERSION` at compile time, e.g., `"0.4.0"`). The `nonce` header field MUST contain a fresh 64-bit random value from the hardware RNG.
+The `WAKE` message MUST include `firmware_abi_version`, `program_hash` (SHA-256 of the resident program, or zero-length if none installed), `battery_mv`, and `firmware_version` (semantic version string derived from `CARGO_PKG_VERSION` at compile time, e.g., `"0.4.0"`). The `nonce` header field MUST contain a fresh 64-bit random value from the hardware RNG. The WAKE message MAY include an optional `blob` field (CBOR key 10) containing a single piggybacked uplink data blob from a prior `send_async()` call. The blob is included only when exactly one message is queued and it fits within the available payload budget (223 bytes minus the space consumed by the four required fields and their CBOR encoding overhead). When the blob would not fit or multiple messages are queued, the `blob` field is omitted and data is sent via APP_DATA after receiving COMMAND.
 
 **Acceptance criteria:**
 
@@ -503,13 +503,16 @@ The firmware MUST provide I2C (`i2c_read`, `i2c_write`, `i2c_write_read`), SPI (
 **Source:** bpf-environment.md §6.2
 
 **Description:**  
-The firmware MUST provide `send()` (fire-and-forget `APP_DATA`) and `send_recv()` (request-response `APP_DATA` / `APP_DATA_REPLY`) helpers. Each call emits an independent authenticated frame with an incrementing sequence number.
+The firmware MUST provide `send()` (fire-and-forget `APP_DATA`) and `send_recv()` (request-response `APP_DATA` / `APP_DATA_REPLY`) helpers. Each call emits an independent authenticated frame with an incrementing sequence number. The firmware MUST also provide `send_async()` (deferred APP_DATA via store-and-forward queue). `send_async()` queues data in RAM for transmission during the next wake cycle.
 
 **Acceptance criteria:**
 
 1. `send()` initiates transmission of an `APP_DATA` frame as a fire-and-forget operation and MUST NOT wait for any `APP_DATA_REPLY` before returning (it may still block briefly while queuing or transmitting the frame).
 2. `send_recv()` transmits an `APP_DATA` frame and blocks until `APP_DATA_REPLY` or timeout.
 3. Each call increments the session sequence number.
+4. `send_async()` returns 0 on success, -1 when the queue is full (max 10 messages), or -2 when the blob exceeds the maximum size.
+5. `send_async()` does not transmit immediately; queued data is sent on the next wake cycle.
+6. `send_async()` is available to both resident and ephemeral programs.
 
 ---
 
@@ -617,6 +620,103 @@ The firmware MUST support configurable I2C bus GPIO pin assignments so that a si
 4. Factory reset (ND-0917) does NOT erase pin config — the board hardware does not change.
 5. The NODE_PROVISION BLE message body may include optional pin config bytes after the encrypted payload; the node parses and persists them to NVS.
 6. Backward compatibility: a NODE_PROVISION body without pin config bytes (from an older pairing tool) is accepted without error.
+
+---
+
+### ND-0609  Async queue management
+
+**Priority:** Must  
+**Source:** bpf-environment.md §6.2
+
+**Description:**  
+The node MUST maintain a RAM-only queue of up to 10 data blobs for deferred transmission via `send_async()`. The queue MUST be cleared after all queued messages are sent (whether piggybacked on WAKE or via APP_DATA). The queue MUST also be cleared on reboot and on program load (UPDATE_PROGRAM or RUN_EPHEMERAL). The queue MUST NOT be persisted to flash.
+
+**Acceptance criteria:**
+
+1. Queue holds up to 10 messages.
+2. Queue is empty after all messages are transmitted.
+3. Queue is empty after program load.
+4. Queue is RAM-only (no flash writes).
+
+---
+
+### ND-0610  WAKE piggybacking
+
+**Priority:** Must  
+**Source:** protocol.md §5.1
+
+**Description:**  
+When exactly one message is in the async queue and it fits within the WAKE payload budget, the node MUST include it as `blob` (CBOR key 10) in the WAKE message. When multiple messages are queued or the single message exceeds the budget, the node MUST omit the `blob` from WAKE and send all queued messages as individual APP_DATA frames after receiving COMMAND.
+
+**Acceptance criteria:**
+
+1. Single fitting message is piggybacked on WAKE.
+2. Multiple messages sent as APP_DATA.
+3. Oversized single message sent as APP_DATA.
+
+---
+
+### ND-0611  Async queue overflow to APP_DATA
+
+**Priority:** Must  
+**Source:** protocol.md §5.1
+
+**Description:**  
+When the async queue contains messages that cannot be piggybacked on WAKE, the node MUST send each queued message as a separate APP_DATA frame after receiving the COMMAND response, using the standard sequence number mechanism. Messages MUST NOT be split or concatenated.
+
+**Acceptance criteria:**
+
+1. Each queued message becomes one APP_DATA frame.
+2. Sequence numbers increment correctly.
+3. No message splitting or concatenation.
+
+---
+
+### ND-0612  sonde_context downlink data
+
+**Priority:** Must  
+**Source:** bpf-environment.md §3.2
+
+**Description:**  
+The `sonde_context` structure passed to BPF programs MUST include `data_start` and `data_end` pointer fields. When a NOP COMMAND carries a piggybacked `blob` (key 10), the firmware MUST populate these fields to point to the blob data. When no blob is present, both fields MUST be zero.
+
+**Acceptance criteria:**
+
+1. `data_start` and `data_end` point to valid blob data when present.
+2. Both are zero when no blob is present.
+3. Data is read-only from the BPF program's perspective.
+
+---
+
+### ND-0613  Async queue capacity error
+
+**Priority:** Must  
+**Source:** bpf-environment.md §6.2
+
+**Description:**  
+When the async queue is full (10 messages) and a BPF program calls `send_async()`, the helper MUST return -1 without queuing the message.
+
+**Acceptance criteria:**
+
+1. 11th `send_async()` call returns -1.
+2. No data is lost from the existing queue.
+
+---
+
+### ND-0614  Store-and-forward backward compatibility
+
+**Priority:** Must  
+**Source:** protocol.md §5.1
+
+**Description:**  
+The existing `send()` and `send_recv()` helpers MUST continue to function identically to their behavior before this change. A WAKE without `blob` and a COMMAND without `blob` MUST be processed exactly as before.
+
+**Acceptance criteria:**
+
+1. `send()` transmits APP_DATA immediately.
+2. `send_recv()` transmits and waits for reply.
+3. WAKE without blob is accepted by gateway.
+4. NOP COMMAND without blob is accepted by node.
 
 ---
 
@@ -1451,6 +1551,12 @@ After a diagnostic relay completes (whether by receiving a reply or exhausting r
 | ND-0606 | Map memory budget enforcement | Must |
 | ND-0607 | Initial map data | Must |
 | ND-0608 | Configurable I2C pin assignments | Should |
+| ND-0609 | Async queue management | Must |
+| ND-0610 | WAKE piggybacking | Must |
+| ND-0611 | Async queue overflow to APP_DATA | Must |
+| ND-0612 | sonde_context downlink data | Must |
+| ND-0613 | Async queue capacity error | Must |
+| ND-0614 | Store-and-forward backward compatibility | Must |
 | ND-0700 | WAKE retry | Must |
 | ND-0701 | Chunk transfer retry | Must |
 | ND-0702 | Response timeout | Must |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -851,14 +851,26 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
+### T-N627a  send_async rejects oversized blob with -2
+
+**Validates:** ND-0602 (AC4)
+
+**Procedure:**
+1. Compute the maximum APP_DATA blob length (same as `send()` — 223 bytes minus CBOR map overhead).
+2. Install a BPF program that calls `send_async()` with a blob of `max + 1` bytes.
+3. Assert: `send_async()` returns -2.
+4. Assert: the queue remains empty (no data piggybacked on next WAKE).
+
+---
+
 ### T-N628  sonde_context downlink data populated
 
 **Validates:** ND-0612
 
 **Procedure:**
-1. Send NOP COMMAND with `blob` `[0xEE, 0xFF]`.
-2. Install BPF program that reads `ctx->data_start` to `ctx->data_end`.
-3. Assert: BPF program finds `[0xEE, 0xFF]`.
+1. Install BPF program that reads `ctx->data_start` to `ctx->data_end`.
+2. On the next WAKE, send NOP COMMAND with `blob` `[0xEE, 0xFF]`.
+3. Assert: in that wake cycle, the BPF program finds `[0xEE, 0xFF]`.
 
 ---
 
@@ -867,8 +879,9 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Validates:** ND-0612
 
 **Procedure:**
-1. Send NOP COMMAND without `blob` field.
-2. Assert: BPF program's `ctx->data_start == 0` and `ctx->data_end == 0`.
+1. Install BPF program that reads `ctx->data_start` and `ctx->data_end`.
+2. On the next WAKE, send NOP COMMAND without `blob` field.
+3. Assert: BPF program's `ctx->data_start == 0` and `ctx->data_end == 0`.
 
 ---
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -2059,7 +2059,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0506 | T-N508, T-N510 |
 | ND-0600 | T-N930 |
 | ND-0601 | T-N600, T-N601, T-N602, T-N603, T-N931 |
-| ND-0602 | T-N604, T-N605, T-N606, T-N621 |
+| ND-0602 | T-N604, T-N605, T-N606, T-N621, T-N627a |
 | ND-0603 | T-N607, T-N608, T-N609, T-N932 |
 | ND-0604 | T-N610, T-N611, T-N612, T-N613, T-N933 |
 | ND-0605 | T-N614, T-N615, T-N934 |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -768,6 +768,144 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
+### T-N621  send_async queues data
+
+**Validates:** ND-0602 (AC4), ND-0609
+
+**Procedure:**
+1. Install a BPF program that calls `send_async([0xCC, 0xDD])`.
+2. Run wake cycle.
+3. Assert: `send_async()` returns 0.
+4. Assert: no APP_DATA frame is transmitted during this wake cycle.
+5. Assert: data remains in queue.
+
+---
+
+### T-N622  send_async piggybacked on WAKE
+
+**Validates:** ND-0610
+
+**Procedure:**
+1. Install program that calls `send_async([0xCC, 0xDD])`.
+2. Complete wake cycle (data queued).
+3. On next wake cycle, capture WAKE frame.
+4. Assert: WAKE CBOR payload contains `blob` (key 10) with value `[0xCC, 0xDD]`.
+
+---
+
+### T-N623  send_async overflow to APP_DATA
+
+**Validates:** ND-0610, ND-0611
+
+**Procedure:**
+1. Install program that calls `send_async()` twice (2 messages queued).
+2. On next wake cycle, capture all frames.
+3. Assert: WAKE does NOT contain `blob`.
+4. Assert: 2 APP_DATA frames sent after COMMAND, each with correct sequence numbers.
+
+---
+
+### T-N624  send_async oversized falls back to APP_DATA
+
+**Validates:** ND-0610
+
+**Procedure:**
+1. Install program that calls `send_async()` with a blob that exceeds the WAKE payload budget.
+2. On next wake cycle, capture frames.
+3. Assert: WAKE does NOT contain `blob`.
+4. Assert: blob sent via APP_DATA after COMMAND.
+
+---
+
+### T-N625  send_async queue full returns error
+
+**Validates:** ND-0613
+
+**Procedure:**
+1. Install program that calls `send_async()` 11 times with small blobs.
+2. Assert: first 10 calls return 0.
+3. Assert: 11th call returns -1.
+
+---
+
+### T-N626  send_async queue cleared after send
+
+**Validates:** ND-0609
+
+**Procedure:**
+1. Call `send_async()` once.
+2. Complete two wake cycles.
+3. Assert: WAKE in second cycle has `blob`.
+4. Assert: WAKE in third cycle does NOT have `blob` (queue was cleared after send).
+
+---
+
+### T-N627  send_async queue cleared on program load
+
+**Validates:** ND-0609
+
+**Procedure:**
+1. Call `send_async()`.
+2. Before next WAKE, trigger UPDATE_PROGRAM.
+3. Assert: the new program's first WAKE does NOT contain the old program's queued `blob`.
+
+---
+
+### T-N628  sonde_context downlink data populated
+
+**Validates:** ND-0612
+
+**Procedure:**
+1. Send NOP COMMAND with `blob` `[0xEE, 0xFF]`.
+2. Install BPF program that reads `ctx->data_start` to `ctx->data_end`.
+3. Assert: BPF program finds `[0xEE, 0xFF]`.
+
+---
+
+### T-N629  sonde_context no downlink data
+
+**Validates:** ND-0612
+
+**Procedure:**
+1. Send NOP COMMAND without `blob` field.
+2. Assert: BPF program's `ctx->data_start == 0` and `ctx->data_end == 0`.
+
+---
+
+### T-N630  Backward compatibility — send() unchanged
+
+**Validates:** ND-0614
+
+**Procedure:**
+1. Install `send_program` that calls `send([0xAA, 0xBB])`.
+2. Run wake cycle.
+3. Assert: APP_DATA sent immediately during wake cycle.
+4. Assert: existing behavior preserved exactly.
+
+---
+
+### T-N631  Backward compatibility — WAKE without blob accepted
+
+**Validates:** ND-0614
+
+**Procedure:**
+1. Send WAKE without `blob` field (existing format).
+2. Assert: gateway processes it normally and responds with COMMAND.
+
+---
+
+### T-N632  send_async from ephemeral program
+
+**Validates:** ND-0609
+
+**Procedure:**
+1. Run ephemeral program that calls `send_async([0x01])`.
+2. Assert: returns 0.
+3. Complete wake cycle.
+4. Assert: data piggybacked on next WAKE.
+
+---
+
 ## 9  Timing and retry tests
 
 ### T-N700  WAKE retry count and timing
@@ -1908,7 +2046,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0506 | T-N508, T-N510 |
 | ND-0600 | T-N930 |
 | ND-0601 | T-N600, T-N601, T-N602, T-N603, T-N931 |
-| ND-0602 | T-N604, T-N605, T-N606 |
+| ND-0602 | T-N604, T-N605, T-N606, T-N621 |
 | ND-0603 | T-N607, T-N608, T-N609, T-N932 |
 | ND-0604 | T-N610, T-N611, T-N612, T-N613, T-N933 |
 | ND-0605 | T-N614, T-N615, T-N934 |
@@ -1939,6 +2077,12 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0917 | T-N906 |
 | ND-0918 | *(verified by sdkconfig.defaults setting)* |
 | ND-0608 | T-N0607a, T-N0607b, T-N0607c, T-N0607d, T-N0607e, T-N0607f |
+| ND-0609 | T-N621, T-N626, T-N627, T-N632 |
+| ND-0610 | T-N622, T-N623, T-N624 |
+| ND-0611 | T-N623 |
+| ND-0612 | T-N628, T-N629 |
+| ND-0613 | T-N625 |
+| ND-0614 | T-N630, T-N631 |
 | ND-1000 | T-N1000, T-N1001 |
 | ND-1001 | T-N1002 |
 | ND-1002 | T-N1003 |

--- a/docs/protocol-crate-validation.md
+++ b/docs/protocol-crate-validation.md
@@ -1069,7 +1069,7 @@ impl Sha256Provider for SoftwareSha256 { /* RustCrypto sha2 */ }
 3. Assert: all fields match, including `blob = Some([0xAA, 0xBB])`.
 4. Encode a `NodeMessage::Wake` with the same fields but `blob=None`.
 5. Decode and assert: `blob` is `None`.
-6. Assert: the CBOR bytes from step 4 do NOT contain key 10.
+6. Decode the CBOR bytes from step 4 as a CBOR map and assert that integer key 10 is not present.
 
 ---
 
@@ -1084,7 +1084,7 @@ impl Sha256Provider for SoftwareSha256 { /* RustCrypto sha2 */ }
 4. Assert: `payload` is `CommandPayload::Nop` (key 5 omitted).
 5. Encode a `GatewayMessage::Command` with same fields but `blob=None`.
 6. Decode and assert: `blob` is `None`.
-7. Assert: the CBOR bytes from step 5 do NOT contain key 10.
+7. Decode the CBOR bytes from step 5 as a CBOR map and assert that integer key 10 is not present.
 
 ---
 

--- a/docs/protocol-crate-validation.md
+++ b/docs/protocol-crate-validation.md
@@ -1054,3 +1054,46 @@ impl Sha256Provider for SoftwareSha256 { /* RustCrypto sha2 */ }
 4. Decode and assert: `status` = 0x01, `payload_len` = 0.
 5. Encode `DIAG_RELAY_RESPONSE` with `status=0x02` and empty payload.
 6. Decode and assert: `status` = 0x02, `payload_len` = 0.
+
+---
+
+## 13  Store-and-forward message encoding
+
+### T-P120  WAKE with optional blob round-trip
+
+**Validates:** protocol.md §5.1
+
+**Procedure:**
+1. Encode a `NodeMessage::Wake` with `firmware_abi_version=1`, `program_hash=[0x42; 32]`, `battery_mv=3300`, `firmware_version="0.4.0"`, and `blob=Some([0xAA, 0xBB])`.
+2. Decode the CBOR bytes back to `NodeMessage::Wake`.
+3. Assert: all fields match, including `blob = Some([0xAA, 0xBB])`.
+4. Encode a `NodeMessage::Wake` with the same fields but `blob=None`.
+5. Decode and assert: `blob` is `None`.
+6. Assert: the CBOR bytes from step 4 do NOT contain key 10.
+
+---
+
+### T-P121  COMMAND NOP with optional blob round-trip
+
+**Validates:** protocol.md §5.2
+
+**Procedure:**
+1. Encode a `GatewayMessage::Command` with `command_type=NOP`, `starting_seq=42`, `timestamp_ms=1700000000000`, and `blob=Some([0xCC, 0xDD])`.
+2. Decode the CBOR bytes back to `GatewayMessage::Command`.
+3. Assert: all fields match, including `blob = Some([0xCC, 0xDD])`.
+4. Assert: `payload` is `CommandPayload::Nop` (key 5 omitted).
+5. Encode a `GatewayMessage::Command` with same fields but `blob=None`.
+6. Decode and assert: `blob` is `None`.
+7. Assert: the CBOR bytes from step 5 do NOT contain key 10.
+
+---
+
+### T-P122  Non-NOP COMMAND ignores blob field
+
+**Validates:** protocol.md §5.2
+
+**Procedure:**
+1. Encode a `GatewayMessage::Command` with `command_type=UPDATE_SCHEDULE`, `starting_seq=1`, `timestamp_ms=1700000000000`, `interval_s=60`, and `blob=None`.
+2. Decode and assert: `blob` is `None`.
+3. Manually construct CBOR bytes for an UPDATE_SCHEDULE COMMAND that includes key 10 with value `[0xFF]`.
+4. Decode and assert: the decoder either ignores the blob (returns `None`) or accepts it — backward compatibility is preserved either way.

--- a/docs/protocol-crate-validation.md
+++ b/docs/protocol-crate-validation.md
@@ -1057,7 +1057,7 @@ impl Sha256Provider for SoftwareSha256 { /* RustCrypto sha2 */ }
 
 ---
 
-## 13  Store-and-forward message encoding
+## 11  Store-and-forward message encoding
 
 ### T-P120  WAKE with optional blob round-trip
 

--- a/docs/protocol-crate-validation.md
+++ b/docs/protocol-crate-validation.md
@@ -1096,4 +1096,4 @@ impl Sha256Provider for SoftwareSha256 { /* RustCrypto sha2 */ }
 1. Encode a `GatewayMessage::Command` with `command_type=UPDATE_SCHEDULE`, `starting_seq=1`, `timestamp_ms=1700000000000`, `interval_s=60`, and `blob=None`.
 2. Decode and assert: `blob` is `None`.
 3. Manually construct CBOR bytes for an UPDATE_SCHEDULE COMMAND that includes key 10 with value `[0xFF]`.
-4. Decode and assert: the decoder either ignores the blob (returns `None`) or accepts it — backward compatibility is preserved either way.
+4. Decode and assert: the decoder ignores key 10 for non-NOP commands and returns `blob=None`.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -589,13 +589,15 @@ The store-and-forward mechanism piggybacks application data on the mandatory WAK
 3. On next NOP COMMAND → include stored reply as `blob` (key 10).
 4. Node's BPF program reads data via `sonde_context.data_start` / `data_end`.
 
-**Timing (two-cycle delivery latency):**
+**Timing (best-case two-cycle delivery latency):**
+
+Delivery occurs on the next NOP COMMAND, which is the next wake cycle in the common case. If intervening cycles use non-NOP commands (UPDATE_PROGRAM, UPDATE_SCHEDULE, etc.), delivery is postponed until the next NOP.
 
 | Cycle | Node action | Gateway action |
 |---|---|---|
 | N | BPF calls `send_async(data)` → queued | — |
 | N+1 | WAKE carries `data` as blob | Routes to handler → handler replies → reply stored |
-| N+2 | — | NOP COMMAND carries stored reply as blob → BPF reads via context |
+| N+2+ | — | Next NOP COMMAND carries stored reply as blob → BPF reads via context |
 
 ```
     Node                          Gateway

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -160,7 +160,7 @@ All payload fields below are CBOR-encoded maps with **integer keys** for compact
 | 7 | `chunk_size` | UPDATE_PROGRAM / RUN_EPHEMERAL |
 | 8 | `chunk_count` | UPDATE_PROGRAM / RUN_EPHEMERAL |
 | 9 | `interval_s` | UPDATE_SCHEDULE |
-| 10 | `blob` | APP_DATA, APP_DATA_REPLY |
+| 10 | `blob` | APP_DATA, APP_DATA_REPLY, WAKE (optional), COMMAND (optional) |
 | 11 | `chunk_index` | GET_CHUNK, CHUNK |
 | 12 | `chunk_data` | CHUNK |
 | 13 | `starting_seq` | COMMAND |
@@ -261,6 +261,7 @@ Sent at the start of each wake cycle (retransmitted up to 3 times if no COMMAND 
 | `program_hash` | bstr | Yes | Hash of the currently installed resident program. Zero-length if no program installed. |
 | `battery_mv` | uint | Yes | Battery voltage in millivolts. |
 | `firmware_version` | tstr | Yes | Firmware version string (e.g., `"0.4.0"`). ASCII-only, maximum 32 bytes. Derived from `CARGO_PKG_VERSION` at compile time. |
+| `blob` | bstr | No | Piggybacked uplink data from the previous wake cycle's `send_async()` call. Omitted when no data is queued, when multiple messages are queued, or when the blob would exceed the available payload budget. When present, the gateway routes this to the handler exactly like an APP_DATA blob (see §6.7). |
 
 `key_hint` and `nonce` are in the fixed header and are not duplicated in the payload. Both are already authenticated by the AEAD construction (the header is AAD).
 
@@ -274,6 +275,7 @@ Sent exactly once in response to a valid, authenticated `WAKE`.
 | `starting_seq` | uint | Yes | Random starting sequence number for this session. The node uses this value in the `nonce` header field of its next outbound message and increments for each subsequent message. |
 | `timestamp_ms` | uint | Yes | Gateway's current UTC time in milliseconds since Unix epoch. The node uses this as its time reference for `sonde_context.timestamp` and `get_time()`. |
 | `payload` | map | Depends on command | **Nested** CBOR map containing command-specific fields (see §5.2.1, §5.2.2). Omitted for `NOP` and `REBOOT`. |
+| `blob` | bstr | No | Piggybacked downlink data — a previously deferred handler reply. Present only on `NOP` commands when the gateway has stored deferred data for this node (see §6.7). This is a top-level COMMAND field, NOT nested inside `payload`. |
 
 The `nonce` in the fixed header echoes the WAKE nonce, binding the response to the request. The `starting_seq` is a CBOR payload field that tells the node where to begin its sequence counter for this wake cycle. The `timestamp_ms` provides the node with an accurate time reference — the node has no independent clock source across deep sleep.
 
@@ -566,6 +568,54 @@ The pairing tool uses the node as a **dumb radio relay** to measure the node→g
 The node retries the ESP-NOW broadcast up to **3 retries** with **200 ms** backoff between attempts, **2-second** listen window per attempt. If no `DIAG_REPLY` is received after all retries, the node returns a timeout status to the pairing tool. Total worst-case node-side duration is approximately **8.6 seconds** (4 broadcasts × 2 s listen + 3 × 200 ms backoff). The pairing tool applies a **10-second** overall timeout.
 
 The diagnostic step is **optional** and **repeatable** — the installer may run it multiple times to test different node positions before committing to provisioning.
+
+### 6.7  Store-and-forward data flow
+
+The store-and-forward mechanism piggybacks application data on the mandatory WAKE↔COMMAND exchange, reducing radio transmissions for the common sensor-read-and-report pattern.
+
+**Uplink (node → gateway):**
+
+1. BPF program calls `send_async(buf, len)` — data queued in RAM (max 10 messages).
+2. On next wake:
+   - If exactly 1 message queued AND it fits in the WAKE payload budget → include as `blob` (key 10) in WAKE.
+   - Otherwise → send all queued messages via APP_DATA after COMMAND (existing mechanism).
+3. Gateway receives WAKE, extracts `blob`, routes to handler as a `DATA` message.
+4. Handler reply is always deferred to next cycle.
+
+**Downlink (gateway → node):**
+
+1. Handler replies to `DATA` with `delivery=1` (deferred) in the `DATA_REPLY`.
+2. Gateway stores the reply for this node (at most one per node; latest wins).
+3. On next NOP COMMAND → include stored reply as `blob` (key 10).
+4. Node's BPF program reads data via `sonde_context.data_start` / `data_end`.
+
+**Timing (two-cycle delivery latency):**
+
+| Cycle | Node action | Gateway action |
+|---|---|---|
+| N | BPF calls `send_async(data)` → queued | — |
+| N+1 | WAKE carries `data` as blob | Routes to handler → handler replies → reply stored |
+| N+2 | — | NOP COMMAND carries stored reply as blob → BPF reads via context |
+
+```
+    Node                          Gateway
+     │                               │
+     │── WAKE {blob: prev_data} ───►│  (routes blob to handler)
+     │                               │  (retrieves stored deferred reply)
+     │◄── COMMAND {NOP, blob: ───────│  (piggybacks stored reply)
+     │         deferred_reply}       │
+     │                               │
+     │  [BPF reads deferred_reply    │
+     │   via ctx->data_start/end]    │
+     │                               │
+     │  [BPF calls send_async(new)]  │
+     │                               │
+     │  [sleep]                      │
+```
+
+**Backward compatibility:** The `blob` field is optional in both WAKE and COMMAND. Nodes and gateways that predate this feature silently ignore unknown CBOR keys (forward compatibility). A new node talking to an old gateway functions normally — piggybacked data is silently dropped but the node remains operational.
+
+**Fallback:** When the async queue contains multiple messages or an oversized message, the node sends them as standard APP_DATA frames after receiving COMMAND, exactly as `send()` / `send_recv()` do today.
 
 ---
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -602,18 +602,22 @@ Delivery occurs on the next NOP COMMAND, which is the next wake cycle in the com
 ```
     Node                          Gateway
      │                               │
-     │── WAKE {blob: prev_data} ───►│  (routes blob to handler)
-     │                               │  (retrieves stored deferred reply)
-     │◄── COMMAND {NOP, blob: ───────│  (piggybacks stored reply)
-     │         deferred_reply}       │
+     │── WAKE {blob: data_N} ──────►│  (routes data_N to handler)
+     │                               │  (retrieves deferred reply from
+     │                               │   data_N-1, stored last cycle)
+     │◄── COMMAND {NOP, blob: ───────│  (piggybacks reply to data_N-1)
+     │         reply_N-1}           │
      │                               │
-     │  [BPF reads deferred_reply    │
+     │  [BPF reads reply_N-1         │
      │   via ctx->data_start/end]    │
      │                               │
-     │  [BPF calls send_async(new)]  │
+     │  [BPF calls send_async(       │
+     │    data_N+1)]                 │
      │                               │
      │  [sleep]                      │
 ```
+
+Note: The COMMAND blob (`reply_N-1`) is the handler's response to a *previous* cycle's WAKE blob, not the current one. The current WAKE's blob (`data_N`) will be replied to on the *next* NOP COMMAND.
 
 **Backward compatibility:** The `blob` field is optional in both WAKE and COMMAND. Nodes and gateways that predate this feature silently ignore unknown CBOR keys (forward compatibility). A new node talking to an old gateway functions normally — piggybacked data is silently dropped but the node remains operational.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -160,7 +160,7 @@ All payload fields below are CBOR-encoded maps with **integer keys** for compact
 | 7 | `chunk_size` | UPDATE_PROGRAM / RUN_EPHEMERAL |
 | 8 | `chunk_count` | UPDATE_PROGRAM / RUN_EPHEMERAL |
 | 9 | `interval_s` | UPDATE_SCHEDULE |
-| 10 | `blob` | APP_DATA, APP_DATA_REPLY, WAKE (optional), COMMAND (optional) |
+| 10 | `blob` | APP_DATA, APP_DATA_REPLY, WAKE (optional), COMMAND (NOP only, top-level) |
 | 11 | `chunk_index` | GET_CHUNK, CHUNK |
 | 12 | `chunk_data` | CHUNK |
 | 13 | `starting_seq` | COMMAND |
@@ -275,7 +275,7 @@ Sent exactly once in response to a valid, authenticated `WAKE`.
 | `starting_seq` | uint | Yes | Random starting sequence number for this session. The node uses this value in the `nonce` header field of its next outbound message and increments for each subsequent message. |
 | `timestamp_ms` | uint | Yes | Gateway's current UTC time in milliseconds since Unix epoch. The node uses this as its time reference for `sonde_context.timestamp` and `get_time()`. |
 | `payload` | map | Depends on command | **Nested** CBOR map containing command-specific fields (see §5.2.1, §5.2.2). Omitted for `NOP` and `REBOOT`. |
-| `blob` | bstr | No | Piggybacked downlink data — a previously deferred handler reply. Present only on `NOP` commands when the gateway has stored deferred data for this node (see §6.7). This is a top-level COMMAND field, NOT nested inside `payload`. |
+| `blob` | bstr | No | Piggybacked downlink data — a previously deferred handler reply. Used on `NOP` commands when the gateway has stored deferred data for this node (see §6.7). This is a top-level COMMAND field, NOT nested inside `payload`. Nodes MUST ignore `blob` unless `command_type` is `NOP`, even if key 10 is present on another command type. |
 
 The `nonce` in the fixed header echoes the WAKE nonce, binding the response to the request. The `starting_seq` is a CBOR payload field that tells the node where to begin its sequence counter for this wake cycle. The `timestamp_ms` provides the node with an accurate time reference — the node has no independent clock source across deep sleep.
 
@@ -584,7 +584,7 @@ The store-and-forward mechanism piggybacks application data on the mandatory WAK
 
 **Downlink (gateway → node):**
 
-1. Handler replies to `DATA` with `delivery=1` (deferred) in the `DATA_REPLY`.
+1. Handler replies to the `DATA` message with a `DATA_REPLY`. For `DATA` originating from a WAKE `blob`, deferred delivery is always enforced by the gateway: the handler may omit `delivery`, and any handler-supplied `delivery` value is ignored for this path.
 2. Gateway stores the reply for this node (at most one per node; latest wins).
 3. On next NOP COMMAND → include stored reply as `blob` (key 10).
 4. Node's BPF program reads data via `sonde_context.data_start` / `data_end`.


### PR DESCRIPTION
## Summary

Specifies a bidirectional store-and-forward data channel that piggybacks on the mandatory WAKE/COMMAND exchange, halving radio transmissions for the common sensor-read-and-report pattern.

## What changed (docs only, no source)

**protocol.md**
- WAKE gains optional `blob` (key 10) for piggybacked uplink
- NOP COMMAND gains optional `blob` (key 10) for deferred downlink
- New section 6.7: store-and-forward data flow + sequence diagram

**bpf-environment.md**
- `sonde_context` extended with `data_start`/`data_end` pointer pair
- New helper #17 `send_async` (queue data for next WAKE)
- Async queue docs (max 10 msgs, RAM-only, cleared on send/reboot)

**gateway-api.md**
- `DATA_REPLY` gains `delivery` field (key 4): 0=immediate, 1=deferred
- New section 4.5: deferred delivery semantics

**Requirements + validation** (node + gateway + protocol-crate)
- Modified: ND-0201, ND-0602, GW-0102, GW-0103, GW-0506
- New requirements: ND-0609..0614, GW-0509..0512
- New test cases: T-N621..T-N632, T-0518..T-0526, T-P120..T-P122

## Design decisions

- Two-cycle delivery latency (send_async -> WAKE -> handler -> COMMAND -> BPF reads)
- Overflow: multiple or oversized queued messages fall back to APP_DATA
- Fully backward compatible: unknown CBOR keys silently ignored per existing decoder
- RAM-only queue (no flash wear)
