### PR TITLE
docs: recommend embedding ctx->timestamp in send_async payloads

### DIFF
--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -407,11 +407,12 @@ Queue an opaque data blob for deferred delivery on the next wake cycle. Unlike `
 
 **Best practice — embed `ctx->timestamp` in async payloads:**
 
-The store-and-forward queue does not automatically stamp blobs with a collection timestamp. Delivery may be delayed across multiple wake cycles (e.g., due to RF interference or non-NOP command priority). To allow handlers to correlate measurements to when they were taken rather than when they were received, always include `ctx->timestamp` in the serialized payload:
+The store-and-forward queue does not automatically stamp blobs with a collection timestamp. Delivery may be delayed across multiple wake cycles (e.g., due to RF interference or non-NOP command priority). To allow handlers to correlate measurements to when they were taken rather than when they were received, always include `ctx->timestamp` in the payload:
 
 ```c
 SEC("sonde")
 int program(struct sonde_context *ctx) {
+    /* BPF is little-endian; handlers must parse accordingly. */
     struct {
         __u64 timestamp;
         __u16 reading;

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -405,6 +405,25 @@ Queue an opaque data blob for deferred delivery on the next wake cycle. Unlike `
 - The handler receives this data as a normal `DATA` message. Non-zero-length replies to piggybacked data are deferred to the next cycle (best-case two-cycle round-trip latency). Zero-length replies produce no deferred delivery.
 - If the queue is full, the BPF program may fall back to `send()` or `send_recv()` for immediate delivery.
 
+**Best practice — embed `ctx->timestamp` in async payloads:**
+
+The store-and-forward queue does not automatically stamp blobs with a collection timestamp. Delivery may be delayed across multiple wake cycles (e.g., due to RF interference or non-NOP command priority). To allow handlers to correlate measurements to when they were taken rather than when they were received, always include `ctx->timestamp` in the serialized payload:
+
+```c
+SEC("sonde")
+int program(struct sonde_context *ctx) {
+    struct {
+        __u64 timestamp;
+        __u16 reading;
+    } payload = {
+        .timestamp = ctx->timestamp,
+        .reading   = /* sensor value */,
+    };
+    send_async(&payload, sizeof(payload));
+    return 0;
+}
+```
+
 **Availability:** Resident and ephemeral.
 
 ---

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -582,6 +582,8 @@ The store-and-forward mechanism piggybacks application data on the mandatory WAK
 3. Gateway receives WAKE, extracts `blob`, routes to handler as a `DATA` message.
 4. Handler reply is always deferred to next cycle.
 
+> **Note:** Async blobs are opaque — the protocol does not automatically stamp them with a collection timestamp. BPF programs should embed `ctx->timestamp` in the payload so handlers can distinguish collection time from delivery time. See [bpf-environment.md §6.2](bpf-environment.md) for the recommended pattern.
+
 **Downlink (gateway → node):**
 
 1. Handler replies to the `DATA` message with a `DATA_REPLY`. For `DATA` originating from a WAKE `blob`, deferred delivery is always enforced by the gateway: the handler may omit `delivery`, and any handler-supplied `delivery` value is ignored for this path.


### PR DESCRIPTION
## Summary

Closes #720 — adds best-practice guidance about embedding `ctx->timestamp` in `send_async()` payloads for store-and-forward delivery.

## Problem

Async blobs are opaque — the protocol does not auto-stamp them with a collection timestamp. If delivery is delayed across multiple wake cycles, handlers cannot distinguish when a measurement was taken versus when it was received.

## Fix

- `bpf-environment.md` §6.2 (`send_async`): Added best-practice note with code example showing `ctx->timestamp` inclusion in serialized payloads
- `protocol.md` §6.7 (store-and-forward): Added note that async blobs are not auto-stamped, with cross-reference to the BPF environment pattern

## Files Changed (2)

- `docs/bpf-environment.md` — best-practice note + code example
- `docs/protocol.md` — note in store-and-forward section

Documentation only — no code, protocol, or firmware changes.