### PR TITLE
fix(node): async queue integration tests, redundant clear, and RTC layout docs

### DIFF
--- a/crates/sonde-node/src/bpf_dispatch.rs
+++ b/crates/sonde-node/src/bpf_dispatch.rs
@@ -2297,6 +2297,41 @@ mod tests {
         assert!(transport.outbound.is_empty());
     }
 
+    /// T-N632: send_async from ephemeral program (ND-0602 AC6).
+    #[test]
+    fn test_helper_send_async_ephemeral() {
+        let mut hal = TestHal::new();
+        let mut transport = TestTransport::new();
+        let mut maps = MapStorage::new(4096);
+        let mut sleep = SleepManager::new(60, WakeReason::Scheduled);
+        let clock = TestClock(0);
+        let identity = default_identity();
+        let mut seq = 0u64;
+        let mut trace = Vec::new();
+        let data = [0x42u8; 10];
+
+        with_test_context(
+            &mut hal,
+            &mut transport,
+            &mut maps,
+            &mut sleep,
+            &clock,
+            &identity,
+            &mut seq,
+            ProgramClass::Ephemeral,
+            &mut trace,
+            || {
+                let result = helper_send_async(data.as_ptr() as u64, data.len() as u64, 0, 0, 0);
+                assert_eq!(
+                    result, 0,
+                    "send_async should succeed from ephemeral program"
+                );
+            },
+        );
+        // No outbound frames — data is queued, not sent immediately.
+        assert!(transport.outbound.is_empty());
+    }
+
     #[test]
     fn test_helper_send_async_queue_full() {
         let mut hal = TestHal::new();

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -1983,7 +1983,10 @@ mod tests {
 
             // Queue must be empty after the cycle because the piggybacked
             // WAKE path consumes and clears the queued blob before step 9b.
-            assert!(async_queue.is_empty(), "queue must be empty after piggyback clear");
+            assert!(
+                async_queue.is_empty(),
+                "queue must be empty after piggyback clear"
+            );
 
             // Piggybacked blob must NOT be resent as APP_DATA.
             // Only 1 WAKE frame should be sent (no APP_DATA frames).

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -767,7 +767,12 @@ where
                     log::warn!("failed to erase peer_payload after WAKE success: {}", e);
                 }
             }
-            // Queue is cleared by drain() after BPF execution (step 9b).
+            // Consume the piggybacked async blob so step 9b does not
+            // resend it as APP_DATA.  single_for_piggyback() only reads
+            // without removing, so clear() is required here.
+            if piggybacked {
+                async_queue.clear();
+            }
             cmd
         }
         Err(e) => {
@@ -1978,6 +1983,14 @@ mod tests {
 
             // Queue must be empty after the cycle (drained in step 9b).
             assert!(async_queue.is_empty(), "queue must be empty after drain");
+
+            // Piggybacked blob must NOT be resent as APP_DATA.
+            // Only 1 WAKE frame should be sent (no APP_DATA frames).
+            assert_eq!(
+                transport.outbound.len(),
+                1,
+                "only WAKE frame expected — piggybacked blob must not be resent as APP_DATA"
+            );
         }
 
         /// T-N626: Async queue is cleared after send (drain empties queue).

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -767,10 +767,7 @@ where
                     log::warn!("failed to erase peer_payload after WAKE success: {}", e);
                 }
             }
-            // Clear async queue if blob was piggybacked on this WAKE.
-            if piggybacked {
-                async_queue.clear();
-            }
+            // Queue is cleared by drain() after BPF execution (step 9b).
             cmd
         }
         Err(e) => {
@@ -1917,6 +1914,148 @@ mod tests {
 
             assert_eq!(outcome, WakeCycleOutcome::Sleep { seconds: 60 });
             assert!(!interp.loaded, "BPF must not run on invalid COMMAND");
+        }
+
+        /// T-N622: When one message is queued and fits, it is piggybacked on WAKE.
+        ///
+        /// Pre-loads the async queue with a single small blob, runs a NOP wake
+        /// cycle, and verifies the outbound WAKE frame contains the blob.
+        #[test]
+        fn t_n622_piggyback_verification() {
+            let psk = [0x42u8; 32];
+            let sha = crate::crypto::SoftwareSha256;
+            let aead = NodeAead;
+            let key_hint = sonde_protocol::key_hint_from_psk(&psk, &sha);
+
+            let command_frame = make_command(&psk, 1, &CommandPayload::Nop);
+            let mut transport = MockTransport::new();
+            transport.queue_response(Some(command_frame));
+
+            let mut storage = MockStorage::new().with_key(key_hint, psk);
+            let mut hal = MockHal;
+            let mut rng = MockRng(0);
+            let clock = MockClock;
+            let mut interp = MockBpfInterpreter::new();
+            let mut map_storage = MapStorage::new(DEFAULT_MAP_BUDGET);
+            let mut async_queue = AsyncQueue::new();
+
+            // Pre-load the queue with a small blob that fits in WAKE.
+            let queued_blob = vec![0xAB; 10];
+            assert_eq!(async_queue.push(queued_blob.clone()), 0);
+
+            let outcome = run_wake_cycle(
+                &mut transport,
+                &mut storage,
+                &mut hal,
+                &mut rng,
+                &clock,
+                &MockBattery,
+                &mut interp,
+                &mut map_storage,
+                &sha,
+                &aead,
+                &mut async_queue,
+            );
+
+            assert_eq!(outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+            // The first outbound frame is the WAKE. Decode it and verify blob.
+            assert!(!transport.outbound.is_empty(), "WAKE frame must be sent");
+            let decoded = decode_frame(&transport.outbound[0]).unwrap();
+            assert_eq!(decoded.header.msg_type, MSG_WAKE);
+            let payload = open_frame(&decoded, &psk, &aead, &sha).unwrap();
+            let wake_msg = sonde_protocol::NodeMessage::decode(MSG_WAKE, &payload).unwrap();
+            match wake_msg {
+                sonde_protocol::NodeMessage::Wake { blob, .. } => {
+                    assert_eq!(
+                        blob,
+                        Some(queued_blob),
+                        "piggybacked blob must appear in WAKE frame"
+                    );
+                }
+                _ => panic!("expected Wake message"),
+            }
+
+            // Queue must be empty after the cycle (drained in step 9b).
+            assert!(async_queue.is_empty(), "queue must be empty after drain");
+        }
+
+        /// T-N626: Async queue is cleared after send (drain empties queue).
+        ///
+        /// Pre-loads the queue with multiple messages so piggybacking is
+        /// skipped, then verifies all messages are sent as APP_DATA and the
+        /// queue is empty afterward.
+        #[test]
+        fn t_n626_queue_cleared_after_send() {
+            let psk = [0x42u8; 32];
+            let sha = crate::crypto::SoftwareSha256;
+            let aead = NodeAead;
+            let key_hint = sonde_protocol::key_hint_from_psk(&psk, &sha);
+
+            let command_frame = make_command(&psk, 1, &CommandPayload::Nop);
+            let mut transport = MockTransport::new();
+            transport.queue_response(Some(command_frame));
+
+            let mut storage = MockStorage::new().with_key(key_hint, psk);
+            let mut hal = MockHal;
+            let mut rng = MockRng(0);
+            let clock = MockClock;
+            let mut interp = MockBpfInterpreter::new();
+            let mut map_storage = MapStorage::new(DEFAULT_MAP_BUDGET);
+            let mut async_queue = AsyncQueue::new();
+
+            // Push 3 blobs — more than 1 means no piggybacking.
+            for i in 0u8..3 {
+                assert_eq!(async_queue.push(vec![i; 5]), 0);
+            }
+
+            let outcome = run_wake_cycle(
+                &mut transport,
+                &mut storage,
+                &mut hal,
+                &mut rng,
+                &clock,
+                &MockBattery,
+                &mut interp,
+                &mut map_storage,
+                &sha,
+                &aead,
+                &mut async_queue,
+            );
+
+            assert_eq!(outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+            // Outbound: 1 WAKE + 3 APP_DATA frames from the drain.
+            assert_eq!(
+                transport.outbound.len(),
+                4,
+                "expected 1 WAKE + 3 APP_DATA frames"
+            );
+
+            // Verify the WAKE frame has no piggybacked blob.
+            let decoded = decode_frame(&transport.outbound[0]).unwrap();
+            assert_eq!(decoded.header.msg_type, MSG_WAKE);
+            let payload = open_frame(&decoded, &psk, &aead, &sha).unwrap();
+            let wake_msg = sonde_protocol::NodeMessage::decode(MSG_WAKE, &payload).unwrap();
+            match wake_msg {
+                sonde_protocol::NodeMessage::Wake { blob, .. } => {
+                    assert!(blob.is_none(), "multiple queued blobs must not piggyback");
+                }
+                _ => panic!("expected Wake message"),
+            }
+
+            // Verify the 3 APP_DATA frames.
+            for idx in 1..=3 {
+                let decoded = decode_frame(&transport.outbound[idx]).unwrap();
+                assert_eq!(
+                    decoded.header.msg_type, MSG_APP_DATA,
+                    "frame {} must be APP_DATA",
+                    idx
+                );
+            }
+
+            // Queue must be empty after the cycle.
+            assert!(async_queue.is_empty(), "queue must be empty after drain");
         }
     }
 }

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -1981,8 +1981,9 @@ mod tests {
                 _ => panic!("expected Wake message"),
             }
 
-            // Queue must be empty after the cycle (drained in step 9b).
-            assert!(async_queue.is_empty(), "queue must be empty after drain");
+            // Queue must be empty after the cycle because the piggybacked
+            // WAKE path consumes and clears the queued blob before step 9b.
+            assert!(async_queue.is_empty(), "queue must be empty after piggyback clear");
 
             // Piggybacked blob must NOT be resent as APP_DATA.
             // Only 1 WAKE frame should be sent (no APP_DATA frames).

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -408,6 +408,29 @@ The queued messages are drained at the start of the next wake cycle (§4.2 step 
 
 The async queue is backed by sleep-retained RAM (RTC slow SRAM on ESP32, heap-allocated in tests) and passed to `run_wake_cycle()` as `&mut AsyncQueue`. It survives deep sleep so that blobs queued in cycle N are available for piggybacking in cycle N+1's WAKE. It is lost on reboot (RTC SRAM is cleared on power-on reset). The queue is cleared when UPDATE_PROGRAM or RUN_EPHEMERAL is received, since a new program load invalidates blobs produced by the old program. The queue capacity is a compile-time constant (10 messages, ~2.2 KB of RTC SRAM).
 
+#### RTC layout
+
+The async queue is stored in RTC slow SRAM (`#[link_section = ".rtc.data"]`
+on ESP32) using a fixed-size layout:
+
+| Field | Offset | Size | Description |
+|-------|--------|------|-------------|
+| `magic` | 0 | 4 B | Validation sentinel `0x5155_4555` ("QUEU") |
+| `count` | 4 | 4 B | Number of occupied slots (0–10) |
+| `items[0..10]` | 8 | 10 × 227 B | Fixed-size message slots |
+
+Each item slot contains a `len: u32` (4 B) followed by `data: [u8; 223]`
+(MAX_APP_DATA_BLOB_SIZE). Total layout: ~2,278 bytes.
+
+On boot, `from_rtc()` validates the magic value and item lengths. If the
+magic does not match or any length exceeds the maximum, the queue is
+discarded and a fresh empty queue is returned. This provides corruption
+recovery after unexpected resets without risking use of inconsistent data.
+
+The `count` field is committed last (volatile write + fence) so that a
+reset mid-push never leaves the queue in a valid-looking but inconsistent
+state — the same commit pattern used by `MapStorage`.
+
 ---
 
 ## 9  Map storage

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -417,7 +417,7 @@ on ESP32) using a fixed-size layout:
 |-------|--------|------|-------------|
 | `magic` | 0 | 4 B | Validation sentinel `0x5155_4555` ("QUEU") |
 | `count` | 4 | 4 B | Number of occupied slots (0–10) |
-| `items[0..10]` | 8 | 10 × 224 B | Fixed-size message slots |
+| `items[0..9]` | 8 | 10 × 224 B | Fixed-size message slots |
 
 Each item slot contains a `len: u32` (4 B) followed by
 `data: [u8; 218]` (`MAX_APP_DATA_BLOB_SIZE`). Because `RtcQueueItem` uses
@@ -430,7 +430,8 @@ magic does not match or any length exceeds the maximum, the queue is
 discarded and a fresh empty queue is returned. This provides corruption
 recovery after unexpected resets without risking use of inconsistent data.
 
-The `count` field is committed last (volatile write + fence) so that a
+The `count` field is committed last (fence + volatile write) so that
+prior item writes are visible before publishing the new count, and a
 reset mid-push never leaves the queue in a valid-looking but inconsistent
 state — the same commit pattern used by `MapStorage`.
 

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -417,10 +417,13 @@ on ESP32) using a fixed-size layout:
 |-------|--------|------|-------------|
 | `magic` | 0 | 4 B | Validation sentinel `0x5155_4555` ("QUEU") |
 | `count` | 4 | 4 B | Number of occupied slots (0–10) |
-| `items[0..10]` | 8 | 10 × 227 B | Fixed-size message slots |
+| `items[0..10]` | 8 | 10 × 224 B | Fixed-size message slots |
 
-Each item slot contains a `len: u32` (4 B) followed by `data: [u8; 223]`
-(MAX_APP_DATA_BLOB_SIZE). Total layout: ~2,278 bytes.
+Each item slot contains a `len: u32` (4 B) followed by
+`data: [u8; 218]` (`MAX_APP_DATA_BLOB_SIZE`). Because `RtcQueueItem` uses
+`#[repr(C)]`, each slot is padded to 4-byte alignment, so
+`size_of::<RtcQueueItem>() == 224` rather than `4 + 218 = 222`. Total
+layout: 2,248 bytes.
 
 On boot, `from_rtc()` validates the magic value and item lengths. If the
 magic does not match or any length exceeds the maximum, the queue is


### PR DESCRIPTION
## Summary

Closes #715 — addresses all 4 findings from the async queue maintenance audit.

## Changes

### F-002 (Medium): Integration tests
- `t_n622_piggyback_verification`: Verifies `send_async` blob appears piggybacked on WAKE (CBOR key 10), and is NOT resent as APP_DATA
- `t_n626_queue_cleared_after_send`: Verifies multiple queued blobs drain as APP_DATA and queue is empty after

### F-003 (Low): Document the piggyback clear
The `async_queue.clear()` after WAKE piggybacking was initially thought to be redundant (issue description), but review revealed it is essential: `single_for_piggyback()` only reads without removing, so without `clear()` the blob would be resent as APP_DATA by `drain()`. Kept the clear with an improved comment explaining why it is necessary.

### F-004 (Low): RTC layout documentation
Added RTC layout section to `node-design.md` §8.6 documenting the magic sentinel (`0x5155_4555`), slot structure (218-byte data + 4-byte len, padded to 224 per slot), corruption recovery, and commit pattern.

### F-006 (Medium): Ephemeral send_async test
Added `test_helper_send_async_ephemeral` in `bpf_dispatch.rs` verifying ephemeral programs can call `send_async()` without error (ND-0602 AC6, T-N632).

## Files Changed (3)

| File | Change |
|------|--------|
| `crates/sonde-node/src/wake_cycle.rs` | Improved clear comment + 2 integration tests |
| `crates/sonde-node/src/bpf_dispatch.rs` | Added ephemeral send_async test |
| `docs/node-design.md` | Added RTC layout documentation |

## Verification

- `cargo test -p sonde-node` — 197 tests pass
- `cargo clippy -p sonde-node -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean