### PR TITLE
fix(protocol): align spec and tests with implementation

### DIFF
--- a/crates/sonde-protocol/tests/validation.rs
+++ b/crates/sonde-protocol/tests/validation.rs
@@ -2316,11 +2316,130 @@ mod aead_tests {
             }
         }
     }
-}
 
-// ---------------------------------------------------------------------------
-// 11  Store-and-forward message encoding
-// ---------------------------------------------------------------------------
+    /// T-P017: Frame exactly minimum size — empty payload round-trips through
+    /// encode_frame / decode_frame / open_frame and produces a 27-byte frame.
+    #[test]
+    fn test_p017_frame_exactly_min_size() {
+        let psk = [0x42u8; 32];
+        let hdr = FrameHeader {
+            key_hint: key_hint_from_psk(&psk, &SoftwareSha256),
+            msg_type: MSG_WAKE,
+            nonce: 1,
+        };
+        let raw = encode_frame(&hdr, &[], &psk, &SoftwareAead, &SoftwareSha256).unwrap();
+        assert_eq!(
+            raw.len(),
+            MIN_FRAME_SIZE,
+            "frame with empty payload must be exactly MIN_FRAME_SIZE (27) bytes"
+        );
+        let decoded = decode_frame(&raw).unwrap();
+        let plaintext = open_frame(&decoded, &psk, &SoftwareAead, &SoftwareSha256).unwrap();
+        assert!(plaintext.is_empty(), "decrypted payload must be empty");
+    }
+
+    /// T-P123: APP_DATA blob at MAX_APP_DATA_BLOB_SIZE (218) succeeds.
+    #[test]
+    fn test_p123_app_data_blob_at_max_succeeds() {
+        let psk = [0x42u8; 32];
+        let blob = vec![0xAA; MAX_APP_DATA_BLOB_SIZE];
+        let msg = NodeMessage::AppData { blob: blob.clone() };
+        let encoded = msg.encode().unwrap();
+        let hdr = FrameHeader {
+            key_hint: key_hint_from_psk(&psk, &SoftwareSha256),
+            msg_type: MSG_APP_DATA,
+            nonce: 1,
+        };
+        let raw = encode_frame(&hdr, &encoded, &psk, &SoftwareAead, &SoftwareSha256).unwrap();
+        assert!(raw.len() <= MAX_FRAME_SIZE);
+        let decoded = decode_frame(&raw).unwrap();
+        let plaintext = open_frame(&decoded, &psk, &SoftwareAead, &SoftwareSha256).unwrap();
+        let decoded_msg = NodeMessage::decode(MSG_APP_DATA, &plaintext).unwrap();
+        match decoded_msg {
+            NodeMessage::AppData { blob: b } => assert_eq!(b, blob),
+            _ => panic!("expected AppData"),
+        }
+    }
+
+    /// T-P124: APP_DATA blob at MAX_PAYLOAD_SIZE (223) fails — CBOR overhead
+    /// pushes the frame beyond MAX_FRAME_SIZE.
+    #[test]
+    fn test_p124_app_data_blob_exceeding_frame_fails() {
+        let psk = [0x42u8; 32];
+        let blob = vec![0xAA; MAX_PAYLOAD_SIZE];
+        let msg = NodeMessage::AppData { blob };
+        let encoded = msg.encode().unwrap();
+        let hdr = FrameHeader {
+            key_hint: key_hint_from_psk(&psk, &SoftwareSha256),
+            msg_type: MSG_APP_DATA,
+            nonce: 1,
+        };
+        let result = encode_frame(&hdr, &encoded, &psk, &SoftwareAead, &SoftwareSha256);
+        assert!(
+            matches!(result, Err(EncodeError::FrameTooLarge)),
+            "APP_DATA blob of MAX_PAYLOAD_SIZE bytes must overflow the frame: {:?}",
+            result
+        );
+    }
+
+    /// T-P125: COMMAND NOP blob at MAX_COMMAND_BLOB_SIZE (193) succeeds.
+    #[test]
+    fn test_p125_command_nop_blob_at_max_succeeds() {
+        let psk = [0x42u8; 32];
+        let blob = vec![0xBB; MAX_COMMAND_BLOB_SIZE];
+        let msg = GatewayMessage::Command {
+            starting_seq: 1,
+            timestamp_ms: 1700000000000,
+            payload: CommandPayload::Nop,
+            blob: Some(blob.clone()),
+        };
+        let encoded = msg.encode().unwrap();
+        let hdr = FrameHeader {
+            key_hint: key_hint_from_psk(&psk, &SoftwareSha256),
+            msg_type: MSG_COMMAND,
+            nonce: 1,
+        };
+        let raw = encode_frame(&hdr, &encoded, &psk, &SoftwareAead, &SoftwareSha256).unwrap();
+        assert!(raw.len() <= MAX_FRAME_SIZE);
+        let decoded = decode_frame(&raw).unwrap();
+        let plaintext = open_frame(&decoded, &psk, &SoftwareAead, &SoftwareSha256).unwrap();
+        let decoded_msg = GatewayMessage::decode(MSG_COMMAND, &plaintext).unwrap();
+        match decoded_msg {
+            GatewayMessage::Command {
+                blob: Some(b),
+                payload: CommandPayload::Nop,
+                ..
+            } => assert_eq!(b, blob),
+            _ => panic!("expected Command/Nop with blob"),
+        }
+    }
+
+    /// T-P126: COMMAND NOP blob at MAX_PAYLOAD_SIZE (223) fails — CBOR overhead
+    /// pushes the frame beyond MAX_FRAME_SIZE.
+    #[test]
+    fn test_p126_command_nop_blob_exceeding_frame_fails() {
+        let psk = [0x42u8; 32];
+        let blob = vec![0xBB; MAX_PAYLOAD_SIZE];
+        let msg = GatewayMessage::Command {
+            starting_seq: 1,
+            timestamp_ms: 1700000000000,
+            payload: CommandPayload::Nop,
+            blob: Some(blob),
+        };
+        let encoded = msg.encode().unwrap();
+        let hdr = FrameHeader {
+            key_hint: key_hint_from_psk(&psk, &SoftwareSha256),
+            msg_type: MSG_COMMAND,
+            nonce: 1,
+        };
+        let result = encode_frame(&hdr, &encoded, &psk, &SoftwareAead, &SoftwareSha256);
+        assert!(
+            matches!(result, Err(EncodeError::FrameTooLarge)),
+            "COMMAND NOP blob of MAX_PAYLOAD_SIZE bytes must overflow the frame: {:?}",
+            result
+        );
+    }
+}
 
 /// T-P120: WAKE with optional blob round-trip
 #[test]

--- a/docs/protocol-crate-design.md
+++ b/docs/protocol-crate-design.md
@@ -200,36 +200,37 @@ Returns `EncodeError::FrameTooLarge` if the result exceeds `MAX_FRAME_SIZE`.
 ### 5.3  Decoding
 
 ```rust
-#[derive(Debug)]
-pub struct DecodedFrame {
+#[derive(Debug, Clone)]
+pub struct DecodedFrame<'a> {
     pub header: FrameHeader,
-    pub ciphertext: Vec<u8>,  // encrypted CBOR bytes
-    pub tag: [u8; 16],        // AES-256-GCM authentication tag
+    pub ciphertext_and_tag: &'a [u8],  // borrowed ciphertext + 16-byte GCM tag
 }
 
-pub fn decode_frame(raw: &[u8]) -> Result<DecodedFrame, DecodeError>
+pub fn decode_frame(raw: &[u8]) -> Result<DecodedFrame<'_>, DecodeError>
 ```
 
 1. Validate `raw.len() >= MIN_FRAME_SIZE`, otherwise return `DecodeError::TooShort`.
 2. Validate `raw.len() <= MAX_FRAME_SIZE`, otherwise return `DecodeError::TooLong`.
-3. Split into header (11), ciphertext (middle), tag (last 16).
-4. Parse header.
-5. Return `DecodedFrame`. Ciphertext is **not** decrypted — caller does that after AES-GCM verification.
+3. Parse the first 11 bytes as the header.
+4. Borrow the remaining bytes (`raw[HEADER_SIZE..]`) as `ciphertext_and_tag`.
+5. Return `DecodedFrame`. The ciphertext and GCM tag are **not** split or copied — the caller passes the combined slice to [`open_frame`] for authenticated decryption.
+
+> **Design note:** `DecodedFrame` borrows directly from the input buffer (zero-copy) to avoid a heap allocation on every received frame. The lifetime parameter `'a` ties the decoded frame to the raw buffer.
 
 ### 5.4  Authenticated decryption
 
 ```rust
 pub fn open_frame(
-    frame: &DecodedFrame,
-    psk: &[u8],
-    aead: &impl AeadProvider,
-    sha: &impl Sha256Provider,
+    frame: &DecodedFrame<'_>,
+    psk: &[u8; 32],
+    aead: &(impl AeadProvider + ?Sized),
+    sha: &(impl Sha256Provider + ?Sized),
 ) -> Result<Vec<u8>, DecodeError>
 ```
 
 1. Construct the 12-byte GCM nonce: `SHA-256(psk)[0..3] ‖ frame.header.msg_type ‖ frame.header.nonce`.
 2. Serialize the header to 11 bytes (AAD).
-3. Call `aead.open(psk, &gcm_nonce, &header_bytes, &[ciphertext ‖ tag])`.
+3. Call `aead.open(psk, &gcm_nonce, &header_bytes, frame.ciphertext_and_tag)`.
 4. On success, return the decrypted plaintext CBOR bytes.
 5. On failure (tag mismatch), return `DecodeError::AuthenticationFailed`.
 
@@ -272,9 +273,6 @@ pub enum NodeMessage {
     },
     DiagRequest {
         diagnostic_type: u8,
-    },
-    PeerRequest {
-        payload: Vec<u8>,
     },
 }
 
@@ -327,10 +325,6 @@ pub enum GatewayMessage {
         rssi_dbm: i8,
         signal_quality: u8,
     },
-    PeerAck {
-        status: u8,
-        proof: Vec<u8>,
-    },
 }
 
 impl GatewayMessage {
@@ -360,6 +354,14 @@ Acknowledges a peer request.
 
 These message types use a **separate CBOR keyspace** scoped to `msg_type` 0x05/0x84 — the same pattern as diagnostic messages (§12).
 
+> **Codec bypass:** `PEER_REQUEST` and `PEER_ACK` are **not** decoded through `NodeMessage::decode()` / `GatewayMessage::decode()`. They intentionally bypass the standard message codec because:
+>
+> 1. `PEER_REQUEST` is encrypted with `phone_psk` (the BLE pairing key), not `node_psk` — the gateway must try a different PSK for these messages. `PEER_ACK` is encrypted with `node_psk` but is handled in the same pre-registration code path.
+> 2. They are pre-registration messages exchanged during BLE-mediated onboarding — the gateway handles them in a separate code path before normal session lookup.
+> 3. Consumers (gateway `engine.rs`, node `peer_request.rs`, pair `crypto.rs`) encode and decode the CBOR payload inline via raw `msg_type` check + direct AEAD/CBOR operations.
+>
+> The `sonde-protocol` crate provides the constants (`MSG_PEER_REQUEST`, `MSG_PEER_ACK`, `PEER_REQ_KEY_PAYLOAD`, `PEER_ACK_KEY_STATUS`, `PEER_ACK_KEY_PROOF`) and the frame-level AEAD codec (`encode_frame` / `decode_frame` / `open_frame`), but not typed encode/decode methods.
+
 ### 6.4  `command_type` / `CommandPayload` consistency invariant
 
 The `command_type` field (CBOR key 4) in the COMMAND payload is the authoritative wire-format discriminator. It MUST match the `CommandPayload` variant in `GatewayMessage::Command`:
@@ -382,6 +384,7 @@ Because `command_type` is fully determined by the `CommandPayload` variant, the 
 - All payloads are CBOR maps with integer keys (§3 constants).
 - Unknown keys in inbound messages are ignored (forward compatibility).
 - Missing required keys produce `DecodeError::MissingField`.
+- String fields (e.g., `firmware_version`) are validated to be ASCII-only and at most `MAX_STRING_FIELD_LEN` (32) bytes. Strings exceeding this limit or containing non-ASCII bytes produce `DecodeError::InvalidFieldType`. This limit prevents unbounded allocation from malicious or buggy peers.
 
 ---
 
@@ -458,6 +461,7 @@ Gateway uses RustCrypto `sha2`; node uses ESP-IDF hardware SHA.
 pub enum EncodeError {
     FrameTooLarge,
     CborError(String),
+    InvalidParameter(String),  // semantically invalid input (e.g., invalid BLE envelope channel)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -470,6 +474,7 @@ pub enum DecodeError {
     MissingField(u64),     // CBOR key that was expected
     InvalidFieldType(u64), // CBOR key with wrong type
     CborError(String),
+    InvalidParameter(String),  // semantically invalid input (e.g., invalid BLE envelope field)
 }
 ```
 

--- a/docs/protocol-crate-validation.md
+++ b/docs/protocol-crate-validation.md
@@ -11,7 +11,7 @@
 
 ## 1  Overview
 
-All tests in this document are pure Rust `#[test]` cases — no hardware, no async runtime, no mocks. The protocol crate is fully testable in isolation using a software `AeadProvider` and `Sha256Provider`. There are 90 test entries with IDs up to `T-P122` across 9 sections: header, frame codec, CBOR messages, program images, integration, modem protocol, BLE envelope, diagnostics, and store-and-forward.
+All tests in this document are pure Rust `#[test]` cases — no hardware, no async runtime, no mocks. The protocol crate is fully testable in isolation using a software `AeadProvider` and `Sha256Provider`. There are 94 test entries with IDs up to `T-P126` across 9 sections: header, frame codec, CBOR messages, program images, integration, modem protocol, BLE envelope, diagnostics, and store-and-forward.
 
 ### Traceability note
 
@@ -1097,3 +1097,55 @@ impl Sha256Provider for SoftwareSha256 { /* RustCrypto sha2 */ }
 2. Decode and assert: `blob` is `None`.
 3. Manually construct CBOR bytes for an UPDATE_SCHEDULE COMMAND that includes key 10 with value `[0xFF]`.
 4. Decode and assert: the decoder ignores key 10 for non-NOP commands and returns `blob=None`.
+
+---
+
+### T-P123  APP_DATA blob at maximum size succeeds
+
+**Validates:** protocol-crate-design.md §3 (`MAX_APP_DATA_BLOB_SIZE` = 218)
+
+**Procedure:**
+1. Create `NodeMessage::AppData { blob: vec![0xAA; 218] }` (exactly `MAX_APP_DATA_BLOB_SIZE`).
+2. Encode with `encode()`.
+3. Frame with `encode_frame()`.
+4. Assert: `encode_frame()` succeeds (total ≤ 250 bytes).
+5. Decode and open the frame.
+6. Assert: decoded blob matches the original 218-byte payload.
+
+---
+
+### T-P124  APP_DATA blob exceeding frame capacity fails
+
+**Validates:** protocol-crate-design.md §3 (MAX_FRAME_SIZE = 250)
+
+**Procedure:**
+1. Create `NodeMessage::AppData { blob: vec![0xAA; MAX_PAYLOAD_SIZE] }` (223 bytes — the entire payload budget before CBOR overhead).
+2. Encode with `encode()`.
+3. Frame with `encode_frame()`.
+4. Assert: `encode_frame()` returns `EncodeError::FrameTooLarge` (CBOR map overhead pushes the frame beyond 250 bytes).
+
+---
+
+### T-P125  COMMAND NOP blob at maximum size succeeds
+
+**Validates:** protocol-crate-design.md §3 (`MAX_COMMAND_BLOB_SIZE` = 193)
+
+**Procedure:**
+1. Create `GatewayMessage::Command` with `CommandPayload::Nop`, `starting_seq=1`, `timestamp_ms=1700000000000`, and `blob=Some(vec![0xBB; 193])` (exactly `MAX_COMMAND_BLOB_SIZE`).
+2. Encode with `encode()`.
+3. Frame with `encode_frame()`.
+4. Assert: `encode_frame()` succeeds (total ≤ 250 bytes).
+5. Decode and open the frame.
+6. Assert: decoded blob matches the original 193-byte payload.
+
+---
+
+### T-P126  COMMAND NOP blob exceeding frame capacity fails
+
+**Validates:** protocol-crate-design.md §3 (MAX_FRAME_SIZE = 250)
+
+**Procedure:**
+1. Create `GatewayMessage::Command` with `CommandPayload::Nop`, `starting_seq=1`, `timestamp_ms=1700000000000`, and `blob=Some(vec![0xBB; MAX_PAYLOAD_SIZE])` (223 bytes — the entire payload budget before CBOR overhead).
+2. Encode with `encode()`.
+3. Frame with `encode_frame()`.
+4. Assert: `encode_frame()` returns `EncodeError::FrameTooLarge` (CBOR map overhead for command fields pushes the frame beyond 250 bytes).


### PR DESCRIPTION
## Summary

Addresses maintenance audit findings from #744 — 2 missing tests and 4 spec-documentation gaps in \sonde-protocol\.

## Changes

### Tests added (\crates/sonde-protocol/tests/validation.rs\)
- **\	est_p017\** (F-005): Frame with empty payload produces exactly MIN_FRAME_SIZE (27) bytes; round-trips through encode/decode/open
- **\	est_p123\** (F-021): APP_DATA blob at \MAX_APP_DATA_BLOB_SIZE\ (218) encodes and round-trips successfully
- **\	est_p124\** (F-021): APP_DATA blob at \MAX_PAYLOAD_SIZE\ (223) overflows frame — returns \FrameTooLarge\
- **\	est_p125\** (F-021): COMMAND NOP blob at \MAX_COMMAND_BLOB_SIZE\ (193) encodes and round-trips successfully
- **\	est_p126\** (F-021): COMMAND NOP blob at \MAX_PAYLOAD_SIZE\ (223) overflows frame — returns \FrameTooLarge\

### Design spec updates (\docs/protocol-crate-design.md\)
- **F-045**: §5.3 — Updated \DecodedFrame\ to zero-copy \DecodedFrame<'a>\ with \ciphertext_and_tag: &'a [u8]\
- **F-045**: §5.4 — Updated \open_frame\ signature to match implementation (\&DecodedFrame<'_>\, \&[u8; 32]\, \?Sized\ bounds)
- **F-003**: §6.1/§6.2 — Removed phantom \PeerRequest\/\PeerAck\ enum variants (not in implementation)
- **F-003**: §6.3 — Added codec bypass documentation explaining why peer messages skip \NodeMessage\/\GatewayMessage\ codec (\PEER_REQUEST\ uses \phone_psk\; \PEER_ACK\ uses \
ode_psk\; both handled inline)
- **F-022**: §8 — Added \InvalidParameter(String)\ to both \EncodeError\ and \DecodeError\
- **F-048**: §6.5 — Documented \MAX_STRING_FIELD_LEN\ (32 bytes) and ASCII-only validation

### Validation spec updates (\docs/protocol-crate-validation.md\)
- Added T-P123..T-P126 test entries for blob boundary conditions
- Updated test count: 90 → 94 entries (IDs up to T-P126)

### False positive
- **F-005/T-P019d**: Already implemented as \ead_nonce_construction\ — no action needed

## Test results
All 166 protocol tests pass (\cargo test -p sonde-protocol\).

Closes #744