### PR TITLE
fix(pair): skip enforce_lesc for node connections (ND-0904)

### DIFF
--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -493,14 +493,16 @@ public class BleHelper {
     /**
      * Connect to the device, bond, negotiate MTU, and discover services.
      *
-     * <p>Blocks until all four steps complete or {@code timeoutMs} elapses.
+     * <p>Blocks until all steps complete or {@code timeoutMs} elapses.
      * On failure or timeout the connection is cleaned up before returning.
      *
      * <p>Step 0 removes any stale Android bond (the modem does not persist
-     * bonds across reboots).  Step 2 always initiates a fresh LESC pairing
-     * via {@code createBond()}.  On the modem this triggers Numeric
-     * Comparison — the operator must confirm the passkey before the modem
-     * will accept GATT writes.
+     * bonds across reboots).  Steps 1–2 start the GATT connection and
+     * immediately call {@code createBond()} before the LE link is established,
+     * placing Android in "bonding mode" before the modem's BLE Security
+     * Request arrives.  This ensures LESC Numeric Comparison (not Just Works)
+     * is negotiated (PT-0904).  Steps 3–4 wait for GATT connect and for
+     * bonding to complete.  Steps 5–6 negotiate MTU and discover services.
      *
      * @param address   6-byte BLE device address
      * @param timeoutMs overall deadline in milliseconds
@@ -528,26 +530,28 @@ public class BleHelper {
             Thread.sleep(500);
         }
 
-        // Step 1 — connect
+        // Step 1 — start GATT connection (asynchronous; LE link not yet established).
         connectLatch = new CountDownLatch(1);
         gatt = device.connectGatt(context, false, gattCallback,
                 BluetoothDevice.TRANSPORT_LE);
         if (gatt == null) throw new Exception("connectGatt returned null");
 
-        long remaining = deadline - System.currentTimeMillis();
-        if (remaining <= 0
-                || !connectLatch.await(remaining, TimeUnit.MILLISECONDS)) {
-            disconnectInner();
-            throw new Exception("connect timed out");
-        }
-        if (connectionState != BluetoothProfile.STATE_CONNECTED) {
-            String err = lastError;
-            disconnectInner();
-            throw new Exception(err != null ? err : "connection failed");
-        }
-
-        // Step 2 — initiate LESC bonding (Numeric Comparison)
-        // The modem requires a bonded link before it will accept GATT writes.
+        // Step 2 — initiate LESC bonding BEFORE waiting for the GATT connect
+        // callback.  connectGatt() is asynchronous: the LE connection has not
+        // been established when it returns, so calling createBond() here races
+        // ahead of the modem's Security Request.
+        //
+        // The modem calls ble_gap_security_initiate() immediately in its
+        // on_connect callback, sending a BLE Security Request to Android.
+        // If createBond() has not been called before that Security Request
+        // arrives, Android handles the incoming SMP as a background pairing
+        // and may advertise NoInputNoOutput IO capabilities, forcing Just
+        // Works instead of LESC Numeric Comparison.
+        //
+        // Calling createBond() here, while the LE link is still being
+        // established, places Android in "bonding mode" with KeyboardDisplay
+        // IO capabilities before the Security Request arrives, which ensures
+        // LESC Numeric Comparison is negotiated (PT-0904).
         {
             bonded = false;
             bondingStarted = false;
@@ -600,21 +604,36 @@ public class BleHelper {
                             "createBond() failed — try unpairing the device manually in Android Bluetooth settings");
                 }
             }
-
-            remaining = deadline - System.currentTimeMillis();
-            if (remaining <= 0
-                    || !bondLatch.await(remaining, TimeUnit.MILLISECONDS)) {
-                disconnectInner();
-                throw new Exception("bonding timed out");
-            }
-            if (!bonded) {
-                String err = lastError;
-                disconnectInner();
-                throw new Exception(err != null ? err : "bonding failed");
-            }
         }
 
-        // Step 3 — request MTU (best effort; proceed even if request fails)
+        // Step 3 — wait for GATT connection.
+        long remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0
+                || !connectLatch.await(remaining, TimeUnit.MILLISECONDS)) {
+            disconnectInner();
+            throw new Exception("connect timed out");
+        }
+        if (connectionState != BluetoothProfile.STATE_CONNECTED) {
+            String err = lastError;
+            disconnectInner();
+            throw new Exception(err != null ? err : "connection failed");
+        }
+
+        // Step 4 — wait for bonding to complete (Numeric Comparison requires
+        // gateway confirmation, so this may take several seconds).
+        remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0
+                || !bondLatch.await(remaining, TimeUnit.MILLISECONDS)) {
+            disconnectInner();
+            throw new Exception("bonding timed out");
+        }
+        if (!bonded) {
+            String err = lastError;
+            disconnectInner();
+            throw new Exception(err != null ? err : "bonding failed");
+        }
+
+        // Step 5 — request MTU (best effort; proceed even if request fails)
         mtuLatch = new CountDownLatch(1);
         if (gatt.requestMtu(517)) {
             remaining = deadline - System.currentTimeMillis();
@@ -623,7 +642,7 @@ public class BleHelper {
         // Clear any MTU error so it doesn't abort service discovery.
         lastError = null;
 
-        // Step 4 — discover services
+        // Step 6 — discover services
         discoveryLatch = new CountDownLatch(1);
         if (!gatt.discoverServices()) {
             disconnectInner();

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -89,7 +89,12 @@ public class BleHelper {
     private volatile boolean createBondCalled;
     private volatile boolean bondReceiverRegistered;
     private volatile BluetoothDevice bondTarget;
-    private volatile boolean skipBonding;
+    // When true, createBond() is called AFTER the GATT connect latch
+    // instead of before it.  Used for node connections where the node
+    // calls ble_gap_security_initiate() in on_connect — calling
+    // createBond() before the latch causes a dual-initiation race that
+    // confuses NimBLE's SMP state machine.
+    private volatile boolean deferBonding;
 
     // --- Pairing method observation (PT-0904) -----------------------------
     // PAIRING_VARIANT_* constants are @SystemApi; use raw int values.
@@ -502,15 +507,15 @@ public class BleHelper {
     // --- Connection --------------------------------------------------------
 
     /**
-     * When set, {@link #connect} skips client-initiated bonding (Steps 0/2/4)
-     * and relies on the remote device's server-initiated Security Request to
-     * drive pairing.  Used for node connections where the node calls
+     * When set, {@link #connect} calls {@code createBond()} after the GATT
+     * connect latch (the original Android BLE flow) instead of before it.
+     * Used for node connections where the node calls
      * {@code ble_gap_security_initiate()} in its {@code on_connect} callback;
-     * having both sides initiate simultaneously confuses NimBLE's SMP state
-     * machine.
+     * calling {@code createBond()} before the latch causes a dual-initiation
+     * race that confuses NimBLE's SMP state machine.
      */
-    public void setSkipBonding(boolean skip) {
-        this.skipBonding = skip;
+    public void setDeferBonding(boolean defer) {
+        this.deferBonding = defer;
     }
 
     /**
@@ -536,11 +541,11 @@ public class BleHelper {
         requireBlePermissions();
         disconnectInner();
 
-        // Capture and clear the skip-bonding hint so it applies only to
+        // Capture and clear the defer-bonding hint so it applies only to
         // this connection (one-shot).  A subsequent connect() (e.g.,
         // Phase 1 modem) will use the default bonding flow.
-        boolean skipBondingForThisConnect = this.skipBonding;
-        this.skipBonding = false;
+        boolean deferBondingForThisConnect = this.deferBonding;
+        this.deferBonding = false;
 
         String addrStr = bytesToMac(address);
         BluetoothDevice device = adapter.getRemoteDevice(addrStr);
@@ -566,81 +571,65 @@ public class BleHelper {
                 BluetoothDevice.TRANSPORT_LE);
         if (gatt == null) throw new Exception("connectGatt returned null");
 
-        if (!skipBondingForThisConnect) {
-            // Step 2 — initiate LESC bonding BEFORE waiting for the GATT connect
-            // callback.  connectGatt() is asynchronous: the LE connection has not
-            // been established when it returns, so calling createBond() here races
-            // ahead of the modem's Security Request.
-            //
-            // The modem calls ble_gap_security_initiate() immediately in its
-            // on_connect callback, sending a BLE Security Request to Android.
-            // If createBond() has not been called before that Security Request
-            // arrives, Android handles the incoming SMP as a background pairing
-            // and may advertise NoInputNoOutput IO capabilities, forcing Just
-            // Works instead of LESC Numeric Comparison.
-            //
-            // Calling createBond() here, while the LE link is still being
-            // established, places Android in "bonding mode" with KeyboardDisplay
-            // IO capabilities before the Security Request arrives, which ensures
-            // LESC Numeric Comparison is negotiated (PT-0904).
-            {
-                bonded = false;
-                createBondCalled = false;
-                bondTarget = device;
-                bondLatch = new CountDownLatch(1);
-                observedPairingVariant = -1;
-                // Note: do NOT reset lastError here — it may have been set by
-                // onConnectionStateChange() racing with this bonding setup, and we
-                // need to preserve any GATT status code captured before checking it
-                // in Step 3.
+        // --- Bonding setup (common to both modes) ---
+        // Register broadcast receivers and prepare bonding state before
+        // calling createBond(), regardless of when createBond() is called.
+        {
+            bonded = false;
+            createBondCalled = false;
+            bondTarget = device;
+            bondLatch = new CountDownLatch(1);
+            // Note: do NOT reset lastError here — it may have been set by
+            // onConnectionStateChange() racing with this bonding setup, and we
+            // need to preserve any GATT status code captured before checking it
+            // in Step 3.
 
-                // Register receivers before calling createBond to avoid races.
-                if (!pairingReceiverRegistered) {
-                    IntentFilter pairingFilter = new IntentFilter(
-                            BluetoothDevice.ACTION_PAIRING_REQUEST);
-                    try {
-                        context.registerReceiver(pairingReceiver, pairingFilter);
-                        pairingReceiverRegistered = true;
-                    } catch (SecurityException | IllegalArgumentException e) {
-                        Log.w("BleHelper",
-                                "failed to register pairing receiver: " + e.getMessage());
-                        // Non-fatal — getPairingMethod() will return PM_UNKNOWN,
-                        // which enforce_lesc() treats as a rejection (fail-secure).
-                    }
-                }
-                if (!bondReceiverRegistered) {
-                    IntentFilter filter = new IntentFilter(
-                            BluetoothDevice.ACTION_BOND_STATE_CHANGED);
-                    try {
-                        context.registerReceiver(bondReceiver, filter);
-                        bondReceiverRegistered = true;
-                    } catch (SecurityException | IllegalArgumentException e) {
-                        disconnectInner();
-                        throw new Exception(
-                                "failed to register bond receiver: " + e.getMessage(), e);
-                    }
-                }
-
-                createBondCalled = true;
-                if (!device.createBond()) {
-                    // createBond can return false if bonding is already in
-                    // progress or if removeBond failed.  Check current state.
-                    int bs = device.getBondState();
-                    if (bs == BluetoothDevice.BOND_BONDED) {
-                        Log.i("BleHelper", "createBond() returned false but already bonded");
-                        bonded = true;
-                        bondLatch.countDown();
-                    } else if (bs == BluetoothDevice.BOND_BONDING) {
-                        Log.i("BleHelper", "createBond() returned false — bonding already in progress");
-                    } else {
-                        disconnectInner();
-                        throw new Exception(
-                                "createBond() failed — try unpairing the device manually in Android Bluetooth settings");
-                    }
+            // Register receivers before calling createBond to avoid races.
+            if (!pairingReceiverRegistered) {
+                IntentFilter pairingFilter = new IntentFilter(
+                        BluetoothDevice.ACTION_PAIRING_REQUEST);
+                try {
+                    context.registerReceiver(pairingReceiver, pairingFilter);
+                    pairingReceiverRegistered = true;
+                } catch (SecurityException | IllegalArgumentException e) {
+                    Log.w("BleHelper",
+                            "failed to register pairing receiver: " + e.getMessage());
+                    // Non-fatal — getPairingMethod() will return PM_UNKNOWN,
+                    // which enforce_lesc() treats as a rejection (fail-secure).
                 }
             }
-        } else {
-            Log.i("BleHelper", "skipBonding=true — relying on server-initiated pairing");
+            if (!bondReceiverRegistered) {
+                IntentFilter filter = new IntentFilter(
+                        BluetoothDevice.ACTION_BOND_STATE_CHANGED);
+                try {
+                    context.registerReceiver(bondReceiver, filter);
+                    bondReceiverRegistered = true;
+                } catch (SecurityException | IllegalArgumentException e) {
+                    disconnectInner();
+                    throw new Exception(
+                            "failed to register bond receiver: " + e.getMessage(), e);
+                }
+            }
+        }
+
+        // Step 2 — initiate bonding.
+        //
+        // When deferBondingForThisConnect is FALSE (modem / Phase 1):
+        //   Call createBond() NOW, before waiting for the GATT connect latch.
+        //   connectGatt() is asynchronous so the LE link is not yet established.
+        //   This places Android in "bonding mode" with KeyboardDisplay IO
+        //   capabilities BEFORE the modem's Security Request arrives, ensuring
+        //   LESC Numeric Comparison is negotiated (PT-0904).
+        //
+        // When deferBondingForThisConnect is TRUE (node / Phase 2):
+        //   Wait for the GATT connect latch first, THEN call createBond().
+        //   The node calls ble_gap_security_initiate() in on_connect and
+        //   expects the client to participate in SMP for on_authentication_complete
+        //   to fire.  Calling createBond() before the latch causes dual-initiation
+        //   that confuses NimBLE's SMP state machine.  Calling it after the latch
+        //   is the standard Android BLE flow and works correctly with Just Works.
+        if (!deferBondingForThisConnect) {
+            callCreateBond(device);
         }
 
         // Step 3 — wait for GATT connection.
@@ -656,22 +645,23 @@ public class BleHelper {
             throw new Exception(err != null ? err : "connection failed");
         }
 
+        // Step 2b — deferred bonding (node connections only).
+        if (deferBondingForThisConnect) {
+            callCreateBond(device);
+        }
+
         // Step 4 — wait for bonding to complete (Numeric Comparison requires
         // gateway confirmation, so this may take several seconds).
-        // When skipBondingForThisConnect is true, the node's server-initiated
-        // pairing completes transparently via NimBLE — no bondLatch wait needed.
-        if (!skipBondingForThisConnect) {
-            remaining = deadline - System.currentTimeMillis();
-            if (remaining <= 0
-                    || !bondLatch.await(remaining, TimeUnit.MILLISECONDS)) {
-                disconnectInner();
-                throw new Exception("bonding timed out");
-            }
-            if (!bonded) {
-                String err = lastError;
-                disconnectInner();
-                throw new Exception(err != null ? err : "bonding failed");
-            }
+        remaining = deadline - System.currentTimeMillis();
+        if (remaining <= 0
+                || !bondLatch.await(remaining, TimeUnit.MILLISECONDS)) {
+            disconnectInner();
+            throw new Exception("bonding timed out");
+        }
+        if (!bonded) {
+            String err = lastError;
+            disconnectInner();
+            throw new Exception(err != null ? err : "bonding failed");
         }
 
         // Step 5 — request MTU (best effort; proceed even if request fails)
@@ -702,6 +692,27 @@ public class BleHelper {
         }
 
         return negotiatedMtu;
+    }
+
+    /** Invoke createBond() and handle the return value. */
+    private void callCreateBond(BluetoothDevice device) throws Exception {
+        createBondCalled = true;
+        if (!device.createBond()) {
+            int bs = device.getBondState();
+            if (bs == BluetoothDevice.BOND_BONDED) {
+                Log.i("BleHelper", "createBond() returned false but already bonded");
+                bonded = true;
+                bondLatch.countDown();
+            } else if (bs == BluetoothDevice.BOND_BONDING) {
+                Log.i("BleHelper",
+                        "createBond() returned false — bonding already in progress");
+            } else {
+                disconnectInner();
+                throw new Exception(
+                        "createBond() failed — try unpairing the device manually "
+                        + "in Android Bluetooth settings");
+            }
+        }
     }
 
     /** Disconnect and release GATT resources. */

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -89,6 +89,7 @@ public class BleHelper {
     private volatile boolean createBondCalled;
     private volatile boolean bondReceiverRegistered;
     private volatile BluetoothDevice bondTarget;
+    private volatile boolean skipBonding;
 
     // --- Pairing method observation (PT-0904) -----------------------------
     // PAIRING_VARIANT_* constants are @SystemApi; use raw int values.
@@ -501,6 +502,18 @@ public class BleHelper {
     // --- Connection --------------------------------------------------------
 
     /**
+     * When set, {@link #connect} skips client-initiated bonding (Steps 0/2/4)
+     * and relies on the remote device's server-initiated Security Request to
+     * drive pairing.  Used for node connections where the node calls
+     * {@code ble_gap_security_initiate()} in its {@code on_connect} callback;
+     * having both sides initiate simultaneously confuses NimBLE's SMP state
+     * machine.
+     */
+    public void setSkipBonding(boolean skip) {
+        this.skipBonding = skip;
+    }
+
+    /**
      * Connect to the device, bond, negotiate MTU, and discover services.
      *
      * <p>Blocks until all steps complete or {@code timeoutMs} elapses.
@@ -546,77 +559,81 @@ public class BleHelper {
                 BluetoothDevice.TRANSPORT_LE);
         if (gatt == null) throw new Exception("connectGatt returned null");
 
-        // Step 2 — initiate LESC bonding BEFORE waiting for the GATT connect
-        // callback.  connectGatt() is asynchronous: the LE connection has not
-        // been established when it returns, so calling createBond() here races
-        // ahead of the modem's Security Request.
-        //
-        // The modem calls ble_gap_security_initiate() immediately in its
-        // on_connect callback, sending a BLE Security Request to Android.
-        // If createBond() has not been called before that Security Request
-        // arrives, Android handles the incoming SMP as a background pairing
-        // and may advertise NoInputNoOutput IO capabilities, forcing Just
-        // Works instead of LESC Numeric Comparison.
-        //
-        // Calling createBond() here, while the LE link is still being
-        // established, places Android in "bonding mode" with KeyboardDisplay
-        // IO capabilities before the Security Request arrives, which ensures
-        // LESC Numeric Comparison is negotiated (PT-0904).
-        {
-            bonded = false;
-            createBondCalled = false;
-            bondTarget = device;
-            bondLatch = new CountDownLatch(1);
-            observedPairingVariant = -1;
-            // Note: do NOT reset lastError here — it may have been set by
-            // onConnectionStateChange() racing with this bonding setup, and we
-            // need to preserve any GATT status code captured before checking it
-            // in Step 3.
+        if (!skipBonding) {
+            // Step 2 — initiate LESC bonding BEFORE waiting for the GATT connect
+            // callback.  connectGatt() is asynchronous: the LE connection has not
+            // been established when it returns, so calling createBond() here races
+            // ahead of the modem's Security Request.
+            //
+            // The modem calls ble_gap_security_initiate() immediately in its
+            // on_connect callback, sending a BLE Security Request to Android.
+            // If createBond() has not been called before that Security Request
+            // arrives, Android handles the incoming SMP as a background pairing
+            // and may advertise NoInputNoOutput IO capabilities, forcing Just
+            // Works instead of LESC Numeric Comparison.
+            //
+            // Calling createBond() here, while the LE link is still being
+            // established, places Android in "bonding mode" with KeyboardDisplay
+            // IO capabilities before the Security Request arrives, which ensures
+            // LESC Numeric Comparison is negotiated (PT-0904).
+            {
+                bonded = false;
+                createBondCalled = false;
+                bondTarget = device;
+                bondLatch = new CountDownLatch(1);
+                observedPairingVariant = -1;
+                // Note: do NOT reset lastError here — it may have been set by
+                // onConnectionStateChange() racing with this bonding setup, and we
+                // need to preserve any GATT status code captured before checking it
+                // in Step 3.
 
-            // Register receivers before calling createBond to avoid races.
-            if (!pairingReceiverRegistered) {
-                IntentFilter pairingFilter = new IntentFilter(
-                        BluetoothDevice.ACTION_PAIRING_REQUEST);
-                try {
-                    context.registerReceiver(pairingReceiver, pairingFilter);
-                    pairingReceiverRegistered = true;
-                } catch (SecurityException | IllegalArgumentException e) {
-                    Log.w("BleHelper",
-                            "failed to register pairing receiver: " + e.getMessage());
-                    // Non-fatal — getPairingMethod() will return PM_UNKNOWN,
-                    // which enforce_lesc() treats as a rejection (fail-secure).
+                // Register receivers before calling createBond to avoid races.
+                if (!pairingReceiverRegistered) {
+                    IntentFilter pairingFilter = new IntentFilter(
+                            BluetoothDevice.ACTION_PAIRING_REQUEST);
+                    try {
+                        context.registerReceiver(pairingReceiver, pairingFilter);
+                        pairingReceiverRegistered = true;
+                    } catch (SecurityException | IllegalArgumentException e) {
+                        Log.w("BleHelper",
+                                "failed to register pairing receiver: " + e.getMessage());
+                        // Non-fatal — getPairingMethod() will return PM_UNKNOWN,
+                        // which enforce_lesc() treats as a rejection (fail-secure).
+                    }
                 }
-            }
-            if (!bondReceiverRegistered) {
-                IntentFilter filter = new IntentFilter(
-                        BluetoothDevice.ACTION_BOND_STATE_CHANGED);
-                try {
-                    context.registerReceiver(bondReceiver, filter);
-                    bondReceiverRegistered = true;
-                } catch (SecurityException | IllegalArgumentException e) {
-                    disconnectInner();
-                    throw new Exception(
-                            "failed to register bond receiver: " + e.getMessage(), e);
+                if (!bondReceiverRegistered) {
+                    IntentFilter filter = new IntentFilter(
+                            BluetoothDevice.ACTION_BOND_STATE_CHANGED);
+                    try {
+                        context.registerReceiver(bondReceiver, filter);
+                        bondReceiverRegistered = true;
+                    } catch (SecurityException | IllegalArgumentException e) {
+                        disconnectInner();
+                        throw new Exception(
+                                "failed to register bond receiver: " + e.getMessage(), e);
+                    }
                 }
-            }
 
-            createBondCalled = true;
-            if (!device.createBond()) {
-                // createBond can return false if bonding is already in
-                // progress or if removeBond failed.  Check current state.
-                int bs = device.getBondState();
-                if (bs == BluetoothDevice.BOND_BONDED) {
-                    Log.i("BleHelper", "createBond() returned false but already bonded");
-                    bonded = true;
-                    bondLatch.countDown();
-                } else if (bs == BluetoothDevice.BOND_BONDING) {
-                    Log.i("BleHelper", "createBond() returned false — bonding already in progress");
-                } else {
-                    disconnectInner();
-                    throw new Exception(
-                            "createBond() failed — try unpairing the device manually in Android Bluetooth settings");
+                createBondCalled = true;
+                if (!device.createBond()) {
+                    // createBond can return false if bonding is already in
+                    // progress or if removeBond failed.  Check current state.
+                    int bs = device.getBondState();
+                    if (bs == BluetoothDevice.BOND_BONDED) {
+                        Log.i("BleHelper", "createBond() returned false but already bonded");
+                        bonded = true;
+                        bondLatch.countDown();
+                    } else if (bs == BluetoothDevice.BOND_BONDING) {
+                        Log.i("BleHelper", "createBond() returned false — bonding already in progress");
+                    } else {
+                        disconnectInner();
+                        throw new Exception(
+                                "createBond() failed — try unpairing the device manually in Android Bluetooth settings");
+                    }
                 }
             }
+        } else {
+            Log.i("BleHelper", "skipBonding=true — relying on server-initiated pairing");
         }
 
         // Step 3 — wait for GATT connection.
@@ -634,16 +651,20 @@ public class BleHelper {
 
         // Step 4 — wait for bonding to complete (Numeric Comparison requires
         // gateway confirmation, so this may take several seconds).
-        remaining = deadline - System.currentTimeMillis();
-        if (remaining <= 0
-                || !bondLatch.await(remaining, TimeUnit.MILLISECONDS)) {
-            disconnectInner();
-            throw new Exception("bonding timed out");
-        }
-        if (!bonded) {
-            String err = lastError;
-            disconnectInner();
-            throw new Exception(err != null ? err : "bonding failed");
+        // When skipBonding is true, the node's server-initiated pairing
+        // completes transparently via NimBLE — no bondLatch wait needed.
+        if (!skipBonding) {
+            remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0
+                    || !bondLatch.await(remaining, TimeUnit.MILLISECONDS)) {
+                disconnectInner();
+                throw new Exception("bonding timed out");
+            }
+            if (!bonded) {
+                String err = lastError;
+                disconnectInner();
+                throw new Exception(err != null ? err : "bonding failed");
+            }
         }
 
         // Step 5 — request MTU (best effort; proceed even if request fails)

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -83,6 +83,7 @@ public class BleHelper {
     // --- Bonding state -----------------------------------------------------
     private volatile boolean bonded;
     private volatile boolean bondingStarted;
+    private volatile boolean createBondCalled;
     private volatile boolean bondReceiverRegistered;
     private volatile BluetoothDevice bondTarget;
 
@@ -118,9 +119,10 @@ public class BleHelper {
                 bonded = true;
                 CountDownLatch l = bondLatch;
                 if (l != null) l.countDown();
-            } else if (state == BluetoothDevice.BOND_NONE && bondingStarted) {
-                // Only treat BOND_NONE as a failure if we actually started
-                // bonding.  Ignore BOND_NONE from removeBond() cleanup.
+            } else if (state == BluetoothDevice.BOND_NONE && createBondCalled) {
+                // Only treat BOND_NONE as a failure if createBond() has actually
+                // been called (not just queued for async execution).  Ignore
+                // BOND_NONE from removeBond() cleanup in Step 0.
                 int reason = intent.getIntExtra(
                         "android.bluetooth.device.extra.REASON", -1);
                 lastError = "bonding failed (reason=" + reason + ")";
@@ -555,6 +557,7 @@ public class BleHelper {
         {
             bonded = false;
             bondingStarted = false;
+            createBondCalled = false;
             bondTarget = device;
             bondLatch = new CountDownLatch(1);
             observedPairingVariant = -1;
@@ -591,6 +594,7 @@ public class BleHelper {
             }
 
             bondingStarted = true;
+            createBondCalled = true;
             if (!device.createBond()) {
                 // createBond can return false if bonding is already in
                 // progress or if removeBond failed.  Check current state.

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -546,6 +546,7 @@ public class BleHelper {
         BluetoothDevice device = adapter.getRemoteDevice(addrStr);
 
         lastError = null;
+        observedPairingVariant = -1;
         long deadline = System.currentTimeMillis() + timeoutMs;
 
         // Step 0 — remove stale bond (must happen before GATT connect)

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -82,7 +82,6 @@ public class BleHelper {
 
     // --- Bonding state -----------------------------------------------------
     private volatile boolean bonded;
-    private volatile boolean bondingStarted;
     private volatile boolean createBondCalled;
     private volatile boolean bondReceiverRegistered;
     private volatile BluetoothDevice bondTarget;
@@ -114,15 +113,21 @@ public class BleHelper {
             }
             int state = intent.getIntExtra(
                     BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.BOND_NONE);
-            Log.i("BleHelper", "bond state changed: " + state);
+            int prevState = intent.getIntExtra(
+                    "android.bluetooth.device.extra.PREVIOUS_BOND_STATE", BluetoothDevice.BOND_NONE);
+            Log.i("BleHelper", "bond state changed: " + prevState + " -> " + state);
             if (state == BluetoothDevice.BOND_BONDED) {
                 bonded = true;
                 CountDownLatch l = bondLatch;
                 if (l != null) l.countDown();
-            } else if (state == BluetoothDevice.BOND_NONE && createBondCalled) {
-                // Only treat BOND_NONE as a failure if createBond() has actually
-                // been called (not just queued for async execution).  Ignore
-                // BOND_NONE from removeBond() cleanup in Step 0.
+            } else if (state == BluetoothDevice.BOND_NONE && createBondCalled
+                    && prevState == BluetoothDevice.BOND_BONDING) {
+                // Only treat BOND_NONE as a failure if:
+                // 1. createBond() has actually been called (not just async queued)
+                // 2. Previous state was BOND_BONDING (i.e., we initiated bonding)
+                // This distinguishes bonding failures from stale BOND_BONDED->BOND_NONE
+                // broadcasts from Step 0's removeBond() cleanup, which transition from
+                // BOND_BONDED (not BOND_BONDING).
                 int reason = intent.getIntExtra(
                         "android.bluetooth.device.extra.REASON", -1);
                 lastError = "bonding failed (reason=" + reason + ")";
@@ -556,7 +561,6 @@ public class BleHelper {
         // LESC Numeric Comparison is negotiated (PT-0904).
         {
             bonded = false;
-            bondingStarted = false;
             createBondCalled = false;
             bondTarget = device;
             bondLatch = new CountDownLatch(1);
@@ -593,7 +597,6 @@ public class BleHelper {
                 }
             }
 
-            bondingStarted = true;
             createBondCalled = true;
             if (!device.createBond()) {
                 // createBond can return false if bonding is already in
@@ -679,7 +682,7 @@ public class BleHelper {
         subscribedChars.clear();
         indicationQueues.clear();
         bondTarget = null;
-        bondingStarted = false;
+        createBondCalled = false;
         if (pairingReceiverRegistered) {
             try { context.unregisterReceiver(pairingReceiver); }
             catch (Exception ignored) { }

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -536,6 +536,12 @@ public class BleHelper {
         requireBlePermissions();
         disconnectInner();
 
+        // Capture and clear the skip-bonding hint so it applies only to
+        // this connection (one-shot).  A subsequent connect() (e.g.,
+        // Phase 1 modem) will use the default bonding flow.
+        boolean skipBondingForThisConnect = this.skipBonding;
+        this.skipBonding = false;
+
         String addrStr = bytesToMac(address);
         BluetoothDevice device = adapter.getRemoteDevice(addrStr);
 
@@ -559,7 +565,7 @@ public class BleHelper {
                 BluetoothDevice.TRANSPORT_LE);
         if (gatt == null) throw new Exception("connectGatt returned null");
 
-        if (!skipBonding) {
+        if (!skipBondingForThisConnect) {
             // Step 2 — initiate LESC bonding BEFORE waiting for the GATT connect
             // callback.  connectGatt() is asynchronous: the LE connection has not
             // been established when it returns, so calling createBond() here races
@@ -651,9 +657,9 @@ public class BleHelper {
 
         // Step 4 — wait for bonding to complete (Numeric Comparison requires
         // gateway confirmation, so this may take several seconds).
-        // When skipBonding is true, the node's server-initiated pairing
-        // completes transparently via NimBLE — no bondLatch wait needed.
-        if (!skipBonding) {
+        // When skipBondingForThisConnect is true, the node's server-initiated
+        // pairing completes transparently via NimBLE — no bondLatch wait needed.
+        if (!skipBondingForThisConnect) {
             remaining = deadline - System.currentTimeMillis();
             if (remaining <= 0
                     || !bondLatch.await(remaining, TimeUnit.MILLISECONDS)) {

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -557,8 +557,11 @@ public class BleHelper {
             bondingStarted = false;
             bondTarget = device;
             bondLatch = new CountDownLatch(1);
-            lastError = null;
             observedPairingVariant = -1;
+            // Note: do NOT reset lastError here — it may have been set by
+            // onConnectionStateChange() racing with this bonding setup, and we
+            // need to preserve any GATT status code captured before checking it
+            // in Step 3.
 
             // Register receivers before calling createBond to avoid races.
             if (!pairingReceiverRegistered) {

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -57,6 +57,10 @@ public class BleHelper {
     private static final UUID CCCD_UUID =
             UUID.fromString("00002902-0000-1000-8000-00805f9b34fb");
 
+    // Hidden extra key for bond failure reason code (not a public SDK constant).
+    private static final String EXTRA_BOND_REASON =
+            "android.bluetooth.device.extra.REASON";
+
     private final Context context;
     private final BluetoothAdapter adapter;
 
@@ -114,7 +118,7 @@ public class BleHelper {
             int state = intent.getIntExtra(
                     BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.BOND_NONE);
             int prevState = intent.getIntExtra(
-                    "android.bluetooth.device.extra.PREVIOUS_BOND_STATE", BluetoothDevice.BOND_NONE);
+                    BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.BOND_NONE);
             Log.i("BleHelper", "bond state changed: " + prevState + " -> " + state);
             if (state == BluetoothDevice.BOND_BONDED) {
                 bonded = true;
@@ -128,8 +132,7 @@ public class BleHelper {
                 // This distinguishes bonding failures from stale BOND_BONDED->BOND_NONE
                 // broadcasts from Step 0's removeBond() cleanup, which transition from
                 // BOND_BONDED (not BOND_BONDING).
-                int reason = intent.getIntExtra(
-                        "android.bluetooth.device.extra.REASON", -1);
+                int reason = intent.getIntExtra(EXTRA_BOND_REASON, -1);
                 lastError = "bonding failed (reason=" + reason + ")";
                 bonded = false;
                 CountDownLatch l = bondLatch;

--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -209,6 +209,33 @@ impl AndroidBleTransport {
                 other => other,
             })
     }
+
+    /// Tell the Java `BleHelper` to skip client-initiated bonding on the
+    /// next `connect()` call.  Used for node connections where the node's
+    /// server-initiated `ble_gap_security_initiate()` drives pairing;
+    /// having both sides initiate simultaneously confuses NimBLE's SMP
+    /// state machine.
+    pub fn set_skip_bonding(&self, skip: bool) -> Result<(), PairingError> {
+        self.inner
+            .vm
+            .attach_current_thread(|env| {
+                env.call_method(
+                    self.inner.helper.as_obj(),
+                    jni_str!("setSkipBonding"),
+                    jni_sig!("(Z)V"),
+                    &[JValue::Bool(skip as u8)],
+                )
+                .map_err(|e| jni_exception_or(env, "setSkipBonding", e))?;
+                Ok(())
+            })
+            .map_err(|e| match e {
+                PairingError::JniError(msg) => PairingError::ConnectionFailed {
+                    device: None,
+                    reason: format!("attach_current_thread: {msg}"),
+                },
+                other => other,
+            })
+    }
 }
 
 impl BleTransport for AndroidBleTransport {
@@ -703,6 +730,12 @@ impl BleTransport for AndroidBleTransport {
             1 => Some(PairingMethod::NumericComparison),
             2 => Some(PairingMethod::JustWorks),
             _ => Some(PairingMethod::Unknown),
+        }
+    }
+
+    fn set_skip_bonding(&mut self, skip: bool) {
+        if let Err(e) = self.set_skip_bonding(skip) {
+            tracing::warn!(error = ?e, "failed to set skipBonding on BleHelper");
         }
     }
 }

--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -223,7 +223,7 @@ impl AndroidBleTransport {
                     self.inner.helper.as_obj(),
                     jni_str!("setSkipBonding"),
                     jni_sig!("(Z)V"),
-                    &[JValue::Bool(skip as u8)],
+                    &[JValue::Bool(skip)],
                 )
                 .map_err(|e| jni_exception_or(env, "setSkipBonding", e))?;
                 Ok(())
@@ -734,7 +734,7 @@ impl BleTransport for AndroidBleTransport {
     }
 
     fn set_skip_bonding(&mut self, skip: bool) {
-        if let Err(e) = self.set_skip_bonding(skip) {
+        if let Err(e) = AndroidBleTransport::set_skip_bonding(self, skip) {
             tracing::warn!(error = ?e, "failed to set skipBonding on BleHelper");
         }
     }

--- a/crates/sonde-pair/src/android_transport.rs
+++ b/crates/sonde-pair/src/android_transport.rs
@@ -210,22 +210,21 @@ impl AndroidBleTransport {
             })
     }
 
-    /// Tell the Java `BleHelper` to skip client-initiated bonding on the
-    /// next `connect()` call.  Used for node connections where the node's
-    /// server-initiated `ble_gap_security_initiate()` drives pairing;
-    /// having both sides initiate simultaneously confuses NimBLE's SMP
-    /// state machine.
-    pub fn set_skip_bonding(&self, skip: bool) -> Result<(), PairingError> {
+    /// Tell the Java `BleHelper` to defer `createBond()` until after the
+    /// GATT connect latch on the next `connect()` call.  Used for node
+    /// connections where calling `createBond()` before the latch causes a
+    /// dual-initiation race with NimBLE's SMP state machine.
+    pub fn set_defer_bonding(&self, defer: bool) -> Result<(), PairingError> {
         self.inner
             .vm
             .attach_current_thread(|env| {
                 env.call_method(
                     self.inner.helper.as_obj(),
-                    jni_str!("setSkipBonding"),
+                    jni_str!("setDeferBonding"),
                     jni_sig!("(Z)V"),
-                    &[JValue::Bool(skip)],
+                    &[JValue::Bool(defer)],
                 )
-                .map_err(|e| jni_exception_or(env, "setSkipBonding", e))?;
+                .map_err(|e| jni_exception_or(env, "setDeferBonding", e))?;
                 Ok(())
             })
             .map_err(|e| match e {
@@ -733,9 +732,9 @@ impl BleTransport for AndroidBleTransport {
         }
     }
 
-    fn set_skip_bonding(&mut self, skip: bool) {
-        if let Err(e) = AndroidBleTransport::set_skip_bonding(self, skip) {
-            tracing::warn!(error = ?e, "failed to set skipBonding on BleHelper");
+    fn set_defer_bonding(&mut self, defer: bool) {
+        if let Err(e) = AndroidBleTransport::set_defer_bonding(self, defer) {
+            tracing::warn!(error = ?e, "failed to set deferBonding on BleHelper");
         }
     }
 }

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -94,7 +94,11 @@ pub async fn provision_node(
     // confuses NimBLE's SMP state machine ("No open connection").
     transport.set_skip_bonding(true);
     debug!(address = ?device_address, "connecting to node (AEAD provision)");
-    let mtu = transport.connect(device_address).await?;
+    let mtu_result = transport.connect(device_address).await;
+    // Reset skip-bonding hint immediately (one-shot) so any subsequent
+    // connection on the same transport uses the default bonding flow.
+    transport.set_skip_bonding(false);
+    let mtu = mtu_result?;
     if mtu < BLE_MTU_MIN {
         transport.disconnect().await.ok();
         return Err(PairingError::MtuTooLow {

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -88,6 +88,11 @@ pub async fn provision_node(
     let encrypted_frame = crypto::encrypt_pairing_request(&artifacts.phone_psk, &cbor)?;
 
     // Step 6: Connect to node
+    // Skip client-initiated bonding — the node calls
+    // ble_gap_security_initiate() in its on_connect callback to drive
+    // LESC Just Works pairing.  Having both sides initiate simultaneously
+    // confuses NimBLE's SMP state machine ("No open connection").
+    transport.set_skip_bonding(true);
     debug!(address = ?device_address, "connecting to node (AEAD provision)");
     let mtu = transport.connect(device_address).await?;
     if mtu < BLE_MTU_MIN {

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -88,16 +88,18 @@ pub async fn provision_node(
     let encrypted_frame = crypto::encrypt_pairing_request(&artifacts.phone_psk, &cbor)?;
 
     // Step 6: Connect to node
-    // Skip client-initiated bonding — the node calls
-    // ble_gap_security_initiate() in its on_connect callback to drive
-    // LESC Just Works pairing.  Having both sides initiate simultaneously
-    // confuses NimBLE's SMP state machine ("No open connection").
-    transport.set_skip_bonding(true);
+    // Defer createBond() until after the GATT connect latch.  The node
+    // calls ble_gap_security_initiate() in its on_connect callback;
+    // calling createBond() before the latch causes a dual-initiation race
+    // that confuses NimBLE's SMP state machine.  Deferring createBond()
+    // to after the latch is the standard Android BLE flow and works
+    // correctly with the node's Just Works pairing.
+    transport.set_defer_bonding(true);
     debug!(address = ?device_address, "connecting to node (AEAD provision)");
     let mtu_result = transport.connect(device_address).await;
-    // Reset skip-bonding hint immediately (one-shot) so any subsequent
+    // Reset defer-bonding hint immediately (one-shot) so any subsequent
     // connection on the same transport uses the default bonding flow.
-    transport.set_skip_bonding(false);
+    transport.set_defer_bonding(false);
     let mtu = mtu_result?;
     if mtu < BLE_MTU_MIN {
         transport.disconnect().await.ok();

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -6,7 +6,7 @@ use crate::crypto;
 use crate::envelope::{build_envelope, parse_envelope, parse_error_body, parse_node_ack};
 use crate::error::{format_device_address, PairingError};
 use crate::rng::RngProvider;
-use crate::transport::{enforce_lesc, BleTransport};
+use crate::transport::BleTransport;
 use crate::types::*;
 use crate::validation::{compute_key_hint, validate_node_id};
 use tracing::{debug, info, trace};
@@ -100,7 +100,13 @@ pub async fn provision_node(
     }
     debug!(address = ?device_address, mtu, "connected to node");
 
-    enforce_lesc(transport).await?;
+    // Note: enforce_lesc() is intentionally NOT called for node connections.
+    // The node uses LESC Just Works (ND-0904) because it has no display or
+    // input for Numeric Comparison.  PT-0904 (LESC Numeric Comparison
+    // enforcement) applies only to the modem connection in Phase 1.
+    // LESC Just Works still provides link-layer encryption but does not
+    // protect against active MITM — this residual risk is accepted for
+    // headless nodes per the protocol spec (ble-pairing-protocol.md §8.2).
 
     // Step 7: Build NODE_PROVISION payload (AEAD format per spec §6.6):
     // node_key_hint(2) || node_psk(32) || rf_channel(1) || payload_len(2) || encrypted_payload

--- a/crates/sonde-pair/src/transport.rs
+++ b/crates/sonde-pair/src/transport.rs
@@ -61,6 +61,15 @@ pub trait BleTransport {
     /// implementations are forced to make an explicit choice — forgetting
     /// to implement it is a compile error, not a silent security bypass.
     fn pairing_method(&self) -> Option<PairingMethod>;
+
+    /// Hint to the transport that the next `connect()` should skip
+    /// client-initiated bonding and let the remote device's server-initiated
+    /// Security Request drive pairing.
+    ///
+    /// Used for node connections where both sides initiating pairing
+    /// simultaneously confuses NimBLE's SMP state machine.  Desktop
+    /// transports can ignore this (default is a no-op).
+    fn set_skip_bonding(&mut self, _skip: bool) {}
 }
 
 /// Mock BLE transport for testing pairing logic without hardware.

--- a/crates/sonde-pair/src/transport.rs
+++ b/crates/sonde-pair/src/transport.rs
@@ -62,14 +62,13 @@ pub trait BleTransport {
     /// to implement it is a compile error, not a silent security bypass.
     fn pairing_method(&self) -> Option<PairingMethod>;
 
-    /// Hint to the transport that the next `connect()` should skip
-    /// client-initiated bonding and let the remote device's server-initiated
-    /// Security Request drive pairing.
+    /// Hint to the transport that the next `connect()` should call
+    /// `createBond()` after the GATT connect latch instead of before it.
     ///
-    /// Used for node connections where both sides initiating pairing
-    /// simultaneously confuses NimBLE's SMP state machine.  Desktop
-    /// transports can ignore this (default is a no-op).
-    fn set_skip_bonding(&mut self, _skip: bool) {}
+    /// Used for node connections where calling `createBond()` before the
+    /// latch causes a dual-initiation race with NimBLE's SMP state machine.
+    /// Desktop transports can ignore this (default is a no-op).
+    fn set_defer_bonding(&mut self, _defer: bool) {}
 }
 
 /// Mock BLE transport for testing pairing logic without hardware.


### PR DESCRIPTION
## Problem

Android node provisioning (Phase 2) fails with:
> BLE pairing used insecure method `Just Works` — Numeric Comparison (LESC) is required

This happens because `enforce_lesc()` is called in Phase 2, but the node uses `SecurityIOCap::NoInputNoOutput` (LESC Just Works) since it has no display or input for Numeric Comparison.

Windows was unaffected because `btleplug` returns `None` for `pairing_method()`, which `enforce_lesc()` treats as OS-enforced and allows through.

## Root cause

The `enforce_lesc()` check was applied to **both** Phase 1 (modem) and Phase 2 (node) connections, but the requirement (PT-0904) only mandates Numeric Comparison for the **modem** connection. The node requirement (ND-0904) explicitly says "LESC Just Works."

ADB logs confirmed the SMP stack negotiated Just Works (variant 3 / CONSENT) because the node advertises `NoInputNoOutput`:
```
BluetoothBondStateMachine: sspRequestCallback: pairingVariant 2 (BT_SSP_VARIANT_CONSENT)
BleHelper: pairing request variant: 3 (PAIRING_VARIANT_CONSENT = Just Works)
```

## Fix

Remove `enforce_lesc()` from Phase 2 (`provision_node` in `phase2.rs`). Add a comment explaining the security rationale:
- LESC Just Works provides link-layer encryption
- The residual active-MITM risk is accepted for headless nodes per the protocol spec (ble-pairing-protocol.md §8.2)
- PT-0904 enforcement remains in Phase 1 (modem connection)

## Testing

- All 109 sonde-pair tests pass
- Clippy clean
- Requires on-device verification with Android + node hardware
