### PR TITLE
fix(node): feed watchdog in BLE pairing loop (ND-0919)

### DIFF
--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -394,7 +394,10 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         }
 
         // Busy-wait with a short sleep to avoid spinning.
+        // Feed the task watchdog on each iteration so the indefinite-duration
+        // BLE pairing session does not trigger the 20 s watchdog (ND-0919 AC 7).
         unsafe {
+            esp_idf_svc::sys::esp_task_wdt_reset();
             esp_idf_svc::sys::vTaskDelay(
                 (POLL_INTERVAL.as_millis() as u32 * esp_idf_svc::sys::CONFIG_FREERTOS_HZ) / 1000,
             );

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -586,7 +586,7 @@ All inbound protocol errors result in **silent discard** — the node does not s
 ## 14  Boot sequence
 
 1. ESP-IDF initialization (clocks, peripherals, wifi/ESP-NOW).
-2. Task watchdog timer is configured and the main task is registered (ND-0919): `CONFIG_ESP_TASK_WDT_EN=y`, 20 s timeout, panic-on-expiry. The main task calls `esp_task_wdt_add()` at startup and `esp_task_wdt_delete()` after the wake cycle completes. If the wake cycle hangs, the watchdog triggers a hardware reset.
+2. Task watchdog timer is configured and the main task is registered (ND-0919): `CONFIG_ESP_TASK_WDT_EN=y`, 20 s timeout, panic-on-expiry. The main task calls `esp_task_wdt_add()` at startup and `esp_task_wdt_delete()` after the wake cycle completes. If the wake cycle hangs, the watchdog triggers a hardware reset. For long-running modes (BLE pairing), the polling loop calls `esp_task_wdt_reset()` on each iteration to prevent spurious resets while still detecting hangs within a single 20 s polling window.
 3. Sample pairing button GPIO for 500 ms (ND-0901).
 4. Read key partition: check magic bytes and load credentials if present. Read NVS `reg_complete` flag (§6.1a).
 5. Determine boot path (ND-0900):

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -1137,6 +1137,8 @@ The ESP-IDF main task stack MUST be at least 16 KB (`CONFIG_ESP_MAIN_TASK_STACK_
 **Description:**  
 The node firmware MUST enable the ESP-IDF task watchdog timer on the main task. The timeout MUST be long enough to cover a full wake cycle (WAKE retries + chunked program transfer + BPF execution + APP_DATA exchanges) but short enough to recover from firmware hangs before excessive battery drain. On expiry, the watchdog MUST trigger a panic/reset so the node reboots into the next scheduled wake cycle.
 
+During long-running modes that exceed the watchdog timeout (e.g., BLE pairing mode), the firmware MUST feed the watchdog periodically via `esp_task_wdt_reset()` to prevent spurious resets while still detecting genuine hangs within each polling iteration.
+
 **Acceptance criteria:**
 
 1. `CONFIG_ESP_TASK_WDT_EN=y` is set in `sdkconfig.defaults`.
@@ -1145,6 +1147,7 @@ The node firmware MUST enable the ESP-IDF task watchdog timer on the main task. 
 4. The main task is explicitly registered with the task watchdog at startup via `esp_task_wdt_add()`.
 5. The main task is deregistered from the task watchdog after the wake cycle completes, before entering deep sleep.
 6. The node completes a normal wake cycle (including maximum WAKE retries and chunked transfer) without triggering the watchdog.
+7. The BLE pairing mode polling loop feeds the watchdog on each iteration via `esp_task_wdt_reset()`, preventing watchdog resets during the indefinite-duration pairing session.
 
 ---
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1831,13 +1831,13 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 2. Assert: `CONFIG_ESP_TASK_WDT_EN=y` is present.
 3. Assert: `CONFIG_ESP_TASK_WDT_TIMEOUT_S=20` is present.
 4. Assert: `CONFIG_ESP_TASK_WDT_PANIC=y` is present.
-5. Inspect `node.rs` main function.
+5. Inspect `crates/sonde-node/src/bin/node.rs` main function.
 6. Assert: `esp_task_wdt_add()` is called at startup to register the main task.
 7. Assert: `esp_task_wdt_delete()` is called after the wake cycle completes.
 8. Inspect `esp_ble_pairing.rs` main polling loop.
 9. Assert: `esp_task_wdt_reset()` is called on each iteration of the BLE pairing polling loop.
 
-> **Note:** Verifying that the watchdog triggers on a stalled main loop requires a special test firmware build and real hardware (similar to modem T-0304). This test validates configuration and registration code only.
+> **Note:** Verifying that the watchdog triggers on a stalled main loop requires a special test firmware build and real hardware (similar to modem T-0304). This test validates configuration, registration, and watchdog-feeding code via source inspection only.
 
 ---
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1834,6 +1834,8 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 5. Inspect `node.rs` main function.
 6. Assert: `esp_task_wdt_add()` is called at startup to register the main task.
 7. Assert: `esp_task_wdt_delete()` is called after the wake cycle completes.
+8. Inspect `esp_ble_pairing.rs` main polling loop.
+9. Assert: `esp_task_wdt_reset()` is called on each iteration of the BLE pairing polling loop.
 
 > **Note:** Verifying that the watchdog triggers on a stalled main loop requires a special test firmware build and real hardware (similar to modem T-0304). This test validates configuration and registration code only.
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1834,7 +1834,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 5. Inspect `crates/sonde-node/src/bin/node.rs` main function.
 6. Assert: `esp_task_wdt_add()` is called at startup to register the main task.
 7. Assert: `esp_task_wdt_delete()` is called after the wake cycle completes.
-8. Inspect `esp_ble_pairing.rs` main polling loop.
+8. Inspect `crates/sonde-node/src/esp_ble_pairing.rs` main polling loop.
 9. Assert: `esp_task_wdt_reset()` is called on each iteration of the BLE pairing polling loop.
 
 > **Note:** Verifying that the watchdog triggers on a stalled main loop requires a special test firmware build and real hardware (similar to modem T-0304). This test validates configuration, registration, and watchdog-feeding code via source inspection only.


### PR DESCRIPTION
## Summary

Fix watchdog timeout panic during BLE pairing mode. The task watchdog (20 s) was not being fed in the BLE polling loop, which runs indefinitely while waiting for a user to complete provisioning.

### Root cause

The main task is registered with the ESP-IDF task watchdog at boot (ND-0919). BLE pairing mode enters an indefinite polling loop (~100 ms per iteration). After 20 s without feeding, the watchdog triggers a panic/reset.

### Fix

Add \sp_task_wdt_reset()\ on each iteration of the BLE pairing polling loop in \sp_ble_pairing.rs\. The watchdog still protects against genuine hangs — if any single polling iteration takes > 20 s, the watchdog fires.

### Spec changes

| Doc | Change |
|-----|--------|
| \
ode-requirements.md\ ND-0919 | Added AC 7: BLE pairing loop feeds watchdog |
| \
ode-design.md\ §14 | Document watchdog feeding during BLE pairing |
| \
ode-validation.md\ T-N942 | Added steps 8-9: verify \sp_task_wdt_reset()\ in polling loop |