### PR TITLE
feat(node): add task watchdog timer (ND-0919)

### DIFF
--- a/crates/sonde-node/sdkconfig.defaults
+++ b/crates/sonde-node/sdkconfig.defaults
@@ -45,6 +45,14 @@ CONFIG_FREERTOS_HZ=1000
 CONFIG_ESP_WIFI_SOFTAP_SUPPORT=n
 CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT=n
 
+# --- Watchdog (ND-0919) ---
+# Enable task watchdog with 20 s timeout and panic-on-expiry.
+# Covers worst-case wake cycle (WAKE retries + chunked transfer + BPF + APP_DATA)
+# while recovering from firmware hangs before excessive battery drain.
+CONFIG_ESP_TASK_WDT_EN=y
+CONFIG_ESP_TASK_WDT_TIMEOUT_S=20
+CONFIG_ESP_TASK_WDT_PANIC=y
+
 # --- Bluetooth / NimBLE (ND-0902) ---
 # Use NimBLE (BLE-only, lightweight) instead of Bluedroid.
 # esp32-nimble requires CONFIG_BT_NIMBLE_ENABLED=y so that esp-idf-sys

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -223,9 +223,8 @@ fn main() {
     // The wake cycle completed normally — no need for watchdog protection
     // during the sleep/reboot path.
     unsafe {
-        let _ = esp_idf_svc::sys::esp_task_wdt_delete(
-            esp_idf_svc::sys::xTaskGetCurrentTaskHandle(),
-        );
+        let _ =
+            esp_idf_svc::sys::esp_task_wdt_delete(esp_idf_svc::sys::xTaskGetCurrentTaskHandle());
     }
 
     match outcome {

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -59,6 +59,27 @@ fn main() {
     };
     info!("boot_reason={} (ND-1000)", boot_reason);
 
+    // Register the main task with the ESP-IDF task watchdog (ND-0919).
+    // The watchdog timeout (CONFIG_ESP_TASK_WDT_TIMEOUT_S=20) covers the
+    // entire wake cycle. No periodic feeding is needed because the node
+    // runs a single wake cycle and then sleeps; if the cycle completes
+    // normally, we deregister before sleeping. If it hangs, the watchdog
+    // triggers a panic/reset.
+    unsafe {
+        let wdt_config = esp_idf_svc::sys::esp_task_wdt_config_t {
+            timeout_ms: 20_000,
+            idle_core_mask: 0,
+            trigger_panic: true,
+        };
+        esp_idf_svc::sys::esp!(esp_idf_svc::sys::esp_task_wdt_reconfigure(&wdt_config))
+            .expect("failed to configure watchdog");
+        esp_idf_svc::sys::esp!(esp_idf_svc::sys::esp_task_wdt_add(
+            esp_idf_svc::sys::xTaskGetCurrentTaskHandle()
+        ))
+        .expect("failed to add task to watchdog");
+    }
+    info!("task watchdog registered (20 s timeout, ND-0919)");
+
     // --- Initialize platform ---
     let peripherals = Peripherals::take().expect("failed to take peripherals");
     let sysloop = EspSystemEventLoop::take().expect("failed to take event loop");
@@ -197,6 +218,15 @@ fn main() {
         &aead,
         &mut async_queue,
     );
+
+    // Deregister from the task watchdog before sleeping (ND-0919).
+    // The wake cycle completed normally — no need for watchdog protection
+    // during the sleep/reboot path.
+    unsafe {
+        let _ = esp_idf_svc::sys::esp_task_wdt_delete(
+            esp_idf_svc::sys::xTaskGetCurrentTaskHandle(),
+        );
+    }
 
     match outcome {
         WakeCycleOutcome::Sleep { seconds } => {

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -560,20 +560,20 @@ All inbound protocol errors result in **silent discard** — the node does not s
 ## 14  Boot sequence
 
 1. ESP-IDF initialization (clocks, peripherals, wifi/ESP-NOW).
-2. Task watchdog timer is active from boot (ND-0919): `CONFIG_ESP_TASK_WDT_EN=y`, 20 s timeout, panic-on-expiry. Protects against firmware hangs (I²C lockup, radio deadlock, blocking calls) that would otherwise drain the battery indefinitely.
+2. Task watchdog timer is configured and the main task is registered (ND-0919): `CONFIG_ESP_TASK_WDT_EN=y`, 20 s timeout, panic-on-expiry. The main task calls `esp_task_wdt_add()` at startup and `esp_task_wdt_delete()` after the wake cycle completes. If the wake cycle hangs, the watchdog triggers a hardware reset.
 3. Sample pairing button GPIO for 500 ms (ND-0901).
-3. Read key partition: check magic bytes and load credentials if present. Read NVS `reg_complete` flag (§6.1a).
-4. Determine boot path (ND-0900):
+4. Read key partition: check magic bytes and load credentials if present. Read NVS `reg_complete` flag (§6.1a).
+5. Determine boot path (ND-0900):
    a. No valid PSK in key partition OR pairing button held ≥ 500 ms → enter BLE pairing mode (§15). Does not return.
    b. PSK present in key partition, `reg_complete` NOT set in NVS → enter PEER_REQUEST registration (§15.7). Does not return (sleeps after listen window).
-   c. PSK present in key partition, `reg_complete` set in NVS → continue to step 5 (normal WAKE cycle).
-5. Read schedule partition: load base interval and active program partition flag.
-6. Read active program partition: decode CBOR image header, extract program hash.
+   c. PSK present in key partition, `reg_complete` set in NVS → continue to step 6 (normal WAKE cycle).
+6. Read schedule partition: load base interval and active program partition flag.
+7. Read active program partition: decode CBOR image header, extract program hash.
    - No program → set `program_hash` to zero-length.
-7. Initialize HAL (I2C buses, SPI buses, GPIO, ADC).
-8. Allocate map storage in RTC SRAM from program's map definitions (if maps survived sleep, data is preserved; if new program, zero-initialize).
-9. Resolve LDDW `src=1` instructions in bytecode to runtime map pointers.
-10. Enter wake cycle engine.
+8. Initialize HAL (I2C buses, SPI buses, GPIO, ADC).
+9. Allocate map storage in RTC SRAM from program's map definitions (if maps survived sleep, data is preserved; if new program, zero-initialize).
+10. Resolve LDDW `src=1` instructions in bytecode to runtime map pointers.
+11. Enter wake cycle engine.
 
 ---
 

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -560,7 +560,8 @@ All inbound protocol errors result in **silent discard** — the node does not s
 ## 14  Boot sequence
 
 1. ESP-IDF initialization (clocks, peripherals, wifi/ESP-NOW).
-2. Sample pairing button GPIO for 500 ms (ND-0901).
+2. Task watchdog timer is active from boot (ND-0919): `CONFIG_ESP_TASK_WDT_EN=y`, 20 s timeout, panic-on-expiry. Protects against firmware hangs (I²C lockup, radio deadlock, blocking calls) that would otherwise drain the battery indefinitely.
+3. Sample pairing button GPIO for 500 ms (ND-0901).
 3. Read key partition: check magic bytes and load credentials if present. Read NVS `reg_complete` flag (§6.1a).
 4. Determine boot path (ND-0900):
    a. No valid PSK in key partition OR pairing button held ≥ 500 ms → enter BLE pairing mode (§15). Does not return.

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -1127,6 +1127,23 @@ The ESP-IDF main task stack MUST be at least 16 KB (`CONFIG_ESP_MAIN_TASK_STACK_
 
 ---
 
+### ND-0919  Task watchdog timer
+
+**Priority:** Must  
+**Source:** issue #721
+
+**Description:**  
+The node firmware MUST enable the ESP-IDF task watchdog timer on the main task. The timeout MUST be long enough to cover a full wake cycle (WAKE retries + chunked program transfer + BPF execution + APP_DATA exchanges) but short enough to recover from firmware hangs before excessive battery drain. On expiry, the watchdog MUST trigger a panic/reset so the node reboots into the next scheduled wake cycle.
+
+**Acceptance criteria:**
+
+1. `CONFIG_ESP_TASK_WDT_EN=y` is set in `sdkconfig.defaults`.
+2. `CONFIG_ESP_TASK_WDT_TIMEOUT_S` is set to 20 seconds.
+3. `CONFIG_ESP_TASK_WDT_PANIC=y` is set so watchdog expiry triggers a reset.
+4. The node completes a normal wake cycle (including maximum WAKE retries and chunked transfer) without triggering the watchdog.
+
+---
+
 ## 10  Operational logging
 
 > **Build-type scope (ND-1012):** The logging requirements in this section (ND-1000–ND-1011) specify log levels for debug and verbose firmware builds. In release firmware builds (without the `verbose` feature), INFO and below are stripped at compile time — those requirements are satisfied by the `verbose` build variant producing the specified output. Release builds emit only WARN and above.

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -1140,7 +1140,9 @@ The node firmware MUST enable the ESP-IDF task watchdog timer on the main task. 
 1. `CONFIG_ESP_TASK_WDT_EN=y` is set in `sdkconfig.defaults`.
 2. `CONFIG_ESP_TASK_WDT_TIMEOUT_S` is set to 20 seconds.
 3. `CONFIG_ESP_TASK_WDT_PANIC=y` is set so watchdog expiry triggers a reset.
-4. The node completes a normal wake cycle (including maximum WAKE retries and chunked transfer) without triggering the watchdog.
+4. The main task is explicitly registered with the task watchdog at startup via `esp_task_wdt_add()`.
+5. The main task is deregistered from the task watchdog after the wake cycle completes, before entering deep sleep.
+6. The node completes a normal wake cycle (including maximum WAKE retries and chunked transfer) without triggering the watchdog.
 
 ---
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1831,8 +1831,11 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 2. Assert: `CONFIG_ESP_TASK_WDT_EN=y` is present.
 3. Assert: `CONFIG_ESP_TASK_WDT_TIMEOUT_S=20` is present.
 4. Assert: `CONFIG_ESP_TASK_WDT_PANIC=y` is present.
+5. Inspect `node.rs` main function.
+6. Assert: `esp_task_wdt_add()` is called at startup to register the main task.
+7. Assert: `esp_task_wdt_delete()` is called after the wake cycle completes.
 
-> **Note:** Verifying that the watchdog triggers on a stalled main loop requires a special test firmware build and real hardware (similar to modem T-0304). This test validates configuration only.
+> **Note:** Verifying that the watchdog triggers on a stalled main loop requires a special test firmware build and real hardware (similar to modem T-0304). This test validates configuration and registration code only.
 
 ---
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1822,6 +1822,20 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
+### T-N942  Task watchdog timer enabled
+
+**Validates:** ND-0919
+
+**Procedure:**
+1. Inspect `sdkconfig.defaults` for the node firmware.
+2. Assert: `CONFIG_ESP_TASK_WDT_EN=y` is present.
+3. Assert: `CONFIG_ESP_TASK_WDT_TIMEOUT_S=20` is present.
+4. Assert: `CONFIG_ESP_TASK_WDT_PANIC=y` is present.
+
+> **Note:** Verifying that the watchdog triggers on a stalled main loop requires a special test firmware build and real hardware (similar to modem T-0304). This test validates configuration only.
+
+---
+
 ### T-N0607a  I2C pins read from NVS at HAL init
 
 **Validates:** ND-0608 (AC 1, 3)


### PR DESCRIPTION
## Summary

Closes #721 — adds ESP-IDF task watchdog timer to the node firmware to protect against firmware hangs.

## Problem

The node firmware had no task watchdog. If a firmware bug caused a hang (I²C lockup, radio deadlock, blocking call), the node would remain awake indefinitely, draining the battery with no recovery path. The modem already has this (MD-0302, 35s).

## Changes

| File | Change |
|------|--------|
| `node-requirements.md` | Add ND-0919 with 6 acceptance criteria |
| `sdkconfig.defaults` | Add `CONFIG_ESP_TASK_WDT_EN=y`, `TIMEOUT_S=20`, `PANIC=y` |
| `node.rs` | Register main task with `esp_task_wdt_add()` at startup, deregister with `esp_task_wdt_delete()` after wake cycle |
| `node-design.md` | Document watchdog in boot sequence §14 step 2; fix numbering (3→11) |
| `node-validation.md` | Add T-N942 configuration + registration validation test |

## Design decisions

- **20s timeout**: Covers worst-case wake cycle — WAKE retries (4×600ms ≈ 2.4s) + chunked transfer + BPF execution + APP_DATA exchanges — with margin. Short enough to recover before excessive battery drain.
- **Panic-on-expiry**: Triggers a hardware reset so the node reboots into the next scheduled wake cycle.
- **No periodic feeding**: The node runs a single wake cycle (not a loop), so the entire cycle is the protected window. The task is deregistered after the cycle completes.
- **T-N942 is config+code inspection**: Runtime watchdog trigger testing requires special firmware + real hardware (same as modem T-0304).

## Validation

All 194 node tests pass. Full workspace clippy clean.