### PR TITLE
test(e2e): implement 9 missing E2E test cases

### DIFF
--- a/crates/sonde-bpf/src/interpreter.rs
+++ b/crates/sonde-bpf/src/interpreter.rs
@@ -640,6 +640,7 @@ pub fn execute_program_no_maps(
 /// # Zero-allocation guarantee
 /// All interpreter state (registers, call stack, BPF stack) lives on the
 /// Rust call stack. No `Vec`, `Box`, or heap allocation occurs.
+#[allow(clippy::manual_checked_ops)] // BPF division-by-zero returns 0 per RFC 9669 §5.2
 pub unsafe fn execute_program(
     prog: &[u8],
     ctx: &mut [u8],

--- a/crates/sonde-bpf/src/interpreter.rs
+++ b/crates/sonde-bpf/src/interpreter.rs
@@ -640,7 +640,7 @@ pub fn execute_program_no_maps(
 /// # Zero-allocation guarantee
 /// All interpreter state (registers, call stack, BPF stack) lives on the
 /// Rust call stack. No `Vec`, `Box`, or heap allocation occurs.
-#[allow(clippy::manual_checked_ops)] // BPF division-by-zero returns 0 per RFC 9669 §5.2
+#[allow(unknown_lints, clippy::manual_checked_ops)] // BPF division-by-zero returns 0 per RFC 9669 §5.2
 pub unsafe fn execute_program(
     prog: &[u8],
     ctx: &mut [u8],
@@ -1123,15 +1123,14 @@ pub unsafe fn execute_program(
                 reg[dst] =
                     TaggedReg::scalar((reg[dst].value as u32 ^ reg[src].value as u32) as u64);
             }
+            ebpf::MOV32_IMM if insn.off == 0 => {
+                reg[dst] = TaggedReg::scalar(insn.imm as u32 as u64);
+            }
             ebpf::MOV32_IMM => {
-                if insn.off == 0 {
-                    reg[dst] = TaggedReg::scalar(insn.imm as u32 as u64);
-                } else {
-                    return Err(BpfError::UnknownOpcode {
-                        pc: pc - 1,
-                        opc: insn.opc,
-                    });
-                }
+                return Err(BpfError::UnknownOpcode {
+                    pc: pc - 1,
+                    opc: insn.opc,
+                });
             }
             ebpf::MOV32_REG => {
                 if insn.off == 0 {

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -932,7 +932,17 @@ async fn t_e2e_041_sequence_number_enforcement() {
     let psk = [0x41; 32];
     env.register_node("seq-node", 1, psk).await;
 
-    let (program, hash) = make_send_program();
+    // Use a large program (200+ NOP instructions) to force multiple chunks.
+    // DEFAULT_CHUNK_SIZE is 128 bytes; this bytecode is 200*8 = 1600 bytes.
+    let mut large_bytecode = Vec::new();
+    for _ in 0..199 {
+        // mov r0, 0 (NOP-equivalent)
+        large_bytecode.extend_from_slice(&[0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    }
+    // exit
+    large_bytecode.extend_from_slice(&[0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+    let (program, hash) = make_program_from_bytecode(&large_bytecode);
     env.storage.store_program(&program).await.unwrap();
 
     let mut node_rec = env.storage.get_node("seq-node").await.unwrap().unwrap();
@@ -951,7 +961,11 @@ async fn t_e2e_041_sequence_number_enforcement() {
         .filter(|(t, _)| *t == sonde_protocol::MSG_GET_CHUNK)
         .map(|(_, n)| *n)
         .collect();
-    assert!(!get_chunk_nonces.is_empty(), "must have GET_CHUNK frames");
+    assert!(
+        get_chunk_nonces.len() >= 2,
+        "program must require at least 2 chunks, got {}",
+        get_chunk_nonces.len()
+    );
     for window in get_chunk_nonces.windows(2) {
         assert_eq!(
             window[1],

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -901,6 +901,17 @@ async fn t_e2e_022_run_ephemeral_via_admin() {
         .filter(|(t, _)| *t == sonde_protocol::MSG_GET_CHUNK)
         .count();
     assert!(get_chunk_count > 0, "ephemeral program must be downloaded");
+
+    // Verify PROGRAM_ACK sent (transfer completed).
+    let ack_count = stats
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_PROGRAM_ACK)
+        .count();
+    assert_eq!(
+        ack_count, 1,
+        "ephemeral transfer must complete with PROGRAM_ACK"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -769,13 +769,19 @@ async fn t_e2e_011_program_already_current_nop() {
 
     let mut node_rec = env.storage.get_node("prog-current").await.unwrap().unwrap();
     node_rec.assigned_program_hash = Some(hash.clone());
-    node_rec.current_program_hash = Some(hash);
     env.storage.upsert_node(&node_rec).await.unwrap();
 
-    // First cycle installs program into node storage.
+    // First cycle: node downloads and installs the program.
     let mut node = NodeProxy::new(1, psk);
     let mut interpreter = SondeBpfInterpreter::new();
-    let _stats1 = node.run_wake_cycle_with(&env, &mut interpreter);
+    let stats1 = node.run_wake_cycle_with(&env, &mut interpreter);
+    assert_eq!(stats1.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+    let ack_count = stats1
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_PROGRAM_ACK)
+        .count();
+    assert_eq!(ack_count, 1, "first cycle must install program");
 
     // Second cycle: hashes match → NOP.
     let stats2 = node.run_wake_cycle_with(&env, &mut interpreter);
@@ -943,8 +949,8 @@ async fn t_e2e_041_sequence_number_enforcement() {
     let psk = [0x41; 32];
     env.register_node("seq-node", 1, psk).await;
 
-    // Use a large program (200+ NOP instructions) to force multiple chunks.
-    // DEFAULT_CHUNK_SIZE is 128 bytes; this bytecode is 200*8 = 1600 bytes.
+    // Use a large program (200 instructions: 199 NOPs + exit = 1600 bytes)
+    // to force multiple chunks. DEFAULT_CHUNK_SIZE is 128 bytes.
     let mut large_bytecode = Vec::new();
     for _ in 0..199 {
         // mov r0, 0 (NOP-equivalent)

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -680,3 +680,291 @@ async fn t_e2e_034_live_reload_handler_remove() {
         "cycle 2: no APP_DATA_REPLY expected (handler was live-removed)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// T-E2E-002 — AEAD authentication round-trip (base case)
+// ---------------------------------------------------------------------------
+
+/// T-E2E-002 — AEAD authentication round-trip.
+///
+/// Validates that AES-256-GCM authentication works correctly across
+/// gateway (RustCryptoAead) and node (NodeAead) for a single wake cycle.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_002_aead_authentication_round_trip() {
+    let env = E2eTestEnv::new();
+    let psk = [0xAA; 32];
+    env.register_node("aead-002", 1, psk).await;
+
+    let mut node = NodeProxy::new(1, psk);
+    let stats = node.run_wake_cycle(&env);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+    assert!(
+        stats.response_count > 0,
+        "gateway must respond to valid AEAD frame"
+    );
+    let rec = env.storage.get_node("aead-002").await.unwrap().unwrap();
+    assert_eq!(rec.last_battery_mv, Some(3300));
+}
+
+// ---------------------------------------------------------------------------
+// T-E2E-010 — Full program update cycle
+// ---------------------------------------------------------------------------
+
+/// T-E2E-010 — Full program update cycle with chunked transfer.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_010_full_program_update_cycle() {
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    let env = E2eTestEnv::new();
+    let psk = [0x10; 32];
+    env.register_node("prog-update", 1, psk).await;
+
+    let (program, hash) = make_send_program();
+    env.storage.store_program(&program).await.unwrap();
+
+    let mut node_rec = env.storage.get_node("prog-update").await.unwrap().unwrap();
+    node_rec.assigned_program_hash = Some(hash.clone());
+    env.storage.upsert_node(&node_rec).await.unwrap();
+
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    let get_chunk_count = stats
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_GET_CHUNK)
+        .count();
+    assert!(get_chunk_count > 0, "node must send GET_CHUNK requests");
+
+    let ack_count = stats
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_PROGRAM_ACK)
+        .count();
+    assert_eq!(ack_count, 1, "node must send exactly one PROGRAM_ACK");
+
+    let updated = env.storage.get_node("prog-update").await.unwrap().unwrap();
+    assert_eq!(updated.current_program_hash, Some(hash));
+}
+
+// ---------------------------------------------------------------------------
+// T-E2E-011 — Program already current → NOP
+// ---------------------------------------------------------------------------
+
+/// T-E2E-011 — Program already current → NOP (no chunked transfer).
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_011_program_already_current_nop() {
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    let env = E2eTestEnv::new();
+    let psk = [0x11; 32];
+    env.register_node("prog-current", 1, psk).await;
+
+    let (program, hash) = make_send_program();
+    env.storage.store_program(&program).await.unwrap();
+
+    let mut node_rec = env.storage.get_node("prog-current").await.unwrap().unwrap();
+    node_rec.assigned_program_hash = Some(hash.clone());
+    node_rec.current_program_hash = Some(hash);
+    env.storage.upsert_node(&node_rec).await.unwrap();
+
+    // First cycle installs program into node storage.
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+    let _stats1 = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    // Second cycle: hashes match → NOP.
+    let stats2 = node.run_wake_cycle_with(&env, &mut interpreter);
+    assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    let get_chunk_count = stats2
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_GET_CHUNK)
+        .count();
+    assert_eq!(get_chunk_count, 0, "no GET_CHUNK when program is current");
+}
+
+// ---------------------------------------------------------------------------
+// T-E2E-020 — UPDATE_SCHEDULE via admin
+// ---------------------------------------------------------------------------
+
+/// T-E2E-020 — UPDATE_SCHEDULE via admin command queue.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_020_update_schedule_via_admin() {
+    use sonde_gateway::engine::PendingCommand;
+
+    let env = E2eTestEnv::new();
+    let psk = [0x20; 32];
+    env.register_node("sched-node", 1, psk).await;
+
+    env.gateway
+        .queue_command(
+            "sched-node",
+            PendingCommand::UpdateSchedule { interval_s: 120 },
+        )
+        .await;
+
+    let mut node = NodeProxy::new(1, psk);
+    let stats = node.run_wake_cycle(&env);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 120 });
+}
+
+// ---------------------------------------------------------------------------
+// T-E2E-021 — REBOOT via admin
+// ---------------------------------------------------------------------------
+
+/// T-E2E-021 — REBOOT via admin command queue.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_021_reboot_via_admin() {
+    use sonde_gateway::engine::PendingCommand;
+
+    let env = E2eTestEnv::new();
+    let psk = [0x21; 32];
+    env.register_node("reboot-node", 1, psk).await;
+
+    env.gateway
+        .queue_command("reboot-node", PendingCommand::Reboot)
+        .await;
+
+    let mut node = NodeProxy::new(1, psk);
+    let stats = node.run_wake_cycle(&env);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Reboot);
+}
+
+// ---------------------------------------------------------------------------
+// T-E2E-022 — RUN_EPHEMERAL via admin
+// ---------------------------------------------------------------------------
+
+/// T-E2E-022 — RUN_EPHEMERAL via admin command queue.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_022_run_ephemeral_via_admin() {
+    use sonde_gateway::engine::PendingCommand;
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    let env = E2eTestEnv::new();
+    let psk = [0x22; 32];
+    env.register_node("eph-node", 1, psk).await;
+
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+
+    // First cycle: NOP (establish session).
+    let _stats0 = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    // Queue ephemeral program for second cycle.
+    let nop_bytecode = [
+        0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mov r0, 0
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    ];
+    let eph_image = ProgramImage {
+        bytecode: nop_bytecode.to_vec(),
+        maps: vec![],
+        map_initial_data: vec![],
+    };
+    let eph_cbor = eph_image.encode_deterministic().unwrap();
+    let sha = TestSha256;
+    let eph_hash = sha.hash(&eph_cbor).to_vec();
+    let eph_program = ProgramRecord {
+        hash: eph_hash.clone(),
+        image: eph_cbor.clone(),
+        size: eph_cbor.len() as u32,
+        verification_profile: VerificationProfile::Ephemeral,
+        abi_version: None,
+        source_filename: None,
+    };
+    env.storage.store_program(&eph_program).await.unwrap();
+
+    env.gateway
+        .queue_command(
+            "eph-node",
+            PendingCommand::RunEphemeral {
+                program_hash: eph_hash,
+            },
+        )
+        .await;
+
+    // Second cycle: RunEphemeral command dispatched.
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    let get_chunk_count = stats
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_GET_CHUNK)
+        .count();
+    assert!(get_chunk_count > 0, "ephemeral program must be downloaded");
+}
+
+// ---------------------------------------------------------------------------
+// T-E2E-040 — Unknown node silent discard
+// ---------------------------------------------------------------------------
+
+/// T-E2E-040 — Unknown node silent discard.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_040_unknown_node_silent_discard() {
+    let env = E2eTestEnv::new();
+    let psk = [0x40; 32];
+    let mut node = NodeProxy::new(99, psk);
+    let stats = node.run_wake_cycle(&env);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+    assert_eq!(stats.response_count, 0, "gateway must not respond");
+}
+
+// ---------------------------------------------------------------------------
+// T-E2E-041 — Sequence number enforcement
+// ---------------------------------------------------------------------------
+
+/// T-E2E-041 — Sequence number enforcement in chunked transfer.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_041_sequence_number_enforcement() {
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    let env = E2eTestEnv::new();
+    let psk = [0x41; 32];
+    env.register_node("seq-node", 1, psk).await;
+
+    let (program, hash) = make_send_program();
+    env.storage.store_program(&program).await.unwrap();
+
+    let mut node_rec = env.storage.get_node("seq-node").await.unwrap().unwrap();
+    node_rec.assigned_program_hash = Some(hash);
+    env.storage.upsert_node(&node_rec).await.unwrap();
+
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+    let stats = node.run_wake_cycle_with(&env, &mut interpreter);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    let get_chunk_nonces: Vec<u64> = stats
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_GET_CHUNK)
+        .map(|(_, n)| *n)
+        .collect();
+    assert!(!get_chunk_nonces.is_empty(), "must have GET_CHUNK frames");
+    for window in get_chunk_nonces.windows(2) {
+        assert_eq!(
+            window[1],
+            window[0] + 1,
+            "GET_CHUNK nonces must increment: {:?}",
+            get_chunk_nonces
+        );
+    }
+
+    let ack_count = stats
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_PROGRAM_ACK)
+        .count();
+    assert_eq!(ack_count, 1, "transfer must complete with PROGRAM_ACK");
+}

--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -1481,3 +1481,77 @@ async fn t_e2e_081_ephemeral_restrictions() {
         "ephemeral map_update_elem must be rejected; map value must remain zero"
     );
 }
+
+// ---------------------------------------------------------------------------
+// T-E2E-080 — Map access through full stack
+// ---------------------------------------------------------------------------
+
+/// T-E2E-080 — E2E map access through full stack.
+///
+/// Installs a resident program with a map definition, runs two wake
+/// cycles, and verifies map allocation and persistence across cycles.
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_080_map_access_through_full_stack() {
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+    use sonde_protocol::MapDef;
+
+    let env = E2eTestEnv::new();
+    let psk = [0x88; 32];
+    env.register_node("map-node", 1, psk).await;
+
+    let image = ProgramImage {
+        bytecode: vec![
+            0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mov r0, 0
+            0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+        ],
+        maps: vec![MapDef {
+            map_type: 1,
+            key_size: 4,
+            value_size: 4,
+            max_entries: 1,
+        }],
+        map_initial_data: vec![vec![0x42, 0x00, 0x00, 0x00]],
+    };
+    let cbor = image.encode_deterministic().unwrap();
+    let sha = TestSha256;
+    let hash = sha.hash(&cbor).to_vec();
+    let size = cbor.len() as u32;
+    let program = ProgramRecord {
+        hash: hash.clone(),
+        image: cbor,
+        size,
+        verification_profile: VerificationProfile::Resident,
+        abi_version: None,
+        source_filename: None,
+    };
+    env.storage.store_program(&program).await.unwrap();
+
+    let mut node_rec = env.storage.get_node("map-node").await.unwrap().unwrap();
+    node_rec.assigned_program_hash = Some(hash);
+    env.storage.upsert_node(&node_rec).await.unwrap();
+
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+
+    // First cycle: program installed with map.
+    let stats1 = node.run_wake_cycle_with(&env, &mut interpreter);
+    assert_eq!(stats1.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    let ack_count = stats1
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_PROGRAM_ACK)
+        .count();
+    assert_eq!(ack_count, 1, "program must be installed on first cycle");
+
+    // Second cycle: hash matches, no re-download, map persists.
+    let stats2 = node.run_wake_cycle_with(&env, &mut interpreter);
+    assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    let get_chunk_count = stats2
+        .sent_frames
+        .iter()
+        .filter(|(t, _)| *t == sonde_protocol::MSG_GET_CHUNK)
+        .count();
+    assert_eq!(get_chunk_count, 0, "no re-download on second cycle");
+}

--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -1544,6 +1544,18 @@ async fn t_e2e_080_map_access_through_full_stack() {
         .count();
     assert_eq!(ack_count, 1, "program must be installed on first cycle");
 
+    // Verify map was allocated with initial data.
+    assert!(
+        node.map_storage.get(0).is_some(),
+        "map 0 must be allocated after program install"
+    );
+    let map = node.map_storage.get(0).unwrap();
+    assert_eq!(
+        map.lookup(0).unwrap(),
+        &[0x42, 0x00, 0x00, 0x00],
+        "map 0 entry 0 must contain initial data"
+    );
+
     // Second cycle: hash matches, no re-download, map persists.
     let stats2 = node.run_wake_cycle_with(&env, &mut interpreter);
     assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
@@ -1554,4 +1566,16 @@ async fn t_e2e_080_map_access_through_full_stack() {
         .filter(|(t, _)| *t == sonde_protocol::MSG_GET_CHUNK)
         .count();
     assert_eq!(get_chunk_count, 0, "no re-download on second cycle");
+
+    // Map data persists across cycles.
+    assert!(
+        node.map_storage.get(0).is_some(),
+        "map 0 must persist across wake cycles"
+    );
+    let map2 = node.map_storage.get(0).unwrap();
+    assert_eq!(
+        map2.lookup(0).unwrap(),
+        &[0x42, 0x00, 0x00, 0x00],
+        "map initial data must persist across cycles"
+    );
 }


### PR DESCRIPTION
## Summary

Closes #717 - implements 9 of 15 missing E2E test cases.

## Tests Added

| Test | Category | Description |
|------|----------|-------------|
| T-E2E-002 | Protocol | AEAD authentication round-trip (base case) |
| T-E2E-010 | Program | Full program update cycle with chunked transfer |
| T-E2E-011 | Program | Program already current - NOP |
| T-E2E-020 | Command | UPDATE_SCHEDULE via admin |
| T-E2E-021 | Command | REBOOT via admin |
| T-E2E-022 | Command | RUN_EPHEMERAL via admin |
| T-E2E-040 | Error | Unknown node silent discard |
| T-E2E-041 | Error | Sequence number enforcement |
| T-E2E-080 | BPF | Map access through full stack |

## Deferred (6 remaining)

- T-E2E-082: Chunked transfer corruption recovery (needs harness frame injection)
- T-E2E-050-054: Modem bridge integration (needs mock modem transport, see #115)

## Validation

All 45 E2E tests pass (was 36).
