### PR TITLE
fix(pair): enrich PairingError variants with device context (PT-1215)

### DIFF
--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -936,9 +936,10 @@ impl sonde_pair::transport::BleTransport for GatewayBleAdapter {
             if address == expected_address {
                 Ok(247)
             } else {
-                Err(sonde_pair::error::PairingError::ConnectionFailed(
-                    "unexpected device address in e2e harness".into(),
-                ))
+                Err(sonde_pair::error::PairingError::ConnectionFailed {
+                    device: None,
+                    reason: "unexpected device address in e2e harness".into(),
+                })
             }
         })
     }
@@ -964,9 +965,10 @@ impl sonde_pair::transport::BleTransport for GatewayBleAdapter {
             if service != sonde_pair::types::GATEWAY_SERVICE_UUID
                 || characteristic != sonde_pair::types::GATEWAY_COMMAND_UUID
             {
-                return Err(sonde_pair::error::PairingError::ConnectionFailed(
-                    "unexpected GATT service/characteristic in e2e harness".into(),
-                ));
+                return Err(sonde_pair::error::PairingError::ConnectionFailed {
+                    device: None,
+                    reason: "unexpected GATT service/characteristic in e2e harness".into(),
+                });
             }
             let mut window = self.window.lock().await;
             // Refresh the registration window if it has expired, so slow CI
@@ -1009,9 +1011,10 @@ impl sonde_pair::transport::BleTransport for GatewayBleAdapter {
             if service != sonde_pair::types::GATEWAY_SERVICE_UUID
                 || characteristic != sonde_pair::types::GATEWAY_COMMAND_UUID
             {
-                return Err(sonde_pair::error::PairingError::ConnectionFailed(
-                    "unexpected GATT service/characteristic in e2e harness".into(),
-                ));
+                return Err(sonde_pair::error::PairingError::ConnectionFailed {
+                    device: None,
+                    reason: "unexpected GATT service/characteristic in e2e harness".into(),
+                });
             }
             let timeout_duration = Duration::from_millis(timeout_ms);
 
@@ -1032,7 +1035,7 @@ impl sonde_pair::transport::BleTransport for GatewayBleAdapter {
 
             match tokio::time::timeout(timeout_duration, wait_future).await {
                 Ok(response) => Ok(response),
-                Err(_) => Err(sonde_pair::error::PairingError::IndicationTimeout),
+                Err(_) => Err(sonde_pair::error::PairingError::IndicationTimeout { device: None }),
             }
         })
     }

--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -488,7 +488,7 @@ impl BleTransport for AndroidBleTransport {
                     })
             })
             .await
-            .map_err(join_err)?;
+            .map_err(join_err)??;
             // Store connected device address on success (PT-1215).
             *self.inner.connected_address.lock().unwrap() = Some(device_str);
             Ok(mtu)

--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -30,7 +30,7 @@ use jni::refs::Global;
 use jni::{jni_sig, jni_str, Env, JavaVM};
 use tracing::debug;
 
-use crate::error::PairingError;
+use crate::error::{format_device_address, PairingError};
 use crate::transport::BleTransport;
 use crate::types::{PairingMethod, ScannedDevice};
 
@@ -75,6 +75,8 @@ struct JniState {
     /// Pairing method reported by Java `BleHelper.getPairingMethod()`.
     /// 0 = Unknown, 1 = NumericComparison, 2 = JustWorks.
     pairing_method: AtomicU8,
+    /// Device address of the current BLE connection (PT-1215).
+    connected_address: std::sync::Mutex<Option<String>>,
 }
 
 // SAFETY: JavaVM is Send+Sync and GlobalRef is Send.  We only access the
@@ -98,13 +100,14 @@ impl AndroidBleTransport {
         // Use the cached class ref (resolved on the main thread which has the
         // application classloader).  Natively-attached threads only see the
         // system classloader, so find_class() for app classes would fail.
-        let cached = CACHED_HELPER_CLASS.get().ok_or_else(|| {
-            PairingError::ConnectionFailed(
-                "BleHelper class not cached — call cache_helper_class() \
-                 from JNI_OnLoad before using the transport"
+        let cached = CACHED_HELPER_CLASS
+            .get()
+            .ok_or_else(|| PairingError::ConnectionFailed {
+                device: None,
+                reason: "BleHelper class not cached — call cache_helper_class() \
+                         from JNI_OnLoad before using the transport"
                     .into(),
-            )
-        })?;
+            })?;
 
         let helper = env
             .new_object(
@@ -123,6 +126,7 @@ impl AndroidBleTransport {
                 vm,
                 helper: helper_ref,
                 pairing_method: AtomicU8::new(0),
+                connected_address: std::sync::Mutex::new(None),
             }),
         })
     }
@@ -143,11 +147,12 @@ impl AndroidBleTransport {
     pub fn cache_helper_class(env: &mut Env<'_>) -> Result<(), PairingError> {
         let cls = env
             .find_class(jni_str!("io/sonde/pair/BleHelper"))
-            .map_err(|e| {
-                PairingError::ConnectionFailed(format!(
+            .map_err(|e| PairingError::ConnectionFailed {
+                device: None,
+                reason: format!(
                     "BleHelper class not found — ensure io.sonde.pair.BleHelper \
                  is compiled into the APK: {e}"
-                ))
+                ),
             })?;
         let global = env.new_global_ref(cls).map_err(jni_err)?;
         let _ = CACHED_HELPER_CLASS.set(global);
@@ -160,17 +165,21 @@ impl AndroidBleTransport {
     /// `JNI_OnLoad`).  The application context is obtained via
     /// `ActivityThread.currentApplication()`.
     pub fn from_cached_vm() -> Result<Self, PairingError> {
-        let vm = CACHED_VM.get().ok_or_else(|| {
-            PairingError::ConnectionFailed("JavaVM not cached — call cache_vm() first".into())
-        })?;
+        let vm = CACHED_VM
+            .get()
+            .ok_or_else(|| PairingError::ConnectionFailed {
+                device: None,
+                reason: "JavaVM not cached — call cache_vm() first".into(),
+            })?;
         vm.attach_current_thread(|env| {
             let context = get_application_context(env)?;
             Self::new(env, &context)
         })
         .map_err(|e| match e {
-            PairingError::JniError(msg) => {
-                PairingError::ConnectionFailed(format!("attach_current_thread: {msg}"))
-            }
+            PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                device: None,
+                reason: format!("attach_current_thread: {msg}"),
+            },
             other => other,
         })
     }
@@ -193,9 +202,10 @@ impl AndroidBleTransport {
                 Ok(())
             })
             .map_err(|e| match e {
-                PairingError::JniError(msg) => {
-                    PairingError::ConnectionFailed(format!("attach_current_thread: {msg}"))
-                }
+                PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                    device: None,
+                    reason: format!("attach_current_thread: {msg}"),
+                },
                 other => other,
             })
     }
@@ -227,9 +237,10 @@ impl BleTransport for AndroidBleTransport {
                         Ok(())
                     })
                     .map_err(|e| match e {
-                        PairingError::JniError(msg) => {
-                            PairingError::ConnectionFailed(format!("attach_current_thread: {msg}"))
-                        }
+                        PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                            device: None,
+                            reason: format!("attach_current_thread: {msg}"),
+                        },
                         other => other,
                     })
             })
@@ -256,9 +267,10 @@ impl BleTransport for AndroidBleTransport {
                         Ok(())
                     })
                     .map_err(|e| match e {
-                        PairingError::JniError(msg) => {
-                            PairingError::ConnectionFailed(format!("attach_current_thread: {msg}"))
-                        }
+                        PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                            device: None,
+                            reason: format!("attach_current_thread: {msg}"),
+                        },
                         other => other,
                     })
             })
@@ -331,7 +343,10 @@ impl BleTransport for AndroidBleTransport {
                                 })
                                 .map_err(jni_err)?;
                             let address: [u8; 6] = addr_bytes.try_into().map_err(|_| {
-                                PairingError::ConnectionFailed("bad address length".into())
+                                PairingError::ConnectionFailed {
+                                    device: None,
+                                    reason: "bad address length".into(),
+                                }
                             })?;
 
                             // RSSI
@@ -383,9 +398,10 @@ impl BleTransport for AndroidBleTransport {
                         Ok(devices)
                     })
                     .map_err(|e| match e {
-                        PairingError::JniError(msg) => {
-                            PairingError::ConnectionFailed(format!("attach_current_thread: {msg}"))
-                        }
+                        PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                            device: None,
+                            reason: format!("attach_current_thread: {msg}"),
+                        },
                         other => other,
                     })
             })
@@ -400,10 +416,13 @@ impl BleTransport for AndroidBleTransport {
     ) -> Pin<Box<dyn Future<Output = Result<u16, PairingError>> + '_>> {
         let inner = self.inner.clone();
         let addr = *address;
+        let device_str = format_device_address(&addr);
         // Reset pairing method before new connection attempt.
         self.inner.pairing_method.store(0, Ordering::Release);
+        // Clear previous connected address.
+        *self.inner.connected_address.lock().unwrap() = None;
         Box::pin(async move {
-            tokio::task::spawn_blocking(move || {
+            let mtu = tokio::task::spawn_blocking(move || {
                 inner
                     .vm
                     .attach_current_thread(|env| {
@@ -461,19 +480,25 @@ impl BleTransport for AndroidBleTransport {
                         Ok(mtu as u16)
                     })
                     .map_err(|e| match e {
-                        PairingError::JniError(msg) => {
-                            PairingError::ConnectionFailed(format!("attach_current_thread: {msg}"))
-                        }
+                        PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                            device: None,
+                            reason: format!("attach_current_thread: {msg}"),
+                        },
                         other => other,
                     })
             })
             .await
-            .map_err(join_err)?
+            .map_err(join_err)?;
+            // Store connected device address on success (PT-1215).
+            *self.inner.connected_address.lock().unwrap() = Some(device_str);
+            Ok(mtu)
         })
     }
 
     fn disconnect(&mut self) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
         let inner = self.inner.clone();
+        // Clear connected address on disconnect (PT-1215).
+        *self.inner.connected_address.lock().unwrap() = None;
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
                 inner
@@ -490,9 +515,10 @@ impl BleTransport for AndroidBleTransport {
                         Ok(())
                     })
                     .map_err(|e| match e {
-                        PairingError::JniError(msg) => {
-                            PairingError::ConnectionFailed(format!("attach_current_thread: {msg}"))
-                        }
+                        PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                            device: None,
+                            reason: format!("attach_current_thread: {msg}"),
+                        },
                         other => other,
                     })
             })
@@ -537,9 +563,10 @@ impl BleTransport for AndroidBleTransport {
                         Ok(())
                     })
                     .map_err(|e| match e {
-                        PairingError::JniError(msg) => {
-                            PairingError::ConnectionFailed(format!("attach_current_thread: {msg}"))
-                        }
+                        PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                            device: None,
+                            reason: format!("attach_current_thread: {msg}"),
+                        },
                         other => other,
                     })
             })
@@ -578,9 +605,9 @@ impl BleTransport for AndroidBleTransport {
                             )
                             .map_err(|e| {
                                 let pe = jni_exception_or(env, "readIndication", e);
-                                if let PairingError::ConnectionFailed(ref msg) = pe {
-                                    if msg.contains("indication timeout") {
-                                        return PairingError::IndicationTimeout;
+                                if let PairingError::ConnectionFailed { ref reason, .. } = pe {
+                                    if reason.contains("indication timeout") {
+                                        return PairingError::IndicationTimeout { device: None };
                                     }
                                 }
                                 pe
@@ -598,9 +625,10 @@ impl BleTransport for AndroidBleTransport {
                         Ok(bytes)
                     })
                     .map_err(|e| match e {
-                        PairingError::JniError(msg) => {
-                            PairingError::ConnectionFailed(format!("attach_current_thread: {msg}"))
-                        }
+                        PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                            device: None,
+                            reason: format!("attach_current_thread: {msg}"),
+                        },
                         other => other,
                     })
             })
@@ -687,21 +715,28 @@ fn get_application_context<'a>(env: &mut Env<'a>) -> Result<JObject<'a>, Pairing
         .and_then(|v| v.l())
         .map_err(|e| jni_exception_or(env, "currentApplication", e))?;
     if app.is_null() {
-        return Err(PairingError::ConnectionFailed(
-            "ActivityThread.currentApplication() returned null".into(),
-        ));
+        return Err(PairingError::ConnectionFailed {
+            device: None,
+            reason: "ActivityThread.currentApplication() returned null".into(),
+        });
     }
     Ok(app)
 }
 
 /// Map a plain JNI error (not a Java exception) to [`PairingError`].
 fn jni_err(e: jni::errors::Error) -> PairingError {
-    PairingError::ConnectionFailed(format!("JNI error: {e}"))
+    PairingError::ConnectionFailed {
+        device: None,
+        reason: format!("JNI error: {e}"),
+    }
 }
 
 /// Map a [`tokio::task::JoinError`] to [`PairingError`].
 fn join_err(e: tokio::task::JoinError) -> PairingError {
-    PairingError::ConnectionFailed(format!("blocking task panicked: {e}"))
+    PairingError::ConnectionFailed {
+        device: None,
+        reason: format!("blocking task panicked: {e}"),
+    }
 }
 
 /// Attempt to extract the Java exception message; fall back to the raw
@@ -713,7 +748,10 @@ fn jni_exception_or(env: &mut Env<'_>, context: &str, err: jni::errors::Error) -
         }
         other => other.to_string(),
     };
-    PairingError::ConnectionFailed(format!("{context}: {detail}"))
+    PairingError::ConnectionFailed {
+        device: None,
+        reason: format!("{context}: {detail}"),
+    }
 }
 
 /// Read and clear the pending Java exception message, if any.

--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -421,6 +421,7 @@ impl BleTransport for AndroidBleTransport {
         self.inner.pairing_method.store(0, Ordering::Release);
         // Clear previous connected address.
         *self.inner.connected_address.lock().unwrap() = None;
+        let device_for_closure = Some(device_str.clone());
         Box::pin(async move {
             let mtu = tokio::task::spawn_blocking(move || {
                 inner
@@ -481,7 +482,7 @@ impl BleTransport for AndroidBleTransport {
                     })
                     .map_err(|e| match e {
                         PairingError::JniError(msg) => PairingError::ConnectionFailed {
-                            device: None,
+                            device: device_for_closure.clone(),
                             reason: format!("attach_current_thread: {msg}"),
                         },
                         other => other,
@@ -537,6 +538,7 @@ impl BleTransport for AndroidBleTransport {
         let svc_str = uuid_to_string(service);
         let chr_str = uuid_to_string(characteristic);
         let data = data.to_vec();
+        let device_addr = self.inner.connected_address.lock().unwrap().clone();
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
                 inner
@@ -564,7 +566,7 @@ impl BleTransport for AndroidBleTransport {
                     })
                     .map_err(|e| match e {
                         PairingError::JniError(msg) => PairingError::ConnectionFailed {
-                            device: None,
+                            device: device_addr.clone(),
                             reason: format!("attach_current_thread: {msg}"),
                         },
                         other => other,
@@ -584,6 +586,7 @@ impl BleTransport for AndroidBleTransport {
         let inner = self.inner.clone();
         let svc_str = uuid_to_string(service);
         let chr_str = uuid_to_string(characteristic);
+        let device_addr = self.inner.connected_address.lock().unwrap().clone();
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
                 inner
@@ -607,7 +610,9 @@ impl BleTransport for AndroidBleTransport {
                                 let pe = jni_exception_or(env, "readIndication", e);
                                 if let PairingError::ConnectionFailed { ref reason, .. } = pe {
                                     if reason.contains("indication timeout") {
-                                        return PairingError::IndicationTimeout { device: None };
+                                        return PairingError::IndicationTimeout {
+                                            device: device_addr.clone(),
+                                        };
                                     }
                                 }
                                 pe
@@ -626,7 +631,7 @@ impl BleTransport for AndroidBleTransport {
                     })
                     .map_err(|e| match e {
                         PairingError::JniError(msg) => PairingError::ConnectionFailed {
-                            device: None,
+                            device: device_addr.clone(),
                             reason: format!("attach_current_thread: {msg}"),
                         },
                         other => other,

--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -485,6 +485,13 @@ impl BleTransport for AndroidBleTransport {
                             device: device_for_closure.clone(),
                             reason: format!("attach_current_thread: {msg}"),
                         },
+                        PairingError::ConnectionFailed {
+                            device: None,
+                            reason,
+                        } => PairingError::ConnectionFailed {
+                            device: device_for_closure.clone(),
+                            reason,
+                        },
                         other => other,
                     })
             })
@@ -569,6 +576,13 @@ impl BleTransport for AndroidBleTransport {
                             device: device_addr.clone(),
                             reason: format!("attach_current_thread: {msg}"),
                         },
+                        PairingError::ConnectionFailed {
+                            device: None,
+                            reason,
+                        } => PairingError::ConnectionFailed {
+                            device: device_addr.clone(),
+                            reason,
+                        },
                         other => other,
                     })
             })
@@ -634,6 +648,18 @@ impl BleTransport for AndroidBleTransport {
                             device: device_addr.clone(),
                             reason: format!("attach_current_thread: {msg}"),
                         },
+                        PairingError::ConnectionFailed {
+                            device: None,
+                            reason,
+                        } => PairingError::ConnectionFailed {
+                            device: device_addr.clone(),
+                            reason,
+                        },
+                        PairingError::IndicationTimeout { device: None } => {
+                            PairingError::IndicationTimeout {
+                                device: device_addr.clone(),
+                            }
+                        }
                         other => other,
                     })
             })

--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -420,7 +420,11 @@ impl BleTransport for AndroidBleTransport {
         // Reset pairing method before new connection attempt.
         self.inner.pairing_method.store(0, Ordering::Release);
         // Clear previous connected address.
-        *self.inner.connected_address.lock().unwrap() = None;
+        *self
+            .inner
+            .connected_address
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = None;
         let device_for_closure = Some(device_str.clone());
         Box::pin(async move {
             let mtu = tokio::task::spawn_blocking(move || {
@@ -498,7 +502,11 @@ impl BleTransport for AndroidBleTransport {
             .await
             .map_err(join_err)??;
             // Store connected device address on success (PT-1215).
-            *self.inner.connected_address.lock().unwrap() = Some(device_str);
+            *self
+                .inner
+                .connected_address
+                .lock()
+                .unwrap_or_else(|p| p.into_inner()) = Some(device_str);
             Ok(mtu)
         })
     }
@@ -506,7 +514,11 @@ impl BleTransport for AndroidBleTransport {
     fn disconnect(&mut self) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
         let inner = self.inner.clone();
         // Clear connected address on disconnect (PT-1215).
-        *self.inner.connected_address.lock().unwrap() = None;
+        *self
+            .inner
+            .connected_address
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) = None;
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
                 inner
@@ -545,7 +557,12 @@ impl BleTransport for AndroidBleTransport {
         let svc_str = uuid_to_string(service);
         let chr_str = uuid_to_string(characteristic);
         let data = data.to_vec();
-        let device_addr = self.inner.connected_address.lock().unwrap().clone();
+        let device_addr = self
+            .inner
+            .connected_address
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone();
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
                 inner
@@ -600,7 +617,12 @@ impl BleTransport for AndroidBleTransport {
         let inner = self.inner.clone();
         let svc_str = uuid_to_string(service);
         let chr_str = uuid_to_string(characteristic);
-        let device_addr = self.inner.connected_address.lock().unwrap().clone();
+        let device_addr = self
+            .inner
+            .connected_address
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone();
         Box::pin(async move {
             tokio::task::spawn_blocking(move || {
                 inner

--- a/crates/sonde-pair/src/btleplug_transport.rs
+++ b/crates/sonde-pair/src/btleplug_transport.rs
@@ -35,7 +35,7 @@ use futures::stream::StreamExt;
 use tracing::debug;
 use uuid::Uuid;
 
-use crate::error::PairingError;
+use crate::error::{format_device_address, PairingError};
 use crate::transport::BleTransport;
 use crate::types::{PairingMethod, ScannedDevice, BLE_MTU_MIN};
 
@@ -61,6 +61,8 @@ const DEFAULT_REPORTED_MTU: u16 = BLE_MTU_MIN;
 pub struct BtleplugTransport {
     adapter: Adapter,
     connected: Option<ConnectedState>,
+    /// Device address of the current connection (PT-1215).
+    connected_address: Option<String>,
 }
 
 /// State for an active BLE connection.
@@ -77,12 +79,18 @@ impl BtleplugTransport {
     pub async fn new() -> Result<Self, PairingError> {
         let manager = Manager::new()
             .await
-            .map_err(|e| PairingError::ConnectionFailed(format!("BLE manager init failed: {e}")))?;
+            .map_err(|e| PairingError::ConnectionFailed {
+                device: None,
+                reason: format!("BLE manager init failed: {e}"),
+            })?;
 
         let adapters = manager
             .adapters()
             .await
-            .map_err(|e| PairingError::ConnectionFailed(format!("failed to list adapters: {e}")))?;
+            .map_err(|e| PairingError::ConnectionFailed {
+                device: None,
+                reason: format!("failed to list adapters: {e}"),
+            })?;
 
         let adapter = adapters
             .into_iter()
@@ -92,6 +100,7 @@ impl BtleplugTransport {
         Ok(Self {
             adapter,
             connected: None,
+            connected_address: None,
         })
     }
 
@@ -101,6 +110,7 @@ impl BtleplugTransport {
     /// if any post-connect step fails (PT-1001).
     async fn post_connect_setup(
         peripheral: &Peripheral,
+        device: &Option<String>,
     ) -> Result<
         (
             Pin<Box<dyn futures::stream::Stream<Item = ValueNotification> + Send>>,
@@ -108,14 +118,23 @@ impl BtleplugTransport {
         ),
         PairingError,
     > {
-        peripheral.discover_services().await.map_err(|e| {
-            PairingError::ConnectionFailed(format!("service discovery failed: {e}"))
-        })?;
+        peripheral
+            .discover_services()
+            .await
+            .map_err(|e| PairingError::ConnectionFailed {
+                device: device.clone(),
+                reason: format!("service discovery failed: {e}"),
+            })?;
         let service_count = peripheral.services().len();
 
-        let notification_stream = peripheral.notifications().await.map_err(|e| {
-            PairingError::ConnectionFailed(format!("failed to obtain notification stream: {e}"))
-        })?;
+        let notification_stream =
+            peripheral
+                .notifications()
+                .await
+                .map_err(|e| PairingError::ConnectionFailed {
+                    device: device.clone(),
+                    reason: format!("failed to obtain notification stream: {e}"),
+                })?;
 
         Ok((notification_stream, service_count))
     }
@@ -125,6 +144,7 @@ impl BtleplugTransport {
     /// Used internally before connecting to a new device and in `Drop`.
     async fn disconnect_inner(&mut self) {
         if let Some(state) = self.connected.take() {
+            self.connected_address = None;
             for uuid in &state.subscribed {
                 if let Some(chr) = state
                     .peripheral
@@ -150,15 +170,15 @@ fn find_characteristic(
     peripheral: &Peripheral,
     service_uuid: Uuid,
     char_uuid: Uuid,
+    device: &Option<String>,
 ) -> Result<BtleCharacteristic, PairingError> {
     peripheral
         .characteristics()
         .into_iter()
         .find(|c| c.service_uuid == service_uuid && c.uuid == char_uuid)
-        .ok_or_else(|| {
-            PairingError::ConnectionFailed(format!(
-                "characteristic {char_uuid} not found in service {service_uuid}"
-            ))
+        .ok_or_else(|| PairingError::ConnectionFailed {
+            device: device.clone(),
+            reason: format!("characteristic {char_uuid} not found in service {service_uuid}"),
         })
 }
 
@@ -176,7 +196,10 @@ impl BleTransport for BtleplugTransport {
             self.adapter
                 .start_scan(filter)
                 .await
-                .map_err(|e| PairingError::ConnectionFailed(format!("scan start failed: {e}")))?;
+                .map_err(|e| PairingError::ConnectionFailed {
+                    device: None,
+                    reason: format!("scan start failed: {e}"),
+                })?;
             debug!(services = ?uuids, "BLE scan started (filter applied in discovery layer)");
             Ok(())
         })
@@ -187,7 +210,10 @@ impl BleTransport for BtleplugTransport {
             self.adapter
                 .stop_scan()
                 .await
-                .map_err(|e| PairingError::ConnectionFailed(format!("scan stop failed: {e}")))?;
+                .map_err(|e| PairingError::ConnectionFailed {
+                    device: None,
+                    reason: format!("scan stop failed: {e}"),
+                })?;
             debug!("BLE scan stopped");
             Ok(())
         })
@@ -197,9 +223,14 @@ impl BleTransport for BtleplugTransport {
         &self,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<ScannedDevice>, PairingError>> + '_>> {
         Box::pin(async move {
-            let peripherals = self.adapter.peripherals().await.map_err(|e| {
-                PairingError::ConnectionFailed(format!("failed to list peripherals: {e}"))
-            })?;
+            let peripherals =
+                self.adapter
+                    .peripherals()
+                    .await
+                    .map_err(|e| PairingError::ConnectionFailed {
+                        device: None,
+                        reason: format!("failed to list peripherals: {e}"),
+                    })?;
 
             let mut devices = Vec::new();
             debug!(
@@ -257,42 +288,58 @@ impl BleTransport for BtleplugTransport {
             // If the adapter has no cached peripherals (e.g. a freshly
             // created transport), run a short scan first so WinRT populates
             // its internal device list.
-            let mut peripherals = self.adapter.peripherals().await.map_err(|e| {
-                PairingError::ConnectionFailed(format!("failed to list peripherals: {e}"))
-            })?;
+            let device_str = format_device_address(&addr);
+            let mut peripherals =
+                self.adapter
+                    .peripherals()
+                    .await
+                    .map_err(|e| PairingError::ConnectionFailed {
+                        device: Some(device_str.clone()),
+                        reason: format!("failed to list peripherals: {e}"),
+                    })?;
 
             if !peripherals.iter().any(|p| p.address() == target_addr) {
                 debug!("target not in cached peripherals, running short scan");
                 self.adapter
                     .start_scan(ScanFilter::default())
                     .await
-                    .map_err(|e| {
-                        PairingError::ConnectionFailed(format!("pre-connect scan failed: {e}"))
+                    .map_err(|e| PairingError::ConnectionFailed {
+                        device: Some(device_str.clone()),
+                        reason: format!("pre-connect scan failed: {e}"),
                     })?;
                 tokio::time::sleep(Duration::from_secs(3)).await;
                 self.adapter.stop_scan().await.ok();
                 peripherals = self.adapter.peripherals().await.map_err(|e| {
-                    PairingError::ConnectionFailed(format!("failed to list peripherals: {e}"))
+                    PairingError::ConnectionFailed {
+                        device: Some(device_str.clone()),
+                        reason: format!("failed to list peripherals: {e}"),
+                    }
                 })?;
             }
 
             let peripheral = peripherals
                 .into_iter()
                 .find(|p| p.address() == target_addr)
-                .ok_or(PairingError::DeviceNotFound)?;
+                .ok_or(PairingError::DeviceNotFound {
+                    device: device_str.clone(),
+                })?;
 
             // Connect with a timeout (PT-1002: 30 s).
             tokio::time::timeout(CONNECT_TIMEOUT, peripheral.connect())
                 .await
                 .map_err(|_| PairingError::Timeout {
+                    device: Some(device_str.clone()),
                     operation: "BLE connect",
                     duration_secs: CONNECT_TIMEOUT.as_secs(),
                 })?
-                .map_err(|e| PairingError::ConnectionFailed(format!("connect failed: {e}")))?;
+                .map_err(|e| PairingError::ConnectionFailed {
+                    device: Some(device_str.clone()),
+                    reason: format!("connect failed: {e}"),
+                })?;
 
             // Post-connect setup — if any step fails, disconnect the
             // peripheral so we don't leak a GATT connection (PT-1001).
-            match Self::post_connect_setup(&peripheral).await {
+            match Self::post_connect_setup(&peripheral, &Some(device_str.clone())).await {
                 Ok((notification_stream, service_count)) => {
                     debug!(
                         address = %target_addr,
@@ -304,6 +351,7 @@ impl BleTransport for BtleplugTransport {
                         notification_stream,
                         subscribed: HashSet::new(),
                     });
+                    self.connected_address = Some(device_str);
                 }
                 Err(e) => {
                     let _ = peripheral.disconnect().await;
@@ -337,13 +385,20 @@ impl BleTransport for BtleplugTransport {
     ) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
         let data = data.to_vec();
         Box::pin(async move {
+            let device_addr = self.connected_address.clone();
             let state = self
                 .connected
                 .as_ref()
-                .ok_or(PairingError::ConnectionDropped)?;
+                .ok_or(PairingError::ConnectionDropped {
+                    device: device_addr.clone(),
+                })?;
 
-            let chr =
-                find_characteristic(&state.peripheral, to_uuid(service), to_uuid(characteristic))?;
+            let chr = find_characteristic(
+                &state.peripheral,
+                to_uuid(service),
+                to_uuid(characteristic),
+                &device_addr,
+            )?;
 
             // First write may fail with "requires authentication" on WinRT if
             // the characteristic has WRITE_ENC/WRITE_AUTHEN permissions.  This
@@ -374,14 +429,18 @@ impl BleTransport for BtleplugTransport {
                                     debug!(error = %retry_err, "retry failed, will try again");
                                 }
                                 Err(retry_err) => {
-                                    return Err(PairingError::GattWriteFailed(
-                                        retry_err.to_string(),
-                                    ));
+                                    return Err(PairingError::GattWriteFailed {
+                                        device: device_addr.clone(),
+                                        reason: retry_err.to_string(),
+                                    });
                                 }
                             }
                         }
                     } else {
-                        return Err(PairingError::GattWriteFailed(msg));
+                        return Err(PairingError::GattWriteFailed {
+                            device: device_addr.clone(),
+                            reason: msg,
+                        });
                     }
                 }
             }
@@ -402,21 +461,30 @@ impl BleTransport for BtleplugTransport {
         timeout_ms: u64,
     ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, PairingError>> + '_>> {
         Box::pin(async move {
+            let device_addr = self.connected_address.clone();
             let state = self
                 .connected
                 .as_mut()
-                .ok_or(PairingError::ConnectionDropped)?;
+                .ok_or(PairingError::ConnectionDropped {
+                    device: device_addr.clone(),
+                })?;
 
             let char_uuid = to_uuid(characteristic);
 
             // Subscribe to indications/notifications lazily on first read.
             if !state.subscribed.contains(&char_uuid) {
-                let chr = find_characteristic(&state.peripheral, to_uuid(service), char_uuid)?;
-                state
-                    .peripheral
-                    .subscribe(&chr)
-                    .await
-                    .map_err(|e| PairingError::GattReadFailed(format!("subscribe failed: {e}")))?;
+                let chr = find_characteristic(
+                    &state.peripheral,
+                    to_uuid(service),
+                    char_uuid,
+                    &device_addr,
+                )?;
+                state.peripheral.subscribe(&chr).await.map_err(|e| {
+                    PairingError::GattReadFailed {
+                        device: device_addr.clone(),
+                        reason: format!("subscribe failed: {e}"),
+                    }
+                })?;
                 state.subscribed.insert(char_uuid);
                 debug!(characteristic = %char_uuid, "subscribed to indications");
             }
@@ -435,7 +503,11 @@ impl BleTransport for BtleplugTransport {
                             return Ok(notif.value);
                         }
                         Some(_) => continue,
-                        None => return Err(PairingError::ConnectionDropped),
+                        None => {
+                            return Err(PairingError::ConnectionDropped {
+                                device: device_addr.clone(),
+                            })
+                        }
                     }
                 }
             })
@@ -443,7 +515,9 @@ impl BleTransport for BtleplugTransport {
 
             match result {
                 Ok(inner) => inner,
-                Err(_) => Err(PairingError::IndicationTimeout),
+                Err(_) => Err(PairingError::IndicationTimeout {
+                    device: device_addr,
+                }),
             }
         })
     }

--- a/crates/sonde-pair/src/btleplug_transport.rs
+++ b/crates/sonde-pair/src/btleplug_transport.rs
@@ -339,7 +339,8 @@ impl BleTransport for BtleplugTransport {
 
             // Post-connect setup — if any step fails, disconnect the
             // peripheral so we don't leak a GATT connection (PT-1001).
-            match Self::post_connect_setup(&peripheral, &Some(device_str.clone())).await {
+            let device = Some(device_str.clone());
+            match Self::post_connect_setup(&peripheral, &device).await {
                 Ok((notification_stream, service_count)) => {
                     debug!(
                         address = %target_addr,

--- a/crates/sonde-pair/src/error.rs
+++ b/crates/sonde-pair/src/error.rs
@@ -51,7 +51,7 @@ pub enum PairingError {
     DeviceOutOfRange { device: Option<String> },
 
     // Transport errors (PT-1215: include device context)
-    #[error("BLE connection failed ({}): {reason} — check that the modem is powered on and not paired to another device", OptionalDevice(device))]
+    #[error("BLE connection to {} failed: {reason} — check that the modem is powered on and not paired to another device", OptionalDevice(device))]
     ConnectionFailed {
         device: Option<String>,
         reason: String,

--- a/crates/sonde-pair/src/error.rs
+++ b/crates/sonde-pair/src/error.rs
@@ -2,6 +2,30 @@
 // Copyright (c) 2026 sonde contributors
 
 use crate::types::{NodeAckStatus, PairingMethod};
+use std::fmt;
+
+/// Format a 6-byte BLE device address as `"AA:BB:CC:DD:EE:FF"`.
+pub fn format_device_address(addr: &[u8; 6]) -> String {
+    format!(
+        "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+        addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]
+    )
+}
+
+/// Display helper for `Option<String>` device addresses in error messages.
+///
+/// Renders `Some("AA:BB:CC:DD:EE:FF")` as `"AA:BB:CC:DD:EE:FF"` and
+/// `None` as `"(unknown device)"`.
+struct OptionalDevice<'a>(&'a Option<String>);
+
+impl fmt::Display for OptionalDevice<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(addr) => f.write_str(addr),
+            None => f.write_str("(unknown device)"),
+        }
+    }
+}
 
 /// Errors that can occur during BLE pairing.
 #[derive(Debug, thiserror::Error)]
@@ -16,39 +40,62 @@ pub enum PairingError {
     BluetoothDisabled,
 
     #[error(
-        "target device not found during scan — check that the modem is powered on and in range"
+        "target device {device} not found during scan — check that the modem is powered on and in range"
     )]
-    DeviceNotFound,
+    DeviceNotFound { device: String },
 
-    #[error("target device is out of BLE range — move closer and retry")]
-    DeviceOutOfRange,
+    #[error(
+        "target device {} is out of BLE range — move closer and retry",
+        OptionalDevice(device)
+    )]
+    DeviceOutOfRange { device: Option<String> },
 
-    // Transport errors
-    #[error("BLE connection failed: {0} — check that the modem is powered on and not paired to another device")]
-    ConnectionFailed(String),
+    // Transport errors (PT-1215: include device context)
+    #[error("BLE connection failed ({}): {reason} — check that the modem is powered on and not paired to another device", OptionalDevice(device))]
+    ConnectionFailed {
+        device: Option<String>,
+        reason: String,
+    },
 
-    #[error("BLE connection dropped unexpectedly — check that the modem is powered on and in range, then retry")]
-    ConnectionDropped,
+    #[error("BLE connection to {} dropped unexpectedly — check that the modem is powered on and in range; if this persists, delete the stale Bluetooth pairing in OS settings and retry", OptionalDevice(device))]
+    ConnectionDropped { device: Option<String> },
 
-    #[error("negotiated MTU {negotiated} is below required minimum {required} — the BLE adapter or modem firmware may need updating")]
-    MtuTooLow { negotiated: u16, required: u16 },
+    #[error("negotiated MTU {negotiated} for {device} is below required minimum {required} — the BLE adapter or modem firmware may need updating")]
+    MtuTooLow {
+        device: String,
+        negotiated: u16,
+        required: u16,
+    },
 
-    #[error("{operation} timed out after {duration_secs}s — check that the modem is powered on and in range")]
+    #[error("{operation} on {} timed out after {duration_secs}s — check that the modem is powered on and in range", OptionalDevice(device))]
     Timeout {
+        device: Option<String>,
         operation: &'static str,
         duration_secs: u64,
     },
 
-    #[error("GATT write failed: {0} — check the BLE connection and retry")]
-    GattWriteFailed(String),
-
-    #[error("GATT read failed: {0} — check the BLE connection and retry")]
-    GattReadFailed(String),
+    #[error(
+        "GATT write to {} failed: {reason} — check the BLE connection and retry",
+        OptionalDevice(device)
+    )]
+    GattWriteFailed {
+        device: Option<String>,
+        reason: String,
+    },
 
     #[error(
-        "indication not received before timeout — check that the modem is powered on and in range"
+        "GATT read from {} failed: {reason} — check the BLE connection and retry",
+        OptionalDevice(device)
     )]
-    IndicationTimeout,
+    GattReadFailed {
+        device: Option<String>,
+        reason: String,
+    },
+
+    #[error(
+        "indication from {} not received before timeout — check that the modem is powered on and in range", OptionalDevice(device)
+    )]
+    IndicationTimeout { device: Option<String> },
 
     // Protocol errors
     #[error("registration failed: {0} — verify the gateway is running and the registration window is open")]
@@ -140,5 +187,97 @@ pub enum PairingError {
 impl From<jni::errors::Error> for PairingError {
     fn from(e: jni::errors::Error) -> Self {
         PairingError::JniError(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_device_address_canonical() {
+        assert_eq!(
+            format_device_address(&[0x00, 0x0A, 0xFF, 0x10, 0x0B, 0xAC]),
+            "00:0A:FF:10:0B:AC"
+        );
+    }
+
+    #[test]
+    fn connection_dropped_includes_device_and_stale_hint() {
+        let err = PairingError::ConnectionDropped {
+            device: Some("AA:BB:CC:DD:EE:FF".into()),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("AA:BB:CC:DD:EE:FF"), "missing device: {msg}");
+        assert!(
+            msg.contains("stale Bluetooth pairing"),
+            "missing stale pairing hint: {msg}"
+        );
+    }
+
+    #[test]
+    fn mtu_too_low_includes_device() {
+        let err = PairingError::MtuTooLow {
+            device: "11:22:33:44:55:66".into(),
+            negotiated: 100,
+            required: 247,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("11:22:33:44:55:66"), "missing device: {msg}");
+        assert!(msg.contains("100"), "missing negotiated: {msg}");
+        assert!(msg.contains("247"), "missing required: {msg}");
+    }
+
+    #[test]
+    fn indication_timeout_includes_device() {
+        let err = PairingError::IndicationTimeout {
+            device: Some("AA:BB:CC:DD:EE:FF".into()),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("AA:BB:CC:DD:EE:FF"), "missing device: {msg}");
+    }
+
+    #[test]
+    fn optional_device_none_renders_unknown() {
+        let err = PairingError::ConnectionDropped { device: None };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("(unknown device)"),
+            "missing fallback text: {msg}"
+        );
+    }
+
+    #[test]
+    fn device_not_found_includes_device() {
+        let err = PairingError::DeviceNotFound {
+            device: "AA:BB:CC:DD:EE:FF".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("AA:BB:CC:DD:EE:FF"), "missing device: {msg}");
+    }
+
+    #[test]
+    fn connection_failed_includes_device_and_reason() {
+        let err = PairingError::ConnectionFailed {
+            device: Some("AA:BB:CC:DD:EE:FF".into()),
+            reason: "connect failed: timeout".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("AA:BB:CC:DD:EE:FF"), "missing device: {msg}");
+        assert!(
+            msg.contains("connect failed: timeout"),
+            "missing reason: {msg}"
+        );
+    }
+
+    #[test]
+    fn gatt_write_failed_includes_device() {
+        let err = PairingError::GattWriteFailed {
+            device: Some("AA:BB:CC:DD:EE:FF".into()),
+            reason: "auth required".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("AA:BB:CC:DD:EE:FF"), "missing device: {msg}");
+        assert!(msg.contains("auth required"), "missing reason: {msg}");
     }
 }

--- a/crates/sonde-pair/src/loopback_transport.rs
+++ b/crates/sonde-pair/src/loopback_transport.rs
@@ -50,7 +50,10 @@ async fn read_envelope(stream: &mut TcpStream) -> Result<Vec<u8>, PairingError> 
     stream
         .read_exact(&mut header)
         .await
-        .map_err(|e| PairingError::GattReadFailed(format!("TCP read header: {e}")))?;
+        .map_err(|e| PairingError::GattReadFailed {
+            device: None,
+            reason: format!("TCP read header: {e}"),
+        })?;
 
     let body_len = u16::from_be_bytes([header[1], header[2]]) as usize;
     let mut envelope = Vec::with_capacity(3 + body_len);
@@ -60,7 +63,10 @@ async fn read_envelope(stream: &mut TcpStream) -> Result<Vec<u8>, PairingError> 
         stream
             .read_exact(&mut envelope[3..])
             .await
-            .map_err(|e| PairingError::GattReadFailed(format!("TCP read body: {e}")))?;
+            .map_err(|e| PairingError::GattReadFailed {
+                device: None,
+                reason: format!("TCP read body: {e}"),
+            })?;
     }
     Ok(envelope)
 }
@@ -95,9 +101,12 @@ impl BleTransport for LoopbackBleTransport {
         _address: &[u8; 6],
     ) -> Pin<Box<dyn Future<Output = Result<u16, PairingError>> + '_>> {
         Box::pin(async {
-            let stream = TcpStream::connect(&self.addr)
-                .await
-                .map_err(|e| PairingError::ConnectionFailed(format!("TCP connect: {e}")))?;
+            let stream = TcpStream::connect(&self.addr).await.map_err(|e| {
+                PairingError::ConnectionFailed {
+                    device: None,
+                    reason: format!("TCP connect: {e}"),
+                }
+            })?;
             self.stream = Some(stream);
             // Return a large MTU — TCP has no MTU constraint.
             Ok(512)
@@ -120,15 +129,21 @@ impl BleTransport for LoopbackBleTransport {
             let stream = self
                 .stream
                 .as_mut()
-                .ok_or(PairingError::ConnectionDropped)?;
+                .ok_or(PairingError::ConnectionDropped { device: None })?;
             stream
                 .write_all(&data)
                 .await
-                .map_err(|e| PairingError::GattWriteFailed(format!("TCP write: {e}")))?;
+                .map_err(|e| PairingError::GattWriteFailed {
+                    device: None,
+                    reason: format!("TCP write: {e}"),
+                })?;
             stream
                 .flush()
                 .await
-                .map_err(|e| PairingError::GattWriteFailed(format!("TCP flush: {e}")))?;
+                .map_err(|e| PairingError::GattWriteFailed {
+                    device: None,
+                    reason: format!("TCP flush: {e}"),
+                })?;
             Ok(())
         })
     }
@@ -143,11 +158,11 @@ impl BleTransport for LoopbackBleTransport {
             let stream = self
                 .stream
                 .as_mut()
-                .ok_or(PairingError::ConnectionDropped)?;
+                .ok_or(PairingError::ConnectionDropped { device: None })?;
             let timeout = tokio::time::Duration::from_millis(timeout_ms);
             match tokio::time::timeout(timeout, read_envelope(stream)).await {
                 Ok(result) => result,
-                Err(_) => Err(PairingError::IndicationTimeout),
+                Err(_) => Err(PairingError::IndicationTimeout { device: None }),
             }
         })
     }
@@ -188,7 +203,7 @@ mod tests {
             let mut transport = LoopbackBleTransport::new("127.0.0.1:1");
             let result = transport.connect(&[0; 6]).await;
             assert!(
-                matches!(result, Err(PairingError::ConnectionFailed(_))),
+                matches!(result, Err(PairingError::ConnectionFailed { .. })),
                 "expected ConnectionFailed, got {result:?}"
             );
         });
@@ -218,7 +233,7 @@ mod tests {
             let mut transport = LoopbackBleTransport::new("127.0.0.1:0");
             let result = transport.write_characteristic(0, 0, &[1, 2, 3]).await;
             assert!(
-                matches!(result, Err(PairingError::ConnectionDropped)),
+                matches!(result, Err(PairingError::ConnectionDropped { .. })),
                 "expected ConnectionDropped, got {result:?}"
             );
         });
@@ -234,7 +249,7 @@ mod tests {
             let mut transport = LoopbackBleTransport::new("127.0.0.1:0");
             let result = transport.read_indication(0, 0, 100).await;
             assert!(
-                matches!(result, Err(PairingError::ConnectionDropped)),
+                matches!(result, Err(PairingError::ConnectionDropped { .. })),
                 "expected ConnectionDropped, got {result:?}"
             );
         });

--- a/crates/sonde-pair/src/phase1.rs
+++ b/crates/sonde-pair/src/phase1.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 sonde contributors
 
 use crate::envelope::{build_envelope, parse_envelope, parse_error_body};
-use crate::error::PairingError;
+use crate::error::{format_device_address, PairingError};
 use crate::rng::RngProvider;
 use crate::transport::{enforce_lesc, BleTransport};
 use crate::types::*;
@@ -57,6 +57,7 @@ pub async fn pair_with_gateway(
     if mtu < BLE_MTU_MIN {
         transport.disconnect().await.ok();
         return Err(PairingError::MtuTooLow {
+            device: format_device_address(device_address),
             negotiated: mtu,
             required: BLE_MTU_MIN,
         });

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -4,7 +4,7 @@
 use crate::cbor::encode_pairing_request;
 use crate::crypto;
 use crate::envelope::{build_envelope, parse_envelope, parse_error_body, parse_node_ack};
-use crate::error::PairingError;
+use crate::error::{format_device_address, PairingError};
 use crate::rng::RngProvider;
 use crate::transport::{enforce_lesc, BleTransport};
 use crate::types::*;
@@ -87,6 +87,7 @@ pub async fn provision_node(
     if mtu < BLE_MTU_MIN {
         transport.disconnect().await.ok();
         return Err(PairingError::MtuTooLow {
+            device: format_device_address(device_address),
             negotiated: mtu,
             required: BLE_MTU_MIN,
         });

--- a/crates/sonde-pair/src/transport.rs
+++ b/crates/sonde-pair/src/transport.rs
@@ -146,10 +146,12 @@ impl BleTransport for MockBleTransport {
         }
         if self.fail_connect {
             return Box::pin(async {
-                Err(PairingError::ConnectionFailed(
-                    "Numeric Comparison pairing required but peripheral only supports Just Works"
-                        .into(),
-                ))
+                Err(PairingError::ConnectionFailed {
+                    device: None,
+                    reason:
+                        "Numeric Comparison pairing required but peripheral only supports Just Works"
+                            .into(),
+                })
             });
         }
         self.connected = true;
@@ -189,7 +191,7 @@ impl BleTransport for MockBleTransport {
         Box::pin(async move {
             match response {
                 Some(result) => result,
-                None => Err(PairingError::IndicationTimeout),
+                None => Err(PairingError::IndicationTimeout { device: None }),
             }
         })
     }

--- a/crates/sonde-pair/src/transport.rs
+++ b/crates/sonde-pair/src/transport.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 sonde contributors
 
-use crate::error::PairingError;
+use crate::error::{format_device_address, PairingError};
 use crate::types::{PairingMethod, ScannedDevice};
 use std::collections::VecDeque;
 use std::future::Future;
@@ -88,6 +88,8 @@ pub struct MockBleTransport {
     /// If true, `connect()` returns `ConnectionFailed` (simulates Just Works
     /// rejection at the transport layer, per T-PT-109).
     pub fail_connect: bool,
+    /// Connected device address for error context (PT-1215).
+    pub connected_address: Option<String>,
 }
 
 impl MockBleTransport {
@@ -104,6 +106,7 @@ impl MockBleTransport {
             read_call_count: 0,
             pairing_method: None,
             fail_connect: false,
+            connected_address: None,
         }
     }
 
@@ -138,16 +141,19 @@ impl BleTransport for MockBleTransport {
 
     fn connect(
         &mut self,
-        _address: &[u8; 6],
+        address: &[u8; 6],
     ) -> Pin<Box<dyn Future<Output = Result<u16, PairingError>> + '_>> {
+        let device_str = format_device_address(address);
         if let Some(err) = self.connect_error.take() {
             self.connected = false;
+            self.connected_address = None;
             return Box::pin(async move { Err(err) });
         }
         if self.fail_connect {
-            return Box::pin(async {
+            self.connected_address = None;
+            return Box::pin(async move {
                 Err(PairingError::ConnectionFailed {
-                    device: None,
+                    device: Some(device_str),
                     reason:
                         "Numeric Comparison pairing required but peripheral only supports Just Works"
                             .into(),
@@ -155,12 +161,14 @@ impl BleTransport for MockBleTransport {
             });
         }
         self.connected = true;
+        self.connected_address = Some(device_str);
         let mtu = self.mtu;
         Box::pin(async move { Ok(mtu) })
     }
 
     fn disconnect(&mut self) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
         self.connected = false;
+        self.connected_address = None;
         self.disconnect_count += 1;
         Box::pin(async { Ok(()) })
     }
@@ -188,10 +196,11 @@ impl BleTransport for MockBleTransport {
     ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, PairingError>> + '_>> {
         self.read_call_count += 1;
         let response = self.responses.pop_front();
+        let device = self.connected_address.clone();
         Box::pin(async move {
             match response {
                 Some(result) => result,
-                None => Err(PairingError::IndicationTimeout { device: None }),
+                None => Err(PairingError::IndicationTimeout { device }),
             }
         })
     }

--- a/crates/sonde-pair/src/transport.rs
+++ b/crates/sonde-pair/src/transport.rs
@@ -150,6 +150,7 @@ impl BleTransport for MockBleTransport {
             return Box::pin(async move { Err(err) });
         }
         if self.fail_connect {
+            self.connected = false;
             self.connected_address = None;
             return Box::pin(async move {
                 Err(PairingError::ConnectionFailed {

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -544,7 +544,7 @@ pub enum PairingError {
     ConnectionDropped { device: Option<String> },
 
     // PT-1215: includes device address + reason.
-    #[error("BLE connection failed ({}): {reason} — check that \
+    #[error("BLE connection to {} failed: {reason} — check that \
              the modem is powered on and not paired to another device",
             OptionalDevice(device))]
     ConnectionFailed { device: Option<String>, reason: String },

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -640,10 +640,11 @@ pub enum PairingError {
 }
 ```
 
-`Some`, or as the literal text `"(unknown device)"` when `None`.  Each
-transport implementation stores the connected device address internally
-(set on successful `connect()`, cleared on `disconnect()`) so that error
-variants constructed during GATT operations can include the peer address.
+The peer address is rendered as the address from `Some(addr)`, or as the
+literal text `"(unknown device)"` when `None`.  Each transport
+implementation stores the connected device address internally (set on
+successful `connect()`, cleared on `disconnect()`) so that error variants
+constructed during GATT operations can include the peer address.
 
 Every variant includes an actionable message for the operator (PT-0501).  No error message consists solely of a code or internal identifier.
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -500,7 +500,17 @@ The `save()` operation is atomic: write to a temporary file, then rename over th
 
 ### 8.1  Error categories
 
-The `PairingError` enum distinguishes three categories (PT-0500):
+The `PairingError` enum distinguishes three categories (PT-0500).
+
+Per PT-1215, device/transport-level error variants include the peer device
+address (formatted as `"AA:BB:CC:DD:EE:FF"`) so users can diagnose root
+causes without source code access.  The `device` field is `Option<String>`
+where the address may not be available (e.g., adapter-level failures before
+any device is targeted), and `String` (non-optional) where the address is
+always known at the call site (e.g., `MtuTooLow`, `DeviceNotFound`).
+
+A helper function `format_device_address(&[u8; 6]) -> String` produces the
+canonical colon-separated hex representation.
 
 ```rust
 #[derive(Debug, thiserror::Error)]
@@ -512,21 +522,51 @@ pub enum PairingError {
     #[error("Bluetooth is disabled — enable Bluetooth in system settings")]
     BluetoothDisabled,
 
-    #[error("device out of range — move closer and retry")]
-    DeviceOutOfRange,
+    // PT-1215: includes device address being searched for.
+    #[error("target device {device} not found during scan — check that \
+             the modem is powered on and in range")]
+    DeviceNotFound { device: String },
+
+    // PT-1215: includes device address when available.
+    #[error("device {device} out of range — move closer and retry")]
+    DeviceOutOfRange { device: Option<String> },
 
     // ── Transport-level errors ──
-    #[error("BLE connection dropped — retry the operation")]
-    ConnectionDropped,
+    // PT-1215: includes device address and stale-pairing hint (AC3).
+    #[error("BLE connection to {device} dropped — check that the modem \
+             is powered on and in range; if this persists, delete the \
+             stale Bluetooth pairing in OS settings and retry")]
+    ConnectionDropped { device: Option<String> },
 
-    #[error("MTU too low ({actual}) — device requires MTU ≥ 247")]
-    MtuTooLow { actual: u16 },
+    // PT-1215: includes device address + reason.
+    #[error("BLE connection failed ({device}): {reason} — check that \
+             the modem is powered on and not paired to another device")]
+    ConnectionFailed { device: Option<String>, reason: String },
 
-    #[error("GATT write failed — retry the operation")]
-    GattWriteFailed,
+    // PT-1215: includes device address.
+    #[error("negotiated MTU {negotiated} for {device} is below required \
+             minimum {required} — the BLE adapter or modem firmware \
+             may need updating")]
+    MtuTooLow { device: String, negotiated: u16, required: u16 },
+
+    // PT-1215: includes device address when available.
+    #[error("GATT write to {device} failed: {reason} — check the BLE \
+             connection and retry")]
+    GattWriteFailed { device: Option<String>, reason: String },
+
+    // PT-1215: includes device address when available.
+    #[error("GATT read from {device} failed: {reason} — check the BLE \
+             connection and retry")]
+    GattReadFailed { device: Option<String>, reason: String },
+
+    // PT-1215: includes device address when available.
+    #[error("indication from {device} not received before timeout — \
+             check that the modem is powered on and in range")]
+    IndicationTimeout { device: Option<String> },
 
     #[error("{operation} timed out after {timeout_secs}s — {suggestion}")]
     Timeout {
+        device: Option<String>,
         operation: &'static str,
         timeout_secs: u64,
         suggestion: &'static str,
@@ -591,6 +631,12 @@ pub enum PairingError {
     RngFailed,
 }
 ```
+
+The `Option<String>` device field renders as the formatted address when
+`Some`, or is omitted from the error message when `None`.  Each transport
+implementation stores the connected device address internally (set on
+successful `connect()`, cleared on `disconnect()`) so that error variants
+constructed during GATT operations can include the peer address.
 
 Every variant includes an actionable message for the operator (PT-0501).  No error message consists solely of a code or internal identifier.
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -632,11 +632,10 @@ pub enum PairingError {
 }
 ```
 
-The `Option<String>` device field renders as the formatted address when
-`Some`, or is omitted from the error message when `None`.  Each transport
-implementation stores the connected device address internally (set on
-successful `connect()`, cleared on `disconnect()`) so that error variants
-constructed during GATT operations can include the peer address.
+`Some`, or as the literal text `"(unknown device)"` when `None`.  Each
+transport implementation stores the connected device address internally
+(set on successful `connect()`, cleared on `disconnect()`) so that error
+variants constructed during GATT operations can include the peer address.
 
 Every variant includes an actionable message for the operator (PT-0501).  No error message consists solely of a code or internal identifier.
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -510,7 +510,9 @@ any device is targeted), and `String` (non-optional) where the address is
 always known at the call site (e.g., `MtuTooLow`, `DeviceNotFound`).
 
 A helper function `format_device_address(&[u8; 6]) -> String` produces the
-canonical colon-separated hex representation.
+canonical colon-separated hex representation.  A private `OptionalDevice`
+newtype wraps `&Option<String>` for use in `thiserror` format strings,
+rendering `Some(addr)` as the address and `None` as `"(unknown device)"`.
 
 ```rust
 #[derive(Debug, thiserror::Error)]
@@ -528,19 +530,23 @@ pub enum PairingError {
     DeviceNotFound { device: String },
 
     // PT-1215: includes device address when available.
-    #[error("device {device} out of range — move closer and retry")]
+    // OptionalDevice renders None as "(unknown device)".
+    #[error("device {} out of range — move closer and retry",
+            OptionalDevice(device))]
     DeviceOutOfRange { device: Option<String> },
 
     // ── Transport-level errors ──
     // PT-1215: includes device address and stale-pairing hint (AC3).
-    #[error("BLE connection to {device} dropped — check that the modem \
+    #[error("BLE connection to {} dropped — check that the modem \
              is powered on and in range; if this persists, delete the \
-             stale Bluetooth pairing in OS settings and retry")]
+             stale Bluetooth pairing in OS settings and retry",
+            OptionalDevice(device))]
     ConnectionDropped { device: Option<String> },
 
     // PT-1215: includes device address + reason.
-    #[error("BLE connection failed ({device}): {reason} — check that \
-             the modem is powered on and not paired to another device")]
+    #[error("BLE connection failed ({}): {reason} — check that \
+             the modem is powered on and not paired to another device",
+            OptionalDevice(device))]
     ConnectionFailed { device: Option<String>, reason: String },
 
     // PT-1215: includes device address.
@@ -550,21 +556,23 @@ pub enum PairingError {
     MtuTooLow { device: String, negotiated: u16, required: u16 },
 
     // PT-1215: includes device address when available.
-    #[error("GATT write to {device} failed: {reason} — check the BLE \
-             connection and retry")]
+    #[error("GATT write to {} failed: {reason} — check the BLE \
+             connection and retry", OptionalDevice(device))]
     GattWriteFailed { device: Option<String>, reason: String },
 
     // PT-1215: includes device address when available.
-    #[error("GATT read from {device} failed: {reason} — check the BLE \
-             connection and retry")]
+    #[error("GATT read from {} failed: {reason} — check the BLE \
+             connection and retry", OptionalDevice(device))]
     GattReadFailed { device: Option<String>, reason: String },
 
     // PT-1215: includes device address when available.
-    #[error("indication from {device} not received before timeout — \
-             check that the modem is powered on and in range")]
+    #[error("indication from {} not received before timeout — \
+             check that the modem is powered on and in range",
+            OptionalDevice(device))]
     IndicationTimeout { device: Option<String> },
 
-    #[error("{operation} timed out after {timeout_secs}s — {suggestion}")]
+    #[error("{operation} on {} timed out after {timeout_secs}s — \
+             {suggestion}", OptionalDevice(device))]
     Timeout {
         device: Option<String>,
         operation: &'static str,

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1082,7 +1082,7 @@ TestNode {
 **Validates:** PT-1215 (AC 1, AC 2)
 
 **Procedure:**
-1. Configure a `MockBleTransport` that returns `ConnectionFailed` on `connect()`.
+1. Configure a `MockBleTransport` so `connect()` returns `ConnectionFailed` with `device: Some("AA:BB:CC:DD:EE:FF")`.
 2. Run `pair_with_gateway` with device address `[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]`.
 3. Assert: the error display string contains `"AA:BB:CC:DD:EE:FF"`.
 4. Assert: the error display string contains the failed operation and reason.

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1077,6 +1077,64 @@ TestNode {
 
 ---
 
+### T-PT-1215a  Connection error includes device address
+
+**Validates:** PT-1215 (AC 1, AC 2)
+
+**Procedure:**
+1. Configure a `MockBleTransport` that returns `ConnectionFailed` on `connect()`.
+2. Run `pair_with_gateway` with device address `[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]`.
+3. Assert: the error display string contains `"AA:BB:CC:DD:EE:FF"`.
+4. Assert: the error display string contains the failed operation and reason.
+
+---
+
+### T-PT-1215b  MTU error includes device address
+
+**Validates:** PT-1215 (AC 1, AC 2)
+
+**Procedure:**
+1. Configure a `MockBleTransport` with MTU 100 (below `BLE_MTU_MIN`).
+2. Run `pair_with_gateway` with device address `[0x11, 0x22, 0x33, 0x44, 0x55, 0x66]`.
+3. Assert: the error is `PairingError::MtuTooLow { .. }`.
+4. Assert: the error display string contains `"11:22:33:44:55:66"`.
+5. Assert: the error display string contains `100` (negotiated) and `247` (required).
+
+---
+
+### T-PT-1215c  Connection dropped includes stale pairing hint
+
+**Validates:** PT-1215 (AC 3)
+
+**Procedure:**
+1. Construct `PairingError::ConnectionDropped { device: Some("AA:BB:CC:DD:EE:FF".into()) }`.
+2. Assert: the error display string contains `"AA:BB:CC:DD:EE:FF"`.
+3. Assert: the error display string contains `"stale"` or `"Bluetooth pairing"`.
+
+---
+
+### T-PT-1215d  Indication timeout includes device address
+
+**Validates:** PT-1215 (AC 1, AC 2)
+
+**Procedure:**
+1. Configure a `MockBleTransport` with no queued responses (causes `IndicationTimeout`).
+2. Run `pair_with_gateway` with device address `[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]`.
+3. Assert: the error is `PairingError::IndicationTimeout { .. }`.
+4. Assert: the error display string contains `"AA:BB:CC:DD:EE:FF"`.
+
+---
+
+### T-PT-1215e  format_device_address produces canonical format
+
+**Validates:** PT-1215 (AC 2)
+
+**Procedure:**
+1. Call `format_device_address(&[0x00, 0x0A, 0xFF, 0x10, 0x0B, 0xAC])`.
+2. Assert: result is `"00:0A:FF:10:0B:AC"`.
+
+---
+
 ### T-PT-1214a  Pin config included in NODE_PROVISION when provided
 
 **Validates:** PT-1214 (AC 1, 2, 4)
@@ -1485,6 +1543,11 @@ TestNode {
 | T-PT-1210 | PT-1210 | Phase transition events logged |
 | T-PT-1211 | PT-1211 | LESC pairing method logged |
 | T-PT-1212 | PT-1212 | Error context in log output |
+| T-PT-1215a | PT-1215 | Connection error includes device address |
+| T-PT-1215b | PT-1215 | MTU error includes device address |
+| T-PT-1215c | PT-1215 | Connection dropped includes stale pairing hint |
+| T-PT-1215d | PT-1215 | Indication timeout includes device address |
+| T-PT-1215e | PT-1215 | `format_device_address` produces canonical format |
 | T-PT-1214a | PT-1214 | Pin config included in NODE_PROVISION when provided |
 | T-PT-1214b | PT-1214 | No pin config in NODE_PROVISION — backward compatible |
 | T-PT-1214c | PT-1214 | Pin config with out-of-range GPIO rejected |


### PR DESCRIPTION
## Summary

Closes #694 — adds device address context to 9 `PairingError` variants so error messages satisfy PT-1215 AC1 (triggering input/parameters) and AC3 (stale pairing hint for connection-dropped errors).

## Variant Changes

| Variant | Before | After |
|---------|--------|-------|
| `ConnectionFailed` | `(String)` | `{ device: Option<String>, reason: String }` |
| `ConnectionDropped` | unit | `{ device: Option<String> }` + stale pairing hint |
| `MtuTooLow` | `{ negotiated, required }` | adds `device: String` |
| `Timeout` | `{ operation, duration_secs }` | adds `device: Option<String>` |
| `GattWriteFailed` | `(String)` | `{ device: Option<String>, reason: String }` |
| `GattReadFailed` | `(String)` | `{ device: Option<String>, reason: String }` |
| `IndicationTimeout` | unit | `{ device: Option<String> }` |
| `DeviceNotFound` | unit | `{ device: String }` |
| `DeviceOutOfRange` | unit | `{ device: Option<String> }` |

## Implementation

- `format_device_address(&[u8; 6]) -> String` helper for canonical `AA:BB:CC:DD:EE:FF` format
- `OptionalDevice` newtype for clean `Option<String>` display in `thiserror` messages
- `BtleplugTransport`: stores `connected_address` on connect, clears on disconnect, threads through `post_connect_setup` and `find_characteristic`
- `AndroidBleTransport`: stores address in `JniState` via `Mutex<Option<String>>`
- All construction sites updated across btleplug, android, loopback, mock transports, phase1, phase2, and e2e harness

## Spec Changes

- `ble-pairing-tool-design.md` section 8.1: updated `PairingError` enum
- `ble-pairing-tool-validation.md`: added 5 test cases T-PT-1215a-e + traceability table entries

## Verification

- `cargo build --workspace` pass
- `cargo clippy --workspace -- -D warnings` pass
- `cargo test -p sonde-pair` pass (107 tests)
- `cargo fmt --all -- --check` pass