### PR TITLE
feat(ci): add arm64 gateway build and .deb installer for NanoPi R5S

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - 'Cargo.lock'
       - 'test-programs/**'
       - 'hw/**'
+      - 'installer/**'
       - '.github/workflows/ci.yml'
   workflow_call:
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -118,6 +118,16 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      - name: Upload arm64 binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gateway-linux-arm64
+          path: |
+            target/release/sonde-gateway
+            target/release/sonde-admin
+          if-no-files-found: error
+          retention-days: 7
+
   installer-windows:
     name: Windows installer (.msi)
     needs: [gateway]

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -69,12 +69,51 @@ jobs:
             DATE=$(date -u +%Y%m%d)
             VERSION="${BASE}+nightly.${DATE}"
           fi
-          bash installer/linux/build-deb.sh --version "${VERSION}"
+          bash installer/linux/build-deb.sh --arch amd64 --version "${VERSION}"
 
       - name: Upload .deb
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sonde-installer-linux
+          name: sonde-installer-linux-amd64
+          path: "*.deb"
+          if-no-files-found: error
+          retention-days: 7
+
+  installer-linux-arm64:
+    name: Linux installer (.deb arm64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          key: arm64-release
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            protobuf-compiler libudev-dev fakeroot dpkg
+
+      - name: Build binaries (release)
+        run: cargo build --release -p sonde-gateway -p sonde-admin
+
+      - name: Build .deb package
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            BASE=$(sed -n '/\[workspace\.package\]/,/^\[/{ s/^version *= *"\(.*\)"/\1/p; }' Cargo.toml)
+            DATE=$(date -u +%Y%m%d)
+            VERSION="${BASE}+nightly.${DATE}"
+          fi
+          bash installer/linux/build-deb.sh --arch arm64 --version "${VERSION}"
+
+      - name: Upload .deb
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sonde-installer-linux-arm64
           path: "*.deb"
           if-no-files-found: error
           retention-days: 7
@@ -135,7 +174,7 @@ jobs:
   # ── Publish release ────────────────────────────────────────────────
   release:
     name: Publish nightly
-    needs: [gateway, node-firmware, modem-firmware, desktop, android, installer-linux, installer-windows]
+    needs: [gateway, node-firmware, modem-firmware, desktop, android, installer-linux, installer-linux-arm64, installer-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -172,6 +211,8 @@ jobs:
           mkdir -p release-assets
           cp artifacts/gateway-linux-x86_64/sonde-gateway  release-assets/sonde-gateway
           cp artifacts/gateway-linux-x86_64/sonde-admin     release-assets/sonde-admin
+          cp artifacts/gateway-linux-arm64/sonde-gateway    release-assets/sonde-gateway-arm64
+          cp artifacts/gateway-linux-arm64/sonde-admin      release-assets/sonde-admin-arm64
           cp artifacts/gateway-windows-x86_64/sonde-gateway.exe release-assets/sonde-gateway.exe
           cp artifacts/gateway-windows-x86_64/sonde-admin.exe   release-assets/sonde-admin.exe
           cp artifacts/node-firmware/flash_image.bin        release-assets/node-flash_image.bin
@@ -182,7 +223,8 @@ jobs:
           if [ -d artifacts/sonde-pair-android-release ]; then
             for f in artifacts/sonde-pair-android-release/*; do cp -r "$f" release-assets/; done
           fi
-          for f in artifacts/sonde-installer-linux/*;  do cp -r "$f" release-assets/; done
+          for f in artifacts/sonde-installer-linux-amd64/*;  do cp -r "$f" release-assets/; done
+          for f in artifacts/sonde-installer-linux-arm64/*;  do cp -r "$f" release-assets/; done
           for f in artifacts/sonde-installer-windows/*; do cp -r "$f" release-assets/; done
 
           # Build release notes
@@ -193,6 +235,8 @@ jobs:
           |-----------|----------------|
           | Gateway (Linux x86_64) | `sonde-gateway` |
           | Admin CLI (Linux x86_64) | `sonde-admin` |
+          | Gateway (Linux arm64) | `sonde-gateway-arm64` |
+          | Admin CLI (Linux arm64) | `sonde-admin-arm64` |
           | Gateway (Windows x86_64) | `sonde-gateway.exe` |
           | Admin CLI (Windows) | `sonde-admin.exe` |
           | ESP32-C3 Node firmware | `node-flash_image.bin` |
@@ -202,7 +246,8 @@ jobs:
           | Android APK (debug) | `*-debug.apk` |
           | Android APK (release) | `*-release.apk` (when signing secrets configured) |
           | Installer — Windows | `sonde-x86_64.msi` |
-          | Installer — Linux | `sonde_*_amd64.deb` |
+          | Installer — Linux (amd64) | `sonde_*_amd64.deb` |
+          | Installer — Linux (arm64) | `sonde_*_arm64.deb` |
 
           ### Flashing firmware
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,26 @@ permissions:
 jobs:
   # ── Linux .deb ──────────────────────────────────────────────────────────────
   deb:
-    name: Build Linux .deb package
-    runs-on: ubuntu-latest
+    name: Build Linux .deb (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            artifact: sonde-linux-deb-amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            artifact: sonde-linux-deb-arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          key: ${{ matrix.arch }}-release
 
       - name: Install system dependencies
         run: |
@@ -49,13 +61,13 @@ jobs:
         run: |
           chmod +x installer/linux/build-deb.sh
           installer/linux/build-deb.sh \
-            --arch amd64 \
+            --arch ${{ matrix.arch }} \
             --version ${{ steps.version.outputs.version }}
 
       - name: Upload .deb artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sonde-linux-deb
+          name: ${{ matrix.artifact }}
           path: sonde_*.deb
           if-no-files-found: error
           retention-days: 7

--- a/installer/linux/build-deb.sh
+++ b/installer/linux/build-deb.sh
@@ -16,9 +16,9 @@
 
 set -euo pipefail
 
-ARCH="amd64"
-VERSION="0.1.0"
 WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ARCH="$(dpkg --print-architecture 2>/dev/null || echo amd64)"
+VERSION="$(sed -n '/\[workspace\.package\]/,/^\[/{ s/^version *= *"\(.*\)"/\1/p; }' "${WORKSPACE_ROOT}/Cargo.toml" 2>/dev/null || echo 0.1.0)"
 TARGET_DIR="${WORKSPACE_ROOT}/target/release"
 
 while [[ $# -gt 0 ]]; do

--- a/installer/linux/build-deb.sh
+++ b/installer/linux/build-deb.sh
@@ -18,7 +18,10 @@ set -euo pipefail
 
 WORKSPACE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ARCH="$(dpkg --print-architecture 2>/dev/null || echo amd64)"
-VERSION="$(sed -n '/\[workspace\.package\]/,/^\[/{ s/^version *= *"\(.*\)"/\1/p; }' "${WORKSPACE_ROOT}/Cargo.toml" 2>/dev/null || echo 0.1.0)"
+VERSION="$(sed -n '/\[workspace\.package\]/,/^\[/{ s/^version *= *"\(.*\)"/\1/p; }' "${WORKSPACE_ROOT}/Cargo.toml" 2>/dev/null || true)"
+if [[ -z "${VERSION}" ]]; then
+    VERSION="0.1.0"
+fi
 TARGET_DIR="${WORKSPACE_ROOT}/target/release"
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary

Adds native arm64 CI build and `.deb` packaging for `sonde-gateway` and `sonde-admin`, targeting the NanoPi R5S (RK3568/aarch64).

## Changes

### `.github/workflows/release.yml`
- Expanded `deb` job into an arch matrix (`amd64` + `arm64`) using native runners (`ubuntu-latest` / `ubuntu-24.04-arm`)
- Each arch builds natively, packages via `build-deb.sh`, and uploads arch-specific artifact (`sonde-linux-deb-amd64`, `sonde-linux-deb-arm64`)

### `.github/workflows/nightly-release.yml`
- New `installer-linux-arm64` job: builds gateway+admin natively on arm64 runner (self-contained, no dependency on x86 CI artifacts), packages `.deb`, and uploads both the `.deb` and raw arm64 binaries
- Renamed x86_64 installer artifact from `sonde-installer-linux` to `sonde-installer-linux-amd64`
- Updated release job to collect both `.deb` artifacts and arm64 raw binaries
- Updated release notes table with arm64 entries

### `.github/workflows/ci.yml`
- Added `installer/**` to PR path triggers (no arm64 build job — that is handled by `release.yml`)

### `installer/linux/build-deb.sh`
- Auto-detect architecture via `dpkg --print-architecture` (fallback: amd64)
- Auto-detect version from `Cargo.toml` workspace with proper empty-string fallback
- CI continues to pass `--arch` and `--version` explicitly

## Testing
- No code changes — pure CI/packaging infrastructure
- Will verify arm64 runner availability on first CI run
