### PR TITLE
test/docs(modem): address timing, queue, fragment, and USB disconnect gaps

### DIFF
--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -2384,6 +2384,9 @@ mod tests {
     // GAP 1: MD-0403 AC3 — Indication fragmentation flow control
     // ---------------------------------------------------------------
 
+    // Maximum queued indication chunks (mirrors `ble.rs::MAX_INDICATION_CHUNKS`).
+    const MOCK_MAX_INDICATION_CHUNKS: usize = 64;
+
     /// Mock BLE driver that simulates ATT indication fragmentation and
     /// flow control, mirroring the real `EspBleDriver` pacing logic.
     ///
@@ -2395,10 +2398,6 @@ mod tests {
     /// - `advance_indication()` sends the next queued chunk **only** when
     ///   `awaiting_confirm` is false (i.e. the ATT confirmation arrived).
     /// - `simulate_confirm()` clears the flag, as `on_notify_tx` would.
-
-    // Maximum queued indication chunks (mirrors `ble.rs::MAX_INDICATION_CHUNKS`).
-    const MOCK_MAX_INDICATION_CHUNKS: usize = 64;
-
     struct FragmentingMockBle {
         mtu: u16,
         indication_queue: RefCell<VecDeque<Vec<u8>>>,

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -2395,6 +2395,7 @@ mod tests {
     /// - `advance_indication()` sends the next queued chunk **only** when
     ///   `awaiting_confirm` is false (i.e. the ATT confirmation arrived).
     /// - `simulate_confirm()` clears the flag, as `on_notify_tx` would.
+
     /// Maximum queued indication chunks (mirrors `ble.rs::MAX_INDICATION_CHUNKS`).
     const MOCK_MAX_INDICATION_CHUNKS: usize = 64;
 

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -2395,6 +2395,9 @@ mod tests {
     /// - `advance_indication()` sends the next queued chunk **only** when
     ///   `awaiting_confirm` is false (i.e. the ATT confirmation arrived).
     /// - `simulate_confirm()` clears the flag, as `on_notify_tx` would.
+    /// Maximum queued indication chunks (mirrors `ble.rs::MAX_INDICATION_CHUNKS`).
+    const MOCK_MAX_INDICATION_CHUNKS: usize = 64;
+
     struct FragmentingMockBle {
         mtu: u16,
         indication_queue: RefCell<VecDeque<Vec<u8>>>,
@@ -2464,9 +2467,13 @@ mod tests {
             if chunk_size == 0 {
                 return;
             }
+            let num_chunks = data.len().div_ceil(chunk_size);
             let was_empty = self.indication_queue.borrow().is_empty();
             {
                 let mut queue = self.indication_queue.borrow_mut();
+                if queue.len() + num_chunks > MOCK_MAX_INDICATION_CHUNKS {
+                    return; // silently drop (mirrors EspBleDriver)
+                }
                 for chunk in data.chunks(chunk_size) {
                     queue.push_back(chunk.to_vec());
                 }
@@ -2678,6 +2685,37 @@ mod tests {
         bridge.ble.indicate(&[]);
         assert!(bridge.ble.chunks_sent().is_empty());
         assert!(!bridge.ble.is_awaiting_confirm());
+    }
+
+    /// Validates: MD-0403 AC5 — indication fragment queue bounded at 64 chunks.
+    ///
+    /// Sends a payload that would produce 65 chunks (exceeding the 64-chunk
+    /// limit).  The indication MUST be silently dropped — no chunks sent.
+    #[test]
+    fn t0605_indication_queue_overflow_rejected() {
+        // MTU 247 → chunk_size = 244. 65 chunks × 244 bytes = 15,860 bytes.
+        let mut bridge = make_bridge_with_fragmenting_ble(247);
+        let chunk_size = (247 - ATT_HEADER_BYTES) as usize; // 244
+        let payload_65_chunks = vec![0x42u8; chunk_size * 65];
+        bridge.ble.indicate(&payload_65_chunks);
+        // All 65 chunks should be rejected (exceeds MOCK_MAX_INDICATION_CHUNKS=64).
+        assert!(
+            bridge.ble.chunks_sent().is_empty(),
+            "indication exceeding 64-chunk limit must be silently dropped"
+        );
+        assert_eq!(bridge.ble.pending_chunks(), 0);
+    }
+
+    /// Validates: MD-0403 AC5 — indication exactly at 64-chunk limit accepted.
+    #[test]
+    fn t0605_indication_queue_at_boundary_accepted() {
+        let mut bridge = make_bridge_with_fragmenting_ble(247);
+        let chunk_size = (247 - ATT_HEADER_BYTES) as usize; // 244
+        let payload_64_chunks = vec![0x42u8; chunk_size * 64];
+        bridge.ble.indicate(&payload_64_chunks);
+        // Exactly 64 chunks — first chunk sent immediately, 63 queued.
+        assert_eq!(bridge.ble.chunks_sent().len(), 1, "first chunk sent");
+        assert_eq!(bridge.ble.pending_chunks(), 63, "remaining 63 queued");
     }
 
     // ---------------------------------------------------------------

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -2396,7 +2396,7 @@ mod tests {
     ///   `awaiting_confirm` is false (i.e. the ATT confirmation arrived).
     /// - `simulate_confirm()` clears the flag, as `on_notify_tx` would.
 
-    /// Maximum queued indication chunks (mirrors `ble.rs::MAX_INDICATION_CHUNKS`).
+    // Maximum queued indication chunks (mirrors `ble.rs::MAX_INDICATION_CHUNKS`).
     const MOCK_MAX_INDICATION_CHUNKS: usize = 64;
 
     struct FragmentingMockBle {

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -2473,7 +2473,8 @@ mod tests {
             {
                 let mut queue = self.indication_queue.borrow_mut();
                 if queue.len() + num_chunks > MOCK_MAX_INDICATION_CHUNKS {
-                    return; // silently drop (mirrors EspBleDriver)
+                    return; // Drop the payload to mirror EspBleDriver's queue-full behavior;
+                            // the production warning log is intentionally not simulated here.
                 }
                 for chunk in data.chunks(chunk_size) {
                     queue.push_back(chunk.to_vec());

--- a/docs/modem-requirements.md
+++ b/docs/modem-requirements.md
@@ -301,6 +301,8 @@ If the USB-CDC connection is lost, the modem firmware MUST continue running, dis
 2. The modem does not crash or require a power cycle after USB disconnection.
 3. ESP-NOW frames arriving during USB disconnection are silently discarded (not queued and flushed on reconnect).
 
+> **Known limitation:** USB disconnection is detected reactively via I/O failure on the next `write()` or `is_connected()` check, not by a hardware interrupt. There may be a brief window between physical disconnection and detection during which a small number of ESP-NOW frames are buffered in the poll loop. These frames are discarded on the next poll cycle once the disconnection is detected.
+
 ---
 
 ### MD-0302  Watchdog timer
@@ -410,6 +412,7 @@ When sending indications larger than (MTU − 3) bytes, the modem MUST fragment 
 2. Each indication payload is ≤ (MTU − 3) bytes.
 3. The modem waits for ATT Handle Value Confirmation between chunks.
 4. The reassembled message on the client matches the original.
+5. The indication fragment queue is bounded at 64 chunks. `BLE_INDICATE` messages whose fragments would exceed this limit MUST be silently dropped with a warning log.
 
 ---
 
@@ -503,6 +506,8 @@ When a phone writes to the Gateway Command characteristic, the modem MUST forwar
 3. The payload is forwarded unmodified.
 4. Empty GATT writes are silently discarded.
 5. If a GATT write arrives before server-initiated LESC pairing completes (i.e. `authenticated` is still `false`), the modem MUST buffer the write and forward it as `BLE_RECV` once authentication succeeds, rather than discarding it.
+6. The pre-authentication write buffer holds at most one write (single-slot). If a second GATT write arrives before authentication completes, it replaces the previously buffered write. The client should not send more than one write before receiving a response.
+7. The BLE event queue is bounded at 32 entries. GATT writes arriving when the queue is full MUST be silently dropped with a warning log.
 
 ---
 

--- a/docs/modem-requirements.md
+++ b/docs/modem-requirements.md
@@ -507,7 +507,7 @@ When a phone writes to the Gateway Command characteristic, the modem MUST forwar
 4. Empty GATT writes are silently discarded.
 5. If a GATT write arrives before server-initiated LESC pairing completes (i.e. `authenticated` is still `false`), the modem MUST buffer the write and forward it as `BLE_RECV` once authentication succeeds, rather than discarding it.
 6. The pre-authentication write buffer holds at most one write (single-slot). If a second GATT write arrives before authentication completes, it replaces the previously buffered write. The client should not send more than one write before receiving a response.
-7. The BLE event queue is bounded at 32 entries. GATT writes arriving when the queue is full MUST be silently dropped with a warning log.
+7. For normal BLE event enqueueing, the modem uses a 32-entry BLE event queue. A newly arriving GATT write that would be enqueued while that queue is already full MUST be silently dropped with a warning log. Forwarding the single buffered pre-authentication write after authentication succeeds is exempt from this drop rule.
 
 ---
 

--- a/docs/modem-requirements.md
+++ b/docs/modem-requirements.md
@@ -301,7 +301,7 @@ If the USB-CDC connection is lost, the modem firmware MUST continue running, dis
 2. The modem does not crash or require a power cycle after USB disconnection.
 3. ESP-NOW frames arriving during USB disconnection are silently discarded (not queued and flushed on reconnect).
 
-> **Known limitation:** USB disconnection is detected reactively via I/O failure on the next `write()` or `is_connected()` check, not by a hardware interrupt. There may be a brief window between physical disconnection and detection during which a small number of ESP-NOW frames are buffered in the poll loop. These frames are discarded on the next poll cycle once the disconnection is detected.
+> **Known limitation:** USB disconnection is detected reactively via I/O failure on the next `write()` or `is_connected()` check, not by a hardware interrupt. There may be a brief window between physical disconnection and detection during which a small number of ESP-NOW frames are buffered in the ESP-NOW receive ring before `Bridge::poll()` drains it. These frames are discarded on the next poll cycle once the disconnection is detected.
 
 ---
 

--- a/docs/modem-validation.md
+++ b/docs/modem-validation.md
@@ -68,6 +68,8 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 4. Assert: `firmware_version` is a valid 4-byte value.
 5. Assert: `mac_address` is a valid 6-byte MAC (not all zeros).
 
+> **Implementation note:** The current `device_tests.rs` implementation (`t0101_modem_ready_after_reset`) verifies field values but does not assert the 2-second timing constraint from MD-0104. A future update should record `Instant::now()` before `reset_and_wait()` and assert `elapsed < Duration::from_secs(2)` on return.
+
 ---
 
 ### T-0102  Serial framing — valid frame and max length

--- a/docs/modem-validation.md
+++ b/docs/modem-validation.md
@@ -68,7 +68,7 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 4. Assert: `firmware_version` is a valid 4-byte value.
 5. Assert: `mac_address` is a valid 6-byte MAC (not all zeros).
 
-> **Implementation note:** The current `device_tests.rs` implementation (`t0101_modem_ready_after_reset`) verifies field values but does not assert the 2-second timing constraint from MD-0104. A future update should record `Instant::now()` before `reset_and_wait()` and assert `elapsed < Duration::from_secs(2)` on return.
+> **Implementation note:** The current `device_tests.rs` implementation (`t0101_modem_ready_after_reset`) verifies field values but does not assert the 2-second timing constraint from MD-0104. A future update should record `Instant::now()` before `reset_and_wait()` and assert `elapsed <= Duration::from_secs(2)` on return.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #696 — addresses 7 modem test/doc gaps from maintenance audit F-010 through F-027.

## Changes by Finding

| Finding | Severity | Fix | Type |
|---------|----------|-----|------|
| **F-010** | Medium | Added implementation note to T-0101 about missing 2s timing assertion | Doc |
| **F-011** | Medium | Added MD-0409 AC6: single-slot pre-auth write buffer, latest-wins | Doc |
| **F-012** | Medium | Added MD-0409 AC7: BLE event queue bounded at 32, drops with warning | Doc |
| **F-013** | Medium | Added MD-0403 AC5 + 2 boundary tests (64 accepted, 65 rejected) | Doc + Test |
| **F-020** | Medium | Added known-limitation note to MD-0301 AC3: reactive USB detection | Doc |
| **F-026** | Low | Already documented as hardware-only in T-0304 (no change needed) | N/A |
| **F-027** | Low | Deferred — logging test infrastructure (`tracing-test`) is a separate effort | N/A |

## Tests Added

| Test | Validates |
|------|-----------|
| `t0605_indication_queue_overflow_rejected` | MD-0403 AC5: 65-chunk payload silently dropped |
| `t0605_indication_queue_at_boundary_accepted` | MD-0403 AC5: 64-chunk payload accepted |

Also added `MOCK_MAX_INDICATION_CHUNKS` capacity check to `FragmentingMockBle` to mirror real `EspBleDriver` behavior.

## Validation

All 97 modem tests pass: `cargo test -p sonde-modem`