### PR TITLE
pair-ui: persist Android pairing artifacts via AndroidPairingStore

### DIFF
--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -486,8 +486,10 @@ async fn pair_gateway(
             if let Err(e) = store.save_artifacts(&artifacts) {
                 // Best-effort clear to prevent mixed old+new state (e.g., new
                 // phone_psk committed but old phone_key_hint left from a
-                // previous pairing).
+                // previous pairing).  Also clear the in-memory cache so it
+                // stays consistent with the (now-empty) persistent store.
                 let _ = store.clear();
+                *state.pairing_artifacts.lock().unwrap() = None;
                 let msg = e.to_string();
                 *state.phase.lock().unwrap() = format!("Error: {msg}");
                 return Err(msg);

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -484,6 +484,10 @@ async fn pair_gateway(
                 }
             };
             if let Err(e) = store.save_artifacts(&artifacts) {
+                // Best-effort clear to prevent mixed old+new state (e.g., new
+                // phone_psk committed but old phone_key_hint left from a
+                // previous pairing).
+                let _ = store.clear();
                 let msg = e.to_string();
                 *state.phase.lock().unwrap() = format!("Error: {msg}");
                 return Err(msg);

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -7,9 +7,10 @@
 //! On Android, BLE operations use [`AndroidBleTransport`].
 //!
 //! Pairing artifacts (phone PSK) are held in memory during the session
-//! and persisted to `pairing-aead.json` via [`FilePairingStore`] on
-//! desktop. The simplified AEAD flow does not use ECDH or gateway
-//! identity TOFU.
+//! and persisted to platform-appropriate secure storage:
+//! [`FilePairingStore`] on desktop, [`AndroidPairingStore`] (backed by
+//! `EncryptedSharedPreferences`) on Android. The simplified AEAD flow
+//! does not use ECDH or gateway identity TOFU.
 //!
 //! All BLE operations use `spawn_blocking` + `Handle::block_on` so that
 //! non-Send futures from [`sonde_pair::transport::BleTransport`] work on
@@ -472,6 +473,12 @@ async fn pair_gateway(
 
     match result {
         Ok(artifacts) => {
+            // Persist to Android secure storage so provisioning works across
+            // app restarts (PT-0800, PT-0801).
+            let mut store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
+            store
+                .save_artifacts(&artifacts)
+                .map_err(|e| e.to_string())?;
             *state.pairing_artifacts.lock().unwrap() = Some(Arc::new(artifacts));
             *state.phase.lock().unwrap() = "Complete".into();
             Ok(())
@@ -505,12 +512,23 @@ async fn provision_node(
 
     let pin_config = resolve_pin_config(i2c_sda, i2c_scl)?;
 
-    let artifacts = state
-        .pairing_artifacts
-        .lock()
-        .unwrap()
-        .clone()
-        .ok_or_else(|| "Not paired — run pair_gateway first".to_string())?;
+    // Load artifacts from in-memory cache, falling back to Android secure storage.
+    let artifacts = {
+        let mut guard = state.pairing_artifacts.lock().unwrap();
+        if guard.is_none() {
+            let store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
+            match store.load_artifacts() {
+                Ok(Some(loaded)) => {
+                    *guard = Some(Arc::new(loaded));
+                }
+                Ok(None) => {}
+                Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
+            }
+        }
+        guard
+            .clone()
+            .ok_or_else(|| "Not paired — run pair_gateway first".to_string())?
+    };
 
     *state.phase.lock().unwrap() = "Provisioning".into();
 
@@ -549,7 +567,15 @@ async fn provision_node(
 #[cfg(target_os = "android")]
 #[tauri::command]
 fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus, String> {
-    let paired = state.pairing_artifacts.lock().unwrap().is_some();
+    let mut paired = state.pairing_artifacts.lock().unwrap().is_some();
+    if !paired {
+        let store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
+        match store.load_artifacts() {
+            Ok(Some(_)) => paired = true,
+            Ok(None) => {}
+            Err(e) => return Err(format!("failed to check pairing status: {e}")),
+        }
+    }
     Ok(PairingStatus {
         paired,
         gateway_id: None,
@@ -560,6 +586,8 @@ fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus
 #[tauri::command]
 fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
     *state.pairing_artifacts.lock().unwrap() = None;
+    let mut store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
+    store.clear().map_err(|e| e.to_string())?;
     *state.phase.lock().unwrap() = "Idle".into();
     Ok(())
 }

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -475,10 +475,19 @@ async fn pair_gateway(
         Ok(artifacts) => {
             // Persist to Android secure storage so provisioning works across
             // app restarts (PT-0800, PT-0801).
-            let mut store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
-            store
-                .save_artifacts(&artifacts)
-                .map_err(|e| e.to_string())?;
+            let mut store = match AndroidPairingStore::from_cached_vm() {
+                Ok(s) => s,
+                Err(e) => {
+                    let msg = e.to_string();
+                    *state.phase.lock().unwrap() = format!("Error: {msg}");
+                    return Err(msg);
+                }
+            };
+            if let Err(e) = store.save_artifacts(&artifacts) {
+                let msg = e.to_string();
+                *state.phase.lock().unwrap() = format!("Error: {msg}");
+                return Err(msg);
+            }
             *state.pairing_artifacts.lock().unwrap() = Some(Arc::new(artifacts));
             *state.phase.lock().unwrap() = "Complete".into();
             Ok(())
@@ -585,9 +594,9 @@ fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus
 #[cfg(target_os = "android")]
 #[tauri::command]
 fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
-    *state.pairing_artifacts.lock().unwrap() = None;
     let mut store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
     store.clear().map_err(|e| e.to_string())?;
+    *state.pairing_artifacts.lock().unwrap() = None;
     *state.phase.lock().unwrap() = "Idle".into();
     Ok(())
 }

--- a/crates/sonde-pair/java/io/sonde/pair/SecureStore.java
+++ b/crates/sonde-pair/java/io/sonde/pair/SecureStore.java
@@ -50,7 +50,9 @@ public class SecureStore {
 
     /** Store a byte array under {@code key}. */
     public void putBytes(String key, byte[] value) {
-        prefs.edit().putString(key, bytesToHex(value)).commit();
+        if (!prefs.edit().putString(key, bytesToHex(value)).commit()) {
+            throw new RuntimeException("SharedPreferences commit failed for key: " + key);
+        }
     }
 
     /**
@@ -67,7 +69,9 @@ public class SecureStore {
     // --- String storage ----------------------------------------------------
 
     public void putString(String key, String value) {
-        prefs.edit().putString(key, value).commit();
+        if (!prefs.edit().putString(key, value).commit()) {
+            throw new RuntimeException("SharedPreferences commit failed for key: " + key);
+        }
     }
 
     /** @return the string value, or {@code null} if absent */
@@ -78,7 +82,9 @@ public class SecureStore {
     // --- Integer storage ---------------------------------------------------
 
     public void putInt(String key, int value) {
-        prefs.edit().putInt(key, value).commit();
+        if (!prefs.edit().putInt(key, value).commit()) {
+            throw new RuntimeException("SharedPreferences commit failed for key: " + key);
+        }
     }
 
     /**
@@ -92,12 +98,16 @@ public class SecureStore {
 
     /** Remove a single key. */
     public void remove(String key) {
-        prefs.edit().remove(key).commit();
+        if (!prefs.edit().remove(key).commit()) {
+            throw new RuntimeException("SharedPreferences commit failed for remove: " + key);
+        }
     }
 
     /** Wipe all entries in the store. */
     public void clear() {
-        prefs.edit().clear().commit();
+        if (!prefs.edit().clear().commit()) {
+            throw new RuntimeException("SharedPreferences commit failed for clear");
+        }
     }
 
     // --- Hex helpers -------------------------------------------------------

--- a/crates/sonde-pair/java/io/sonde/pair/SecureStore.java
+++ b/crates/sonde-pair/java/io/sonde/pair/SecureStore.java
@@ -50,7 +50,7 @@ public class SecureStore {
 
     /** Store a byte array under {@code key}. */
     public void putBytes(String key, byte[] value) {
-        prefs.edit().putString(key, bytesToHex(value)).apply();
+        prefs.edit().putString(key, bytesToHex(value)).commit();
     }
 
     /**
@@ -67,7 +67,7 @@ public class SecureStore {
     // --- String storage ----------------------------------------------------
 
     public void putString(String key, String value) {
-        prefs.edit().putString(key, value).apply();
+        prefs.edit().putString(key, value).commit();
     }
 
     /** @return the string value, or {@code null} if absent */
@@ -78,7 +78,7 @@ public class SecureStore {
     // --- Integer storage ---------------------------------------------------
 
     public void putInt(String key, int value) {
-        prefs.edit().putInt(key, value).apply();
+        prefs.edit().putInt(key, value).commit();
     }
 
     /**
@@ -92,12 +92,12 @@ public class SecureStore {
 
     /** Remove a single key. */
     public void remove(String key) {
-        prefs.edit().remove(key).apply();
+        prefs.edit().remove(key).commit();
     }
 
     /** Wipe all entries in the store. */
     public void clear() {
-        prefs.edit().clear().apply();
+        prefs.edit().clear().commit();
     }
 
     // --- Hex helpers -------------------------------------------------------

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -806,7 +806,7 @@ TestNode {
 
 ### T-PT-607  Android Tauri commands persist via AndroidPairingStore
 
-**Validates:** PT-0800, PT-0801
+**Validates:** PT-0800, PT-0801  
 **Type:** Manual / platform test (requires Android device)
 
 **Procedure:**

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -804,6 +804,25 @@ TestNode {
 
 ---
 
+### T-PT-607  Android Tauri commands persist via AndroidPairingStore
+
+**Validates:** PT-0800, PT-0801
+**Type:** Manual / platform test (requires Android device)
+
+**Procedure:**
+1. Install the app on an Android device.  Ensure no prior pairing exists (fresh install or clear via Settings → Clear Data).
+2. Complete Phase 1 (pair with a gateway modem).
+3. Force-stop the app (Android Settings → Force Stop, or swipe from recents).
+4. Re-launch the app.
+5. Assert: the app reports "paired" status (pairing artifacts survived the restart via `EncryptedSharedPreferences`).
+6. Navigate to Phase 2 (node provisioning).
+7. Assert: provisioning proceeds without "Not paired" error (artifacts loaded from `AndroidPairingStore`).
+8. Use the "Clear pairing" UI action.
+9. Force-stop and re-launch the app.
+10. Assert: the app reports "unpaired" status (`EncryptedSharedPreferences` were cleared by `AndroidPairingStore::clear()`).
+
+---
+
 ## 9  Security tests
 
 ### T-PT-700  No key material in default logs
@@ -1566,6 +1585,7 @@ TestNode {
 | T-PT-604 | PT-0801 | Android secure storage uses EncryptedSharedPreferences |
 | T-PT-605 | PT-0801 | Windows secure storage uses restricted file permissions |
 | T-PT-606 | PT-0801 | Windows DPAPI PSK protect/unprotect semantics |
+| T-PT-607 | PT-0800, PT-0801 | Android Tauri commands persist via AndroidPairingStore |
 | T-PT-700 | PT-0900 | No key material in default logs |
 | T-PT-701 | PT-0900 | No key material in verbose logs |
 | T-PT-702 | PT-0901 | All randomness from injectable RNG provider |


### PR DESCRIPTION
## Summary

The Android Tauri commands (pair_gateway, provision_node, get_pairing_status, clear_pairing) only held pairing artifacts in the in-memory AppState. When the app was closed or force-stopped, all pairing state was lost — requiring re-pairing on every launch. The desktop commands already correctly persist via FilePairingStore.

## Root Cause

Pure implementation defect: the AndroidPairingStore (backed by EncryptedSharedPreferences via JNI) was fully implemented and JNI-initialized in JNI_OnLoad, but the Android Tauri commands never called it.

## Changes

### crates/sonde-pair-ui/src-tauri/src/lib.rs

Wire all 4 Android commands to AndroidPairingStore, matching the desktop pattern:

| Command | Fix |
|---------|-----|
| pair_gateway | Call store.save_artifacts() after successful Phase 1 |
| provision_node | Fall back to store.load_artifacts() when in-memory cache is empty |
| get_pairing_status | Fall back to store.load_artifacts() to check persistent store |
| clear_pairing | Call store.clear() to wipe EncryptedSharedPreferences |

Error handling: store failures propagate as errors to the UI (matching desktop behavior and user preference for durable-or-fail).

Persist-before-cache ordering: pair_gateway persists to the store before updating the in-memory Arc, so a persistence failure does not leave stale in-memory state.

### crates/sonde-pair/java/io/sonde/pair/SecureStore.java

Changed all 5 mutation methods from pply() to commit(). pply() writes to memory immediately but flushes to disk asynchronously — if the app is terminated before the flush completes, the write is lost. commit() is synchronous, ensuring writes are durable when save_artifacts() returns.

### docs/ble-pairing-tool-validation.md

Added T-PT-607 (manual Android test): pair gateway, force-stop, relaunch, verify paired status survives; clear pairing, force-stop, relaunch, verify unpaired.

## Traceability

- **PT-0800** (Pairing store contents): all 4 commands now persist/load/clear artifacts
- **PT-0801** (Platform-appropriate secure storage): AndroidPairingStore uses EncryptedSharedPreferences + Android Keystore; writes are now durable via commit()
- **T-PT-607**: new manual validation test covering the Android persistence round-trip