### PR TITLE
feat: multi-arch Alpine container image for sonde-gateway (GW-1800)

### DIFF
--- a/.github/docker/Dockerfile.gateway
+++ b/.github/docker/Dockerfile.gateway
@@ -21,7 +21,8 @@
 #       --port /dev/ttyACM0 --key-provider env
 
 # ── Stage 1: build ──────────────────────────────────────────────────────────
-FROM rust:alpine AS builder
+# rust:alpine — pinned by digest for reproducible builds.
+FROM rust:alpine@sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334 AS builder
 
 RUN apk add --no-cache musl-dev protobuf
 
@@ -37,7 +38,8 @@ RUN cargo build --release -p sonde-gateway --no-default-features \
        -p sonde-tmp102-handler
 
 # ── Stage 2: runtime ────────────────────────────────────────────────────────
-FROM alpine:3.21
+# alpine:3.21 — pinned by digest for reproducible builds.
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 # Non-root user for the gateway process (GW-1802 AC3).
 RUN addgroup -S sonde && adduser -S sonde -G sonde \

--- a/.github/docker/Dockerfile.gateway
+++ b/.github/docker/Dockerfile.gateway
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Multi-stage Dockerfile for the sonde-gateway container image.
+# Produces a minimal Alpine-based image containing sonde-gateway,
+# sonde-admin, and the sensor handler binaries.
+#
+# Published to ghcr.io/alan-jowett/sonde-gateway by the
+# gateway-container.yml CI workflow (GW-1800).
+#
+# Build:
+#   docker build -f .github/docker/Dockerfile.gateway -t sonde-gateway .
+#
+# Run:
+#   docker run -d \
+#     -v sonde-data:/var/lib/sonde \
+#     -e SONDE_MASTER_KEY=<64-hex-chars> \
+#     --device /dev/ttyACM0 \
+#     --group-add <host-dialout-gid> \
+#     sonde-gateway \
+#       --port /dev/ttyACM0 --key-provider env
+
+# ── Stage 1: build ──────────────────────────────────────────────────────────
+FROM rust:alpine AS builder
+
+RUN apk add --no-cache musl-dev protobuf
+
+WORKDIR /src
+COPY . .
+
+# Build sonde-gateway without the keyring (D-Bus) feature.
+# The container uses --key-provider file or --key-provider env instead.
+RUN cargo build --release -p sonde-gateway --no-default-features \
+    && cargo build --release \
+       -p sonde-admin \
+       -p sonde-sht40-handler \
+       -p sonde-tmp102-handler
+
+# ── Stage 2: runtime ────────────────────────────────────────────────────────
+FROM alpine:3.21
+
+# Non-root user for the gateway process (GW-1802 AC3).
+RUN addgroup -S sonde && adduser -S sonde -G sonde \
+    && mkdir -p /var/lib/sonde \
+    && chown sonde:sonde /var/lib/sonde
+
+COPY --from=builder /src/target/release/sonde-gateway      /usr/local/bin/
+COPY --from=builder /src/target/release/sonde-admin         /usr/local/bin/
+COPY --from=builder /src/target/release/sonde-sht40-handler /usr/local/bin/
+COPY --from=builder /src/target/release/sonde-tmp102-handler /usr/local/bin/
+
+# Persist the database across container restarts (GW-1802 AC2).
+VOLUME /var/lib/sonde
+
+USER sonde
+
+ENTRYPOINT ["sonde-gateway"]
+CMD ["--db", "/var/lib/sonde/sonde.db"]

--- a/.github/docker/Dockerfile.gateway.dockerignore
+++ b/.github/docker/Dockerfile.gateway.dockerignore
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Exclude large/unnecessary directories from the gateway Docker build context.
+target/
+hw/
+docs/
+sensor-data/
+logs/
+rfcxml/
+prevail-rust/tests/upstream/external/
+.git/
+*.etl
+*.xlsx
+*.wprp

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -80,11 +80,12 @@ jobs:
             'whoami | grep -q sonde && touch /var/lib/sonde/test && rm /var/lib/sonde/test'
 
       # Push the per-arch image with a temporary tag (consumed by the
-      # manifest job). Public user-facing tags are only created after
-      # BOTH architectures pass.
+      # manifest job). Include the workflow run ID so overlapping runs
+      # for the same commit cannot overwrite each other's temporary tags.
+      # Public user-facing tags are only created after BOTH architectures pass.
       - name: Push per-arch image
         run: |
-          ARCH_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-${{ github.sha }}-${{ matrix.arch }}"
+          ARCH_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-${{ github.sha }}-${{ github.run_id }}-${{ matrix.arch }}"
           docker tag "${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }}" "$ARCH_TAG"
           docker push "$ARCH_TAG"
 
@@ -129,8 +130,8 @@ jobs:
         run: |
           set -euo pipefail
           BASE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          AMD64="${BASE}:build-${{ github.sha }}-amd64"
-          ARM64="${BASE}:build-${{ github.sha }}-arm64"
+          AMD64="${BASE}:build-${{ github.sha }}-${{ github.run_id }}-amd64"
+          ARM64="${BASE}:build-${{ github.sha }}-${{ github.run_id }}-arm64"
 
           IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
           for TAG in "${TAG_ARRAY[@]}"; do

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -84,6 +85,7 @@ jobs:
       # for the same commit cannot overwrite each other's temporary tags.
       # Public user-facing tags are only created after BOTH architectures pass.
       - name: Push per-arch image
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: |
           ARCH_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-${{ github.sha }}-${{ github.run_id }}-${{ matrix.arch }}"
           docker tag "${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }}" "$ARCH_TAG"
@@ -93,6 +95,7 @@ jobs:
   manifest:
     name: Publish multi-arch manifest
     needs: [build]
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Build and publish the sonde-gateway multi-arch container image to GHCR.
+# Produces linux/amd64 and linux/arm64 images using native GitHub runners,
+# then combines them into a single multi-arch manifest (GW-1800).
+#
+# Triggered by nightly-release.yml (workflow_call) and on release tags.
+# Can also be run manually via workflow_dispatch.
+
+name: Gateway Container
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: alan-jowett/sonde-gateway
+
+jobs:
+  # ── Per-architecture native builds ────────────────────────────────
+  build:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
+      - name: Build container image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c816612f # v6
+        with:
+          context: .
+          file: .github/docker/Dockerfile.gateway
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }}
+
+      # Smoke tests: verify binaries exist and basic functionality works
+      # before pushing (GW-1800, matches esp-dev-container pattern).
+      - name: Smoke test — binary versions
+        run: |
+          docker run --rm ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
+          docker run --rm --entrypoint sonde-admin ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
+          docker run --rm --entrypoint sonde-sht40-handler ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
+          docker run --rm --entrypoint sonde-tmp102-handler ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
+
+      - name: Smoke test — static musl linkage
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'ldd /usr/local/bin/sonde-gateway 2>&1 | grep -q "not a dynamic executable"'
+
+      - name: Smoke test — non-root user and writable volume
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'whoami | grep -q sonde && touch /var/lib/sonde/test && rm /var/lib/sonde/test'
+
+      # Push the per-arch image with a temporary tag (consumed by the
+      # manifest job). Public user-facing tags are only created after
+      # BOTH architectures pass.
+      - name: Push per-arch image
+        run: |
+          ARCH_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-${{ github.sha }}-${{ matrix.arch }}"
+          docker tag "${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }}" "$ARCH_TAG"
+          docker push "$ARCH_TAG"
+
+  # ── Combine per-arch images into a multi-arch manifest ────────────
+  manifest:
+    name: Publish multi-arch manifest
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
+      - name: Determine tags
+        id: tags
+        run: |
+          set -euo pipefail
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          TAGS="sha-${SHORT_SHA}"
+
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            TAGS="${TAGS},${VERSION},latest"
+          else
+            DATE=$(date -u +%Y%m%d)
+            TAGS="${TAGS},nightly,nightly-${DATE}"
+          fi
+
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push multi-arch manifest
+        run: |
+          set -euo pipefail
+          BASE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          AMD64="${BASE}:build-${{ github.sha }}-amd64"
+          ARM64="${BASE}:build-${{ github.sha }}-arm64"
+
+          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          for TAG in "${TAG_ARRAY[@]}"; do
+            docker buildx imagetools create \
+              --tag "${BASE}:${TAG}" \
+              "${AMD64}" "${ARM64}"
+          done
+
+      - name: Clean up temporary per-arch tags
+        run: |
+          # Per-arch build tags are consumed; they will expire via GHCR
+          # retention policy. No explicit deletion needed.
+          echo "Manifest published successfully."

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -26,6 +26,10 @@ jobs:
     name: Gateway
     uses: ./.github/workflows/ci.yml
 
+  gateway-container:
+    name: Gateway container
+    uses: ./.github/workflows/gateway-container.yml
+
   node-firmware:
     name: Node firmware
     uses: ./.github/workflows/esp32.yml
@@ -184,7 +188,7 @@ jobs:
   # ── Publish release ────────────────────────────────────────────────
   release:
     name: Publish nightly
-    needs: [gateway, node-firmware, modem-firmware, desktop, android, installer-linux, installer-linux-arm64, installer-windows]
+    needs: [gateway, gateway-container, node-firmware, modem-firmware, desktop, android, installer-linux, installer-linux-arm64, installer-windows]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -258,6 +262,7 @@ jobs:
           | Installer — Windows | `sonde-x86_64.msi` |
           | Installer — Linux (amd64) | `sonde_*_amd64.deb` |
           | Installer — Linux (arm64) | `sonde_*_arm64.deb` |
+          | Container (multi-arch) | `ghcr.io/alan-jowett/sonde-gateway` |
 
           ### Flashing firmware
 

--- a/crates/sonde-gateway/Cargo.toml
+++ b/crates/sonde-gateway/Cargo.toml
@@ -62,5 +62,5 @@ tower = "0.5"
 
 [features]
 default = ["keyring"]
-keyring = ["secret-service"]
+keyring = ["dep:secret-service"]
 python-tests = []

--- a/crates/sonde-gateway/Cargo.toml
+++ b/crates/sonde-gateway/Cargo.toml
@@ -52,7 +52,7 @@ windows-service = "0.8.0"
 tracing-etw = "0.2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-secret-service = { version = "5", features = ["rt-tokio-crypto-rust"] }
+secret-service = { version = "5", features = ["rt-tokio-crypto-rust"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["test-util"] }
@@ -61,4 +61,6 @@ hyper-util = "0.1"
 tower = "0.5"
 
 [features]
+default = ["keyring"]
+keyring = ["secret-service"]
 python-tests = []

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -235,17 +235,17 @@ fn build_key_provider(cli: &Cli) -> Result<Box<dyn KeyProvider>, Box<dyn std::er
             }
         }
         KeyProviderKind::SecretService => {
-            #[cfg(target_os = "linux")]
+            #[cfg(all(target_os = "linux", feature = "keyring"))]
             {
                 use sonde_gateway::key_provider::SecretServiceKeyProvider;
                 Ok(Box::new(SecretServiceKeyProvider::new(
                     cli.key_label.clone(),
                 )))
             }
-            #[cfg(not(target_os = "linux"))]
+            #[cfg(not(all(target_os = "linux", feature = "keyring")))]
             {
                 Err(KeyProviderError::NotAvailable(
-                    "secret-service backend is only available on Linux".into(),
+                    "secret-service backend is only available on Linux with the `keyring` feature".into(),
                 )
                 .into())
             }

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -73,7 +73,7 @@ enum KeyProviderKind {
     Env,
     /// Decrypt a DPAPI-protected blob file given by `--master-key-file` (Windows only).
     Dpapi,
-    /// Retrieve the key from the Linux D-Bus Secret Service keyring (Linux only).
+    /// Retrieve the key from the Linux D-Bus Secret Service keyring (requires `keyring` feature).
     SecretService,
 }
 
@@ -146,7 +146,7 @@ struct Cli {
     /// - `file`           — Read 64 hex chars from `--master-key-file` (default).
     /// - `env`            — Read 64 hex chars from `SONDE_MASTER_KEY` env var.
     /// - `dpapi`          — Decrypt a DPAPI-protected blob at `--master-key-file` (Windows only).
-    /// - `secret-service` — Retrieve from the Linux D-Bus Secret Service keyring (Linux only).
+    /// - `secret-service` — Retrieve from the Linux D-Bus Secret Service keyring (Linux with `keyring` feature).
     #[arg(long, default_value = "file", value_enum)]
     key_provider: KeyProviderKind,
 

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -245,7 +245,8 @@ fn build_key_provider(cli: &Cli) -> Result<Box<dyn KeyProvider>, Box<dyn std::er
             #[cfg(not(all(target_os = "linux", feature = "keyring")))]
             {
                 Err(KeyProviderError::NotAvailable(
-                    "secret-service backend is only available on Linux with the `keyring` feature".into(),
+                    "secret-service backend is only available on Linux with the `keyring` feature"
+                        .into(),
                 )
                 .into())
             }

--- a/crates/sonde-gateway/src/key_provider.rs
+++ b/crates/sonde-gateway/src/key_provider.rs
@@ -545,7 +545,7 @@ mod dpapi {
 /// example, once during initial deployment or after a key rotation:
 ///
 /// ```no_run
-/// # #[cfg(target_os = "linux")] {
+/// # #[cfg(all(target_os = "linux", feature = "keyring"))] {
 /// use sonde_gateway::key_provider::store_in_secret_service;
 /// let key: [u8; 32] = /* your 32-byte key */
 /// #   [0u8; 32];
@@ -563,12 +563,12 @@ mod dpapi {
 /// For headless servers without an interactive session, configure a
 /// file-backed keyring (e.g. `gnome-keyring-daemon --daemonize --unlock`) or
 /// use `systemd-creds` as an alternative.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 pub struct SecretServiceKeyProvider {
     label: String,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 impl SecretServiceKeyProvider {
     /// Create a provider that retrieves the secret with the given `label`.
     ///
@@ -580,14 +580,14 @@ impl SecretServiceKeyProvider {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 impl Default for SecretServiceKeyProvider {
     fn default() -> Self {
         Self::new("sonde-gateway-master-key")
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 impl KeyProvider for SecretServiceKeyProvider {
     fn load_master_key(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
         let label = self.label.clone();
@@ -662,7 +662,7 @@ impl KeyProvider for SecretServiceKeyProvider {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 async fn ss_load(label: &str) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
     use secret_service::{EncryptionType, SecretService};
     use std::collections::HashMap;
@@ -719,7 +719,7 @@ async fn ss_load(label: &str) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
 ///
 /// Use this during initial deployment or after a key rotation, then switch to
 /// `--key-provider secret-service` on the next gateway start.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 pub fn store_in_secret_service(key: &[u8; 32], label: &str) -> Result<(), KeyProviderError> {
     // Use Zeroizing<Vec<u8>> so the key copy is cleared on drop.
     let key_bytes: Zeroizing<Vec<u8>> = Zeroizing::new(key.to_vec());
@@ -738,7 +738,7 @@ pub fn store_in_secret_service(key: &[u8; 32], label: &str) -> Result<(), KeyPro
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 async fn ss_store(key_bytes: &[u8], label: &str) -> Result<(), KeyProviderError> {
     use secret_service::{EncryptionType, SecretService};
     use std::collections::HashMap;
@@ -779,7 +779,7 @@ async fn ss_store(key_bytes: &[u8], label: &str) -> Result<(), KeyProviderError>
 /// Used exclusively by the generation path so that concurrent instances cannot
 /// overwrite each other's newly-generated key.  Callers should load the key
 /// after this call to obtain the canonical stored value.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 fn store_in_secret_service_if_not_exists(
     key: &[u8; 32],
     label: &str,
@@ -802,7 +802,7 @@ fn store_in_secret_service_if_not_exists(
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 async fn ss_store_if_not_exists(key_bytes: &[u8], label: &str) -> Result<(), KeyProviderError> {
     use secret_service::{EncryptionType, SecretService};
     use std::collections::HashMap;

--- a/crates/sonde-gateway/tests/key_provider.rs
+++ b/crates/sonde-gateway/tests/key_provider.rs
@@ -196,8 +196,9 @@ fn t0603i_secret_service_item_not_found() {
 #[cfg(not(all(target_os = "linux", feature = "keyring")))]
 #[test]
 fn t0603j_secret_service_unavailable_on_non_linux() {
-    let err =
-        KeyProviderError::NotAvailable("secret-service backend is only available on Linux with the `keyring` feature".into());
+    let err = KeyProviderError::NotAvailable(
+        "secret-service backend is only available on Linux with the `keyring` feature".into(),
+    );
     assert!(err.to_string().contains("Linux"));
 }
 

--- a/crates/sonde-gateway/tests/key_provider.rs
+++ b/crates/sonde-gateway/tests/key_provider.rs
@@ -190,12 +190,12 @@ fn t0603i_secret_service_item_not_found() {
     );
 }
 
-// ── T-0603j: SecretServiceKeyProvider — unavailable on non-Linux ────────────
+// ── T-0603j: SecretServiceKeyProvider — unavailable without keyring ──────────
 
-/// T-0603j  SecretServiceKeyProvider — unavailable on non-Linux.
+/// T-0603j  SecretServiceKeyProvider — unavailable without `keyring` feature.
 #[cfg(not(all(target_os = "linux", feature = "keyring")))]
 #[test]
-fn t0603j_secret_service_unavailable_on_non_linux() {
+fn t0603j_secret_service_unavailable_without_keyring() {
     let err = KeyProviderError::NotAvailable(
         "secret-service backend is only available on Linux with the `keyring` feature".into(),
     );

--- a/crates/sonde-gateway/tests/key_provider.rs
+++ b/crates/sonde-gateway/tests/key_provider.rs
@@ -152,11 +152,12 @@ fn t0603g_dpapi_unavailable_on_non_windows() {
 // ── T-0603h: SecretServiceKeyProvider — round-trip (Linux only) ─────────────
 
 // T-0603h and T-0603i require a running Secret Service daemon (GNOME Keyring
-// or KWallet). These tests are gated on cfg(target_os = "linux") and marked
-// #[ignore] since they require a D-Bus session bus and running keyring daemon.
+// or KWallet). These tests are gated on cfg(target_os = "linux", feature = "keyring")
+// and marked #[ignore] since they require a D-Bus session bus and running
+// keyring daemon.
 
 /// T-0603h  SecretServiceKeyProvider — round-trip (Linux only).
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 #[test]
 #[ignore = "requires running Secret Service daemon (D-Bus session bus)"]
 fn t0603h_secret_service_round_trip() {
@@ -173,7 +174,7 @@ fn t0603h_secret_service_round_trip() {
 // ── T-0603i: SecretServiceKeyProvider — item not found ──────────────────────
 
 /// T-0603i  SecretServiceKeyProvider — item not found.
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "keyring"))]
 #[test]
 #[ignore = "requires running Secret Service daemon (D-Bus session bus)"]
 fn t0603i_secret_service_item_not_found() {
@@ -192,11 +193,11 @@ fn t0603i_secret_service_item_not_found() {
 // ── T-0603j: SecretServiceKeyProvider — unavailable on non-Linux ────────────
 
 /// T-0603j  SecretServiceKeyProvider — unavailable on non-Linux.
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(all(target_os = "linux", feature = "keyring")))]
 #[test]
 fn t0603j_secret_service_unavailable_on_non_linux() {
     let err =
-        KeyProviderError::NotAvailable("secret-service backend is only available on Linux".into());
+        KeyProviderError::NotAvailable("secret-service backend is only available on Linux with the `keyring` feature".into());
     assert!(err.to_string().contains("Linux"));
 }
 

--- a/crates/sonde-gateway/tests/key_provider.rs
+++ b/crates/sonde-gateway/tests/key_provider.rs
@@ -152,9 +152,9 @@ fn t0603g_dpapi_unavailable_on_non_windows() {
 // ── T-0603h: SecretServiceKeyProvider — round-trip (Linux only) ─────────────
 
 // T-0603h and T-0603i require a running Secret Service daemon (GNOME Keyring
-// or KWallet). These tests are gated on cfg(target_os = "linux", feature = "keyring")
-// and marked #[ignore] since they require a D-Bus session bus and running
-// keyring daemon.
+// or KWallet). These tests are gated on
+// cfg(all(target_os = "linux", feature = "keyring")) and marked #[ignore]
+// since they require a D-Bus session bus and running keyring daemon.
 
 /// T-0603h  SecretServiceKeyProvider — round-trip (Linux only).
 #[cfg(all(target_os = "linux", feature = "keyring"))]

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1795,7 +1795,7 @@ Each architecture (`linux/amd64`, `linux/arm64`) is built natively on a per-arch
 
 **Multi-stage Dockerfile** (`.github/docker/Dockerfile.gateway`):
 
-1. **Builder stage** (`rust:alpine`): installs `musl-dev` and `protobuf`, builds all four binaries with `--no-default-features` (excludes the `keyring` feature and its `secret-service`/`zbus` dependency tree).
+1. **Builder stage** (`rust:alpine`): installs `musl-dev` and `protobuf`, builds all four binaries; the `sonde-gateway` build uses `--no-default-features` to exclude the `keyring` feature and its `secret-service`/`zbus` dependency tree.
 2. **Runtime stage** (`alpine:3.21`): copies only the compiled binaries, creates a non-root `sonde` user, and declares `VOLUME /var/lib/sonde`.
 
 ### 22.3  Feature flag: `keyring` (GW-1803)

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1778,3 +1778,50 @@ All diagnostic events are logged at `INFO` level **(GW-1706)**:
 - `DIAG_REPLY` sent: RSSI value, signal quality assessment, target MAC.
 - Decryption failures are logged at `DEBUG` level (consistent with GW-1302).
 - PSK values are never logged (consistent with GW-1307).
+
+---
+
+## 22  Container image
+
+> **Requirements:** GW-1800 (multi-arch image), GW-1801 (tagging), GW-1802 (runtime configuration), GW-1803 (optional secret-service).
+
+### 22.1  Overview
+
+The gateway is distributed as a multi-architecture Docker container image alongside the traditional bare-metal binaries and `.deb` packages. The image targets Alpine Linux (musl libc) for minimal size and contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, and `sonde-tmp102-handler`.
+
+### 22.2  Build strategy
+
+Each architecture (`linux/amd64`, `linux/arm64`) is built natively on a per-arch GitHub Actions runner — no QEMU cross-compilation. The per-arch images are combined into a single multi-arch manifest using `docker buildx imagetools create`.
+
+**Multi-stage Dockerfile** (`.github/docker/Dockerfile.gateway`):
+
+1. **Builder stage** (`rust:alpine`): installs `musl-dev` and `protobuf-dev`, builds all four binaries with `--no-default-features` (excludes the `keyring` feature and its `secret-service`/`zbus` dependency tree).
+2. **Runtime stage** (`alpine:3.21`): copies only the compiled binaries, creates a non-root `sonde` user, and declares `VOLUME /var/lib/sonde`.
+
+### 22.3  Feature flag: `keyring` (GW-1803)
+
+The `secret-service` dependency (D-Bus keyring via `zbus`) is gated behind a `keyring` cargo feature, enabled by default. Container builds pass `--no-default-features` to exclude it, since containers use `--key-provider file` or `--key-provider env` instead. All `#[cfg(target_os = "linux")]` gates on secret-service code are extended to `#[cfg(all(target_os = "linux", feature = "keyring"))]`.
+
+### 22.4  Tagging strategy (GW-1801)
+
+| Trigger | Tags |
+|---------|------|
+| Release tag (`v*`) | `latest`, semver (e.g., `0.4.0`), `sha-<short>` |
+| Nightly / schedule / dispatch | `nightly`, `nightly-YYYYMMDD`, `sha-<short>` |
+
+Public tags are created only after both architectures pass smoke tests.
+
+### 22.5  Runtime configuration (GW-1802)
+
+| Property | Value |
+|----------|-------|
+| `ENTRYPOINT` | `sonde-gateway` |
+| `CMD` | `--db /var/lib/sonde/sonde.db` |
+| `VOLUME` | `/var/lib/sonde` |
+| `USER` | `sonde` (non-root) |
+
+Serial device access requires the operator to pass `--device=/dev/ttyACM0` and `--group-add <host-dialout-gid>` at `docker run` time.
+
+### 22.6  CI integration
+
+The `gateway-container.yml` workflow is called by `nightly-release.yml` as a parallel job. The nightly release job waits for the container build to complete before publishing the GitHub release. The container workflow is also triggered independently on release tags and `workflow_dispatch`.

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1795,7 +1795,7 @@ Each architecture (`linux/amd64`, `linux/arm64`) is built natively on a per-arch
 
 **Multi-stage Dockerfile** (`.github/docker/Dockerfile.gateway`):
 
-1. **Builder stage** (`rust:alpine`): installs `musl-dev` and `protobuf-dev`, builds all four binaries with `--no-default-features` (excludes the `keyring` feature and its `secret-service`/`zbus` dependency tree).
+1. **Builder stage** (`rust:alpine`): installs `musl-dev` and `protobuf`, builds all four binaries with `--no-default-features` (excludes the `keyring` feature and its `secret-service`/`zbus` dependency tree).
 2. **Runtime stage** (`alpine:3.21`): copies only the compiled binaries, creates a non-root `sonde` user, and declares `VOLUME /var/lib/sonde`.
 
 ### 22.3  Feature flag: `keyring` (GW-1803)
@@ -1824,4 +1824,4 @@ Serial device access requires the operator to pass `--device=/dev/ttyACM0` and `
 
 ### 22.6  CI integration
 
-The `gateway-container.yml` workflow is called by `nightly-release.yml` as a parallel job. The nightly release job waits for the container build to complete before publishing the GitHub release. The container workflow is also triggered independently on release tags and `workflow_dispatch`.
+The `gateway-container.yml` workflow is called by `nightly-release.yml` as a parallel job. The nightly release job waits for the container build to complete before publishing the GitHub release. Release-tag container builds are therefore driven indirectly via `nightly-release.yml`, while `gateway-container.yml` itself is also available via `workflow_dispatch`.

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2052,6 +2052,82 @@ The gateway MUST log `DIAG_REQUEST` reception and `DIAG_REPLY` transmission at `
 
 ---
 
+## 17  Container image
+
+### GW-1800  Multi-architecture container image
+
+**Priority:** Must  
+**Source:** Issue #780
+
+**Description:**  
+The CI MUST produce a multi-architecture Docker container image (`linux/amd64` + `linux/arm64`) published to `ghcr.io/alan-jowett/sonde-gateway`. The image MUST be based on Alpine Linux (musl libc) for minimal size. A multi-stage build ensures the final image contains no Rust toolchain, build artifacts, or source code. Each architecture MUST be built natively on a per-arch GitHub runner (no QEMU cross-compilation).
+
+**Acceptance criteria:**
+
+1. The image is based on Alpine Linux (musl libc).
+2. The image contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, and `sonde-tmp102-handler` binaries.
+3. `docker manifest inspect` shows both `linux/amd64` and `linux/arm64` platforms.
+4. The final image contains no Rust toolchain, build artifacts, or source code.
+5. Each architecture is built on a native runner (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`).
+6. Per-arch images pass smoke tests (binary execution, linkage verification) before any public tag is created.
+
+---
+
+### GW-1801  Container image tagging
+
+**Priority:** Must  
+**Source:** Issue #780
+
+**Description:**  
+Container images MUST follow a consistent tagging strategy. Release builds (git tags matching `v*`) receive the `latest` tag and a semver tag. Nightly builds receive `nightly` and `nightly-YYYYMMDD` tags. Every image is also tagged with its git SHA for traceability. Public tags are only created after both architecture builds pass, preventing partial/broken images from being tagged.
+
+**Acceptance criteria:**
+
+1. Nightly builds are tagged `nightly` and `nightly-YYYYMMDD`.
+2. Release builds (tag `v*`) are tagged `latest` and the semver version (e.g., `0.4.0`).
+3. Every image is also tagged `sha-<short-sha>`.
+4. Public tags are created only after both amd64 and arm64 builds succeed.
+5. Pull request builds do not publish images.
+
+---
+
+### GW-1802  Container runtime configuration
+
+**Priority:** Must  
+**Source:** Issue #780
+
+**Description:**  
+The container image MUST be configured for production use. The `ENTRYPOINT` is `sonde-gateway` with a default `CMD` that points the database to the declared volume. A `VOLUME` at `/var/lib/sonde` is declared for database persistence. The gateway runs as a non-root `sonde` user inside the container. The `--key-provider file` and `--key-provider env` backends work without D-Bus.
+
+**Acceptance criteria:**
+
+1. `ENTRYPOINT` is `sonde-gateway`.
+2. `CMD` defaults to `--db /var/lib/sonde/sonde.db`.
+3. `VOLUME /var/lib/sonde` is declared for database persistence.
+4. The gateway runs as a non-root `sonde` user inside the container.
+5. `--key-provider file` and `--key-provider env` work without D-Bus.
+6. Serial device access requires the operator to pass `--device` and `--group-add` at `docker run` time.
+
+---
+
+### GW-1803  Optional secret-service dependency
+
+**Priority:** Must  
+**Source:** Issue #780
+
+**Description:**  
+The `secret-service` (D-Bus keyring) dependency MUST be behind a cargo feature flag so container builds can exclude it, reducing compile time and eliminating the D-Bus runtime dependency. A `keyring` feature flag controls the `secret-service` dependency. The default feature set includes `keyring` so existing builds are unchanged.
+
+**Acceptance criteria:**
+
+1. A `keyring` cargo feature flag controls the `secret-service` dependency.
+2. `--key-provider secret-service` is only available when compiled with the `keyring` feature.
+3. The default feature set includes `keyring` (no behavior change for existing builds).
+4. Container builds use `--no-default-features` to exclude `keyring`.
+5. Building with `--no-default-features` produces a working binary that supports `file` and `env` key providers.
+
+---
+
 ## Appendix A  Requirement index
 
 | ID | Title | Priority |
@@ -2167,3 +2243,7 @@ The gateway MUST log `DIAG_REQUEST` reception and `DIAG_REPLY` transmission at `
 | GW-1704 | DIAG_REPLY construction | Must |
 | GW-1705 | Configurable RSSI thresholds | Should |
 | GW-1706 | Diagnostic logging | Must |
+| GW-1800 | Multi-architecture container image | Must |
+| GW-1801 | Container image tagging | Must |
+| GW-1802 | Container runtime configuration | Must |
+| GW-1803 | Optional secret-service dependency | Must |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -3254,8 +3254,8 @@ A configurable stub handler process (or in-process mock) that:
 **Preconditions:** Container image built.
 
 **Steps:**
-1. Run `docker run --rm <image> sh -c 'whoami'`.
-2. Run `docker run --rm <image> sh -c 'touch /var/lib/sonde/test && rm /var/lib/sonde/test'`.
+1. Run `docker run --rm --entrypoint sh <image> -c 'whoami'`.
+2. Run `docker run --rm --entrypoint sh <image> -c 'touch /var/lib/sonde/test && rm /var/lib/sonde/test'`.
 3. Run `docker run --rm <image> --help` and verify `--key-provider env` appears in the output.
 
 **Expected:**

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -3256,12 +3256,12 @@ A configurable stub handler process (or in-process mock) that:
 **Steps:**
 1. Run `docker run --rm <image> sh -c 'whoami'`.
 2. Run `docker run --rm <image> sh -c 'touch /var/lib/sonde/test && rm /var/lib/sonde/test'`.
-3. Run `docker run --rm -e SONDE_MASTER_KEY=<64-hex> <image> --key-provider env --help`.
+3. Run `docker run --rm <image> --help` and verify `--key-provider env` appears in the output.
 
 **Expected:**
 1. `whoami` outputs `sonde`.
 2. File creation in `/var/lib/sonde` succeeds (writable by `sonde` user).
-3. `--key-provider env` is accepted without D-Bus errors.
+3. `--key-provider env` is accepted by the CLI help path.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -3197,6 +3197,121 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+## 17  Container image tests
+
+### T-1800  Container image contains expected binaries
+
+**Traces to:** GW-1800 (AC-2, AC-4)
+
+**Preconditions:** Container image built from `Dockerfile.gateway` for the native architecture.
+
+**Steps:**
+1. Run `docker run --rm <image> --version`.
+2. Run `docker run --rm --entrypoint sonde-admin <image> --version`.
+3. Run `docker run --rm --entrypoint sonde-sht40-handler <image> --version`.
+4. Run `docker run --rm --entrypoint sonde-tmp102-handler <image> --version`.
+
+**Expected:**
+1. All four commands exit 0 and print version strings.
+2. No Rust toolchain or source code is present in the image.
+
+---
+
+### T-1801  Container image tagging — nightly
+
+**Traces to:** GW-1801 (AC-1, AC-3)
+
+**Preconditions:** Workflow triggered by schedule or `workflow_dispatch` (not a `v*` tag).
+
+**Steps:**
+1. Inspect the tags created by the manifest job.
+
+**Expected:**
+1. Tags include `nightly`, `nightly-YYYYMMDD`, and `sha-<short>`.
+2. The `latest` tag is NOT created.
+
+---
+
+### T-1801a  Container image tagging — release
+
+**Traces to:** GW-1801 (AC-2, AC-3)
+
+**Preconditions:** Workflow triggered by a `v*` tag push.
+
+**Steps:**
+1. Inspect the tags created by the manifest job.
+
+**Expected:**
+1. Tags include `latest`, the semver version, and `sha-<short>`.
+2. The `nightly` and `nightly-YYYYMMDD` tags are NOT created.
+
+---
+
+### T-1802  Container runs as non-root with writable volume
+
+**Traces to:** GW-1802 (AC-2, AC-3, AC-4)
+
+**Preconditions:** Container image built.
+
+**Steps:**
+1. Run `docker run --rm <image> sh -c 'whoami'`.
+2. Run `docker run --rm <image> sh -c 'touch /var/lib/sonde/test && rm /var/lib/sonde/test'`.
+3. Run `docker run --rm -e SONDE_MASTER_KEY=<64-hex> <image> --key-provider env --help`.
+
+**Expected:**
+1. `whoami` outputs `sonde`.
+2. File creation in `/var/lib/sonde` succeeds (writable by `sonde` user).
+3. `--key-provider env` is accepted without D-Bus errors.
+
+---
+
+### T-1803  Build without keyring feature
+
+**Traces to:** GW-1803 (AC-1, AC-2, AC-4, AC-5)
+
+**Preconditions:** `cargo build -p sonde-gateway --no-default-features` succeeds.
+
+**Steps:**
+1. Build `sonde-gateway` with `--no-default-features`.
+2. Run the resulting binary with `--key-provider file --master-key-file <path> --help`.
+3. Run the resulting binary with `--key-provider secret-service`.
+
+**Expected:**
+1. Build succeeds without the `secret-service` / `zbus` dependency.
+2. `--key-provider file` is accepted.
+3. `--key-provider secret-service` returns a `NotAvailable` error mentioning the `keyring` feature.
+
+---
+
+### T-1804  Multi-arch manifest contains both platforms
+
+**Traces to:** GW-1800 (AC-3, AC-5), GW-1801 (AC-4)
+
+**Preconditions:** Both amd64 and arm64 builds have completed and passed smoke tests.
+
+**Steps:**
+1. Run `docker manifest inspect ghcr.io/alan-jowett/sonde-gateway:<tag>`.
+
+**Expected:**
+1. The manifest lists two platforms: `linux/amd64` and `linux/arm64`.
+2. Each platform entry references a distinct image digest.
+
+---
+
+### T-1805  Static musl linkage verified
+
+**Traces to:** GW-1800 (AC-1)
+
+**Preconditions:** Container image built.
+
+**Steps:**
+1. Run `docker run --rm --entrypoint sh <image> -c 'ldd /usr/local/bin/sonde-gateway 2>&1'`.
+
+**Expected:**
+1. Output contains `not a dynamic executable`.
+
+---
+
 | GW-1306 | T-1306a, T-1306b, T-1306c, T-1306d |
 | GW-1307 | T-1307a, T-1307b, T-1307c, T-1307d, T-1307e, T-1307f, T-1307g, T-1307h, T-1307i |
 | GW-1308 | T-1308 |
@@ -3223,3 +3338,7 @@ A configurable stub handler process (or in-process mock) that:
 | GW-1704 | T-1709, T-1710 |
 | GW-1705 | T-1708, T-1717 |
 | GW-1706 | T-1711 |
+| GW-1800 | T-1800, T-1804, T-1805 |
+| GW-1801 | T-1801, T-1801a, T-1804 |
+| GW-1802 | T-1802 |
+| GW-1803 | T-1803 |


### PR DESCRIPTION
## Summary

Add CI to build and publish a multi-architecture (`linux/amd64` + `linux/arm64`) Docker container image based on Alpine Linux (musl libc).

**Image:** `ghcr.io/alan-jowett/sonde-gateway`

**Contents:** `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, `sonde-tmp102-handler`

## Changes

### Code
- **`keyring` cargo feature** on `sonde-gateway` (default-enabled) gates the `secret-service` / D-Bus dependency. Container builds exclude it via `--no-default-features` (GW-1803).
- All `#[cfg(target_os = "linux")]` on secret-service code extended to `#[cfg(all(target_os = "linux", feature = "keyring"))]`

### CI
- **`Dockerfile.gateway`** — multi-stage: `rust:alpine` builder → `alpine:3.21` runtime, non-root `sonde` user, `VOLUME /var/lib/sonde`
- **`gateway-container.yml`** — native per-arch builds (no QEMU), smoke tests, multi-arch manifest via `docker buildx imagetools create`
- **Nightly integration** — added as parallel job in `nightly-release.yml`

### Specifications
- **Requirements:** GW-1800–GW-1803 (§17 Container image)
- **Design:** §22 (container image architecture)
- **Validation:** T-1800–T-1805 (container test cases)

## Run example

```bash
docker run -d \
  -v sonde-data:/var/lib/sonde \
  -e SONDE_MASTER_KEY=<64-hex-chars> \
  --device /dev/ttyACM0 \
  --group-add <host-dialout-gid> \
  ghcr.io/alan-jowett/sonde-gateway \
    --port /dev/ttyACM0 --key-provider env
```

## Tagging

| Trigger | Tags |
|---------|------|
| Release (`v*`) | `latest`, semver, `sha-<short>` |
| Nightly | `nightly`, `nightly-YYYYMMDD`, `sha-<short>` |

Closes #780