### PR TITLE
ci(hw): trigger CI on hw/ file changes (HW-0902)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'test-programs/**'
+      - 'hw/**'
       - '.github/workflows/ci.yml'
   workflow_call:
 


### PR DESCRIPTION
## Summary

Closes #700 - adds hw/** to CI workflow path filter (HW-0902).

## Change

One line added to .github/workflows/ci.yml path filter: hw/**

The sonde-kicad integration tests reference hw/carrier-board/ir files.
Without this path trigger, changes to hw/ files would not run CI,
potentially leaving broken KiCad test fixtures undetected.

## Validation

Existing sonde-kicad tests (39 total) already pass in the workspace CI run.
