### PR TITLE
fix(pair-ui): restore to node scan when paired; fix back navigation

### DIFF
--- a/crates/sonde-pair-ui/src/index.html
+++ b/crates/sonde-pair-ui/src/index.html
@@ -75,6 +75,7 @@
           <div id="pair-details"></div>
         </div>
         <button id="btn-to-node">Continue to Node Provisioning</button>
+        <button id="btn-clear-gw-done" class="btn-danger">Clear Pairing</button>
       </div>
     </section>
 

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -185,7 +185,7 @@ class Navigator {
   back() { this.goTo(this.currentPage - 1); }
 
   restore() {
-    // Seed history with sentinel so page-1 back stays put (PT-1220)
+    // Seed history with sentinel at the bottom so back on page 1 is a no-op (PT-1220 AC 3)
     history.replaceState({ page: 0, sentinel: true }, "", "");
 
     const saved = parseInt(localStorage.getItem(STORAGE_KEY), 10);
@@ -200,12 +200,23 @@ class Navigator {
       target = 0;
     }
 
-    // Push the actual target page into history so state is in sync
-    history.pushState({ page: target }, "", "");
+    // Pages 5–6 require ephemeral state (selected node / provisioning-success context)
+    // that cannot survive a restart — fall back to Node Scan (PT-1219 AC 4)
+    if (target >= 4) {
+      target = isPaired ? 3 : 0;
+    }
+
+    // Push all intermediate pages so back navigation traverses each step (PT-1220 AC 3)
+    for (let i = 0; i <= target; i++) {
+      history.pushState({ page: i }, "", "");
+    }
 
     this._skipPush = true;
-    this.goTo(target, { push: false });
-    this._skipPush = false;
+    try {
+      this.goTo(target, { push: false });
+    } finally {
+      this._skipPush = false;
+    }
   }
 
   get current() { return this.currentPage; }
@@ -532,9 +543,11 @@ async function refreshPairingStatus() {
     const s = await invoke("get_pairing_status");
     if (s.paired) {
       isPaired = true;
-      pairingStatus.textContent = "Paired \u2014 Gateway " + (s.gateway_id || "").substring(0, 8) + "\u2026";
+      const gwLabel = "Gateway " + (s.gateway_id || "").substring(0, 8) + "\u2026";
+      pairingStatus.textContent = "Paired \u2014 " + gwLabel;
       btnGetStarted.classList.add("hidden");
       btnSkipToNode.classList.remove("hidden");
+      pairDetails.textContent = gwLabel;
     } else {
       isPaired = false;
       pairingStatus.textContent = "Not paired";
@@ -603,6 +616,7 @@ btnPair.addEventListener("click", pairGateway);
 
 // Page 3: Pairing Complete
 btnToNode.addEventListener("click", () => navigator_.next());
+document.getElementById("btn-clear-gw-done").addEventListener("click", clearPairing);
 
 // Page 4: Node Scan
 btnScanStartNode.addEventListener("click", startScan);
@@ -634,8 +648,10 @@ verboseToggle.addEventListener("change", toggleVerbose);
 // Back navigation (PT-1220)
 window.addEventListener("popstate", (e) => {
   if (e.state && e.state.sentinel) {
-    // Re-push so the sentinel remains for next back press
+    // At the bottom of the history stack — navigate to page 1 and re-establish
+    // a no-exit floor so further back presses stay on page 1 (PT-1220 AC 2, 3)
     history.pushState({ page: 0 }, "", "");
+    navigator_.goTo(0, { push: false });
     return;
   }
   if (e.state && typeof e.state.page === "number") {

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -201,7 +201,8 @@ class Navigator {
     }
 
     // Pages 5–6 require ephemeral state (selected node / provisioning-success context)
-    // that cannot survive a restart — fall back to Node Scan (PT-1219 AC 4)
+    // that cannot survive a restart — fall back to Node Scan when paired,
+    // or Welcome when unpaired, consistent with the prerequisite check above (PT-1219 AC 4)
     if (target >= 4) {
       target = isPaired ? 3 : 0;
     }

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -41,6 +41,7 @@ const pairStatus = document.getElementById("pair-status");
 // Page 3: Pairing Complete
 const pairDetails = document.getElementById("pair-details");
 const btnToNode = document.getElementById("btn-to-node");
+const btnClearGwDone = document.getElementById("btn-clear-gw-done");
 
 // Page 4: Node Scan
 const btnScanStartNode = document.getElementById("btn-scan-start-node");
@@ -617,7 +618,7 @@ btnPair.addEventListener("click", pairGateway);
 
 // Page 3: Pairing Complete
 btnToNode.addEventListener("click", () => navigator_.next());
-document.getElementById("btn-clear-gw-done").addEventListener("click", clearPairing);
+btnClearGwDone.addEventListener("click", clearPairing);
 
 // Page 4: Node Scan
 btnScanStartNode.addEventListener("click", startScan);

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -880,14 +880,14 @@ class Navigator {
   goTo(pageIndex)              // show page, hide others, update stepper, persist
   next()                       // goTo(currentPage + 1), clamped
   back()                       // goTo(currentPage - 1), clamped at 0
-  restore()                    // read localStorage, goTo saved page (or 0)
+  restore()                    // read localStorage, validate prerequisites, push intermediate history, goTo saved page (or earliest valid)
   get current()                // returns currentPage index
 }
 ```
 
 **Page transitions:** `goTo()` applies CSS classes (`slide-in-right` for forward, `slide-in-left` for back) to animate the transition.  Transitions are ≤ 300 ms.  The previous page gets `slide-out-left` or `slide-out-right` respectively.
 
-**Persistence:** `goTo()` saves `currentPage` (0-based) to `localStorage` key `sonde-pair-page`.  `restore()` reads this key on startup, validates that the saved page's prerequisites are met (e.g., pairing artifacts exist for pages 3–6), and navigates to the saved page or the earliest valid page if prerequisites are missing.  Invalid values default to page 0.
+**Persistence:** `goTo()` saves `currentPage` (0-based) to `localStorage` key `sonde-pair-page`.  `restore()` reads this key on startup, validates prerequisites (pairing artifacts for pages 3–6; non-ephemeral context for pages 5–6), and navigates to the saved page or the earliest valid page if prerequisites are missing.  Pages 5–6 (Node Provision, Done) require ephemeral state (selected node address and provisioning-success context respectively) that cannot survive a restart; if the saved page is 5 or 6, `restore()` falls back to page 4 (Node Scan).  Invalid or out-of-range values default to the earliest valid page (page 1 if unpaired, page 4 if paired).  After determining the target page N, `restore()` pushes all intermediate states (pages 1 through N) into the history stack so that back navigation traverses each page in sequence.
 
 ### Stepper bar
 
@@ -906,9 +906,9 @@ The stepper is non-interactive (no click handlers).
 
 ### Back navigation
 
-Back navigation uses the History API (`history.pushState` / `popstate`).  Each `goTo()` call pushes a state entry `{ page: N }`.  On startup, an initial sentinel state `{ page: 0 }` is pushed via `history.replaceState` so that `popstate` on page 1 replays the sentinel (staying on page 1) rather than exiting the app.
+Back navigation uses the History API (`history.pushState` / `popstate`).  Each `goTo()` call pushes a state entry `{ page: N }`.  On startup, a sentinel state `{ sentinel: true }` is installed via `history.replaceState` at the bottom of the stack; all intermediate pages (1 through N) are then pushed so the history stack is `[sentinel, page1, ..., pageN]`.
 
-The `popstate` listener reads `event.state.page` and calls `navigator.goTo()` without pushing another history entry (to avoid infinite loops).
+When `popstate` fires with the sentinel state, the handler MUST navigate the UI to page 1 (Welcome) and push a new `{ page: 0 }` state so subsequent back actions remain on page 1 and do not navigate away.  Non-sentinel states invoke `navigator.goTo()` without pushing another history entry (to avoid duplicates).
 
 On Android, the Tauri WebView dispatches hardware-back as a browser back event, which triggers `popstate`.  The sentinel state ensures the app does not exit on page 1.
 

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -1234,6 +1234,7 @@ The UI MUST persist the current page index to `localStorage` so that the wizard 
 1. On page transition, the current page index (0-based) is saved to `localStorage`.
 2. On app launch, the saved page index is read and the corresponding page is displayed, provided the page's prerequisites are met (e.g., pairing artifacts for pages 3–6).
 3. If `localStorage` is empty, contains an invalid page index, or the saved page's prerequisites are not met, the app navigates to the earliest valid page (page 1 if unpaired, page 4 if already paired).
+4. The selected BLE node address is ephemeral and is never persisted across restarts.  Page 5 (Node Provision) requires a selected node address; page 6 (Done) requires in-memory provisioning-success context.  Both are ephemeral.  If the saved page is 5 or 6, the app MUST fall back to page 4 (Node Scan) regardless of pairing state, so the user can scan and select a node.
 
 ---
 
@@ -1251,7 +1252,7 @@ Additionally, a visible back arrow button MUST be rendered in the header bar on 
 
 1. Pressing back on pages 2–6 navigates to the previous page.
 2. Pressing back on page 1 does nothing (the app does not exit).
-3. Back navigation uses the History API (`pushState`/`popstate`) with a sentinel state on page 1.
+3. Back navigation uses the History API (`pushState`/`popstate`) with a sentinel state at the bottom of the history stack.  When the app restores to page N on launch, all intermediate pages (1 through N) MUST be pushed into history so that back navigation traverses each page in sequence.  On encountering the sentinel, the app MUST update the visible UI to page 1 (Welcome) and MUST re-establish a no-exit state so that further back actions while on page 1 remain on page 1 and do not navigate away.
 4. The stepper bar updates correctly on back navigation.
 5. Navigating back from a scan page stops any active scan and clears the selected device.
 6. A back arrow button is visible in the header on pages 2–6.

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -1234,7 +1234,7 @@ The UI MUST persist the current page index to `localStorage` so that the wizard 
 1. On page transition, the current page index (0-based) is saved to `localStorage`.
 2. On app launch, the saved page index is read and the corresponding page is displayed, provided the page's prerequisites are met (e.g., pairing artifacts for pages 3–6).
 3. If `localStorage` is empty, contains an invalid page index, or the saved page's prerequisites are not met, the app navigates to the earliest valid page (page 1 if unpaired, page 4 if already paired).
-4. The selected BLE node address is ephemeral and is never persisted across restarts.  Page 5 (Node Provision) requires a selected node address; page 6 (Done) requires in-memory provisioning-success context.  Both are ephemeral.  If the saved page is 5 or 6, the app MUST fall back to page 4 (Node Scan) regardless of pairing state, so the user can scan and select a node.
+4. The selected BLE node address is ephemeral and is never persisted across restarts.  Page 5 (Node Provision) requires a selected node address; page 6 (Done) requires in-memory provisioning-success context.  Both are ephemeral.  If the saved page is 5 or 6, the app MUST fall back to page 4 (Node Scan) if page 4's prerequisites are met (i.e., the app is paired); otherwise, the app MUST fall back to the earliest valid page as defined in AC 3.
 
 ---
 

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1405,8 +1405,9 @@ TestNode {
 
 ---
 
+### T-PT-1221a  RSSI indicator shows correct quality level
 
-
+**Validates:** PT-1221 (AC 1–4)
 **Validates:** PT-1221 (AC 1–4)  
 **Type:** Manual / platform test
 

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1407,7 +1407,6 @@ TestNode {
 
 ### T-PT-1221a  RSSI indicator shows correct quality level
 
-**Validates:** PT-1221 (AC 1–4)
 **Validates:** PT-1221 (AC 1–4)  
 **Type:** Manual / platform test
 

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1318,7 +1318,7 @@ TestNode {
 
 ### T-PT-1219b  Page restored on app restart
 
-**Validates:** PT-1219 (AC 2, 3)  
+**Validates:** PT-1219 (AC 2, 3, 4)  
 **Type:** Manual / platform test
 
 **Procedure:**
@@ -1331,6 +1331,12 @@ TestNode {
 7. Clear pairing artifacts and set `localStorage.setItem('sonde-pair-page', '4')`.
 8. Reload the app.
 9. Assert: page 1 (Welcome) is visible (prerequisites not met, redirects to earliest valid page).
+10. With pairing artifacts present, set `localStorage.setItem('sonde-pair-page', '4')` (0-based index for Node Provision page).
+11. Reload the app.
+12. Assert: page 4 (Node Scan) is visible — the provision page requires an ephemeral selected-node address; the app falls back to the node scan page (PT-1219 AC 4).
+13. With pairing artifacts present, set `localStorage.setItem('sonde-pair-page', '5')` (0-based index for Done page).
+14. Reload the app.
+15. Assert: page 4 (Node Scan) is visible — the done page requires ephemeral provisioning-success context; the app falls back to the node scan page (PT-1219 AC 4).
 
 ---
 
@@ -1379,7 +1385,27 @@ TestNode {
 
 ---
 
-### T-PT-1221a  RSSI indicator shows correct quality level
+### T-PT-1220e  Back navigation works after app restore to mid-flow page
+
+**Validates:** PT-1220 (AC 1, 3)  
+**Type:** Manual / platform test
+
+**Procedure:**
+1. With pairing artifacts present, set `localStorage.setItem('sonde-pair-page', '3')` (0-based index for Node Scan page).
+2. Reload the app.
+3. Assert: page 4 (Node Scan) is displayed.
+4. Press back (browser back or back arrow button).
+5. Assert: page 3 (Pairing Complete) is displayed.
+6. Press back.
+7. Assert: page 2 (Gateway Scan) is displayed.
+8. Press back.
+9. Assert: page 1 (Welcome) is displayed.
+10. Press back.
+11. Assert: page 1 (Welcome) is still displayed; the app does not navigate away.
+
+---
+
+
 
 **Validates:** PT-1221 (AC 1–4)  
 **Type:** Manual / platform test
@@ -1588,6 +1614,7 @@ TestNode {
 | T-PT-1220b | PT-1220 | Back navigation on page 1 does nothing |
 | T-PT-1220c | PT-1220 | Scan stopped when navigating away from scan page |
 | T-PT-1220d | PT-1220 | Visible back button in header (desktop) |
+| T-PT-1220e | PT-1220 | Back navigation works after app restore to mid-flow page |
 | T-PT-1221a | PT-1221 | RSSI indicator shows correct quality level |
 | T-PT-1221b | PT-1221 | RSSI indicator updates on poll interval |
 | T-PT-1221c | PT-1221 | RSSI boundary values classified correctly |


### PR DESCRIPTION
## Summary

Fixes two bugs in the Sonde Pairing Tool that made the app unusable when it already had gateway pairing artifacts on disk.

### Bug 1 — Stuck on Node Provision with no scan path

When the app relaunched with \isPaired=true\ and \localStorage\ had saved page index \4\ (Node Provision), \estore()\ navigated there directly. \selectedAddressNode\ is always \
ull\ on a fresh launch (ephemeral, never persisted), leaving the Provision button disabled with no path to BLE scanning.

**Fix:** \estore()\ now clamps \	arget\ to page 3 (Node Scan) when the saved page is 4 or 5, since both require ephemeral state that cannot survive a restart (PT-1219 AC 4).

### Bug 2 — Back button did nothing

\estore()\ created only two history entries: \[sentinel, pageN]\. Pressing back immediately hit the sentinel; the old handler pushed \{page:0}\ *without calling \
avigator_.goTo()\*, so the UI stayed frozen on pageN forever.

**Fix:** \estore()\ now pushes all intermediate pages \