### PR TITLE
fix(gateway): re-send SET_CHANNEL after modem warm reboot (GW-1103)

### DIFF
--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -1233,7 +1233,7 @@ impl GatewayAdmin for AdminService {
 
         // Spawn a task that forwards BLE events to the stream, handles
         // timeout, cancellation, and client disconnect.
-        tokio::spawn(async move {
+        let event_handle = tokio::spawn(async move {
             use crate::ble_pairing::BlePairingEventKind;
 
             let timeout = tokio::time::sleep(std::time::Duration::from_secs(duration_s as u64));
@@ -1322,6 +1322,8 @@ impl GatewayAdmin for AdminService {
             }
         });
 
+        controller.set_event_task(event_handle).await;
+
         Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
             rx,
         )))
@@ -1338,8 +1340,8 @@ impl GatewayAdmin for AdminService {
             .as_ref()
             .ok_or_else(|| Status::unavailable("modem transport not configured"))?;
 
-        // Cancel the timeout task from OpenBlePairing (if running).
-        controller.cancel_timeout().await;
+        // Cancel the timeout task from OpenBlePairing (if running) and await it.
+        controller.cancel_and_wait().await;
         controller.close_window().await;
         transport
             .send_ble_disable()

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -723,6 +723,20 @@ async fn run_gateway(
             continue;
         }
 
+        // Normal disconnect: abort all remaining tasks before reconnecting so
+        // the old gRPC server releases its UDS/named-pipe socket and its
+        // Arc<UsbEspNowTransport> clone, preventing bind failures and transport
+        // leaks on the next reconnect iteration (GW-1103, GW-1301).
+        ble_controller.cancel_and_wait().await;
+        health_cancel.cancel();
+        frame_loop.abort();
+        ble_loop.abort();
+        grpc_handle.abort();
+        let _ = frame_loop.await;
+        let _ = ble_loop.await;
+        let _ = grpc_handle.await;
+        let _ = health_handle.await;
+
         // GW-1301: log modem disconnecting before reconnect attempt.
         info!("modem disconnecting");
 

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -484,6 +484,12 @@ async fn run_gateway(
         info!(channel = channel_for_transport, "modem transport ready");
         backoff = Duration::from_secs(1); // reset on success
 
+        // Extract warm-reboot signals before moving the transport into tasks.
+        // The flag is set (Release) before the notify fires, guarding against
+        // a competing select! arm winning the same poll cycle (GW-1103 AC7).
+        let warm_reboot_notify = transport.warm_reboot_notify();
+        let warm_reboot_flag = transport.warm_reboot_flag();
+
         // 7. Start gRPC admin server (only on first iteration)
         // Re-create the admin service with the new transport reference each time.
         let ble_controller = Arc::new(sonde_gateway::ble_pairing::BlePairingController::new());
@@ -497,7 +503,7 @@ async fn run_gateway(
         .with_handler_router(handler_router.clone());
         let admin_socket = cli.admin_socket.clone();
 
-        let grpc_handle = tokio::spawn(async move {
+        let mut grpc_handle = tokio::spawn(async move {
             if let Err(e) = sonde_gateway::admin::serve_admin(admin_service, &admin_socket).await {
                 error!("gRPC server error: {}", e);
             }
@@ -508,7 +514,7 @@ async fn run_gateway(
         let transport_ref = transport.clone();
         let gateway_ref = gateway.clone();
 
-        let frame_loop = tokio::spawn(async move {
+        let mut frame_loop = tokio::spawn(async move {
             loop {
                 match transport_ref.recv_with_rssi().await {
                     Ok((raw_frame, peer_addr, rssi)) => {
@@ -536,7 +542,7 @@ async fn run_gateway(
         // rather than capturing the CLI startup value.
         let ble_channel = channel_for_transport;
         let ble_ctrl = Arc::clone(&ble_controller);
-        let ble_loop = tokio::spawn(async move {
+        let mut ble_loop = tokio::spawn(async move {
             use sonde_gateway::ble_pairing::handle_ble_recv;
             use sonde_gateway::modem::BleEvent;
             use tracing::{debug, warn};
@@ -656,7 +662,7 @@ async fn run_gateway(
 
         // 8b. Modem health monitor (GW-1102).
         let health_cancel = tokio_util::sync::CancellationToken::new();
-        let health_handle = sonde_gateway::modem::spawn_health_monitor(
+        let mut health_handle = sonde_gateway::modem::spawn_health_monitor(
             Arc::downgrade(&transport),
             Duration::from_secs(30),
             health_cancel.clone(),
@@ -670,18 +676,18 @@ async fn run_gateway(
                 health_cancel.cancel();
                 break; // exit the outer reconnect loop
             }
-            _ = frame_loop => {
+            _ = &mut frame_loop => {
                 error!("frame processing loop exited — modem likely disconnected");
             }
-            _ = ble_loop => {
+            _ = &mut ble_loop => {
                 error!("BLE event loop exited — modem likely disconnected");
             }
-            _ = grpc_handle => {
+            _ = &mut grpc_handle => {
                 error!("gRPC server exited unexpectedly");
                 health_cancel.cancel();
                 break; // gRPC failure is not recoverable
             }
-            result = health_handle => {
+            result = &mut health_handle => {
                 let reconnect = result.unwrap_or(false);
                 if reconnect {
                     error!("health monitor: sustained poll failures — triggering modem reconnect");
@@ -689,6 +695,32 @@ async fn run_gateway(
                     error!("health monitor exited — modem likely disconnected");
                 }
             }
+            // Wake up when the reader task signals a modem warm reboot.
+            // The warm_reboot_flag acts as a latch so the event is not lost
+            // if this arm does not win the select! poll (GW-1103 AC7).
+            _ = warm_reboot_notify.notified() => {}
+        }
+
+        // GW-1103 AC7-9: warm reboot recovery — re-run full startup immediately.
+        if warm_reboot_flag.load(std::sync::atomic::Ordering::Acquire) {
+            info!("modem warm reboot detected — reconnecting immediately");
+            // Cancel the BLE pairing session before dropping the transport so
+            // the event-forwarding task releases its Arc<UsbEspNowTransport>.
+            ble_controller.cancel_and_wait().await;
+            health_cancel.cancel();
+            frame_loop.abort();
+            ble_loop.abort();
+            grpc_handle.abort();
+            let _ = frame_loop.await;
+            let _ = ble_loop.await;
+            let _ = grpc_handle.await;
+            let _ = health_handle.await;
+            // Explicitly await the reader task so the serial port read half is
+            // released before the next open() call (GW-1103 AC8).
+            transport.abort_reader_and_wait().await;
+            drop(transport);
+            // Skip the backoff sleep — reconnect immediately (GW-1103 AC8).
+            continue;
         }
 
         // GW-1301: log modem disconnecting before reconnect attempt.

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -711,10 +711,21 @@ async fn run_gateway(
             frame_loop.abort();
             ble_loop.abort();
             grpc_handle.abort();
-            let _ = frame_loop.await;
-            let _ = ble_loop.await;
-            let _ = grpc_handle.await;
-            let _ = health_handle.await;
+            // Guard each await with is_finished(): if a handle's output was already
+            // consumed by the select! arm above, awaiting it again would hang
+            // (poll returns Pending indefinitely once the output is taken).
+            if !frame_loop.is_finished() {
+                let _ = frame_loop.await;
+            }
+            if !ble_loop.is_finished() {
+                let _ = ble_loop.await;
+            }
+            if !grpc_handle.is_finished() {
+                let _ = grpc_handle.await;
+            }
+            if !health_handle.is_finished() {
+                let _ = health_handle.await;
+            }
             // Explicitly await the reader task so the serial port read half is
             // released before the next open() call (GW-1103 AC8).
             transport.abort_reader_and_wait().await;
@@ -732,10 +743,18 @@ async fn run_gateway(
         frame_loop.abort();
         ble_loop.abort();
         grpc_handle.abort();
-        let _ = frame_loop.await;
-        let _ = ble_loop.await;
-        let _ = grpc_handle.await;
-        let _ = health_handle.await;
+        if !frame_loop.is_finished() {
+            let _ = frame_loop.await;
+        }
+        if !ble_loop.is_finished() {
+            let _ = ble_loop.await;
+        }
+        if !grpc_handle.is_finished() {
+            let _ = grpc_handle.await;
+        }
+        if !health_handle.is_finished() {
+            let _ = health_handle.await;
+        }
 
         // GW-1301: log modem disconnecting before reconnect attempt.
         info!("modem disconnecting");

--- a/crates/sonde-gateway/src/ble_pairing.rs
+++ b/crates/sonde-gateway/src/ble_pairing.rs
@@ -205,11 +205,18 @@ impl BlePairingController {
         if let Some(token) = self.timeout_cancel.lock().await.take() {
             token.cancel();
         }
-        // Await graceful exit; the task sends WindowClosed before returning
-        // so we must not abort it here.
+        // Await graceful exit up to 500 ms (task sends WindowClosed before
+        // returning). If the channel is full or the task is otherwise stuck,
+        // abort it so warm-reboot recovery is never blocked indefinitely.
         let handle = self.event_task.lock().await.take();
         if let Some(handle) = handle {
-            let _ = handle.await;
+            let abort = handle.abort_handle();
+            if tokio::time::timeout(std::time::Duration::from_millis(500), handle)
+                .await
+                .is_err()
+            {
+                abort.abort();
+            }
         }
     }
 

--- a/crates/sonde-gateway/src/ble_pairing.rs
+++ b/crates/sonde-gateway/src/ble_pairing.rs
@@ -207,15 +207,17 @@ impl BlePairingController {
         }
         // Await graceful exit up to 500 ms (task sends WindowClosed before
         // returning). If the channel is full or the task is otherwise stuck,
-        // abort it so warm-reboot recovery is never blocked indefinitely.
+        // abort it and wait again so the transport Arc is released before
+        // warm-reboot recovery proceeds.
         let handle = self.event_task.lock().await.take();
-        if let Some(handle) = handle {
-            let abort = handle.abort_handle();
-            if tokio::time::timeout(std::time::Duration::from_millis(500), handle)
+        if let Some(mut handle) = handle {
+            if tokio::time::timeout(std::time::Duration::from_millis(500), &mut handle)
                 .await
                 .is_err()
             {
-                abort.abort();
+                handle.abort();
+                let _ =
+                    tokio::time::timeout(std::time::Duration::from_millis(500), &mut handle).await;
             }
         }
     }

--- a/crates/sonde-gateway/src/ble_pairing.rs
+++ b/crates/sonde-gateway/src/ble_pairing.rs
@@ -191,8 +191,11 @@ impl BlePairingController {
 
     /// Store the JoinHandle of the event-forwarding task spawned by OpenBlePairing.
     pub async fn set_event_task(&self, handle: tokio::task::JoinHandle<()>) {
-        if let Some(old) = self.event_task.lock().await.replace(handle) {
+        if let Some(mut old) = self.event_task.lock().await.replace(handle) {
             old.abort();
+            // Await with a bounded timeout so the aborted task releases any
+            // captured Arc<UsbEspNowTransport> before this call returns.
+            let _ = tokio::time::timeout(std::time::Duration::from_millis(500), &mut old).await;
         }
     }
 

--- a/crates/sonde-gateway/src/ble_pairing.rs
+++ b/crates/sonde-gateway/src/ble_pairing.rs
@@ -112,6 +112,8 @@ pub struct BlePairingController {
     passkey_tx: tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<bool>>>,
     /// Cancel token for the auto-close timeout task.
     timeout_cancel: tokio::sync::Mutex<Option<tokio_util::sync::CancellationToken>>,
+    /// JoinHandle for the active open_ble_pairing event-forwarding task.
+    event_task: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     /// Broadcast channel for forwarding BLE pairing events to admin streams.
     event_tx: tokio::sync::broadcast::Sender<BlePairingEventKind>,
 }
@@ -138,6 +140,7 @@ impl BlePairingController {
             window: tokio::sync::Mutex::new(RegistrationWindow::new()),
             passkey_tx: tokio::sync::Mutex::new(None),
             timeout_cancel: tokio::sync::Mutex::new(None),
+            event_task: tokio::sync::Mutex::new(None),
             event_tx,
         }
     }
@@ -183,6 +186,29 @@ impl BlePairingController {
     pub async fn cancel_timeout(&self) {
         if let Some(token) = self.timeout_cancel.lock().await.take() {
             token.cancel();
+        }
+    }
+
+    /// Store the JoinHandle of the event-forwarding task spawned by OpenBlePairing.
+    pub async fn set_event_task(&self, handle: tokio::task::JoinHandle<()>) {
+        if let Some(old) = self.event_task.lock().await.replace(handle) {
+            old.abort();
+        }
+    }
+
+    /// Cancel the timeout token and await the event-forwarding task.
+    ///
+    /// Used during warm reboot recovery to ensure the task releases its
+    /// `Arc<UsbEspNowTransport>` before the transport is dropped.
+    pub async fn cancel_and_wait(&self) {
+        // Fire the cancel token so the task's cancel arm fires.
+        if let Some(token) = self.timeout_cancel.lock().await.take() {
+            token.cancel();
+        }
+        // Await graceful exit; the task sends WindowClosed before returning
+        // so we must not abort it here.
+        if let Some(handle) = self.event_task.lock().await.take() {
+            let _ = handle.await;
         }
     }
 

--- a/crates/sonde-gateway/src/modem.rs
+++ b/crates/sonde-gateway/src/modem.rs
@@ -103,12 +103,18 @@ pub struct UsbEspNowTransport {
     channel_ack_slot: Arc<std::sync::Mutex<Option<oneshot::Sender<u8>>>>,
     scan_slot: Arc<std::sync::Mutex<Option<oneshot::Sender<ScanResult>>>>,
     modem_mac: [u8; 6],
-    reader_handle: tokio::task::JoinHandle<()>,
+    reader_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+    warm_reboot_notify: Arc<tokio::sync::Notify>,
+    warm_reboot_flag: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Drop for UsbEspNowTransport {
     fn drop(&mut self) {
-        self.reader_handle.abort();
+        if let Ok(mut guard) = self.reader_handle.lock() {
+            if let Some(h) = guard.take() {
+                h.abort();
+            }
+        }
     }
 }
 
@@ -136,11 +142,18 @@ impl UsbEspNowTransport {
         let scan_slot: Arc<std::sync::Mutex<Option<oneshot::Sender<ScanResult>>>> =
             Arc::new(std::sync::Mutex::new(None));
 
+        let warm_reboot_notify: Arc<tokio::sync::Notify> =
+            Arc::new(tokio::sync::Notify::new());
+        let warm_reboot_flag: Arc<std::sync::atomic::AtomicBool> =
+            Arc::new(std::sync::atomic::AtomicBool::new(false));
+
         // Start background reader task.
         let reader_handle = {
             let status_slot = Arc::clone(&status_slot);
             let channel_ack_slot = Arc::clone(&channel_ack_slot);
             let scan_slot = Arc::clone(&scan_slot);
+            let warm_reboot_notify = Arc::clone(&warm_reboot_notify);
+            let warm_reboot_flag = Arc::clone(&warm_reboot_flag);
             let mut read_half = read_half;
             let mut decoder = FrameDecoder::new();
             // Oneshots are registered before RESET is sent. A stale
@@ -172,6 +185,8 @@ impl UsbEspNowTransport {
                                             &status_slot,
                                             &channel_ack_slot,
                                             &scan_slot,
+                                            &warm_reboot_notify,
+                                            &warm_reboot_flag,
                                         )
                                         .await;
                                     }
@@ -264,7 +279,9 @@ impl UsbEspNowTransport {
                     channel_ack_slot,
                     scan_slot,
                     modem_mac,
-                    reader_handle,
+                    reader_handle: std::sync::Mutex::new(Some(reader_handle)),
+                    warm_reboot_notify,
+                    warm_reboot_flag,
                 })
             }
             Err(e) => {
@@ -277,6 +294,43 @@ impl UsbEspNowTransport {
     /// Return the modem's MAC address reported during startup.
     pub fn modem_mac(&self) -> &[u8; 6] {
         &self.modem_mac
+    }
+
+    /// Return a clone of the warm-reboot notification primitive.
+    ///
+    /// The notify fires when the reader task detects an unexpected `MODEM_READY`
+    /// (GW-1103 AC7).  Pair with [`warm_reboot_flag`] to avoid losing the
+    /// notification if a competing `select!` arm wins.
+    pub fn warm_reboot_notify(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.warm_reboot_notify)
+    }
+
+    /// Return a clone of the warm-reboot flag.
+    ///
+    /// Set to `true` (Release ordering) immediately before
+    /// [`warm_reboot_notify`] fires so the caller can detect a warm reboot
+    /// even if the `notified()` future was dropped by a competing `select!` arm.
+    pub fn warm_reboot_flag(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        Arc::clone(&self.warm_reboot_flag)
+    }
+
+    /// Abort the background reader task and wait for it to exit.
+    ///
+    /// Must be called before dropping the transport during warm-reboot
+    /// recovery to ensure the serial port read half is released before the
+    /// next `UsbEspNowTransport::new()` call opens the port.
+    pub async fn abort_reader_and_wait(&self) {
+        let handle = {
+            let mut guard = self
+                .reader_handle
+                .lock()
+                .expect("reader_handle poisoned");
+            guard.take()
+        };
+        if let Some(h) = handle {
+            h.abort();
+            let _ = h.await;
+        }
     }
 
     /// Receive the next BLE event from the modem.
@@ -730,6 +784,8 @@ async fn dispatch_message(
     status_slot: &Arc<Mutex<Option<oneshot::Sender<ModemStatus>>>>,
     channel_ack_slot: &Arc<std::sync::Mutex<Option<oneshot::Sender<u8>>>>,
     scan_slot: &Arc<std::sync::Mutex<Option<oneshot::Sender<ScanResult>>>>,
+    warm_reboot_notify: &Arc<tokio::sync::Notify>,
+    warm_reboot_flag: &Arc<std::sync::atomic::AtomicBool>,
 ) {
     match msg {
         ModemMessage::RecvFrame(rf) => {
@@ -797,7 +853,36 @@ async fn dispatch_message(
             if let Some(tx) = ready_tx.take() {
                 let _ = tx.send(mr);
             } else {
-                info!("unexpected MODEM_READY (no pending waiter)");
+                // GW-1103 AC7: unexpected MODEM_READY signals a modem warm reboot.
+                // Cancel all pending waiters so in-flight operations fail immediately.
+                warn!(
+                    guidance = "gateway will abort consumer tasks and re-run startup sequence",
+                    "modem warm reboot detected"
+                );
+                if ack_tx.take().is_some() {
+                    debug!("cancelling startup SET_CHANNEL_ACK waiter due to warm reboot");
+                }
+                {
+                    let mut slot = status_slot.lock().await;
+                    if slot.take().is_some() {
+                        debug!("cancelling pending STATUS waiter due to warm reboot");
+                    }
+                }
+                {
+                    let mut slot = channel_ack_slot.lock().expect("channel_ack_slot poisoned");
+                    if slot.take().is_some() {
+                        debug!("cancelling pending SET_CHANNEL_ACK waiter due to warm reboot");
+                    }
+                }
+                {
+                    let mut slot = scan_slot.lock().expect("scan_slot poisoned");
+                    if slot.take().is_some() {
+                        debug!("cancelling pending SCAN_RESULT waiter due to warm reboot");
+                    }
+                }
+                // Set the flag before notifying so the caller can't miss the event.
+                warm_reboot_flag.store(true, std::sync::atomic::Ordering::Release);
+                warm_reboot_notify.notify_one();
             }
         }
         ModemMessage::SetChannelAck(ch) => {

--- a/crates/sonde-gateway/src/modem.rs
+++ b/crates/sonde-gateway/src/modem.rs
@@ -427,7 +427,7 @@ impl UsbEspNowTransport {
             let mut slot = self
                 .channel_ack_slot
                 .lock()
-                .expect("channel_ack_slot poisoned");
+                .unwrap_or_else(|e| e.into_inner());
             if slot.is_some() {
                 return Err(TransportError::Io(
                     "channel change already in progress".into(),
@@ -468,7 +468,7 @@ impl UsbEspNowTransport {
     /// The slot is cleared on drop (cancellation-safe).
     pub async fn scan_channels(&self) -> Result<ScanResult, TransportError> {
         let rx = {
-            let mut slot = self.scan_slot.lock().expect("scan_slot poisoned");
+            let mut slot = self.scan_slot.lock().unwrap_or_else(|e| e.into_inner());
             if slot.is_some() {
                 return Err(TransportError::Io(
                     "channel scan already in progress".into(),
@@ -767,7 +767,7 @@ struct SlotGuard<T>(Arc<std::sync::Mutex<Option<T>>>);
 
 impl<T> Drop for SlotGuard<T> {
     fn drop(&mut self) {
-        self.0.lock().expect("slot guard poisoned").take();
+        self.0.lock().unwrap_or_else(|e| e.into_inner()).take();
     }
 }
 
@@ -867,13 +867,13 @@ async fn dispatch_message(
                     }
                 }
                 {
-                    let mut slot = channel_ack_slot.lock().expect("channel_ack_slot poisoned");
+                    let mut slot = channel_ack_slot.lock().unwrap_or_else(|e| e.into_inner());
                     if slot.take().is_some() {
                         debug!("cancelling pending SET_CHANNEL_ACK waiter due to warm reboot");
                     }
                 }
                 {
-                    let mut slot = scan_slot.lock().expect("scan_slot poisoned");
+                    let mut slot = scan_slot.lock().unwrap_or_else(|e| e.into_inner());
                     if slot.take().is_some() {
                         debug!("cancelling pending SCAN_RESULT waiter due to warm reboot");
                     }
@@ -889,7 +889,7 @@ async fn dispatch_message(
             if let Some(tx) = ack_tx.take() {
                 let _ = tx.send(ch);
             } else {
-                let mut slot = channel_ack_slot.lock().expect("channel_ack_slot poisoned");
+                let mut slot = channel_ack_slot.lock().unwrap_or_else(|e| e.into_inner());
                 if let Some(tx) = slot.take() {
                     let _ = tx.send(ch);
                 } else {
@@ -906,7 +906,7 @@ async fn dispatch_message(
             }
         }
         ModemMessage::ScanResult(sr) => {
-            let mut slot = scan_slot.lock().expect("scan_slot poisoned");
+            let mut slot = scan_slot.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(tx) = slot.take() {
                 let _ = tx.send(sr);
             } else {
@@ -940,13 +940,13 @@ async fn dispatch_message(
                 }
             }
             {
-                let mut slot = channel_ack_slot.lock().expect("channel_ack_slot poisoned");
+                let mut slot = channel_ack_slot.lock().unwrap_or_else(|e| e.into_inner());
                 if slot.take().is_some() {
                     debug!("cancelling pending SET_CHANNEL_ACK waiter due to modem error");
                 }
             }
             {
-                let mut slot = scan_slot.lock().expect("scan_slot poisoned");
+                let mut slot = scan_slot.lock().unwrap_or_else(|e| e.into_inner());
                 if slot.take().is_some() {
                     debug!("cancelling pending SCAN_RESULT waiter due to modem error");
                 }

--- a/crates/sonde-gateway/tests/modem_transport.rs
+++ b/crates/sonde-gateway/tests/modem_transport.rs
@@ -703,14 +703,15 @@ async fn t1104d_unexpected_modem_ready_fires_warm_reboot_notify() {
 
 /// T-1104e  After modem warm reboot, gateway recovers with persisted channel.
 ///
-/// Validates GW-1103 (criteria 7–8) and GW-0808 (AC6):
-///   - warm reboot sets flag + fires notify (transport-level precondition)
+/// Validates GW-1103 (criteria 7–8) and GW-0808 (AC6) at the transport level:
+///   - warm reboot detection: flag set, notify fires (transport precondition)
 ///   - after abort_reader_and_wait() + drop, a new transport created with the
 ///     persisted channel (7) sends RESET → SET_CHANNEL(7), not SET_CHANNEL(1)
 ///
-/// The no-backoff and backoff-reset properties are validated by code inspection
-/// of `run_gateway` (the reconnect loop `continue`s without sleeping, and
-/// `backoff` is reset to 1 s after each successful `UsbEspNowTransport::new()`).
+/// Note: The no-backoff and backoff-reset requirements (GW-1103 AC8–AC9) live
+/// in `run_gateway`'s reconnect loop and cannot be asserted at this transport
+/// level. They require a gateway-level harness to exercise `run_gateway` with
+/// a mock serial port, which is tracked as a future test improvement.
 #[tokio::test]
 async fn t1104e_warm_reboot_recovery_uses_persisted_channel() {
     use std::sync::atomic::Ordering;

--- a/crates/sonde-gateway/tests/modem_transport.rs
+++ b/crates/sonde-gateway/tests/modem_transport.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 sonde contributors
 
 //! Modem transport tests (T-1100 through T-1108 except T-1105 which is
-//! already in phase2d.rs).
+//! already in phase2d.rs). Also includes T-1104d (warm reboot detection).
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -632,5 +632,69 @@ async fn t1104c_health_poll_sustained_failures_trigger_reconnect() {
     assert!(
         reconnect_needed,
         "health monitor must signal reconnect after sustained failures"
+    );
+}
+
+// ── T-1104d: Warm reboot — unexpected MODEM_READY fires notify and flag ──
+
+/// T-1104d  Unexpected MODEM_READY fires warm_reboot_notify and sets warm_reboot_flag.
+///
+/// After startup, an unsolicited MODEM_READY (modem warm reboot) must:
+///   - set the warm_reboot_flag to true (GW-1103 AC7)
+///   - fire warm_reboot_notify (GW-1103 AC7)
+///   - cancel any pending waiters (tested via channel_ack_slot via change_channel)
+#[tokio::test]
+async fn t1104d_unexpected_modem_ready_fires_warm_reboot_notify() {
+    let (transport, mut server) = create_transport_and_server(6).await;
+
+    let warm_reboot_notify = transport.warm_reboot_notify();
+    let warm_reboot_flag = transport.warm_reboot_flag();
+
+    // Register a pending change_channel waiter. This exercises the
+    // channel_ack_slot cancellation path inside dispatch_message.
+    let transport_arc = Arc::new(transport);
+    let ch_task = {
+        let t = Arc::clone(&transport_arc);
+        tokio::spawn(async move { t.change_channel(7).await })
+    };
+
+    // Consume the SET_CHANNEL command sent by change_channel.
+    let mut decoder = FrameDecoder::new();
+    let mut buf = [0u8; 256];
+    let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+    assert!(
+        matches!(msg, ModemMessage::SetChannel(7)),
+        "expected SetChannel(7) from change_channel"
+    );
+
+    // Now inject an unsolicited MODEM_READY (simulates modem warm reboot).
+    let ready = ModemMessage::ModemReady(ModemReady {
+        firmware_version: [1, 0, 0, 0],
+        mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+    });
+    server
+        .write_all(&encode_modem_frame(&ready).unwrap())
+        .await
+        .unwrap();
+
+    // warm_reboot_notify must fire.
+    tokio::time::timeout(Duration::from_secs(1), warm_reboot_notify.notified())
+        .await
+        .expect("warm_reboot_notify must fire on unexpected MODEM_READY");
+
+    assert!(
+        warm_reboot_flag.load(std::sync::atomic::Ordering::Acquire),
+        "warm_reboot_flag must be set after unexpected MODEM_READY"
+    );
+
+    // The pending change_channel waiter must have been cancelled (channel
+    // closed → Err returned).
+    let ch_result = tokio::time::timeout(Duration::from_secs(1), ch_task)
+        .await
+        .expect("change_channel task did not complete in time")
+        .expect("change_channel task panicked");
+    assert!(
+        ch_result.is_err(),
+        "change_channel must return Err when cancelled by warm reboot"
     );
 }

--- a/crates/sonde-gateway/tests/modem_transport.rs
+++ b/crates/sonde-gateway/tests/modem_transport.rs
@@ -687,11 +687,16 @@ async fn t1104d_unexpected_modem_ready_fires_warm_reboot_notify() {
         "warm_reboot_flag must be set after unexpected MODEM_READY"
     );
 
-    // The pending change_channel waiter must have been cancelled (channel
-    // closed → Err returned).
-    let ch_result = tokio::time::timeout(Duration::from_secs(1), ch_task)
+    // The pending change_channel waiter must have been cancelled BEFORE the
+    // notify fired (GW-1103 AC7: waiters are cancelled before notify_one()).
+    // Use a tight 50ms timeout: if ch_task isn't already resolved by the time
+    // warm_reboot_notify fires, the ordering invariant is violated.
+    let ch_result = tokio::time::timeout(Duration::from_millis(50), ch_task)
         .await
-        .expect("change_channel task did not complete in time")
+        .expect(
+            "change_channel must already be resolved before warm_reboot_notify fires \
+             — waiters are cancelled before notify_one() per GW-1103 AC7",
+        )
         .expect("change_channel task panicked");
     assert!(
         ch_result.is_err(),

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -175,13 +175,13 @@ When the modem firmware reboots without dropping the USB-CDC serial connection (
 
 The `UsbEspNowTransport` exposes:
 - `warm_reboot_notify: Arc<tokio::sync::Notify>` — fired by the reader task when it receives an unexpected `MODEM_READY`, after cancelling all pending operation waiters (channel-ack, status, and scan slots).
-- A cancellation mechanism (e.g. `CancellationToken`) that allows the reader task to be cleanly stopped on demand. The reader task polls the token each iteration; on cancellation it exits, releasing the serial port.
+- `abort_reader_and_wait()` — aborts the reader task's `JoinHandle` and waits for it to finish so the serial port is released before reconnect.
 
 The gateway main loop `select!`s on `warm_reboot_notify.notified()` alongside the normal shutdown and frame-loop exit paths. On warm reboot notification:
 
 1. The gateway aborts all spawned consumer tasks (`frame_loop`, `ble_loop`, `grpc_handle`) and cancels the health monitor. This releases all `Arc<UsbEspNowTransport>` clones held by those tasks.
-2. The gateway calls the transport's cancel method, causing the reader task to exit and release the serial port.
-3. The local `transport` Arc is dropped; all transport resources are freed.
+2. The gateway calls `abort_reader_and_wait()`, which aborts the transport reader task and waits for it to release the serial port.
+3. The local `transport` Arc is dropped; once the remaining clones are gone, the transport's remaining resources are freed.
 4. The gateway immediately (no backoff) reopens the serial port and calls `UsbEspNowTransport::new()` with the persisted channel read from the database (GW-0808). All consumer tasks are re-spawned as on first startup.
 5. After successful warm reboot recovery, the exponential backoff counter is reset to its initial value (1 s), so any subsequent serial disconnect starts fresh.
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -169,6 +169,24 @@ When the serial reader task encounters an OS I/O error (e.g. USB-CDC disconnect,
 4. The `recv()` and BLE event channels remain open during reconnection — callers block until the transport recovers.
 5. If the port cannot be reopened (e.g. device permanently removed), the backoff loop continues indefinitely; the operator can shut down the gateway via Ctrl-C or service stop.
 
+**Warm reboot recovery (GW-1103 criteria 7–8):**
+
+When the modem firmware reboots without dropping the USB-CDC serial connection (a "warm reboot"), the modem sends an unsolicited `MODEM_READY`. The gateway detects this via an unexpected `MODEM_READY` arriving outside the startup handshake.
+
+The `UsbEspNowTransport` exposes:
+- `warm_reboot_notify: Arc<tokio::sync::Notify>` — fired by the reader task when it receives an unexpected `MODEM_READY`, after cancelling all pending operation waiters (channel-ack, status, and scan slots).
+- A cancellation mechanism (e.g. `CancellationToken`) that allows the reader task to be cleanly stopped on demand. The reader task polls the token each iteration; on cancellation it exits, releasing the serial port.
+
+The gateway main loop `select!`s on `warm_reboot_notify.notified()` alongside the normal shutdown and frame-loop exit paths. On warm reboot notification:
+
+1. The gateway aborts all spawned consumer tasks (`frame_loop`, `ble_loop`, `grpc_handle`) and cancels the health monitor. This releases all `Arc<UsbEspNowTransport>` clones held by those tasks.
+2. The gateway calls the transport's cancel method, causing the reader task to exit and release the serial port.
+3. The local `transport` Arc is dropped; all transport resources are freed.
+4. The gateway immediately (no backoff) reopens the serial port and calls `UsbEspNowTransport::new()` with the persisted channel read from the database (GW-0808). All consumer tasks are re-spawned as on first startup.
+5. After successful warm reboot recovery, the exponential backoff counter is reset to its initial value (1 s), so any subsequent serial disconnect starts fresh.
+
+Note: If multiple `MODEM_READY` messages arrive in rapid succession (overlapping warm reboots), `tokio::sync::Notify` coalesces them — at most one notification is delivered. Notifications that arrive while recovery is already in progress are absorbed by the already-pending notify permit and handled in the next reconnect iteration if recovery fails, or discarded if recovery succeeds (the reader task is no longer running and cannot fire further notifications).
+
 **`send()` implementation:**
 
 Constructs a `SEND_FRAME` envelope (`peer_mac || frame_data`) and writes it to the serial port. Does not wait for any modem or radio delivery acknowledgement — fire-and-forget at the radio layer, while still awaiting the serial write as needed. The 250-byte ESP-NOW frame limit is enforced by the modem.

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -943,7 +943,7 @@ The gateway MUST persist the current ESP-NOW radio channel in the database so th
 
 1. The `--channel` CLI flag seeds the initial channel value **only** if no channel entry exists in the database yet. If a persisted channel exists, the database value takes precedence.
 2. `SetModemChannel` (admin RPC) MUST update both the modem and the database atomically — if the modem channel change succeeds, the new channel MUST be written to the database before the RPC returns.
-3. On modem reconnect (GW-1103), the gateway MUST restore the channel from the database (not the CLI `--channel` value).
+3. On modem reconnect (GW-1103), the gateway MUST restore the channel from the database (not the CLI `--channel` value). This applies to both serial-disconnect reconnects and modem warm reboots (GW-1103 criteria 3–5 and 7–8).
 4. BLE pairing (`REGISTER_PHONE` response) MUST include the `rf_channel` read from the database, not the CLI startup value.
 
 **Acceptance criteria:**
@@ -953,6 +953,7 @@ The gateway MUST persist the current ESP-NOW radio channel in the database so th
 3. After `SetModemChannel(7)`, a BLE `REGISTER_PHONE` response contains `rf_channel = 7`.
 4. On a fresh database with `--channel 3`, the database is seeded with channel 3.
 5. On an existing database with persisted channel 7, `--channel 3` is ignored — the gateway starts on channel 7.
+6. After `SetModemChannel(7)`, a modem warm reboot (unexpected `MODEM_READY` while serial port is open) causes the gateway to re-execute the startup sequence and send `SET_CHANNEL(7)` (not channel 1).
 
 ---
 
@@ -1177,6 +1178,8 @@ On receiving an `ERROR` message from the modem, the gateway MUST log the error c
 
 When the serial port itself becomes unavailable (e.g. USB-CDC disconnect due to modem reset, OS error 995 on Windows), the gateway MUST NOT exit. Instead, the serial reader task MUST signal the transport layer, which MUST attempt to reopen the serial port with exponential backoff (starting at 1 s, capped at 30 s). Once the port reopens, the gateway MUST re-execute the modem startup sequence (`RESET` → `MODEM_READY` → `SET_CHANNEL`), using the persisted channel from the database (GW-0808), not the CLI `--channel` startup value. Frame processing and BLE event loops MUST block (not exit) while reconnection is in progress.
 
+When the modem firmware reboots while the serial port remains physically open (a "warm reboot"), the gateway detects this via an unexpected `MODEM_READY` message. The gateway MUST re-execute the same startup re-initialization as a serial-disconnect reconnect (`RESET` → `MODEM_READY` → `SET_CHANNEL` with the persisted database channel per GW-0808), **except** that no port-reopen or backoff phase is needed — recovery MUST begin immediately. The exponential backoff counter MUST be reset to its initial value (1 s) after a successful warm reboot recovery. Any pending in-flight operations (`change_channel`, `scan_channels`, `poll_status`) MUST fail promptly when the warm reboot is detected.
+
 **Acceptance criteria:**
 
 1. `ERROR` messages are logged with the error code and message text.
@@ -1185,6 +1188,9 @@ When the serial port itself becomes unavailable (e.g. USB-CDC disconnect due to 
 4. Once the port is reopened and `MODEM_READY` is received, the gateway resumes normal frame processing without requiring a restart.
 5. The gateway process does not exit due to a transient modem serial disconnect.
 6. When the health monitor detects N consecutive poll failures (default 3), it MUST log at `ERROR` level and signal the caller that a modem reconnect is needed. The failure counter MUST reset to zero on any successful poll.
+7. When the gateway receives an unexpected `MODEM_READY` (modem warm reboot without serial disconnect), it MUST immediately re-execute the full startup sequence (`RESET` → `MODEM_READY` → `SET_CHANNEL`) using the persisted channel from the database, with no backoff delay.
+8. After a successful warm reboot recovery, the exponential backoff counter MUST be reset to its initial value (1 s).
+9. When a warm reboot is detected, any in-flight `change_channel`, `scan_channels`, or `poll_status` operations MUST fail promptly (callers receive an error, not a hang).
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1709,6 +1709,32 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1104d  Modem warm reboot — unexpected MODEM_READY fires warm_reboot_notify and cancels pending waiters
+
+**Validates:** GW-1103 (criteria 7, 9)
+
+**Procedure:**
+1. Create a `UsbEspNowTransport` connected to a mock duplex stream. Complete startup handshake with `SET_CHANNEL(1)`.
+2. Register a pending `change_channel` waiter (put a sender in `channel_ack_slot`).
+3. Simulate a modem warm reboot: send an unsolicited `MODEM_READY` from the mock stream (without closing the port).
+4. Assert: `warm_reboot_notify` fires (the reader task detected the unexpected `MODEM_READY`).
+5. Assert: the pending `channel_ack_slot` sender was cancelled (dropped) before `warm_reboot_notify` fired — the waiter receives an error, not a hang.
+
+---
+
+### T-1104e  Modem warm reboot — gateway re-runs startup with persisted channel, no backoff
+
+**Validates:** GW-1103 (criteria 7–8), GW-0808 (AC 6)
+
+**Procedure:**
+1. Start a gateway instance (simulated with a mock modem duplex stream). Persist channel 7 via `SetModemChannel(7)`.
+2. Simulate a modem warm reboot: send an unsolicited `MODEM_READY` from the mock stream.
+3. Assert: the gateway does **not** sleep before starting recovery (no measurable delay between warm reboot detection and the next `RESET` being sent).
+4. Assert: the gateway sends `RESET` and then `SET_CHANNEL(7)` — not `SET_CHANNEL(1)` — as part of the re-initialization.
+5. Assert: after successful recovery, a subsequent simulated serial disconnect triggers a reconnect with a 1 s backoff (not a previously accumulated backoff value).
+
+---
+
 **Validates:** GW-1102
 
 **Procedure:**

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1729,9 +1729,9 @@ A configurable stub handler process (or in-process mock) that:
 **Procedure:**
 1. Start a gateway instance (simulated with a mock modem duplex stream). Persist channel 7 via `SetModemChannel(7)`.
 2. Simulate a modem warm reboot: send an unsolicited `MODEM_READY` from the mock stream.
-3. Assert: the gateway does **not** sleep before starting recovery (no measurable delay between warm reboot detection and the next `RESET` being sent).
+3. Assert: the gateway does **not** sleep before starting recovery (no measurable delay between warm reboot detection and the next `RESET` being sent). *(Manual/expected — not yet automated; requires a gateway-level test harness.)*
 4. Assert: the gateway sends `RESET` and then `SET_CHANNEL(7)` — not `SET_CHANNEL(1)` — as part of the re-initialization.
-5. Assert: after successful recovery, a subsequent simulated serial disconnect triggers a reconnect with a 1 s backoff (not a previously accumulated backoff value).
+5. Assert: after successful recovery, a subsequent simulated serial disconnect triggers a reconnect with a 1 s backoff (not a previously accumulated backoff value). *(Manual/expected — not yet automated; requires a gateway-level test harness.)*
 
 ---
 


### PR DESCRIPTION
Fix GW-1103 warm reboot path. See commit message for details.