### PR TITLE
docs(node): clarify WAKE retry count and add map data skip logging

### DIFF
--- a/crates/sonde-node/src/map_storage.rs
+++ b/crates/sonde-node/src/map_storage.rs
@@ -528,6 +528,13 @@ impl MapStorage {
             if let Some(map) = self.maps.get_mut(i) {
                 if data.len() == map.def.value_size as usize {
                     let _ = map.update(0, data);
+                } else {
+                    log::debug!(
+                        "map[{}]: skipping initial data (got {} bytes, expected {})",
+                        i,
+                        data.len(),
+                        map.def.value_size
+                    );
                 }
             }
         }

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -600,7 +600,7 @@ The program image format MUST support optional initial data for each map definit
 1. A program image with `initial_data` (CBOR key 5) in a map definition is accepted and decoded correctly.
 2. After map allocation, entry 0 of each map with non-empty initial data contains the specified bytes.
 3. Maps without initial data (empty or absent key 5) remain zero-filled after allocation.
-4. Initial data whose length does not match `value_size` is silently ignored (map remains zero-filled). A `debug!()` log MAY be emitted for diagnostic purposes; this log is compiled out in release builds.
+4. Initial data whose length does not match `value_size` is ignored without error (map remains zero-filled). A `debug!()` log may be emitted for diagnostic purposes; visibility depends on build features and log level configuration (see ND-1012).
 
 ---
 
@@ -728,7 +728,7 @@ The existing `send()` and `send_recv()` helpers MUST continue to function identi
 **Source:** protocol.md §9.1
 
 **Description:**  
-If the node sends `WAKE` and receives no `COMMAND` response within the transport timeout (ND-0702), the node MUST retry up to 3 times with a 400 ms backoff delay after each timeout. On a timeout-only path, successive WAKE transmissions are ~600 ms apart (200 ms response timeout + 400 ms backoff). After max retries, the node MUST sleep until the next scheduled wake interval.
+If the node sends `WAKE` and receives no `COMMAND` response within the transport timeout (ND-0702), the node MUST send up to 4 WAKE frames (1 initial + up to 3 retries) with a 400 ms backoff delay after each timeout. On a timeout-only path, successive WAKE transmissions are ~600 ms apart (200 ms response timeout + 400 ms backoff). After all retries are exhausted, the node MUST sleep until the next scheduled wake interval.
 
 **Acceptance criteria:**
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -734,7 +734,7 @@ If the node sends `WAKE` and receives no `COMMAND` response within the transport
 
 1. The node sends up to 4 WAKE frames (1 initial + up to 3 retries).
 2. The backoff delay after each response timeout is 400 ms.
-3. After 3 failures, the node sleeps without executing BPF.
+3. After all retries are exhausted, the node sleeps without executing BPF.
 
 ---
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -732,7 +732,7 @@ If the node sends `WAKE` and receives no `COMMAND` response within the transport
 
 **Acceptance criteria:**
 
-1. The node retries up to 3 times.
+1. The node sends up to 4 WAKE frames (1 initial + up to 3 retries).
 2. The backoff delay after each response timeout is 400 ms.
 3. After 3 failures, the node sleeps without executing BPF.
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -600,7 +600,7 @@ The program image format MUST support optional initial data for each map definit
 1. A program image with `initial_data` (CBOR key 5) in a map definition is accepted and decoded correctly.
 2. After map allocation, entry 0 of each map with non-empty initial data contains the specified bytes.
 3. Maps without initial data (empty or absent key 5) remain zero-filled after allocation.
-4. Initial data whose length does not match `value_size` is silently ignored (map remains zero-filled).
+4. Initial data whose length does not match `value_size` is silently ignored (map remains zero-filled). A `debug!()` log MAY be emitted for diagnostic purposes; this log is compiled out in release builds.
 
 ---
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1345,6 +1345,10 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ### T-N1014  bpf_trace_printk emitted at INFO level
 
+> **Naming note:** This test validates ND-1006. The ID T-N1014 follows the
+> sequential allocation order in which it was added; a future renumbering
+> pass may rename it to T-N1006 for consistency.
+
 **Validates:** ND-1006
 
 **Procedure:**
@@ -1356,6 +1360,10 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 ---
 
 ### T-N1015  BPF helper I/O logging at DEBUG level
+
+> **Naming note:** This test validates ND-1010. The ID T-N1015 follows the
+> sequential allocation order in which it was added; a future renumbering
+> pass may rename it to T-N1010 for consistency.
 
 **Validates:** ND-1010
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1346,8 +1346,8 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 ### T-N1014  bpf_trace_printk emitted at INFO level
 
 > **Naming note:** This test validates ND-1006. The ID T-N1014 follows the
-> sequential allocation order in which it was added; a future renumbering
-> pass may rename it to T-N1006 for consistency.
+> sequential allocation order in which it was added; it is not named
+> T-N1006 because that ID is already assigned to a different test case.
 
 **Validates:** ND-1006
 
@@ -1362,8 +1362,8 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 ### T-N1015  BPF helper I/O logging at DEBUG level
 
 > **Naming note:** This test validates ND-1010. The ID T-N1015 follows the
-> sequential allocation order in which it was added; a future renumbering
-> pass may rename it to T-N1010 for consistency.
+> sequential allocation order in which it was added; it is not named
+> T-N1010 because that ID is already assigned to a different test case.
 
 **Validates:** ND-1010
 


### PR DESCRIPTION
## Summary

Closes #698 — addresses 3 node documentation and logging findings (F-018, F-019, F-023).

## Changes

| Finding | Fix | File |
|---------|-----|------|
| **F-018** | Clarify ND-0700 AC1: 'sends up to 4 WAKE frames (1 initial + up to 3 retries)' | `node-requirements.md` |
| **F-019** | Add `debug!()` log when `apply_initial_data()` skips mismatched sizes | `map_storage.rs` |
| **F-023** | Add naming cross-reference notes to T-N1014 → ND-1006 and T-N1015 → ND-1010 | `node-validation.md` |

## Validation
All 194 node tests pass: `cargo test -p sonde-node`