### PR TITLE
modem: fix Android LESC NC pairing via encryption-state polling fallback

### DIFF
--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -126,6 +126,10 @@ struct BleState {
     /// fallback and a late `on_authentication_complete` from promoting a
     /// rejected client to `authenticated`.
     pairing_rejected: bool,
+    /// True once an unexpected `ble_gap_conn_find` error has been logged by
+    /// `check_encryption_fallback()`, so the warning fires at most once per
+    /// connection rather than every poll cycle (~5 ms).
+    enc_fallback_err_logged: bool,
     /// GATT write received before authentication completed.  Buffered here
     /// and flushed to `events` once `authenticated` becomes `true`, so
     /// clients that write immediately after connecting (before the
@@ -149,6 +153,7 @@ impl BleState {
             confirm_sent_at: None,
             timeout_fired: false,
             pairing_rejected: false,
+            enc_fallback_err_logged: false,
             pending_write: None,
         }
     }
@@ -274,6 +279,7 @@ impl EspBleDriver {
                 s.confirm_sent_at = None;
                 s.timeout_fired = false;
                 s.pairing_rejected = false;
+                s.enc_fallback_err_logged = false;
                 s.pending_write = None;
                 if s.events.len() < MAX_BLE_EVENT_QUEUE {
                     s.events.push_back(BleEvent::Disconnected {
@@ -514,6 +520,7 @@ impl Ble for EspBleDriver {
             s.confirm_sent_at = None;
             s.timeout_fired = false;
             s.pairing_rejected = false;
+            s.enc_fallback_err_logged = false;
             s.pending_write = None;
             // Events are NOT cleared here — BLE_DISABLE needs
             // BLE_DISCONNECTED to flow through (modem-protocol.md §4.14).
@@ -716,23 +723,38 @@ impl Ble for EspBleDriver {
         };
 
         // Query NimBLE for the connection security state directly.
-        let (encrypted, current_mtu, peer_addr_raw) = unsafe {
+        // Split into two unsafe blocks: the first captures the raw descriptor
+        // (so the error path can re-acquire the state lock outside unsafe),
+        // the second reads the field values from the descriptor.
+        let (rc, raw_desc) = unsafe {
             let mut desc = esp_idf_sys::ble_gap_conn_desc::default();
             let rc = esp_idf_sys::ble_gap_conn_find(conn_handle, &mut desc);
-            if rc != 0 {
-                if rc != esp_idf_sys::BLE_HS_ENOTCONN as i32 {
-                    // Unexpected error — log once for field diagnostics.
+            (rc, desc)
+        };
+        if rc != 0 {
+            if rc != esp_idf_sys::BLE_HS_ENOTCONN as i32 {
+                // Rate-limit to once per connection — the fallback runs every
+                // ~5 ms so an unguarded warn! would flood the log.
+                let should_log = {
+                    let mut s = self.state.lock().unwrap_or_else(|p| p.into_inner());
+                    let first = !s.enc_fallback_err_logged;
+                    s.enc_fallback_err_logged = true;
+                    first
+                };
+                if should_log {
                     warn!(
                         "BLE: enc fallback: ble_gap_conn_find(handle={}) rc={}",
                         conn_handle, rc
                     );
                 }
-                return;
             }
+            return;
+        }
+        let (encrypted, current_mtu, peer_addr_raw) = unsafe {
             (
-                desc.sec_state.encrypted() != 0,
+                raw_desc.sec_state.encrypted() != 0,
                 esp_idf_sys::ble_att_mtu(conn_handle),
-                desc.peer_ota_addr.val,
+                raw_desc.peer_ota_addr.val,
             )
         };
 

--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -715,7 +715,11 @@ impl Ble for EspBleDriver {
             {
                 return;
             }
-            (s.conn_handle, s.confirm_sent_at.is_some(), s.confirm_sent_at)
+            (
+                s.conn_handle,
+                s.confirm_sent_at.is_some(),
+                s.confirm_sent_at,
+            )
         };
         // Only applies to the NC pairing path.
         if !in_nc_pairing {

--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -356,31 +356,8 @@ impl EspBleDriver {
                             s.mtu
                         );
                         true
-                    } else if s.pairing_pending {
-                        if s.deferred_connected.is_none() {
-                            info!("BLE: LESC pairing complete — deferring BLE_CONNECTED until operator confirms");
-                            s.deferred_connected = Some((peer_addr, s.mtu));
-                        }
-                        false
                     } else {
-                        if !s.authenticated {
-                            info!("BLE: pairing complete — sending BLE_CONNECTED (MD-0410)");
-                            s.authenticated = true;
-                            s.connection_start = None;
-                            s.confirm_sent_at = None;
-                            // Flush any GATT write that arrived before auth completed.
-                            if let Some(data) = s.pending_write.take() {
-                                info!("BLE: flushing buffered GATT write {} bytes", data.len());
-                                s.events.push_back(BleEvent::Recv(data));
-                            }
-                            let mtu = s.mtu;
-                            if s.events.len() < MAX_BLE_EVENT_QUEUE {
-                                s.events.push_back(BleEvent::Connected {
-                                    peer_addr,
-                                    mtu,
-                                });
-                            }
-                        }
+                        complete_pairing_under_lock(&mut s, peer_addr, "pairing complete");
                         false
                     }
                 } else {
@@ -713,7 +690,8 @@ impl Ble for EspBleDriver {
     /// was silently dropped.
     ///
     /// Only runs during an active NC pairing session (`confirm_sent_at` set)
-    /// and is a no-op once `authenticated` or `timeout_fired` is set.
+    /// and is a no-op once `authenticated`, `timeout_fired`, or `pairing_rejected`
+    /// is set.
     fn check_encryption_fallback(&self) {
         // Acquire initial state under the lock, then release before the unsafe
         // NimBLE call to avoid holding the mutex across a potential NimBLE lock.
@@ -736,8 +714,16 @@ impl Ble for EspBleDriver {
         // Query NimBLE for the connection security state directly.
         let (encrypted, current_mtu, peer_addr_raw) = unsafe {
             let mut desc = esp_idf_sys::ble_gap_conn_desc::default();
-            if esp_idf_sys::ble_gap_conn_find(conn_handle, &mut desc) != 0 {
-                return; // Connection not found — not yet established.
+            let rc = esp_idf_sys::ble_gap_conn_find(conn_handle, &mut desc);
+            if rc != 0 {
+                if rc != esp_idf_sys::BLE_HS_ENOTCONN as i32 {
+                    // Unexpected error — log once for field diagnostics.
+                    warn!(
+                        "BLE: enc fallback: ble_gap_conn_find(handle={}) rc={}",
+                        conn_handle, rc
+                    );
+                }
+                return;
             }
             (
                 desc.sec_state.encrypted() != 0,
@@ -767,36 +753,52 @@ impl Ble for EspBleDriver {
             return;
         }
         s.mtu = current_mtu;
+        complete_pairing_under_lock(&mut s, peer_addr_raw, "enc fallback");
+    }
+}
+
+impl EspBleDriver {
+    /// Advance the pairing state machine under the held state lock.
+    ///
+    /// Handles the two final pairing outcomes after all guards have passed
+    /// (`timeout_fired`, `pairing_rejected`, and `mtu < BLE_MTU_MIN` checked
+    /// by the caller):
+    ///
+    /// - If `pairing_pending`, defer `BleEvent::Connected` until the operator
+    ///   confirms (sets `deferred_connected` if not already set).
+    /// - Otherwise, mark the session authenticated and emit the event.
+    ///
+    /// `log_prefix` appears in info/debug messages to identify the call site
+    /// (e.g., `"pairing complete"` or `"enc fallback"`).
+    fn complete_pairing_under_lock(s: &mut BleState, peer_addr: [u8; MAC_SIZE], log_prefix: &str) {
         if s.pairing_pending {
-            // Operator has not confirmed yet — defer until they do.
             if s.deferred_connected.is_none() {
-                info!("BLE: enc fallback: deferring BLE_CONNECTED until operator confirms");
-                s.deferred_connected = Some((peer_addr_raw, s.mtu));
+                info!(
+                    "BLE: {}: deferring BLE_CONNECTED until operator confirms",
+                    log_prefix
+                );
+                s.deferred_connected = Some((peer_addr, s.mtu));
             }
         } else if !s.authenticated {
-            // Operator already confirmed (or confirmed first) — authenticate now.
+            info!("BLE: {}: sending BLE_CONNECTED (MD-0410)", log_prefix);
             s.authenticated = true;
             s.connection_start = None;
             s.confirm_sent_at = None;
             if let Some(data) = s.pending_write.take() {
                 info!(
-                    "BLE: enc fallback: flushing buffered GATT write {} bytes",
+                    "BLE: {}: flushing buffered GATT write {} bytes",
+                    log_prefix,
                     data.len()
                 );
                 s.events.push_back(BleEvent::Recv(data));
             }
             let mtu = s.mtu;
             if s.events.len() < MAX_BLE_EVENT_QUEUE {
-                s.events.push_back(BleEvent::Connected {
-                    peer_addr: peer_addr_raw,
-                    mtu,
-                });
+                s.events.push_back(BleEvent::Connected { peer_addr, mtu });
             }
         }
     }
-}
 
-impl EspBleDriver {
     /// Send the next indication chunk from the queue, if any.
     ///
     /// Uses `notify_with()` which queues the indication via

--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -833,12 +833,19 @@ impl EspBleDriver {
             s.connection_start = None;
             s.confirm_sent_at = None;
             if let Some(data) = s.pending_write.take() {
-                info!(
-                    "BLE: {}: flushing buffered GATT write {} bytes",
-                    log_prefix,
-                    data.len()
-                );
-                s.events.push_back(BleEvent::Recv(data));
+                if s.events.len() < MAX_BLE_EVENT_QUEUE {
+                    info!(
+                        "BLE: {}: flushing buffered GATT write {} bytes",
+                        log_prefix,
+                        data.len()
+                    );
+                    s.events.push_back(BleEvent::Recv(data));
+                } else {
+                    warn!(
+                        "BLE: {}: dropping buffered GATT write — event queue full",
+                        log_prefix
+                    );
+                }
             }
             let mtu = s.mtu;
             if s.events.len() < MAX_BLE_EVENT_QUEUE {

--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -121,6 +121,11 @@ struct BleState {
     /// while `check_pairing_timeout()` retries `disconnect()` on subsequent
     /// polls until `on_disconnect` clears `conn_handle`.
     timeout_fired: bool,
+    /// True after the operator has rejected the Numeric Comparison (i.e.,
+    /// `pairing_confirm_reply(false)` was called).  Prevents the encryption
+    /// fallback and a late `on_authentication_complete` from promoting a
+    /// rejected client to `authenticated`.
+    pairing_rejected: bool,
     /// GATT write received before authentication completed.  Buffered here
     /// and flushed to `events` once `authenticated` becomes `true`, so
     /// clients that write immediately after connecting (before the
@@ -143,6 +148,7 @@ impl BleState {
             connection_start: None,
             confirm_sent_at: None,
             timeout_fired: false,
+            pairing_rejected: false,
             pending_write: None,
         }
     }
@@ -267,6 +273,7 @@ impl EspBleDriver {
                 s.connection_start = None;
                 s.confirm_sent_at = None;
                 s.timeout_fired = false;
+                s.pairing_rejected = false;
                 s.pending_write = None;
                 if s.events.len() < MAX_BLE_EVENT_QUEUE {
                     s.events.push_back(BleEvent::Disconnected {
@@ -338,6 +345,11 @@ impl EspBleDriver {
                         // approval (MD-0414 AC#4).
                         warn!("BLE: ignoring late SMP completion after pairing timeout");
                         true
+                    } else if s.pairing_rejected {
+                        // Operator rejected this session — discard the late
+                        // SMP completion to prevent promoting a rejected peer.
+                        warn!("BLE: ignoring late SMP completion after operator rejection");
+                        true
                     } else if s.mtu < BLE_MTU_MIN {
                         warn!(
                             "BLE: pairing complete but MTU too low ({}); disconnecting (MD-0402)",
@@ -345,25 +357,29 @@ impl EspBleDriver {
                         );
                         true
                     } else if s.pairing_pending {
-                        info!("BLE: LESC pairing complete — deferring BLE_CONNECTED until operator confirms");
-                        s.deferred_connected = Some((peer_addr, s.mtu));
+                        if s.deferred_connected.is_none() {
+                            info!("BLE: LESC pairing complete — deferring BLE_CONNECTED until operator confirms");
+                            s.deferred_connected = Some((peer_addr, s.mtu));
+                        }
                         false
                     } else {
-                        info!("BLE: pairing complete — sending BLE_CONNECTED (MD-0410)");
-                        s.authenticated = true;
-                        s.connection_start = None;
-                        s.confirm_sent_at = None;
-                        // Flush any GATT write that arrived before auth completed.
-                        if let Some(data) = s.pending_write.take() {
-                            info!("BLE: flushing buffered GATT write {} bytes", data.len());
-                            s.events.push_back(BleEvent::Recv(data));
-                        }
-                        let mtu = s.mtu;
-                        if s.events.len() < MAX_BLE_EVENT_QUEUE {
-                            s.events.push_back(BleEvent::Connected {
-                                peer_addr,
-                                mtu,
-                            });
+                        if !s.authenticated {
+                            info!("BLE: pairing complete — sending BLE_CONNECTED (MD-0410)");
+                            s.authenticated = true;
+                            s.connection_start = None;
+                            s.confirm_sent_at = None;
+                            // Flush any GATT write that arrived before auth completed.
+                            if let Some(data) = s.pending_write.take() {
+                                info!("BLE: flushing buffered GATT write {} bytes", data.len());
+                                s.events.push_back(BleEvent::Recv(data));
+                            }
+                            let mtu = s.mtu;
+                            if s.events.len() < MAX_BLE_EVENT_QUEUE {
+                                s.events.push_back(BleEvent::Connected {
+                                    peer_addr,
+                                    mtu,
+                                });
+                            }
                         }
                         false
                     }
@@ -516,6 +532,7 @@ impl Ble for EspBleDriver {
             s.connection_start = None;
             s.confirm_sent_at = None;
             s.timeout_fired = false;
+            s.pairing_rejected = false;
             s.pending_write = None;
             // Events are NOT cleared here — BLE_DISABLE needs
             // BLE_DISCONNECTED to flow through (modem-protocol.md §4.14).
@@ -595,6 +612,7 @@ impl Ble for EspBleDriver {
                     }
                     s.pairing_pending = false;
                     s.deferred_connected = None;
+                    s.pairing_rejected = true;
                     s.conn_handle
                 } else {
                     None
@@ -683,6 +701,97 @@ impl Ble for EspBleDriver {
                 warn!("BLE: pairing timeout exceeded — disconnecting (MD-0414 AC#4)");
             }
             let _ = BLEDevice::take().get_server().disconnect(handle);
+        }
+    }
+
+    /// Polling fallback for Android LESC Numeric Comparison.
+    ///
+    /// Some versions of esp32-nimble fail to call `on_authentication_complete`
+    /// when `ble_gap_conn_find` returns an error inside the `ENC_CHANGE` event
+    /// handler.  This method probes NimBLE directly for link encryption state
+    /// each poll cycle, completing the pairing state machine when the callback
+    /// was silently dropped.
+    ///
+    /// Only runs during an active NC pairing session (`confirm_sent_at` set)
+    /// and is a no-op once `authenticated` or `timeout_fired` is set.
+    fn check_encryption_fallback(&self) {
+        // Acquire initial state under the lock, then release before the unsafe
+        // NimBLE call to avoid holding the mutex across a potential NimBLE lock.
+        let (conn_handle, in_nc_pairing) = {
+            let s = self.state.lock().unwrap_or_else(|p| p.into_inner());
+            if s.authenticated || s.timeout_fired || s.pairing_rejected {
+                return;
+            }
+            (s.conn_handle, s.confirm_sent_at.is_some())
+        };
+        // Only applies to the NC pairing path.
+        if !in_nc_pairing {
+            return;
+        }
+        let conn_handle = match conn_handle {
+            Some(h) => h,
+            None => return,
+        };
+
+        // Query NimBLE for the connection security state directly.
+        let (encrypted, current_mtu, peer_addr_raw) = unsafe {
+            let mut desc = esp_idf_sys::ble_gap_conn_desc::default();
+            if esp_idf_sys::ble_gap_conn_find(conn_handle, &mut desc) != 0 {
+                return; // Connection not found — not yet established.
+            }
+            (
+                desc.sec_state.encrypted() != 0,
+                esp_idf_sys::ble_att_mtu(conn_handle),
+                desc.peer_ota_addr.val,
+            )
+        };
+
+        if !encrypted {
+            return;
+        }
+
+        // Android delays ATT MTU exchange until after SMP.  If MTU is still
+        // at the default 23, wait for the MTU update instead of disconnecting.
+        if current_mtu < BLE_MTU_MIN {
+            return;
+        }
+
+        info!(
+            "BLE: enc fallback: link encrypted mtu={} — completing authentication (MD-0410)",
+            current_mtu
+        );
+
+        let mut s = self.state.lock().unwrap_or_else(|p| p.into_inner());
+        // Re-check all guards after re-acquiring the lock.
+        if s.authenticated || s.timeout_fired || s.pairing_rejected {
+            return;
+        }
+        s.mtu = current_mtu;
+        if s.pairing_pending {
+            // Operator has not confirmed yet — defer until they do.
+            if s.deferred_connected.is_none() {
+                info!("BLE: enc fallback: deferring BLE_CONNECTED until operator confirms");
+                s.deferred_connected = Some((peer_addr_raw, s.mtu));
+            }
+        } else if !s.authenticated {
+            // Operator already confirmed (or confirmed first) — authenticate now.
+            s.authenticated = true;
+            s.connection_start = None;
+            s.confirm_sent_at = None;
+            if let Some(data) = s.pending_write.take() {
+                info!(
+                    "BLE: enc fallback: flushing buffered GATT write {} bytes",
+                    data.len()
+                );
+                s.events.push_back(BleEvent::Recv(data));
+            }
+            let mtu = s.mtu;
+            if s.events.len() < MAX_BLE_EVENT_QUEUE {
+                s.events.push_back(BleEvent::Connected {
+                    peer_addr: peer_addr_raw,
+                    mtu,
+                });
+            }
         }
     }
 }

--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -774,8 +774,15 @@ impl Ble for EspBleDriver {
         );
 
         let mut s = self.state.lock().unwrap_or_else(|p| p.into_inner());
-        // Re-check all guards after re-acquiring the lock.
-        if s.authenticated || s.timeout_fired || s.pairing_rejected {
+        // Re-check all guards after re-acquiring the lock.  Also verify the
+        // conn_handle hasn't changed (a disconnect+reconnect resets all flags,
+        // so without this check we'd complete pairing on the new connection
+        // using the old connection's peer address).
+        if s.conn_handle != Some(conn_handle)
+            || s.authenticated
+            || s.timeout_fired
+            || s.pairing_rejected
+        {
             return;
         }
         s.mtu = current_mtu;

--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -706,12 +706,16 @@ impl Ble for EspBleDriver {
     fn check_encryption_fallback(&self) {
         // Acquire initial state under the lock, then release before the unsafe
         // NimBLE call to avoid holding the mutex across a potential NimBLE lock.
-        let (conn_handle, in_nc_pairing) = {
+        let (conn_handle, in_nc_pairing, confirm_sent_at) = {
             let s = self.state.lock().unwrap_or_else(|p| p.into_inner());
-            if s.authenticated || s.timeout_fired || s.pairing_rejected {
+            if s.authenticated
+                || s.timeout_fired
+                || s.pairing_rejected
+                || s.deferred_connected.is_some()
+            {
                 return;
             }
-            (s.conn_handle, s.confirm_sent_at.is_some())
+            (s.conn_handle, s.confirm_sent_at.is_some(), s.confirm_sent_at)
         };
         // Only applies to the NC pairing path.
         if !in_nc_pairing {
@@ -774,14 +778,21 @@ impl Ble for EspBleDriver {
         );
 
         let mut s = self.state.lock().unwrap_or_else(|p| p.into_inner());
-        // Re-check all guards after re-acquiring the lock.  Also verify the
-        // conn_handle hasn't changed (a disconnect+reconnect resets all flags,
-        // so without this check we'd complete pairing on the new connection
-        // using the old connection's peer address).
+        // Re-check all guards after re-acquiring the lock.
+        // - conn_handle: a disconnect resets the handle to None; prevents acting
+        //   on a stale snapshot.
+        // - confirm_sent_at: NimBLE reuses small connection-handle integers, so
+        //   conn_handle alone isn't sufficient.  confirm_sent_at is set to
+        //   Some(Instant::now()) when NC pairing starts; a reused-handle new
+        //   connection will have a different (or None) value.
+        // - deferred_connected: set when pairing completes while pairing_pending;
+        //   would make complete_pairing_under_lock a no-op anyway, skip early.
         if s.conn_handle != Some(conn_handle)
+            || s.confirm_sent_at != confirm_sent_at
             || s.authenticated
             || s.timeout_fired
             || s.pairing_rejected
+            || s.deferred_connected.is_some()
         {
             return;
         }

--- a/crates/sonde-modem/src/ble.rs
+++ b/crates/sonde-modem/src/ble.rs
@@ -357,7 +357,11 @@ impl EspBleDriver {
                         );
                         true
                     } else {
-                        complete_pairing_under_lock(&mut s, peer_addr, "pairing complete");
+                        EspBleDriver::complete_pairing_under_lock(
+                            &mut s,
+                            peer_addr,
+                            "pairing complete",
+                        );
                         false
                     }
                 } else {
@@ -753,7 +757,7 @@ impl Ble for EspBleDriver {
             return;
         }
         s.mtu = current_mtu;
-        complete_pairing_under_lock(&mut s, peer_addr_raw, "enc fallback");
+        Self::complete_pairing_under_lock(&mut s, peer_addr_raw, "enc fallback");
     }
 }
 

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -166,6 +166,12 @@ pub trait Ble {
     ///
     /// Must be called once per poll cycle.
     fn check_pairing_timeout(&self) {}
+    /// Poll the NimBLE link security state as a fallback for Android LESC
+    /// Numeric Comparison, in case `on_authentication_complete` did not fire
+    /// due to a `ble_gap_conn_find` race in the ENC_CHANGE event handler.
+    ///
+    /// Must be called once per poll cycle.
+    fn check_encryption_fallback(&self) {}
     /// Drain one queued BLE event, or `None` if empty.
     fn drain_event(&self) -> Option<BleEvent>;
 }
@@ -353,6 +359,9 @@ impl<S: SerialPort, R: Radio, B: Ble> Bridge<S, R, B> {
 
         // Enforce BLE pairing timeout (MD-0414 AC#4).
         self.ble.check_pairing_timeout();
+
+        // Android LESC NC: polling fallback for missed on_authentication_complete.
+        self.ble.check_encryption_fallback();
 
         // Forward any BLE events to the gateway over USB-CDC.
         // Cap at MAX_BLE_EVENTS_PER_POLL to prevent starvation of serial
@@ -1170,6 +1179,7 @@ mod tests {
         pairing_replies: Vec<bool>,
         event_queue: RefCell<VecDeque<BleEvent>>,
         check_pairing_timeout_count: Cell<usize>,
+        check_encryption_fallback_count: Cell<usize>,
         enable_count: Cell<usize>,
         disable_count: Cell<usize>,
     }
@@ -1182,6 +1192,7 @@ mod tests {
                 pairing_replies: Vec::new(),
                 event_queue: RefCell::new(VecDeque::new()),
                 check_pairing_timeout_count: Cell::new(0),
+                check_encryption_fallback_count: Cell::new(0),
                 enable_count: Cell::new(0),
                 disable_count: Cell::new(0),
             }
@@ -1217,6 +1228,10 @@ mod tests {
         fn check_pairing_timeout(&self) {
             self.check_pairing_timeout_count
                 .set(self.check_pairing_timeout_count.get() + 1);
+        }
+        fn check_encryption_fallback(&self) {
+            self.check_encryption_fallback_count
+                .set(self.check_encryption_fallback_count.get() + 1);
         }
         fn drain_event(&self) -> Option<BleEvent> {
             self.event_queue.borrow_mut().pop_front()
@@ -1371,6 +1386,17 @@ mod tests {
         assert_eq!(bridge.ble.check_pairing_timeout_count.get(), 1);
         bridge.poll();
         assert_eq!(bridge.ble.check_pairing_timeout_count.get(), 2);
+    }
+
+    /// Validates: poll() calls check_encryption_fallback() exactly once per cycle.
+    #[test]
+    fn poll_calls_check_encryption_fallback() {
+        let mut bridge = make_bridge_with_ble();
+        assert_eq!(bridge.ble.check_encryption_fallback_count.get(), 0);
+        bridge.poll();
+        assert_eq!(bridge.ble.check_encryption_fallback_count.get(), 1);
+        bridge.poll();
+        assert_eq!(bridge.ble.check_encryption_fallback_count.get(), 2);
     }
 
     /// Validates: T-0613 (BLE_RECV forwarded to gateway)


### PR DESCRIPTION
## Problem

Android LESC Numeric Comparison (NC) pairing with the modem times out after 30 seconds, while Windows Just Works pairing succeeds.

**Root cause**: In esp32-nimble's \BLE_GAP_EVENT_ENC_CHANGE\ handler, \le_gap_conn_find(enc_change.conn_handle)\ fails silently (returns \BLE_HS_ENOTCONN\) due to a race in the NimBLE host stack during LESC key exchange. The handler early-returns without calling \on_authentication_complete\, leaving the pairing state machine stuck — the \deferred_connected\ field is never set, the 30s timeout fires, and Android disconnects.

Windows avoids this because btleplug uses Just Works pairing (no NC passkey, no \pairing_pending\ flag), so \on_authentication_complete\ takes a different code path.

## Fix

Add a polling fallback \check_encryption_fallback()\ called each bridge poll cycle (~5ms). It queries NimBLE directly via \sp_idf_sys::ble_gap_conn_find\ using the \conn_handle\ stored in \BleState\ during \on_connect\ (known-valid). When the link is confirmed encrypted and MTU is sufficient, it completes the pairing state machine exactly as \on_authentication_complete\ would have.

**Design decisions**:

- **Gate on \confirm_sent_at.is_some()\** (NC pairing path only) — Windows Just Works stays on the original callback path.
- **Wait on low MTU** — Android delays ATT MTU exchange until after SMP; if MTU is still 23, return and wait for the MTU update event before authenticating.
- **\pairing_rejected\ flag** — new field guards against a late SMP completion (via fallback *or* callback) promoting a peer after the operator pressed reject. \pairing_confirm_reply(false)\ sets it; \on_disconnect\/\disable()\ clear it.
- **Double-auth guards in \on_authentication_complete\** — \deferred_connected.is_none()\ and \!s.authenticated\ checks prevent duplicate \BleEvent::Connected\ if both the fallback and the callback fire.

## Testing

- All 98 host tests pass (97 existing + 1 new \poll_calls_check_encryption_fallback\ test).
- Hardware test with Android required to verify end-to-end fix.
- Windows Just Works pairing unaffected (fallback no-ops when \confirm_sent_at.is_none()\).