### PR TITLE
fix(pair): extract timeout constants and add pin config CBOR test

### DIFF
--- a/crates/sonde-pair/src/phase1.rs
+++ b/crates/sonde-pair/src/phase1.rs
@@ -10,6 +10,9 @@ use crate::validation::validate_rf_channel;
 use tracing::{debug, info, trace};
 use zeroize::Zeroizing;
 
+/// PHONE_REGISTERED indication timeout in milliseconds (PT-1002).
+const PHONE_REGISTERED_TIMEOUT_MS: u64 = 30_000;
+
 /// Callback for reporting Phase 1 sub-phase progress (PT-0701).
 ///
 /// ## AEAD flow (`pair_with_gateway`)
@@ -106,10 +109,14 @@ async fn do_pair_with_gateway(
         .write_characteristic(GATEWAY_SERVICE_UUID, GATEWAY_COMMAND_UUID, &register)
         .await?;
 
-    // Step 4: Read indication (timeout 30s)
+    // Step 4: Read indication (timeout per PT-1002)
     trace!("waiting for PHONE_REGISTERED indication (30 s timeout)");
     let response = transport
-        .read_indication(GATEWAY_SERVICE_UUID, GATEWAY_COMMAND_UUID, 30_000)
+        .read_indication(
+            GATEWAY_SERVICE_UUID,
+            GATEWAY_COMMAND_UUID,
+            PHONE_REGISTERED_TIMEOUT_MS,
+        )
         .await?;
     let (msg_type, payload) = parse_envelope(&response)?;
     trace!(

--- a/crates/sonde-pair/src/phase1.rs
+++ b/crates/sonde-pair/src/phase1.rs
@@ -110,7 +110,10 @@ async fn do_pair_with_gateway(
         .await?;
 
     // Step 4: Read indication (timeout per PT-1002)
-    trace!("waiting for PHONE_REGISTERED indication (30 s timeout)");
+    trace!(
+        timeout_ms = PHONE_REGISTERED_TIMEOUT_MS,
+        "waiting for PHONE_REGISTERED indication"
+    );
     let response = transport
         .read_indication(
             GATEWAY_SERVICE_UUID,

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -184,7 +184,10 @@ async fn do_provision_node(
         .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &message)
         .await?;
 
-    trace!("waiting for NODE_ACK indication (5 s timeout)");
+    trace!(
+        timeout_ms = NODE_ACK_TIMEOUT_MS,
+        "waiting for NODE_ACK indication"
+    );
     let response = transport
         .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, NODE_ACK_TIMEOUT_MS)
         .await?;

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -732,9 +732,9 @@ mod tests {
         // Verify keys are in ascending order (deterministic CBOR §4.2).
         let decoded: ciborium::Value = ciborium::from_reader(buf.as_slice()).unwrap();
         if let ciborium::Value::Map(pairs) = decoded {
-            let keys: Vec<i128> = pairs
+            let keys: Vec<u64> = pairs
                 .iter()
-                .map(|(k, _)| i128::from(k.as_integer().unwrap()))
+                .map(|(k, _)| u64::try_from(k.as_integer().unwrap()).unwrap())
                 .collect();
             assert_eq!(keys, vec![1, 2], "keys must be in ascending order");
         } else {

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -12,6 +12,12 @@ use crate::validation::{compute_key_hint, validate_node_id};
 use tracing::{debug, info, trace};
 use zeroize::Zeroizing;
 
+/// NODE_ACK indication timeout in milliseconds (PT-1002).
+const NODE_ACK_TIMEOUT_MS: u64 = 5_000;
+
+/// DIAG_RELAY_RESPONSE indication timeout in milliseconds (PT-1303).
+const DIAG_RELAY_TIMEOUT_MS: u64 = 10_000;
+
 /// Map a BLE provisioning message type byte to its spec name (PT-0702).
 fn msg_type_name(t: u8) -> &'static str {
     match t {
@@ -180,7 +186,7 @@ async fn do_provision_node(
 
     trace!("waiting for NODE_ACK indication (5 s timeout)");
     let response = transport
-        .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, 5000)
+        .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, NODE_ACK_TIMEOUT_MS)
         .await?;
     let (msg_type, payload) = parse_envelope(&response)?;
     trace!(
@@ -268,9 +274,9 @@ pub async fn check_rssi(
         .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &envelope)
         .await?;
 
-    // 4. Wait for DIAG_RELAY_RESPONSE (10s timeout, PT-1303).
+    // 4. Wait for DIAG_RELAY_RESPONSE (timeout per PT-1303).
     let response = transport
-        .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, 10_000)
+        .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, DIAG_RELAY_TIMEOUT_MS)
         .await?;
 
     // 5. Parse BLE envelope.
@@ -691,5 +697,45 @@ mod tests {
 
         let result = check_rssi(&mut transport, &artifacts).await;
         assert!(matches!(result, Err(PairingError::DiagnosticFailed(_))));
+    }
+
+    /// Validates: PT-1214 AC2 — pin config CBOR deterministic encoding.
+    ///
+    /// The pin config CBOR map must use integer keys in ascending order
+    /// (key 1 = i2c0_sda, key 2 = i2c0_scl) with minimal-length encoding.
+    #[test]
+    fn pin_config_cbor_deterministic() {
+        let pc = PinConfig {
+            i2c0_sda: 5,
+            i2c0_scl: 6,
+        };
+        let pin_cbor = ciborium::Value::Map(vec![
+            (
+                ciborium::Value::Integer(1.into()),
+                ciborium::Value::Integer(pc.i2c0_sda.into()),
+            ),
+            (
+                ciborium::Value::Integer(2.into()),
+                ciborium::Value::Integer(pc.i2c0_scl.into()),
+            ),
+        ]);
+        let mut buf = Vec::new();
+        ciborium::into_writer(&pin_cbor, &mut buf).unwrap();
+
+        // Expected: A2 01 05 02 06
+        // A2 = map(2), 01 = key 1, 05 = value 5, 02 = key 2, 06 = value 6
+        assert_eq!(buf, [0xA2, 0x01, 0x05, 0x02, 0x06]);
+
+        // Verify keys are in ascending order (deterministic CBOR §4.2).
+        let decoded: ciborium::Value = ciborium::from_reader(buf.as_slice()).unwrap();
+        if let ciborium::Value::Map(pairs) = decoded {
+            let keys: Vec<i128> = pairs
+                .iter()
+                .map(|(k, _)| i128::from(k.as_integer().unwrap()))
+                .collect();
+            assert_eq!(keys, vec![1, 2], "keys must be in ascending order");
+        } else {
+            panic!("expected CBOR map");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #697 — addresses 5 BLE pairing spec/test maintenance findings (F-015 through F-025).

## Changes

### F-024: Extract timeout constants (code)
Replaced hardcoded magic numbers with named constants traceable to requirements:
| Constant | Value | Source |
|---|---|---|
| `PHONE_REGISTERED_TIMEOUT_MS` | 30,000 ms | PT-1002 |
| `NODE_ACK_TIMEOUT_MS` | 5,000 ms | PT-1002 |
| `DIAG_RELAY_TIMEOUT_MS` | 10,000 ms | PT-1303 |

### F-017: Pin config CBOR determinism test
Added `pin_config_cbor_deterministic` test in `phase2.rs` validating PT-1214 AC2:
- CBOR map uses integer keys in ascending order (1, 2)
- Exact byte output: `A2 01 05 02 06`

### Already resolved (no changes needed)
- **F-015**: HMAC references in `ble-pairing-protocol.md` are already marked RETIRED
- **F-016**: `resolve_pin_config` asymmetric rejection tests already exist in `sonde-pair-ui`

### Deferred
- **F-025**: PT-0601 (Should priority) — already-paired detection requires UI/store integration

## Validation
All 108 sonde-pair tests pass: `cargo test -p sonde-pair`