### PR TITLE
fix(gateway): warn when WAKE blob has no matching handler

### DIFF
--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -955,7 +955,10 @@ impl Gateway {
                 tokio::spawn(async move {
                     let (handler_result, handler_count) = {
                         let router = handler_router.read().await;
-                        (router.find_handler_cloned(&program_hash), router.handler_count())
+                        (
+                            router.find_handler_cloned(&program_hash),
+                            router.handler_count(),
+                        )
                     };
                     if let Some((config, process_arc)) = handler_result {
                         let timestamp = SystemTime::now()
@@ -995,7 +998,8 @@ impl Gateway {
                             }
                         }
                     } else {
-                        let ph_hex: String = program_hash.iter().map(|b| format!("{b:02x}")).collect();
+                        let ph_hex: String =
+                            program_hash.iter().map(|b| format!("{b:02x}")).collect();
                         warn!(
                             node_id = %node_id,
                             program_hash = %ph_hex,

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -953,9 +953,9 @@ impl Gateway {
                 let program_hash = program_hash.clone();
                 let nonce = header.nonce;
                 tokio::spawn(async move {
-                    let handler_result = {
+                    let (handler_result, handler_count) = {
                         let router = handler_router.read().await;
-                        router.find_handler_cloned(&program_hash)
+                        (router.find_handler_cloned(&program_hash), router.handler_count())
                     };
                     if let Some((config, process_arc)) = handler_result {
                         let timestamp = SystemTime::now()
@@ -994,6 +994,14 @@ impl Gateway {
                                 );
                             }
                         }
+                    } else {
+                        let ph_hex: String = program_hash.iter().map(|b| format!("{b:02x}")).collect();
+                        warn!(
+                            node_id = %node_id,
+                            program_hash = %ph_hex,
+                            handler_count,
+                            "WAKE blob dropped: no handler matched `program_hash`"
+                        );
                     }
                 });
             }

--- a/crates/sonde-gateway/tests/logging.rs
+++ b/crates/sonde-gateway/tests/logging.rs
@@ -843,7 +843,14 @@ async fn t1309_wake_blob_no_handler_warn() {
         logs_contain("node_id=node-1309"),
         "WARN must include node_id"
     );
-    assert!(logs_contain(&ph_hex), "WARN must include program_hash hex");
+    assert!(
+        logs_contain("program_hash="),
+        "WARN must include program_hash field key"
+    );
+    assert!(
+        logs_contain(&ph_hex),
+        "WARN must include program_hash hex value"
+    );
     assert!(
         logs_contain("handler_count=0"),
         "WARN must include handler_count"

--- a/crates/sonde-gateway/tests/logging.rs
+++ b/crates/sonde-gateway/tests/logging.rs
@@ -818,14 +818,22 @@ async fn t1309_wake_blob_no_handler_warn() {
     let cbor = msg.encode().unwrap();
     let frame = encode_frame(&header, &cbor, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
 
+    let ph_hex: String = program_hash.iter().map(|b| format!("{b:02x}")).collect();
+
     let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(
         resp.is_some(),
         "expected COMMAND response even when no handler"
     );
 
-    // Allow the background task to run.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    // Poll for the background task's warning log instead of a fixed delay.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while !logs_contain("WAKE blob dropped: no handler matched") {
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 
     assert!(
         logs_contain("WAKE blob dropped: no handler matched"),
@@ -835,6 +843,7 @@ async fn t1309_wake_blob_no_handler_warn() {
         logs_contain("node_id=node-1309"),
         "WARN must include node_id"
     );
+    assert!(logs_contain(&ph_hex), "WARN must include program_hash hex");
     assert!(
         logs_contain("handler_count=0"),
         "WARN must include handler_count"

--- a/crates/sonde-gateway/tests/logging.rs
+++ b/crates/sonde-gateway/tests/logging.rs
@@ -819,7 +819,10 @@ async fn t1309_wake_blob_no_handler_warn() {
     let frame = encode_frame(&header, &cbor, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
 
     let resp = gw.process_frame(&frame, node.peer_address()).await;
-    assert!(resp.is_some(), "expected COMMAND response even when no handler");
+    assert!(
+        resp.is_some(),
+        "expected COMMAND response even when no handler"
+    );
 
     // Allow the background task to run.
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/crates/sonde-gateway/tests/logging.rs
+++ b/crates/sonde-gateway/tests/logging.rs
@@ -779,3 +779,61 @@ fn decode_command(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
     (decoded.header, msg)
 }
+
+// ── T-1309  WAKE blob no-handler warning ───────────────────────────────
+
+/// T-1309: Validates that a WAKE blob with no matching handler emits a WARN
+/// containing node_id, program_hash, and handler_count (GW-0504 AC6 parity
+/// for WAKE-originated blobs).
+#[tokio::test]
+#[traced_test]
+async fn t1309_wake_blob_no_handler_warn() {
+    use sonde_protocol::encode_frame;
+
+    let storage = Arc::new(InMemoryStorage::new());
+    let gw = make_gateway(storage.clone());
+
+    let psk = [0x77u8; 32];
+    let key_hint = compute_key_hint(&psk);
+    let node = TestNode::new("node-1309", key_hint, psk);
+    let program_hash = store_test_program(&storage, b"prog-1309").await;
+
+    let mut record = node.to_record();
+    record.assigned_program_hash = Some(program_hash.clone());
+    storage.upsert_node(&record).await.unwrap();
+
+    // Build a WAKE that includes a non-empty blob.
+    let header = FrameHeader {
+        key_hint: node.key_hint,
+        msg_type: MSG_WAKE,
+        nonce: 9900,
+    };
+    let msg = NodeMessage::Wake {
+        firmware_abi_version: 1,
+        program_hash: program_hash.clone(),
+        battery_mv: 3300,
+        firmware_version: "0.4.0".into(),
+        blob: Some(vec![0x01, 0x02, 0x03]),
+    };
+    let cbor = msg.encode().unwrap();
+    let frame = encode_frame(&header, &cbor, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
+
+    let resp = gw.process_frame(&frame, node.peer_address()).await;
+    assert!(resp.is_some(), "expected COMMAND response even when no handler");
+
+    // Allow the background task to run.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    assert!(
+        logs_contain("WAKE blob dropped: no handler matched"),
+        "expected WARN for unhandled WAKE blob"
+    );
+    assert!(
+        logs_contain("node_id=node-1309"),
+        "WARN must include node_id"
+    );
+    assert!(
+        logs_contain("handler_count=0"),
+        "WARN must include handler_count"
+    );
+}


### PR DESCRIPTION
## Problem

When a node sends a WAKE frame with a piggybacked async blob, the gateway silently dropped the blob if no handler was registered for the node's \program_hash\. This made it impossible to diagnose misconfigured handler routing — the gateway appeared healthy but data was lost with no indication.

The \APP_DATA\ path already emits a \WARN\ with \
ode_id\, \program_hash\, and \handler_count\ in this situation. The WAKE blob path was missing the equivalent \lse\ branch entirely.

## Fix

- Capture \handler_count\ inside the read-lock alongside \ind_handler_cloned\ so both fields are available after the lock is released
- Add the missing \lse\ branch with a \WARN\ matching the \APP_DATA\ pattern:
  \\\
  WARN sonde_gateway::engine: WAKE blob dropped: no handler matched \program_hash\
       node_id=... program_hash=... handler_count=0
  \\\

## Tests

Adds **T-1309** to \	ests/logging.rs\ with \#[traced_test]\ asserting the warning is emitted (node_id, handler_count fields verified).