### PR TITLE
fix(gateway): abort subsystem tasks on shutdown to avoid GW-1400 watchdog

### DIFF
--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -673,7 +673,26 @@ async fn run_gateway(
         tokio::select! {
             _ = &mut shutdown => {
                 info!("shutdown signal received, stopping gateway");
+                // Abort all subsystem tasks so the tokio runtime does not
+                // block on orphaned futures during teardown (GW-1400).
+                ble_controller.cancel_and_wait().await;
                 health_cancel.cancel();
+                frame_loop.abort();
+                ble_loop.abort();
+                grpc_handle.abort();
+                if !frame_loop.is_finished() {
+                    let _ = frame_loop.await;
+                }
+                if !ble_loop.is_finished() {
+                    let _ = ble_loop.await;
+                }
+                if !grpc_handle.is_finished() {
+                    let _ = grpc_handle.await;
+                }
+                if !health_handle.is_finished() {
+                    let _ = health_handle.await;
+                }
+                transport.abort_reader_and_wait().await;
                 break; // exit the outer reconnect loop
             }
             _ = &mut frame_loop => {
@@ -684,7 +703,22 @@ async fn run_gateway(
             }
             _ = &mut grpc_handle => {
                 error!("gRPC server exited unexpectedly");
+                // Abort all subsystem tasks so the tokio runtime does not
+                // block on orphaned futures during teardown (GW-1400).
+                ble_controller.cancel_and_wait().await;
                 health_cancel.cancel();
+                frame_loop.abort();
+                ble_loop.abort();
+                if !frame_loop.is_finished() {
+                    let _ = frame_loop.await;
+                }
+                if !ble_loop.is_finished() {
+                    let _ = ble_loop.await;
+                }
+                if !health_handle.is_finished() {
+                    let _ = health_handle.await;
+                }
+                transport.abort_reader_and_wait().await;
                 break; // gRPC failure is not recoverable
             }
             result = &mut health_handle => {


### PR DESCRIPTION
## Summary

Fixes #777 — the gateway shutdown path did not abort subsystem tasks, causing the 5-second GW-1400 force-exit watchdog to fire on every graceful shutdown.

## Root cause

The shutdown `select!` arm in `run_gateway` only cancelled the health monitor and broke out of the reconnect loop. The `frame_loop`, `ble_loop`, `grpc_handle`, `ble_controller`, and modem reader task were left orphaned, blocking tokio runtime teardown.

The same issue existed in the unrecoverable gRPC failure arm.

## Changes

Mirror the existing cleanup from the normal-disconnect path (lines 741-757) into both terminal-exit arms:

1. `ble_controller.cancel_and_wait().await` — release BLE-held `Arc<UsbEspNowTransport>`
2. `health_cancel.cancel()` — stop health monitor
3. Abort and await `frame_loop`, `ble_loop`, `grpc_handle`, `health_handle`
4. `transport.abort_reader_and_wait().await` — release serial port

## Testing

- `cargo clippy -p sonde-gateway -- -D warnings` — clean
- `cargo test -p sonde-gateway` — all 142 tests pass (132 unit + 9 integration + 1 doc-test)

## Traceability

- **Requirement**: GW-1400 (bounded shutdown time)
- **File changed**: `crates/sonde-gateway/src/bin/gateway.rs`