### PR TITLE
fix(pair): ensure LESC Numeric Comparison on Android by calling createBond() before connect latch

### DIFF
--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -493,14 +493,16 @@ public class BleHelper {
     /**
      * Connect to the device, bond, negotiate MTU, and discover services.
      *
-     * <p>Blocks until all four steps complete or {@code timeoutMs} elapses.
+     * <p>Blocks until all steps complete or {@code timeoutMs} elapses.
      * On failure or timeout the connection is cleaned up before returning.
      *
      * <p>Step 0 removes any stale Android bond (the modem does not persist
-     * bonds across reboots).  Step 2 always initiates a fresh LESC pairing
-     * via {@code createBond()}.  On the modem this triggers Numeric
-     * Comparison — the operator must confirm the passkey before the modem
-     * will accept GATT writes.
+     * bonds across reboots).  Steps 1–2 start the GATT connection and
+     * immediately call {@code createBond()} before the LE link is established,
+     * placing Android in "bonding mode" before the modem's BLE Security
+     * Request arrives.  This ensures LESC Numeric Comparison (not Just Works)
+     * is negotiated (PT-0904).  Steps 3–4 wait for GATT connect and for
+     * bonding to complete.  Steps 5–6 negotiate MTU and discover services.
      *
      * @param address   6-byte BLE device address
      * @param timeoutMs overall deadline in milliseconds
@@ -528,26 +530,28 @@ public class BleHelper {
             Thread.sleep(500);
         }
 
-        // Step 1 — connect
+        // Step 1 — start GATT connection (asynchronous; LE link not yet established).
         connectLatch = new CountDownLatch(1);
         gatt = device.connectGatt(context, false, gattCallback,
                 BluetoothDevice.TRANSPORT_LE);
         if (gatt == null) throw new Exception("connectGatt returned null");
 
-        long remaining = deadline - System.currentTimeMillis();
-        if (remaining <= 0
-                || !connectLatch.await(remaining, TimeUnit.MILLISECONDS)) {
-            disconnectInner();
-            throw new Exception("connect timed out");
-        }
-        if (connectionState != BluetoothProfile.STATE_CONNECTED) {
-            String err = lastError;
-            disconnectInner();
-            throw new Exception(err != null ? err : "connection failed");
-        }
-
-        // Step 2 — initiate LESC bonding (Numeric Comparison)
-        // The modem requires a bonded link before it will accept GATT writes.
+        // Step 2 — initiate LESC bonding BEFORE waiting for the GATT connect
+        // callback.  connectGatt() is asynchronous: the LE connection has not
+        // been established when it returns, so calling createBond() here races
+        // ahead of the modem's Security Request.
+        //
+        // The modem calls ble_gap_security_initiate() immediately in its
+        // on_connect callback, sending a BLE Security Request to Android.
+        // If createBond() has not been called before that Security Request
+        // arrives, Android handles the incoming SMP as a background pairing
+        // and may advertise NoInputNoOutput IO capabilities, forcing Just
+        // Works instead of LESC Numeric Comparison.
+        //
+        // Calling createBond() here, while the LE link is still being
+        // established, places Android in "bonding mode" with KeyboardDisplay
+        // IO capabilities before the Security Request arrives, which ensures
+        // LESC Numeric Comparison is negotiated (PT-0904).
         {
             bonded = false;
             bondingStarted = false;
@@ -600,21 +604,36 @@ public class BleHelper {
                             "createBond() failed — try unpairing the device manually in Android Bluetooth settings");
                 }
             }
-
-            remaining = deadline - System.currentTimeMillis();
-            if (remaining <= 0
-                    || !bondLatch.await(remaining, TimeUnit.MILLISECONDS)) {
-                disconnectInner();
-                throw new Exception("bonding timed out");
-            }
-            if (!bonded) {
-                String err = lastError;
-                disconnectInner();
-                throw new Exception(err != null ? err : "bonding failed");
-            }
         }
 
-        // Step 3 — request MTU (best effort; proceed even if request fails)
+        // Step 3 — wait for GATT connection.
+        long remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0
+                || !connectLatch.await(remaining, TimeUnit.MILLISECONDS)) {
+            disconnectInner();
+            throw new Exception("connect timed out");
+        }
+        if (connectionState != BluetoothProfile.STATE_CONNECTED) {
+            String err = lastError;
+            disconnectInner();
+            throw new Exception(err != null ? err : "connection failed");
+        }
+
+        // Step 4 — wait for bonding to complete (Numeric Comparison requires
+        // gateway confirmation, so this may take several seconds).
+        remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0
+                || !bondLatch.await(remaining, TimeUnit.MILLISECONDS)) {
+            disconnectInner();
+            throw new Exception("bonding timed out");
+        }
+        if (!bonded) {
+            String err = lastError;
+            disconnectInner();
+            throw new Exception(err != null ? err : "bonding failed");
+        }
+
+        // Step 5 — request MTU (best effort; proceed even if request fails)
         mtuLatch = new CountDownLatch(1);
         if (gatt.requestMtu(517)) {
             remaining = deadline - System.currentTimeMillis();
@@ -623,7 +642,7 @@ public class BleHelper {
         // Clear any MTU error so it doesn't abort service discovery.
         lastError = null;
 
-        // Step 4 — discover services
+        // Step 6 — discover services
         discoveryLatch = new CountDownLatch(1);
         if (!gatt.discoverServices()) {
             disconnectInner();

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -83,6 +83,7 @@ public class BleHelper {
     // --- Bonding state -----------------------------------------------------
     private volatile boolean bonded;
     private volatile boolean bondingStarted;
+    private volatile boolean createBondCalled;
     private volatile boolean bondReceiverRegistered;
     private volatile BluetoothDevice bondTarget;
 
@@ -118,9 +119,10 @@ public class BleHelper {
                 bonded = true;
                 CountDownLatch l = bondLatch;
                 if (l != null) l.countDown();
-            } else if (state == BluetoothDevice.BOND_NONE && bondingStarted) {
-                // Only treat BOND_NONE as a failure if we actually started
-                // bonding.  Ignore BOND_NONE from removeBond() cleanup.
+            } else if (state == BluetoothDevice.BOND_NONE && createBondCalled) {
+                // Only treat BOND_NONE as a failure if createBond() has actually
+                // been called (not just queued for async execution).  Ignore
+                // BOND_NONE from removeBond() cleanup in Step 0.
                 int reason = intent.getIntExtra(
                         "android.bluetooth.device.extra.REASON", -1);
                 lastError = "bonding failed (reason=" + reason + ")";
@@ -555,6 +557,7 @@ public class BleHelper {
         {
             bonded = false;
             bondingStarted = false;
+            createBondCalled = false;
             bondTarget = device;
             bondLatch = new CountDownLatch(1);
             observedPairingVariant = -1;
@@ -591,6 +594,7 @@ public class BleHelper {
             }
 
             bondingStarted = true;
+            createBondCalled = true;
             if (!device.createBond()) {
                 // createBond can return false if bonding is already in
                 // progress or if removeBond failed.  Check current state.

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -82,7 +82,6 @@ public class BleHelper {
 
     // --- Bonding state -----------------------------------------------------
     private volatile boolean bonded;
-    private volatile boolean bondingStarted;
     private volatile boolean createBondCalled;
     private volatile boolean bondReceiverRegistered;
     private volatile BluetoothDevice bondTarget;
@@ -114,15 +113,21 @@ public class BleHelper {
             }
             int state = intent.getIntExtra(
                     BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.BOND_NONE);
-            Log.i("BleHelper", "bond state changed: " + state);
+            int prevState = intent.getIntExtra(
+                    "android.bluetooth.device.extra.PREVIOUS_BOND_STATE", BluetoothDevice.BOND_NONE);
+            Log.i("BleHelper", "bond state changed: " + prevState + " -> " + state);
             if (state == BluetoothDevice.BOND_BONDED) {
                 bonded = true;
                 CountDownLatch l = bondLatch;
                 if (l != null) l.countDown();
-            } else if (state == BluetoothDevice.BOND_NONE && createBondCalled) {
-                // Only treat BOND_NONE as a failure if createBond() has actually
-                // been called (not just queued for async execution).  Ignore
-                // BOND_NONE from removeBond() cleanup in Step 0.
+            } else if (state == BluetoothDevice.BOND_NONE && createBondCalled
+                    && prevState == BluetoothDevice.BOND_BONDING) {
+                // Only treat BOND_NONE as a failure if:
+                // 1. createBond() has actually been called (not just async queued)
+                // 2. Previous state was BOND_BONDING (i.e., we initiated bonding)
+                // This distinguishes bonding failures from stale BOND_BONDED->BOND_NONE
+                // broadcasts from Step 0's removeBond() cleanup, which transition from
+                // BOND_BONDED (not BOND_BONDING).
                 int reason = intent.getIntExtra(
                         "android.bluetooth.device.extra.REASON", -1);
                 lastError = "bonding failed (reason=" + reason + ")";
@@ -556,7 +561,6 @@ public class BleHelper {
         // LESC Numeric Comparison is negotiated (PT-0904).
         {
             bonded = false;
-            bondingStarted = false;
             createBondCalled = false;
             bondTarget = device;
             bondLatch = new CountDownLatch(1);
@@ -593,7 +597,6 @@ public class BleHelper {
                 }
             }
 
-            bondingStarted = true;
             createBondCalled = true;
             if (!device.createBond()) {
                 // createBond can return false if bonding is already in
@@ -679,7 +682,7 @@ public class BleHelper {
         subscribedChars.clear();
         indicationQueues.clear();
         bondTarget = null;
-        bondingStarted = false;
+        createBondCalled = false;
         if (pairingReceiverRegistered) {
             try { context.unregisterReceiver(pairingReceiver); }
             catch (Exception ignored) { }

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -557,8 +557,11 @@ public class BleHelper {
             bondingStarted = false;
             bondTarget = device;
             bondLatch = new CountDownLatch(1);
-            lastError = null;
             observedPairingVariant = -1;
+            // Note: do NOT reset lastError here — it may have been set by
+            // onConnectionStateChange() racing with this bonding setup, and we
+            // need to preserve any GATT status code captured before checking it
+            // in Step 3.
 
             // Register receivers before calling createBond to avoid races.
             if (!pairingReceiverRegistered) {

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -57,6 +57,10 @@ public class BleHelper {
     private static final UUID CCCD_UUID =
             UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
 
+    // Hidden extra key for bond failure reason code (not a public SDK constant).
+    private static final String EXTRA_BOND_REASON =
+            "android.bluetooth.device.extra.REASON";
+
     private final Context context;
     private final BluetoothAdapter adapter;
 
@@ -114,7 +118,7 @@ public class BleHelper {
             int state = intent.getIntExtra(
                     BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.BOND_NONE);
             int prevState = intent.getIntExtra(
-                    "android.bluetooth.device.extra.PREVIOUS_BOND_STATE", BluetoothDevice.BOND_NONE);
+                    BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.BOND_NONE);
             Log.i("BleHelper", "bond state changed: " + prevState + " -> " + state);
             if (state == BluetoothDevice.BOND_BONDED) {
                 bonded = true;
@@ -128,8 +132,7 @@ public class BleHelper {
                 // This distinguishes bonding failures from stale BOND_BONDED->BOND_NONE
                 // broadcasts from Step 0's removeBond() cleanup, which transition from
                 // BOND_BONDED (not BOND_BONDING).
-                int reason = intent.getIntExtra(
-                        "android.bluetooth.device.extra.REASON", -1);
+                int reason = intent.getIntExtra(EXTRA_BOND_REASON, -1);
                 lastError = "bonding failed (reason=" + reason + ")";
                 bonded = false;
                 CountDownLatch l = bondLatch;


### PR DESCRIPTION
## Problem

Android BLE pairing fails with:
> BLE pairing used insecure method `Just Works` — Numeric Comparison (LESC) is required

Windows works fine. The root cause is a race between the modem's BLE Security Request and when the Android app calls `createBond()`.

## Root cause

The modem calls `ble_gap_security_initiate()` immediately inside its `on_connect` callback, which sends a **BLE Security Request** to the Android client.

The old `BleHelper.connect()` flow was:
1. `connectGatt()` → wait for `STATE_CONNECTED`
2. Register `pairingReceiver`, call `createBond()`

By step 2, the LE link was already established and the modem's Security Request had already arrived at Android. Without `createBond()` having been called, Android handled the incoming SMP as a **background pairing** and advertised `NoInputNoOutput` IO capabilities, forcing **Just Works** (`PAIRING_VARIANT_CONSENT = 3`). The `enforce_lesc()` check then rejected the connection.

Windows was unaffected because `BtleplugTransport::pairing_method()` returns `None`, which `enforce_lesc()` treats as OS-enforced LESC, bypassing the check.

## Fix

Move `createBond()` to **immediately after `connectGatt()` returns**, before waiting for the connect latch (step 2→step 1 in terms of ordering):

```
connectGatt()           ← async; LE link not yet established
createBond()            ← Android enters bonding mode NOW
                           (KeyboardDisplay IO capabilities)
wait connectLatch       ← LE link establishes; modem sends Security Request
                           Android responds with Numeric Comparison ✓
wait bondLatch          ← gateway confirms; BOND_BONDED
MTU + service discovery
```

Since `connectGatt()` is asynchronous, the LE link is not established when it returns. Calling `createBond()` synchronously before `connectLatch.await()` ensures Android is in bonding mode before the modem's Security Request arrives.

`gatt` is created before `createBond()`, so all `disconnectInner()` cleanup paths remain correct.