### PR TITLE
feat(pair-ui): add visible back button in header (PT-1220)

### DIFF
--- a/crates/sonde-pair-ui/src/index.html
+++ b/crates/sonde-pair-ui/src/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
   <header>
-    <h1>Sonde Pairing Tool</h1>
+    <div class="header-row">
+      <button id="btn-back" class="btn-back hidden" aria-label="Back">&#8592;</button>
+      <h1>Sonde Pairing Tool</h1>
+    </div>
     <!-- Stepper bar (PT-1218): 3 phases, non-clickable -->
     <div id="stepper" class="stepper">
       <div class="step step--active" data-step="0">

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -589,7 +589,7 @@ async function pollLogs() {
 // ---------------------------------------------------------------------------
 
 // Header back button (PT-1220 AC 8)
-btnBack.addEventListener("click", () => navigator_.back());
+btnBack.addEventListener("click", () => history.back());
 
 // Page 1: Welcome
 btnGetStarted.addEventListener("click", () => navigator_.next());

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -21,6 +21,9 @@ const pages = [
 // Stepper (PT-1218)
 const stepperSteps = document.querySelectorAll("#stepper .step");
 
+// Back button (PT-1220 AC 6–8)
+const btnBack = document.getElementById("btn-back");
+
 // Page 1: Welcome
 const pairingStatus = document.getElementById("pairing-status");
 const btnGetStarted = document.getElementById("btn-get-started");
@@ -217,6 +220,8 @@ class Navigator {
         el.classList.add("step--active");
       }
     });
+    // PT-1220 AC 6–7: show back button on pages 2–6, hide on page 1
+    btnBack.classList.toggle("hidden", this.currentPage === 0);
   }
 
   _cleanupScanPage(pageIndex, { preserveSelection = false } = {}) {
@@ -582,6 +587,9 @@ async function pollLogs() {
 // ---------------------------------------------------------------------------
 // Event bindings
 // ---------------------------------------------------------------------------
+
+// Header back button (PT-1220 AC 8)
+btnBack.addEventListener("click", () => navigator_.back());
 
 // Page 1: Welcome
 btnGetStarted.addEventListener("click", () => navigator_.next());

--- a/crates/sonde-pair-ui/src/styles.css
+++ b/crates/sonde-pair-ui/src/styles.css
@@ -56,7 +56,6 @@ header {
 }
 
 .btn-back:hover { background: rgba(255,255,255,0.1); }
-.btn-back.hidden { display: none; }
 
 header h1 {
   font-size: 18px;

--- a/crates/sonde-pair-ui/src/styles.css
+++ b/crates/sonde-pair-ui/src/styles.css
@@ -37,6 +37,27 @@ header {
   gap: 12px;
 }
 
+.header-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.btn-back {
+  background: none;
+  border: none;
+  color: var(--text);
+  font-size: 20px;
+  padding: 4px 8px;
+  cursor: pointer;
+  line-height: 1;
+  border-radius: var(--radius);
+  transition: background 0.15s;
+}
+
+.btn-back:hover { background: rgba(255,255,255,0.1); }
+.btn-back.hidden { display: none; }
+
 header h1 {
   font-size: 18px;
   font-weight: 600;

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -912,6 +912,16 @@ The `popstate` listener reads `event.state.page` and calls `navigator.goTo()` wi
 
 On Android, the Tauri WebView dispatches hardware-back as a browser back event, which triggers `popstate`.  The sentinel state ensures the app does not exit on page 1.
 
+#### Visible back button (PT-1220 AC 6–8)
+
+A `←` back arrow button is rendered inside the `<header>` element, to the left of the app title.  The button:
+
+- Is hidden on page 1 (Welcome) and visible on pages 2–6.
+- Calls `navigator.back()` (which invokes `goTo(currentPage - 1)`) on click.
+- Uses `id="btn-back"` and is styled as a borderless icon button that blends with the header.
+
+The `Navigator.goTo()` method updates the button's visibility: hidden when `pageIndex === 0`, visible otherwise.
+
 ### Scan lifecycle on page transitions
 
 When navigating away from a scan page (page 2 or page 4):

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -917,7 +917,7 @@ On Android, the Tauri WebView dispatches hardware-back as a browser back event, 
 A `←` back arrow button is rendered inside the `<header>` element, to the left of the app title.  The button:
 
 - Is hidden on page 1 (Welcome) and visible on pages 2–6.
-- Calls `navigator.back()` (which invokes `goTo(currentPage - 1)`) on click.
+- Calls `history.back()` on click, which triggers the existing `popstate` handler and correctly pops the history stack (matching PT-1220's "same as platform back action" semantics).
 - Uses `id="btn-back"` and is styled as a borderless icon button that blends with the header.
 
 The `Navigator.goTo()` method updates the button's visibility: hidden when `pageIndex === 0`, visible otherwise.

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -1245,6 +1245,8 @@ The UI MUST persist the current page index to `localStorage` so that the wizard 
 **Description:**  
 The UI MUST support back navigation via the browser/platform back action (hardware back button on Android, browser back on desktop).  Back navigation returns to the previous wizard page.  On page 1, back navigation does nothing (no exit).
 
+Additionally, a visible back arrow button MUST be rendered in the header bar on all pages except page 1 (Welcome).  This ensures desktop platforms (Windows, Linux) that lack a hardware back button still provide a discoverable back-navigation affordance.  Clicking the back arrow triggers the same navigation as the platform back action.
+
 **Acceptance criteria:**
 
 1. Pressing back on pages 2–6 navigates to the previous page.
@@ -1252,6 +1254,9 @@ The UI MUST support back navigation via the browser/platform back action (hardwa
 3. Back navigation uses the History API (`pushState`/`popstate`) with a sentinel state on page 1.
 4. The stepper bar updates correctly on back navigation.
 5. Navigating back from a scan page stops any active scan and clears the selected device.
+6. A back arrow button is visible in the header on pages 2–6.
+7. The back arrow button is hidden on page 1 (Welcome).
+8. Clicking the back arrow navigates to the previous page (same behavior as AC 1).
 
 ---
 

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1359,6 +1359,25 @@ TestNode {
 
 ---
 
+### T-PT-1220d  Visible back button in header (desktop)
+
+**Validates:** PT-1220 (AC 6, 7, 8)  
+**Type:** Manual / platform test
+
+**Procedure:**
+1. Launch the app on a desktop platform (Windows or Linux).
+2. Assert: on page 1 (Welcome), the back arrow button is not visible.
+3. Navigate to page 2 (Gateway Scan).
+4. Assert: a back arrow button (`←`) is visible in the header, to the left of the title.
+5. Click the back arrow button.
+6. Assert: page 1 (Welcome) is visible; stepper shows Gateway phase active.
+7. Navigate forward to page 4 (Node Scan).
+8. Assert: the back arrow button is visible.
+9. Click the back arrow button.
+10. Assert: page 3 (Pairing Complete) is visible.
+
+---
+
 ### T-PT-1221a  RSSI indicator shows correct quality level
 
 **Validates:** PT-1221 (AC 1–4)  
@@ -1567,6 +1586,7 @@ TestNode {
 | T-PT-1220a | PT-1220 | Back navigation returns to previous page |
 | T-PT-1220b | PT-1220 | Back navigation on page 1 does nothing |
 | T-PT-1220c | PT-1220 | Scan stopped when navigating away from scan page |
+| T-PT-1220d | PT-1220 | Visible back button in header (desktop) |
 | T-PT-1221a | PT-1221 | RSSI indicator shows correct quality level |
 | T-PT-1221b | PT-1221 | RSSI indicator updates on poll interval |
 | T-PT-1221c | PT-1221 | RSSI boundary values classified correctly |

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1371,10 +1371,11 @@ TestNode {
 4. Assert: a back arrow button (`←`) is visible in the header, to the left of the title.
 5. Click the back arrow button.
 6. Assert: page 1 (Welcome) is visible; stepper shows Gateway phase active.
-7. Navigate forward to page 4 (Node Scan).
-8. Assert: the back arrow button is visible.
-9. Click the back arrow button.
-10. Assert: page 3 (Pairing Complete) is visible.
+7. From this fresh state, complete gateway pairing until page 3 (Pairing Complete) is visible.
+8. Navigate forward to page 4 (Node Scan).
+9. Assert: the back arrow button is visible.
+10. Click the back arrow button.
+11. Assert: page 3 (Pairing Complete) is visible.
 
 ---
 


### PR DESCRIPTION
## Summary

Add a visible \←\ back arrow button to the pairing tool header bar on desktop platforms (Windows, Linux) that lack a hardware back button.

### Problem

PT-1220 specified back navigation via browser/platform back action (hardware back on Android, browser back on desktop), but on Windows there is no discoverable UI affordance to navigate back through the wizard pages.

### Changes

**Specification (PT-1220 AC 6–8):**
- Back arrow button visible in header on pages 2–6
- Hidden on page 1 (Welcome)
- Click triggers same navigation as platform back action

**Implementation:**
- \index.html\: added \tn-back\ element in header with \.header-row\ wrapper
- \styles.css\: added \.header-row\ and \.btn-back\ styles (borderless icon button)
- \main.js\: added DOM ref, visibility toggle in \_updateStepper()\, click listener calling \
avigator_.back()\

**Validation:**
- Added T-PT-1220d manual test case for desktop back button behavior
- Updated traceability matrix

### Traceability

| Requirement | Design | Validation | Implementation |
|------------|--------|------------|----------------|
| PT-1220 AC 6–8 | §Back navigation | T-PT-1220d | \index.html\, \styles.css\, \main.js\ |