### PR TITLE
fix(bpf): make spi_transfer verifiable with in-place buffer (ABI break)

### DIFF
--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -567,13 +567,7 @@ impl Hal for MockHal {
     fn i2c_write_read(&mut self, _h: u32, _w: &[u8], _r: &mut [u8]) -> i32 {
         0
     }
-    fn spi_transfer(
-        &mut self,
-        _h: u32,
-        _tx: Option<&[u8]>,
-        _rx: Option<&mut [u8]>,
-        _l: usize,
-    ) -> i32 {
+    fn spi_transfer(&mut self, _h: u32, _buf: &mut [u8]) -> i32 {
         0
     }
     fn gpio_read(&self, _pin: u32) -> i32 {

--- a/crates/sonde-gateway/src/sonde_platform.rs
+++ b/crates/sonde-gateway/src/sonde_platform.rs
@@ -87,15 +87,15 @@ static SONDE_HELPERS: [HelperPrototype; 17] = [
         context_descriptor: None,
         unsupported: false,
     },
-    // 4: spi_transfer(handle, *tx, *rx, len) -> i32
+    // 4: spi_transfer(handle, *buf, len) -> i32
     HelperPrototype {
         name: "spi_transfer",
         return_type: Ret::Integer,
         argument_type: [
             Arg::Anything,
-            Arg::PtrToReadableMemOrNull,
-            Arg::PtrToWritableMemOrNull,
+            Arg::PtrToWritableMem,
             Arg::ConstSize,
+            Arg::DontCare,
             Arg::DontCare,
         ],
         reallocate_packet: false,

--- a/crates/sonde-gateway/src/sonde_platform.rs
+++ b/crates/sonde-gateway/src/sonde_platform.rs
@@ -532,4 +532,27 @@ mod tests {
         assert_eq!(found.value_size, 128);
         assert_eq!(found.map_type, 0);
     }
+
+    /// Verify `spi_transfer` (helper #4) has a verifiable ptr+size pairing.
+    ///
+    /// The old signature `(handle, *tx, *rx, len)` was unverifiable because
+    /// `ConstSize` only binds to the immediately preceding pointer, leaving
+    /// `*tx` unchecked.  The new in-place signature `(handle, *buf, len)`
+    /// places `PtrToWritableMem` immediately before `ConstSize`.
+    #[test]
+    fn spi_transfer_prototype_has_ptr_size_pair() {
+        let platform = SondePlatform::new();
+        let proto = platform.get_helper_prototype(4);
+        assert_eq!(proto.name, "spi_transfer");
+        assert_eq!(
+            proto.argument_type[1],
+            Arg::PtrToWritableMem,
+            "arg 2 must be PtrToWritableMem (in-place buffer)"
+        );
+        assert_eq!(
+            proto.argument_type[2],
+            Arg::ConstSize,
+            "arg 3 must be ConstSize (bound to preceding ptr)"
+        );
+    }
 }

--- a/crates/sonde-node/src/bpf_dispatch.rs
+++ b/crates/sonde-node/src/bpf_dispatch.rs
@@ -1066,7 +1066,7 @@ mod tests {
 
     #[test]
     fn test_helper_spi_transfer() {
-        // T-N602: SPI echo — rx matches tx.
+        // T-N602: SPI in-place transfer — mock XORs buffer with 0xFF.
         let mut hal = TestHal::new();
         let mut transport = TestTransport::new();
         let mut maps = MapStorage::new(4096);
@@ -1971,7 +1971,7 @@ mod tests {
                 assert_eq!(r, 0, "i2c_write_read should succeed for ephemeral");
                 assert_eq!(wr_buf, [0x1A, 0x2B], "i2c_write_read must fill read buf");
 
-                // SPI transfer — verify in-place echo
+                // SPI transfer — verify in-place mutation
                 let spi_h = crate::hal::spi_handle(0) as u64;
                 let r = helper_spi_transfer(
                     spi_h,

--- a/crates/sonde-node/src/bpf_dispatch.rs
+++ b/crates/sonde-node/src/bpf_dispatch.rs
@@ -387,29 +387,23 @@ pub fn helper_i2c_write_read(r1: u64, r2: u64, r3: u64, r4: u64, r5: u64) -> u64
     result
 }
 
-/// Helper 4: SPI full-duplex transfer.
-/// Args: r1=handle, r2=tx_ptr (0=none), r3=rx_ptr (0=none), r4=len.
-pub fn helper_spi_transfer(r1: u64, r2: u64, r3: u64, r4: u64, _r5: u64) -> u64 {
+/// Helper 4: In-place SPI full-duplex transfer.
+/// Args: r1=handle, r2=buf_ptr, r3=len.
+/// The buffer is read for TX, then overwritten with RX.
+pub fn helper_spi_transfer(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
     let result = with_ctx(|ctx| {
         let handle = r1 as u32;
-        let tx_ptr = r2 as *const u8;
-        let rx_ptr = r3 as *mut u8;
-        let len = r4 as usize;
+        let buf_ptr = r2 as *mut u8;
+        let len = r3 as usize;
         if len == 0 || len > MAX_BUS_TRANSFER_LEN {
             return (-1i64) as u64;
         }
+        if buf_ptr.is_null() {
+            return (-1i64) as u64;
+        }
         unsafe {
-            let tx = if tx_ptr.is_null() {
-                None
-            } else {
-                Some(core::slice::from_raw_parts(tx_ptr, len))
-            };
-            let rx = if rx_ptr.is_null() {
-                None
-            } else {
-                Some(core::slice::from_raw_parts_mut(rx_ptr, len))
-            };
-            (*ctx.hal).spi_transfer(handle, tx, rx, len) as i64 as u64
+            let buf = core::slice::from_raw_parts_mut(buf_ptr, len);
+            (*ctx.hal).spi_transfer(handle, buf) as i64 as u64
         }
     })
     .unwrap_or((-1i64) as u64);
@@ -805,18 +799,11 @@ mod tests {
             buf[..copy_len].copy_from_slice(&self.i2c_read_data[..copy_len]);
             0
         }
-        fn spi_transfer(
-            &mut self,
-            _handle: u32,
-            tx: Option<&[u8]>,
-            rx: Option<&mut [u8]>,
-            _len: usize,
-        ) -> i32 {
+        fn spi_transfer(&mut self, _handle: u32, buf: &mut [u8]) -> i32 {
             if self.spi_echo {
-                if let (Some(tx_data), Some(rx_buf)) = (tx, rx) {
-                    let n = tx_data.len().min(rx_buf.len());
-                    rx_buf[..n].copy_from_slice(&tx_data[..n]);
-                }
+                // Echo: buf already contains tx data; for the mock, the
+                // "received" data is a copy of tx.  Since buf is in-place,
+                // the data is already there — nothing to do.
             }
             0
         }
@@ -1085,8 +1072,8 @@ mod tests {
         let identity = default_identity();
         let mut seq = 0u64;
         let mut trace = Vec::new();
-        let tx = [0xDE, 0xAD, 0xBE, 0xEF];
-        let mut rx = [0u8; 4];
+        let mut buf = [0xDE, 0xAD, 0xBE, 0xEF];
+        let expected = buf;
 
         with_test_context(
             &mut hal,
@@ -1102,15 +1089,16 @@ mod tests {
                 let handle = crate::hal::spi_handle(0);
                 let result = helper_spi_transfer(
                     handle as u64,
-                    tx.as_ptr() as u64,
-                    rx.as_mut_ptr() as u64,
-                    tx.len() as u64,
+                    buf.as_mut_ptr() as u64,
+                    buf.len() as u64,
+                    0,
                     0,
                 );
                 assert_eq!(result, 0);
             },
         );
-        assert_eq!(rx, tx);
+        // In-place echo: buf should still contain original data
+        assert_eq!(buf, expected);
     }
 
     #[test]
@@ -1768,8 +1756,8 @@ mod tests {
         let identity = default_identity();
         let mut seq = 0u64;
         let mut trace = Vec::new();
-        let tx = [0xCA, 0xFE];
-        let mut rx = [0u8; 2];
+        let mut buf = [0xCA, 0xFE];
+        let expected = buf;
 
         with_test_context(
             &mut hal,
@@ -1785,15 +1773,15 @@ mod tests {
                 let handle = crate::hal::spi_handle(0);
                 let result = helper_spi_transfer(
                     handle as u64,
-                    tx.as_ptr() as u64,
-                    rx.as_mut_ptr() as u64,
-                    tx.len() as u64,
+                    buf.as_mut_ptr() as u64,
+                    buf.len() as u64,
+                    0,
                     0,
                 );
                 assert_eq!(result, 0, "spi_transfer must work for ephemeral programs");
             },
         );
-        assert_eq!(rx, tx);
+        assert_eq!(buf, expected);
     }
 
     // ===================================================================
@@ -1931,8 +1919,8 @@ mod tests {
         let mut read_buf = [0u8; 2];
         let write_data = [0x55u8; 2];
         let mut wr_buf = [0u8; 2];
-        let mut spi_rx = [0u8; 2];
-        let spi_tx = [0xAA, 0xBB];
+        let mut spi_buf = [0xAA, 0xBB];
+        let spi_expected = spi_buf;
 
         with_test_context(
             &mut hal,
@@ -1980,17 +1968,20 @@ mod tests {
                 assert_eq!(r, 0, "i2c_write_read should succeed for ephemeral");
                 assert_eq!(wr_buf, [0x1A, 0x2B], "i2c_write_read must fill read buf");
 
-                // SPI transfer — verify echo (rx = tx)
+                // SPI transfer — verify in-place echo
                 let spi_h = crate::hal::spi_handle(0) as u64;
                 let r = helper_spi_transfer(
                     spi_h,
-                    spi_tx.as_ptr() as u64,
-                    spi_rx.as_mut_ptr() as u64,
-                    spi_tx.len() as u64,
+                    spi_buf.as_mut_ptr() as u64,
+                    spi_buf.len() as u64,
+                    0,
                     0,
                 );
                 assert_eq!(r, 0, "spi_transfer should succeed for ephemeral");
-                assert_eq!(spi_rx, spi_tx, "spi_transfer must echo tx into rx");
+                assert_eq!(
+                    spi_buf, spi_expected,
+                    "spi_transfer must preserve data in-place"
+                );
 
                 // GPIO read — verify pin state returned
                 let r = helper_gpio_read(5, 0, 0, 0, 0);

--- a/crates/sonde-node/src/bpf_dispatch.rs
+++ b/crates/sonde-node/src/bpf_dispatch.rs
@@ -1092,7 +1092,7 @@ mod tests {
                 assert_eq!(result, 0);
             },
         );
-        // In-place echo: buf should still contain original data
+        // Echo mock: buffer should contain echoed RX data (RX == TX)
         assert_eq!(buf, expected);
     }
 
@@ -1975,7 +1975,7 @@ mod tests {
                 assert_eq!(r, 0, "spi_transfer should succeed for ephemeral");
                 assert_eq!(
                     spi_buf, spi_expected,
-                    "spi_transfer must preserve data in-place"
+                    "spi_transfer echo: buffer must contain echoed RX data (RX == TX)"
                 );
 
                 // GPIO read — verify pin state returned

--- a/crates/sonde-node/src/bpf_dispatch.rs
+++ b/crates/sonde-node/src/bpf_dispatch.rs
@@ -764,7 +764,6 @@ mod tests {
         i2c_return: i32,
         gpio_states: [i32; 32],
         adc_values: [i32; 8],
-        spi_echo: bool,
     }
 
     impl TestHal {
@@ -774,7 +773,6 @@ mod tests {
                 i2c_return: 0,
                 gpio_states: [0; 32],
                 adc_values: [0; 8],
-                spi_echo: true,
             }
         }
     }
@@ -799,12 +797,9 @@ mod tests {
             buf[..copy_len].copy_from_slice(&self.i2c_read_data[..copy_len]);
             0
         }
-        fn spi_transfer(&mut self, _handle: u32, buf: &mut [u8]) -> i32 {
-            if self.spi_echo {
-                // Echo: buf already contains tx data; for the mock, the
-                // "received" data is a copy of tx.  Since buf is in-place,
-                // the data is already there — nothing to do.
-            }
+        fn spi_transfer(&mut self, _handle: u32, _buf: &mut [u8]) -> i32 {
+            // In-place echo: buf already contains tx data and the mock
+            // treats "received" data as identical to tx, so nothing to do.
             0
         }
         fn gpio_read(&self, pin: u32) -> i32 {

--- a/crates/sonde-node/src/bpf_dispatch.rs
+++ b/crates/sonde-node/src/bpf_dispatch.rs
@@ -401,6 +401,10 @@ pub fn helper_spi_transfer(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64
         if buf_ptr.is_null() {
             return (-1i64) as u64;
         }
+        // SAFETY: buf_ptr is non-null (checked above), len is capped to
+        // MAX_BUS_TRANSFER_LEN, and the BPF verifier guarantees the
+        // argument points to a writable region of at least len bytes
+        // via its PtrToWritableMem + ConstSize checks.
         unsafe {
             let buf = core::slice::from_raw_parts_mut(buf_ptr, len);
             (*ctx.hal).spi_transfer(handle, buf) as i64 as u64
@@ -797,9 +801,13 @@ mod tests {
             buf[..copy_len].copy_from_slice(&self.i2c_read_data[..copy_len]);
             0
         }
-        fn spi_transfer(&mut self, _handle: u32, _buf: &mut [u8]) -> i32 {
-            // In-place echo: buf already contains tx data and the mock
-            // treats "received" data as identical to tx, so nothing to do.
+        fn spi_transfer(&mut self, _handle: u32, buf: &mut [u8]) -> i32 {
+            // Simulate SPI RX by flipping all bits.  This proves the helper
+            // passes the correct slice to the HAL and that the caller
+            // observes the overwritten contents.
+            for b in buf.iter_mut() {
+                *b ^= 0xFF;
+            }
             0
         }
         fn gpio_read(&self, pin: u32) -> i32 {
@@ -1068,7 +1076,7 @@ mod tests {
         let mut seq = 0u64;
         let mut trace = Vec::new();
         let mut buf = [0xDE, 0xAD, 0xBE, 0xEF];
-        let expected = buf;
+        let expected_rx: [u8; 4] = [0xDE ^ 0xFF, 0xAD ^ 0xFF, 0xBE ^ 0xFF, 0xEF ^ 0xFF];
 
         with_test_context(
             &mut hal,
@@ -1092,8 +1100,8 @@ mod tests {
                 assert_eq!(result, 0);
             },
         );
-        // Echo mock: buffer should contain echoed RX data (RX == TX)
-        assert_eq!(buf, expected);
+        // Mock XORs each byte with 0xFF — proves HAL received the buffer.
+        assert_eq!(buf, expected_rx);
     }
 
     #[test]
@@ -1752,7 +1760,7 @@ mod tests {
         let mut seq = 0u64;
         let mut trace = Vec::new();
         let mut buf = [0xCA, 0xFE];
-        let expected = buf;
+        let expected: [u8; 2] = [0xCA ^ 0xFF, 0xFE ^ 0xFF];
 
         with_test_context(
             &mut hal,
@@ -1776,7 +1784,7 @@ mod tests {
                 assert_eq!(result, 0, "spi_transfer must work for ephemeral programs");
             },
         );
-        assert_eq!(buf, expected);
+        assert_eq!(buf, expected, "mock XORs buffer, proving in-place write");
     }
 
     // ===================================================================
@@ -1915,7 +1923,7 @@ mod tests {
         let write_data = [0x55u8; 2];
         let mut wr_buf = [0u8; 2];
         let mut spi_buf = [0xAA, 0xBB];
-        let spi_expected = spi_buf;
+        let spi_expected: [u8; 2] = [0xAA ^ 0xFF, 0xBB ^ 0xFF];
 
         with_test_context(
             &mut hal,
@@ -1975,7 +1983,7 @@ mod tests {
                 assert_eq!(r, 0, "spi_transfer should succeed for ephemeral");
                 assert_eq!(
                     spi_buf, spi_expected,
-                    "spi_transfer echo: buffer must contain echoed RX data (RX == TX)"
+                    "spi_transfer: mock XORs buffer, proving HAL received correct slice"
                 );
 
                 // GPIO read — verify pin state returned

--- a/crates/sonde-node/src/esp_hal.rs
+++ b/crates/sonde-node/src/esp_hal.rs
@@ -243,13 +243,7 @@ impl hal::Hal for EspHal {
         }
     }
 
-    fn spi_transfer(
-        &mut self,
-        _handle: u32,
-        _tx: Option<&[u8]>,
-        _rx: Option<&mut [u8]>,
-        _len: usize,
-    ) -> i32 {
+    fn spi_transfer(&mut self, _handle: u32, _buf: &mut [u8]) -> i32 {
         -1 // SPI requires device-specific CS pin configuration
     }
 

--- a/crates/sonde-node/src/hal.rs
+++ b/crates/sonde-node/src/hal.rs
@@ -35,14 +35,11 @@ pub trait Hal {
     /// Combined I2C write-then-read in a single transaction (repeated start).
     fn i2c_write_read(&mut self, handle: u32, write_data: &[u8], read_buf: &mut [u8]) -> i32;
 
-    /// Full-duplex SPI transfer.
-    fn spi_transfer(
-        &mut self,
-        handle: u32,
-        tx: Option<&[u8]>,
-        rx: Option<&mut [u8]>,
-        len: usize,
-    ) -> i32;
+    /// In-place full-duplex SPI transfer.
+    ///
+    /// The buffer is read for transmit data, then overwritten with received
+    /// data.  For receive-only transfers, fill the buffer with zeros.
+    fn spi_transfer(&mut self, handle: u32, buf: &mut [u8]) -> i32;
 
     /// Read the state of a GPIO pin. Returns 0 (low), 1 (high), or negative on error.
     fn gpio_read(&self, pin: u32) -> i32;

--- a/crates/sonde-node/src/lib.rs
+++ b/crates/sonde-node/src/lib.rs
@@ -37,7 +37,7 @@ pub mod traits;
 pub mod wake_cycle;
 
 /// Firmware ABI version. Bumped when the helper API changes.
-pub const FIRMWARE_ABI_VERSION: u32 = 1;
+pub const FIRMWARE_ABI_VERSION: u32 = 2;
 
 /// Shared log-capture utility for tests (ND-1006, ND-1010).
 ///

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -1236,13 +1236,7 @@ mod tests {
         fn i2c_write_read(&mut self, _h: u32, _w: &[u8], _r: &mut [u8]) -> i32 {
             0
         }
-        fn spi_transfer(
-            &mut self,
-            _h: u32,
-            _tx: Option<&[u8]>,
-            _rx: Option<&mut [u8]>,
-            _l: usize,
-        ) -> i32 {
+        fn spi_transfer(&mut self, _h: u32, _buf: &mut [u8]) -> i32 {
             0
         }
         fn gpio_read(&self, _pin: u32) -> i32 {

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -274,17 +274,18 @@ Write bytes then read bytes in a single I2C transaction (repeated start). This i
 #### `spi_transfer`
 
 ```c
-int spi_transfer(uint32_t handle, const void *tx, void *rx, uint32_t len);
+int spi_transfer(uint32_t handle, void *buf, uint32_t len);
 ```
 
-Full-duplex SPI transfer. Simultaneously transmits and receives `len` bytes.
+In-place full-duplex SPI transfer.  The buffer is read for transmit data,
+then overwritten with received data.  For receive-only transfers, fill
+the buffer with zeros before calling.
 
 | Parameter | Description |
 |---|---|
 | `handle` | SPI handle: `(bus << 16)`. |
-| `tx` | Transmit buffer (can be NULL for read-only). |
-| `rx` | Receive buffer (can be NULL for write-only). |
-| `len` | Number of bytes to transfer. |
+| `buf` | In-place buffer: read for TX, overwritten with RX. |
+| `len` | Number of bytes to transfer (1–4096). |
 
 **Returns:** `0` on success, negative on failure.
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -557,8 +557,8 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 **Procedure:**
 1. Configure mock SPI to echo transmitted bytes.
-2. Install program that calls `spi_transfer()`.
-3. Assert: received data matches expected echo.
+2. Fill a buffer with test data, call `spi_transfer()` with the buffer.
+3. Assert: buffer contents after the call match the original test data (echo).
 
 ---
 

--- a/test-programs/include/sonde_helpers.h
+++ b/test-programs/include/sonde_helpers.h
@@ -172,20 +172,18 @@ static int (*i2c_write_read)(__u32 handle,
                              void *read_ptr, __u32 read_len) = (void *)3;
 
 /**
- * spi_transfer — full-duplex SPI transfer.
+ * spi_transfer — in-place full-duplex SPI transfer.
  *
- * Simultaneously transmits and receives @len bytes.  Pass NULL for @tx to
- * perform a receive-only transfer; pass NULL for @rx to perform a
- * transmit-only transfer.
+ * The buffer is read for transmit data, then overwritten with received
+ * data.  For receive-only transfers, fill the buffer with zeros.
  *
  * @handle: SPI_HANDLE(bus)
- * @tx:     transmit buffer (NULL for receive-only)
- * @rx:     receive buffer  (NULL for transmit-only)
- * @len:    number of bytes
+ * @buf:    in-place buffer (read for TX, overwritten with RX)
+ * @len:    number of bytes (1–4096)
  * Returns: 0 on success, negative on error
  */
 static int (*spi_transfer)(__u32 handle,
-                           const void *tx, void *rx,
+                           void *buf,
                            __u32 len) = (void *)4;
 
 /**


### PR DESCRIPTION
## Summary

Closes #707 — fixes unverifiable `spi_transfer` (BPF helper #4) by switching to an in-place buffer model.

## Problem

The old signature `spi_transfer(handle, *tx, *rx, len)` was unverifiable: the Prevail verifier binds `ConstSize` only to the immediately preceding pointer, so `*tx` had no bounds check while `*rx` was covered by `len`.

## Solution

Replace with an in-place buffer model: `spi_transfer(handle, *buf, len)`

The buffer is read for TX data, then overwritten with RX data. This gives a clean `PtrToWritableMem` + `ConstSize` pairing that the verifier can bounds-check.

| Aspect | Before | After |
|--------|--------|-------|
| C signature | `spi_transfer(handle, *tx, *rx, len)` | `spi_transfer(handle, *buf, len)` |
| Args used | 4 | 3 |
| Verifier | Unverifiable (tx has no size) | Clean ptr+size pair |
| HAL trait | `(handle, Option<tx>, Option<rx>, len)` | `(handle, &mut buf)` |

## ABI Break

This changes helper #4's argument layout. `FIRMWARE_ABI_VERSION` bumped from 1 to 2. All compiled BPF programs calling `spi_transfer` must be recompiled. No SPI sensors are deployed yet — low risk.

## Files Changed (10)

| File | Change |
|------|--------|
| `hal.rs` | Simplified `Hal::spi_transfer` to `(handle, &mut [u8])` |
| `lib.rs` | `FIRMWARE_ABI_VERSION` bumped 1 to 2 |
| `sonde_platform.rs` | Verifier: `PtrToWritableMem + ConstSize` + new prototype test |
| `bpf_dispatch.rs` | Helper impl + 3 updated tests |
| `sonde_helpers.h` | C header: `spi_transfer(handle, *buf, len)` |
| `esp_hal.rs`, `wake_cycle.rs`, `harness.rs` | Hal impl updates |
| `bpf-environment.md` | Spec updated with in-place semantics |
| `node-validation.md` | T-N602 procedure updated |

## Verification

- `cargo build --workspace` pass
- `cargo clippy --workspace -- -D warnings` pass
- `cargo test -p sonde-node` pass (194 tests)
- `cargo test -p sonde-gateway` pass (131 tests incl. new prototype test)
- `cargo fmt --all -- --check` pass

## Follow-up

End-to-end Prevail verification tests for all 17 helpers tracked in #729.