### PR TITLE
feat(modem): emit BUTTONSHORT and BUTTONLONG events (GPIO active-low on 1-Wire line)

### DIFF
--- a/crates/sonde-gateway/src/modem.rs
+++ b/crates/sonde-gateway/src/modem.rs
@@ -69,6 +69,7 @@ fn modem_msg_label(msg: &ModemMessage) -> &'static str {
         ModemMessage::BlePairingConfirmReply(_) => "BLE_PAIRING_CONFIRM_REPLY",
         ModemMessage::ScanChannels => "SCAN_CHANNELS",
         ModemMessage::ScanResult(_) => "SCAN_RESULT",
+        ModemMessage::EventButton(_) => "EVENT_BUTTON",
         ModemMessage::Unknown { .. } | _ => "UNKNOWN",
     }
 }

--- a/crates/sonde-modem/src/bin/modem.rs
+++ b/crates/sonde-modem/src/bin/modem.rs
@@ -82,7 +82,32 @@ fn main() {
         panic!("fatal: ESP-NOW init failed");
     });
 
-    let mut bridge = Bridge::with_ble(usb, espnow, ble, counters);
+    use sonde_modem::bridge::ButtonScanner;
+
+    // Configure GPIO2 (XIAO D1 / 1-Wire data line) as input with internal
+    // pull-up for button detection (MD-0600).
+    unsafe {
+        esp_idf_sys::gpio_reset_pin(esp_idf_sys::gpio_num_t_GPIO_NUM_2);
+        esp_idf_sys::esp!(esp_idf_sys::gpio_set_direction(
+            esp_idf_sys::gpio_num_t_GPIO_NUM_2,
+            esp_idf_sys::gpio_mode_t_GPIO_MODE_INPUT,
+        ))
+        .expect("failed to configure GPIO2 direction");
+        esp_idf_sys::esp!(esp_idf_sys::gpio_set_pull_mode(
+            esp_idf_sys::gpio_num_t_GPIO_NUM_2,
+            esp_idf_sys::gpio_pull_mode_t_GPIO_PULLUP_ONLY,
+        ))
+        .expect("failed to configure GPIO2 pull-up");
+    }
+    info!("GPIO2 configured as button input (active-low, pull-up — MD-0600)");
+
+    let button_scanner = ButtonScanner::new(|| {
+        // Active-low: GPIO reads 0 when pressed, 1 when idle.
+        // Return true when pressed.
+        unsafe { esp_idf_sys::gpio_get_level(esp_idf_sys::gpio_num_t_GPIO_NUM_2) == 0 }
+    });
+
+    let mut bridge = Bridge::with_ble_and_button(usb, espnow, ble, button_scanner, counters);
 
     // Initialize the task watchdog with a 10-second timeout (MD-0302).
     unsafe {

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -334,7 +334,7 @@ impl ButtonPoll for NoButton {
 
 impl<F: FnMut() -> bool> ButtonPoll for ButtonScanner<F> {
     fn poll(&mut self) -> Option<u8> {
-        self.poll()
+        ButtonScanner::poll(self)
     }
 }
 

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -268,9 +268,12 @@ impl<F: FnMut() -> bool> ButtonScanner<F> {
                     // Glitch — return to idle.
                     self.state = ButtonState::Idle;
                 } else if now.duration_since(since) >= debounce {
-                    // Debounce confirmed — record press start as now (MD-0602:
-                    // duration is measured from debounced press to debounced release).
-                    self.state = ButtonState::Pressed { press_start: now };
+                    // Debounce confirmed — record the actual debounced transition
+                    // instant, not `now`, so poll-cadence jitter doesn't inflate
+                    // or deflate the measured press duration (MD-0602).
+                    self.state = ButtonState::Pressed {
+                        press_start: since + debounce,
+                    };
                 }
                 None
             }
@@ -289,9 +292,12 @@ impl<F: FnMut() -> bool> ButtonScanner<F> {
                     self.state = ButtonState::Pressed { press_start };
                     None
                 } else if now.duration_since(since) >= debounce {
-                    // Debounced release — classify.
+                    // Debounced release — classify using the true debounced
+                    // release instant so poll-cadence jitter doesn't skew the
+                    // measured duration.
                     self.state = ButtonState::Idle;
-                    let duration = now.duration_since(press_start);
+                    let debounced_release = since + debounce;
+                    let duration = debounced_release.duration_since(press_start);
                     if duration >= BUTTON_LONG_THRESHOLD {
                         Some(BUTTON_TYPE_LONG)
                     } else {

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -12,11 +12,13 @@
 
 use log::{debug, info, warn};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use sonde_protocol::modem::{
     encode_modem_frame, BleConnected, BleDisconnected, BlePairingConfirm, BlePairingConfirmReply,
-    BleRecv, FrameDecoder, ModemCodecError, ModemError, ModemMessage, ModemReady, ModemStatus,
-    RecvFrame, ScanEntry, ScanResult, SendFrame, MAC_SIZE, MODEM_ERR_CHANNEL_SET_FAILED,
+    BleRecv, EventButton, FrameDecoder, ModemCodecError, ModemError, ModemMessage, ModemReady,
+    ModemStatus, RecvFrame, ScanEntry, ScanResult, SendFrame, BUTTON_TYPE_LONG, BUTTON_TYPE_SHORT,
+    MAC_SIZE, MODEM_ERR_CHANNEL_SET_FAILED,
 };
 
 use crate::status::ModemCounters;
@@ -86,6 +88,7 @@ fn msg_type_label(msg: &ModemMessage) -> &'static str {
         ModemMessage::BleConnected(_) => "BLE_CONNECTED",
         ModemMessage::BleDisconnected(_) => "BLE_DISCONNECTED",
         ModemMessage::BlePairingConfirm(_) => "BLE_PAIRING_CONFIRM",
+        ModemMessage::EventButton(_) => "EVENT_BUTTON",
         _ => "UNKNOWN",
     }
 }
@@ -189,24 +192,160 @@ impl Ble for NoBle {
     }
 }
 
-/// Bridge between a serial port, a radio driver, and an optional BLE driver.
-pub struct Bridge<S: SerialPort, R: Radio, B: Ble = NoBle> {
+// ---------------------------------------------------------------------------
+// Button scanner (MD-0600 – MD-0605)
+// ---------------------------------------------------------------------------
+
+/// Debounce window for button press/release transitions (MD-0601).
+const BUTTON_DEBOUNCE_MS: u64 = 30;
+
+/// Threshold separating short from long presses (MD-0602).
+const BUTTON_LONG_THRESHOLD: Duration = Duration::from_secs(1);
+
+/// Internal state of the button debounce/classification state machine.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ButtonState {
+    /// GPIO is HIGH (not pressed). Waiting for a LOW transition.
+    Idle,
+    /// GPIO went LOW. Waiting for debounce period to confirm press.
+    DebouncePress { since: Instant },
+    /// Debounced press confirmed. Recording hold duration.
+    Pressed { press_start: Instant },
+    /// GPIO went HIGH after press. Waiting for debounce period to confirm release.
+    DebounceRelease { press_start: Instant, since: Instant },
+}
+
+/// Platform-independent button scanner.
+///
+/// Polls a GPIO read function each main-loop iteration, debounces transitions,
+/// classifies press duration, and returns button events. The scanner does not
+/// perform any I/O — the caller (bridge) handles USB-CDC emission.
+pub struct ButtonScanner<F: FnMut() -> bool> {
+    read_gpio: F,
+    state: ButtonState,
+}
+
+impl<F: FnMut() -> bool> ButtonScanner<F> {
+    /// Create a new button scanner with the given GPIO read function.
+    ///
+    /// `read_gpio` should return `true` when the button is pressed (active-low
+    /// GPIO reads LOW → caller inverts to `true`).
+    pub fn new(read_gpio: F) -> Self {
+        Self {
+            read_gpio,
+            state: ButtonState::Idle,
+        }
+    }
+
+    /// Poll the button GPIO and advance the state machine.
+    ///
+    /// Returns `Some(BUTTON_TYPE_SHORT)` or `Some(BUTTON_TYPE_LONG)` when a
+    /// debounced release is detected, or `None` otherwise.
+    pub fn poll(&mut self) -> Option<u8> {
+        let pressed = (self.read_gpio)();
+        let now = Instant::now();
+        let debounce = Duration::from_millis(BUTTON_DEBOUNCE_MS);
+
+        match self.state {
+            ButtonState::Idle => {
+                if pressed {
+                    self.state = ButtonState::DebouncePress { since: now };
+                }
+                None
+            }
+            ButtonState::DebouncePress { since } => {
+                if !pressed {
+                    // Glitch — return to idle.
+                    self.state = ButtonState::Idle;
+                } else if now.duration_since(since) >= debounce {
+                    // Debounce confirmed — record press start as now (MD-0602:
+                    // duration is measured from debounced press to debounced release).
+                    self.state = ButtonState::Pressed { press_start: now };
+                }
+                None
+            }
+            ButtonState::Pressed { press_start } => {
+                if !pressed {
+                    self.state = ButtonState::DebounceRelease {
+                        press_start,
+                        since: now,
+                    };
+                }
+                None
+            }
+            ButtonState::DebounceRelease {
+                press_start,
+                since,
+            } => {
+                if pressed {
+                    // Bounce — return to pressed.
+                    self.state = ButtonState::Pressed { press_start };
+                    None
+                } else if now.duration_since(since) >= debounce {
+                    // Debounced release — classify.
+                    self.state = ButtonState::Idle;
+                    let duration = now.duration_since(press_start);
+                    if duration >= BUTTON_LONG_THRESHOLD {
+                        Some(BUTTON_TYPE_LONG)
+                    } else {
+                        Some(BUTTON_TYPE_SHORT)
+                    }
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+/// No-op button scanner for builds without GPIO (host-side testing).
+pub struct NoButton;
+
+impl NoButton {
+    pub fn poll(&mut self) -> Option<u8> {
+        None
+    }
+}
+
+/// Abstraction over a button input (GPIO on device, mock/no-op in tests).
+pub trait ButtonPoll {
+    /// Poll the button and return `Some(button_type)` on a classified release.
+    fn poll(&mut self) -> Option<u8>;
+}
+
+impl ButtonPoll for NoButton {
+    fn poll(&mut self) -> Option<u8> {
+        None
+    }
+}
+
+impl<F: FnMut() -> bool> ButtonPoll for ButtonScanner<F> {
+    fn poll(&mut self) -> Option<u8> {
+        self.poll()
+    }
+}
+
+/// Bridge between a serial port, a radio driver, an optional BLE driver,
+/// and an optional button scanner.
+pub struct Bridge<S: SerialPort, R: Radio, B: Ble = NoBle, Btn: ButtonPoll = NoButton> {
     usb: S,
     radio: R,
     ble: B,
+    button: Btn,
     ble_enabled: bool,
     counters: Arc<ModemCounters>,
     decoder: FrameDecoder,
     rx_buf: [u8; 64],
 }
 
-impl<S: SerialPort, R: Radio> Bridge<S, R, NoBle> {
+impl<S: SerialPort, R: Radio> Bridge<S, R, NoBle, NoButton> {
     /// Create a bridge without BLE support (no-op BLE driver).
     pub fn new(usb: S, radio: R, counters: Arc<ModemCounters>) -> Self {
         Self {
             usb,
             radio,
             ble: NoBle,
+            button: NoButton,
             ble_enabled: false,
             counters,
             decoder: FrameDecoder::new(),
@@ -215,19 +354,43 @@ impl<S: SerialPort, R: Radio> Bridge<S, R, NoBle> {
     }
 }
 
-impl<S: SerialPort, R: Radio, B: Ble> Bridge<S, R, B> {
-    /// Create a bridge with a BLE driver (BLE starts disabled).
-    ///
-    /// The driver is explicitly disabled during construction so that
-    /// `ble_enabled` and the hardware state are guaranteed to be in sync.
-    /// Callers that need BLE active must send a `BLE_ENABLE` command after
-    /// construction; the driver will never be silently left enabled.
+impl<S: SerialPort, R: Radio, B: Ble> Bridge<S, R, B, NoButton> {
+    /// Create a bridge with a BLE driver (BLE starts disabled, no button scanner).
     pub fn with_ble(usb: S, radio: R, mut ble: B, counters: Arc<ModemCounters>) -> Self {
         ble.disable();
         Self {
             usb,
             radio,
             ble,
+            button: NoButton,
+            ble_enabled: false,
+            counters,
+            decoder: FrameDecoder::new(),
+            rx_buf: [0u8; 64],
+        }
+    }
+}
+
+impl<S: SerialPort, R: Radio, B: Ble, Btn: ButtonPoll> Bridge<S, R, B, Btn> {
+    /// Create a bridge with a BLE driver and a button scanner.
+    ///
+    /// The BLE driver is explicitly disabled during construction so that
+    /// `ble_enabled` and the hardware state are guaranteed to be in sync.
+    /// Callers that need BLE active must send a `BLE_ENABLE` command after
+    /// construction; the driver will never be silently left enabled.
+    pub fn with_ble_and_button(
+        usb: S,
+        radio: R,
+        mut ble: B,
+        button: Btn,
+        counters: Arc<ModemCounters>,
+    ) -> Self {
+        ble.disable();
+        Self {
+            usb,
+            radio,
+            ble,
+            button,
             ble_enabled: false,
             counters,
             decoder: FrameDecoder::new(),
@@ -386,6 +549,13 @@ impl<S: SerialPort, R: Radio, B: Ble> Bridge<S, R, B> {
                 }
                 None => break,
             }
+        }
+
+        // Poll button GPIO and emit EVENT_BUTTON on classified release (MD-0603).
+        if let Some(button_type) = self.button.poll() {
+            let msg = ModemMessage::EventButton(EventButton { button_type });
+            self.send_msg(&msg);
+            info!("EVENT_BUTTON: button_type={}", button_type);
         }
     }
 
@@ -3502,5 +3672,250 @@ mod tests {
             recv_count, total
         );
         assert_eq!(bridge.counters.rx_count(), total as u32);
+    }
+
+    // -----------------------------------------------------------------------
+    // Button scanner tests (T-0801 through T-0810, host-side)
+    // -----------------------------------------------------------------------
+
+    use std::cell::Cell as StdCell;
+    use std::rc::Rc;
+
+    /// Create a ButtonScanner with a controllable pressed state.
+    fn make_test_scanner() -> (Rc<StdCell<bool>>, ButtonScanner<impl FnMut() -> bool>) {
+        let pressed = Rc::new(StdCell::new(false));
+        let pressed_clone = pressed.clone();
+        let scanner = ButtonScanner::new(move || pressed_clone.get());
+        (pressed, scanner)
+    }
+
+    #[test]
+    fn button_short_press() {
+        let (pressed, mut scanner) = make_test_scanner();
+
+        // Idle — not pressed.
+        assert_eq!(scanner.poll(), None);
+
+        // Press the button.
+        pressed.set(true);
+        assert_eq!(scanner.poll(), None); // enters DebouncePress
+
+        // Wait past debounce (simulate by polling after 30ms).
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        assert_eq!(scanner.poll(), None); // enters Pressed
+
+        // Release after < 1s total (short press).
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        pressed.set(false);
+        assert_eq!(scanner.poll(), None); // enters DebounceRelease
+
+        // Wait past release debounce.
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        let result = scanner.poll();
+        assert_eq!(result, Some(BUTTON_TYPE_SHORT));
+
+        // Back to idle.
+        assert_eq!(scanner.poll(), None);
+    }
+
+    #[test]
+    fn button_long_press() {
+        let (pressed, mut scanner) = make_test_scanner();
+
+        pressed.set(true);
+        scanner.poll(); // DebouncePress
+
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        scanner.poll(); // Pressed
+
+        // Hold for > 1s.
+        std::thread::sleep(std::time::Duration::from_millis(1050));
+        pressed.set(false);
+        scanner.poll(); // DebounceRelease
+
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        let result = scanner.poll();
+        assert_eq!(result, Some(BUTTON_TYPE_LONG));
+    }
+
+    #[test]
+    fn button_glitch_rejected() {
+        let (pressed, mut scanner) = make_test_scanner();
+
+        // Brief press shorter than debounce.
+        pressed.set(true);
+        scanner.poll(); // DebouncePress
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        pressed.set(false);
+        assert_eq!(scanner.poll(), None); // back to Idle
+
+        // No event should appear.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        assert_eq!(scanner.poll(), None);
+    }
+
+    #[test]
+    fn button_no_event_while_held() {
+        let (pressed, mut scanner) = make_test_scanner();
+
+        pressed.set(true);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        scanner.poll(); // Pressed
+
+        // Hold for 2 seconds — no event emitted.
+        for _ in 0..20 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            assert_eq!(scanner.poll(), None);
+        }
+
+        // Release.
+        pressed.set(false);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        let result = scanner.poll();
+        assert_eq!(result, Some(BUTTON_TYPE_LONG));
+    }
+
+    #[test]
+    fn button_back_to_back_presses() {
+        let (pressed, mut scanner) = make_test_scanner();
+
+        // First press — short.
+        pressed.set(true);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        pressed.set(false);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        assert_eq!(scanner.poll(), Some(BUTTON_TYPE_SHORT));
+
+        // Second press — long.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        pressed.set(true);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(1050));
+        pressed.set(false);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        assert_eq!(scanner.poll(), Some(BUTTON_TYPE_LONG));
+    }
+
+    #[test]
+    fn button_boundary_999ms_short_1000ms_long() {
+        // T-0803: 999 ms press → SHORT, 1000 ms press → LONG.
+        let (pressed, mut scanner) = make_test_scanner();
+
+        // 999 ms press (should be SHORT).
+        pressed.set(true);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        scanner.poll(); // Pressed confirmed at this point
+        // Hold for ~964 ms (999 - 35 debounce) — but duration is measured
+        // from debounced press (when Pressed state begins), so sleep ~964 ms.
+        std::thread::sleep(std::time::Duration::from_millis(930));
+        pressed.set(false);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        let result = scanner.poll();
+        assert_eq!(result, Some(BUTTON_TYPE_SHORT));
+
+        // 1100 ms press (comfortably LONG to avoid timing jitter).
+        pressed.set(true);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        pressed.set(false);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        let result = scanner.poll();
+        assert_eq!(result, Some(BUTTON_TYPE_LONG));
+    }
+
+    #[test]
+    fn button_release_bounce_rejected() {
+        // T-0809: bounce during release should not create a second event.
+        let (pressed, mut scanner) = make_test_scanner();
+
+        // Press for 500 ms.
+        pressed.set(true);
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        scanner.poll();
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        // Release — but bounce (briefly return to pressed before debounce completes).
+        pressed.set(false);
+        scanner.poll(); // enters DebounceRelease
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        pressed.set(true); // bounce back
+        assert_eq!(scanner.poll(), None); // should return to Pressed, not classify
+
+        // Now truly release.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        pressed.set(false);
+        scanner.poll(); // DebounceRelease again
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        let result = scanner.poll();
+        assert_eq!(result, Some(BUTTON_TYPE_SHORT));
+
+        // Verify no second event.
+        assert_eq!(scanner.poll(), None);
+    }
+
+    #[test]
+    fn button_event_bridge_integration() {
+        // Verify that the bridge emits EVENT_BUTTON when the scanner fires.
+        let pressed = Rc::new(StdCell::new(false));
+        let pressed_clone = pressed.clone();
+        let scanner = ButtonScanner::new(move || pressed_clone.get());
+
+        let mut bridge = Bridge::with_ble_and_button(
+            MockSerial::new(),
+            MockRadio::new(),
+            MockBle::new(),
+            scanner,
+            ModemCounters::new(),
+        );
+
+        // Press the button.
+        pressed.set(true);
+        bridge.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        bridge.poll();
+
+        // Release after short press.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        pressed.set(false);
+        bridge.poll();
+        std::thread::sleep(std::time::Duration::from_millis(35));
+        bridge.poll();
+
+        // Decode the EVENT_BUTTON from the serial output.
+        let tx = bridge.usb.take_tx();
+        assert!(!tx.is_empty(), "expected EVENT_BUTTON on serial output");
+
+        // Find the EVENT_BUTTON frame in the output (there may be a
+        // MODEM_READY from with_ble_and_button's disable call too).
+        let mut decoder = FrameDecoder::new();
+        decoder.push(&tx);
+        let mut found_button = false;
+        loop {
+            match decoder.decode() {
+                Ok(Some(ModemMessage::EventButton(eb))) => {
+                    assert_eq!(eb.button_type, BUTTON_TYPE_SHORT);
+                    found_button = true;
+                }
+                Ok(Some(_)) => {} // skip MODEM_READY etc.
+                Ok(None) => break,
+                Err(_) => break,
+            }
+        }
+        assert!(found_button, "EVENT_BUTTON not found in serial output");
     }
 }

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -212,7 +212,10 @@ enum ButtonState {
     /// Debounced press confirmed. Recording hold duration.
     Pressed { press_start: Instant },
     /// GPIO went HIGH after press. Waiting for debounce period to confirm release.
-    DebounceRelease { press_start: Instant, since: Instant },
+    DebounceRelease {
+        press_start: Instant,
+        since: Instant,
+    },
 }
 
 /// Platform-independent button scanner.
@@ -273,10 +276,7 @@ impl<F: FnMut() -> bool> ButtonScanner<F> {
                 }
                 None
             }
-            ButtonState::DebounceRelease {
-                press_start,
-                since,
-            } => {
+            ButtonState::DebounceRelease { press_start, since } => {
                 if pressed {
                     // Bounce — return to pressed.
                     self.state = ButtonState::Pressed { press_start };
@@ -3815,8 +3815,8 @@ mod tests {
         scanner.poll();
         std::thread::sleep(std::time::Duration::from_millis(35));
         scanner.poll(); // Pressed confirmed at this point
-        // Hold for ~964 ms (999 - 35 debounce) — but duration is measured
-        // from debounced press (when Pressed state begins), so sleep ~964 ms.
+                        // Hold for ~964 ms (999 - 35 debounce) — but duration is measured
+                        // from debounced press (when Pressed state begins), so sleep ~964 ms.
         std::thread::sleep(std::time::Duration::from_millis(930));
         pressed.set(false);
         scanner.poll();

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -246,7 +246,14 @@ impl<F: FnMut() -> bool> ButtonScanner<F> {
     /// debounced release is detected, or `None` otherwise.
     pub fn poll(&mut self) -> Option<u8> {
         let pressed = (self.read_gpio)();
-        let now = Instant::now();
+        self.poll_at(Instant::now(), pressed)
+    }
+
+    /// Advance the state machine with an explicit timestamp and GPIO state.
+    ///
+    /// This is the core logic, separated from `poll()` so tests can inject
+    /// a deterministic clock without sleeping.
+    pub fn poll_at(&mut self, now: Instant, pressed: bool) -> Option<u8> {
         let debounce = Duration::from_millis(BUTTON_DEBOUNCE_MS);
 
         match self.state {
@@ -3689,188 +3696,194 @@ mod tests {
         (pressed, scanner)
     }
 
+    /// Deterministic time offsets for button tests.
+    const MS: Duration = Duration::from_millis(1);
+
     #[test]
     fn button_short_press() {
-        let (pressed, mut scanner) = make_test_scanner();
+        let (_, mut scanner) = make_test_scanner();
+        let t0 = Instant::now();
 
         // Idle — not pressed.
-        assert_eq!(scanner.poll(), None);
+        assert_eq!(scanner.poll_at(t0, false), None);
 
         // Press the button.
-        pressed.set(true);
-        assert_eq!(scanner.poll(), None); // enters DebouncePress
+        assert_eq!(scanner.poll_at(t0, true), None); // DebouncePress
 
-        // Wait past debounce (simulate by polling after 30ms).
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        assert_eq!(scanner.poll(), None); // enters Pressed
+        // Before debounce completes — still nothing.
+        assert_eq!(scanner.poll_at(t0 + MS * 20, true), None);
 
-        // Release after < 1s total (short press).
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        pressed.set(false);
-        assert_eq!(scanner.poll(), None); // enters DebounceRelease
+        // Past debounce (30 ms) — enters Pressed.
+        assert_eq!(scanner.poll_at(t0 + MS * 30, true), None);
 
-        // Wait past release debounce.
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        let result = scanner.poll();
-        assert_eq!(result, Some(BUTTON_TYPE_SHORT));
+        // Release at 230 ms (200 ms hold).
+        assert_eq!(scanner.poll_at(t0 + MS * 230, false), None); // DebounceRelease
+
+        // Past release debounce — classify as SHORT.
+        assert_eq!(
+            scanner.poll_at(t0 + MS * 260, false),
+            Some(BUTTON_TYPE_SHORT)
+        );
 
         // Back to idle.
-        assert_eq!(scanner.poll(), None);
+        assert_eq!(scanner.poll_at(t0 + MS * 300, false), None);
     }
 
     #[test]
     fn button_long_press() {
-        let (pressed, mut scanner) = make_test_scanner();
+        let (_, mut scanner) = make_test_scanner();
+        let t0 = Instant::now();
 
-        pressed.set(true);
-        scanner.poll(); // DebouncePress
+        // Press.
+        scanner.poll_at(t0, true);
+        scanner.poll_at(t0 + MS * 30, true); // Pressed
 
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        scanner.poll(); // Pressed
+        // Release at 1200 ms (1170 ms hold).
+        scanner.poll_at(t0 + MS * 1200, false); // DebounceRelease
 
-        // Hold for > 1s.
-        std::thread::sleep(std::time::Duration::from_millis(1050));
-        pressed.set(false);
-        scanner.poll(); // DebounceRelease
-
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        let result = scanner.poll();
-        assert_eq!(result, Some(BUTTON_TYPE_LONG));
+        // Past release debounce.
+        assert_eq!(
+            scanner.poll_at(t0 + MS * 1230, false),
+            Some(BUTTON_TYPE_LONG)
+        );
     }
 
     #[test]
     fn button_glitch_rejected() {
-        let (pressed, mut scanner) = make_test_scanner();
+        let (_, mut scanner) = make_test_scanner();
+        let t0 = Instant::now();
 
         // Brief press shorter than debounce.
-        pressed.set(true);
-        scanner.poll(); // DebouncePress
-        std::thread::sleep(std::time::Duration::from_millis(10));
-        pressed.set(false);
-        assert_eq!(scanner.poll(), None); // back to Idle
+        scanner.poll_at(t0, true); // DebouncePress
+                                   // Release before 30 ms.
+        assert_eq!(scanner.poll_at(t0 + MS * 10, false), None); // back to Idle
 
-        // No event should appear.
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        assert_eq!(scanner.poll(), None);
+        // No event.
+        assert_eq!(scanner.poll_at(t0 + MS * 100, false), None);
     }
 
     #[test]
     fn button_no_event_while_held() {
-        let (pressed, mut scanner) = make_test_scanner();
+        let (_, mut scanner) = make_test_scanner();
+        let t0 = Instant::now();
 
-        pressed.set(true);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        scanner.poll(); // Pressed
+        scanner.poll_at(t0, true);
+        scanner.poll_at(t0 + MS * 30, true); // Pressed
 
-        // Hold for 2 seconds — no event emitted.
-        for _ in 0..20 {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            assert_eq!(scanner.poll(), None);
+        // Hold for 2 seconds — no event.
+        for i in 1..=20 {
+            assert_eq!(scanner.poll_at(t0 + MS * 30 + MS * 100 * i, true), None);
         }
 
-        // Release.
-        pressed.set(false);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        let result = scanner.poll();
-        assert_eq!(result, Some(BUTTON_TYPE_LONG));
+        // Release at 2030 ms.
+        scanner.poll_at(t0 + MS * 2030, false);
+        assert_eq!(
+            scanner.poll_at(t0 + MS * 2060, false),
+            Some(BUTTON_TYPE_LONG)
+        );
     }
 
     #[test]
     fn button_back_to_back_presses() {
-        let (pressed, mut scanner) = make_test_scanner();
+        let (_, mut scanner) = make_test_scanner();
+        let t0 = Instant::now();
 
-        // First press — short.
-        pressed.set(true);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        pressed.set(false);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        assert_eq!(scanner.poll(), Some(BUTTON_TYPE_SHORT));
+        // First press — short (200 ms hold).
+        scanner.poll_at(t0, true);
+        scanner.poll_at(t0 + MS * 30, true); // Pressed
+        scanner.poll_at(t0 + MS * 230, false); // DebounceRelease
+        assert_eq!(
+            scanner.poll_at(t0 + MS * 260, false),
+            Some(BUTTON_TYPE_SHORT)
+        );
 
-        // Second press — long.
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        pressed.set(true);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(1050));
-        pressed.set(false);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        assert_eq!(scanner.poll(), Some(BUTTON_TYPE_LONG));
+        // Second press — long (1200 ms hold).
+        scanner.poll_at(t0 + MS * 400, true);
+        scanner.poll_at(t0 + MS * 430, true); // Pressed
+        scanner.poll_at(t0 + MS * 1630, false); // DebounceRelease
+        assert_eq!(
+            scanner.poll_at(t0 + MS * 1660, false),
+            Some(BUTTON_TYPE_LONG)
+        );
     }
 
     #[test]
     fn button_boundary_999ms_short_1000ms_long() {
-        // T-0803: 999 ms press → SHORT, 1000 ms press → LONG.
-        let (pressed, mut scanner) = make_test_scanner();
+        // T-0803: exactly 999 ms → SHORT, exactly 1000 ms → LONG.
+        let (_, mut scanner) = make_test_scanner();
+        let t0 = Instant::now();
 
-        // 999 ms press (should be SHORT).
-        pressed.set(true);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        scanner.poll(); // Pressed confirmed at this point
-                        // Hold for ~964 ms (999 - 35 debounce) — but duration is measured
-                        // from debounced press (when Pressed state begins), so sleep ~964 ms.
-        std::thread::sleep(std::time::Duration::from_millis(930));
-        pressed.set(false);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        let result = scanner.poll();
-        assert_eq!(result, Some(BUTTON_TYPE_SHORT));
+        // 999 ms press: debounced press at t0+30, release at t0+30+999=t0+1029,
+        // debounced release at t0+1059. Duration = 1059 - 30 = 1029... no.
+        // Duration is measured from press_start (set to `now` at t0+30) to
+        // the classification `now` (at t0+30+999+30 = t0+1059).
+        // duration = 1059 - 30 = 1029 ms. That's > 1000 ms. Need to be precise.
+        //
+        // press_start = t0+30 (when DebouncePress→Pressed transition fires).
+        // For a 999 ms hold: release GPIO at t0+30+999 = t0+1029.
+        // Debounced release fires at t0+1029+30 = t0+1059.
+        // Duration at classification = t0+1059 - t0+30 = 1029 ms → LONG.
+        // That's because debounce adds to the measured duration.
+        //
+        // The spec says duration is from debounced press to debounced release.
+        // So 999 ms between those two events means:
+        //   press_start = t0+30, classification_now = t0+30+999 = t0+1029.
+        //   release GPIO must happen at t0+1029-30 = t0+999 (so release
+        //   debounce completes at t0+1029).
+        //
+        // Simpler: press at t0, debounce at t0+30 (press_start=t0+30),
+        // release at t0+30+969=t0+999, debounce release at t0+999+30=t0+1029.
+        // classification now=t0+1029, duration=t0+1029 - t0+30 = 999 ms → SHORT. ✓
 
-        // 1100 ms press (comfortably LONG to avoid timing jitter).
-        pressed.set(true);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(1100));
-        pressed.set(false);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        let result = scanner.poll();
-        assert_eq!(result, Some(BUTTON_TYPE_LONG));
+        // 999 ms between debounced press and debounced release → SHORT.
+        scanner.poll_at(t0, true); // DebouncePress
+        scanner.poll_at(t0 + MS * 30, true); // Pressed, press_start = t0+30
+        scanner.poll_at(t0 + MS * 999, false); // DebounceRelease
+        assert_eq!(
+            scanner.poll_at(t0 + MS * 1029, false), // duration = 1029-30 = 999 ms
+            Some(BUTTON_TYPE_SHORT)
+        );
+
+        // 1000 ms between debounced press and debounced release → LONG.
+        scanner.poll_at(t0 + MS * 1100, true); // DebouncePress
+        scanner.poll_at(t0 + MS * 1130, true); // Pressed, press_start = t0+1130
+        scanner.poll_at(t0 + MS * 2100, false); // DebounceRelease
+        assert_eq!(
+            scanner.poll_at(t0 + MS * 2130, false), // duration = 2130-1130 = 1000 ms
+            Some(BUTTON_TYPE_LONG)
+        );
     }
 
     #[test]
     fn button_release_bounce_rejected() {
         // T-0809: bounce during release should not create a second event.
-        let (pressed, mut scanner) = make_test_scanner();
+        let (_, mut scanner) = make_test_scanner();
+        let t0 = Instant::now();
 
-        // Press for 500 ms.
-        pressed.set(true);
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        scanner.poll();
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        // Press for 200 ms.
+        scanner.poll_at(t0, true);
+        scanner.poll_at(t0 + MS * 30, true); // Pressed
 
-        // Release — but bounce (briefly return to pressed before debounce completes).
-        pressed.set(false);
-        scanner.poll(); // enters DebounceRelease
-        std::thread::sleep(std::time::Duration::from_millis(10));
-        pressed.set(true); // bounce back
-        assert_eq!(scanner.poll(), None); // should return to Pressed, not classify
+        // Release — but bounce back within debounce window.
+        scanner.poll_at(t0 + MS * 230, false); // DebounceRelease
+        assert_eq!(scanner.poll_at(t0 + MS * 240, true), None); // bounce → Pressed
 
         // Now truly release.
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        pressed.set(false);
-        scanner.poll(); // DebounceRelease again
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        let result = scanner.poll();
-        assert_eq!(result, Some(BUTTON_TYPE_SHORT));
+        scanner.poll_at(t0 + MS * 300, false); // DebounceRelease
+        assert_eq!(
+            scanner.poll_at(t0 + MS * 330, false),
+            Some(BUTTON_TYPE_SHORT)
+        );
 
-        // Verify no second event.
-        assert_eq!(scanner.poll(), None);
+        // No second event.
+        assert_eq!(scanner.poll_at(t0 + MS * 400, false), None);
     }
 
     #[test]
     fn button_event_bridge_integration() {
         // Verify that the bridge emits EVENT_BUTTON when the scanner fires.
+        // This test still uses real timing via bridge.poll() since it tests
+        // the full integration path including USB-CDC emission.
         let pressed = Rc::new(StdCell::new(false));
         let pressed_clone = pressed.clone();
         let scanner = ButtonScanner::new(move || pressed_clone.get());

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -561,8 +561,14 @@ impl<S: SerialPort, R: Radio, B: Ble, Btn: ButtonPoll> Bridge<S, R, B, Btn> {
         // Poll button GPIO and emit EVENT_BUTTON on classified release (MD-0603).
         if let Some(button_type) = self.button.poll() {
             let msg = ModemMessage::EventButton(EventButton { button_type });
-            self.send_msg(&msg);
-            info!("EVENT_BUTTON: button_type={}", button_type);
+            if self.send_msg(&msg) {
+                info!("EVENT_BUTTON: button_type={}", button_type);
+            } else {
+                warn!(
+                    "EVENT_BUTTON dropped: button_type={} (USB-CDC not writable)",
+                    button_type
+                );
+            }
         }
     }
 
@@ -3879,34 +3885,46 @@ mod tests {
         assert_eq!(scanner.poll_at(t0 + MS * 400, false), None);
     }
 
+    /// Mock ButtonPoll that fires a single event on a chosen poll count.
+    struct MockButtonPoll {
+        polls: usize,
+        fire_on_poll: usize,
+    }
+
+    impl MockButtonPoll {
+        fn new(fire_on_poll: usize) -> Self {
+            Self {
+                polls: 0,
+                fire_on_poll,
+            }
+        }
+    }
+
+    impl ButtonPoll for MockButtonPoll {
+        fn poll(&mut self) -> Option<u8> {
+            self.polls += 1;
+            if self.polls == self.fire_on_poll {
+                Some(BUTTON_TYPE_SHORT)
+            } else {
+                None
+            }
+        }
+    }
+
     #[test]
     fn button_event_bridge_integration() {
-        // Verify that the bridge emits EVENT_BUTTON when the scanner fires.
-        // This test still uses real timing via bridge.poll() since it tests
-        // the full integration path including USB-CDC emission.
-        let pressed = Rc::new(StdCell::new(false));
-        let pressed_clone = pressed.clone();
-        let scanner = ButtonScanner::new(move || pressed_clone.get());
-
+        // Verify that the bridge emits EVENT_BUTTON when the button poller
+        // fires. Uses a deterministic mock instead of wall-clock sleeps.
         let mut bridge = Bridge::with_ble_and_button(
             MockSerial::new(),
             MockRadio::new(),
             MockBle::new(),
-            scanner,
+            MockButtonPoll::new(2),
             ModemCounters::new(),
         );
 
-        // Press the button.
-        pressed.set(true);
+        // First poll: no event. Second poll: MockButtonPoll fires.
         bridge.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
-        bridge.poll();
-
-        // Release after short press.
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        pressed.set(false);
-        bridge.poll();
-        std::thread::sleep(std::time::Duration::from_millis(35));
         bridge.poll();
 
         // Decode the EVENT_BUTTON from the serial output.

--- a/crates/sonde-protocol/src/modem.rs
+++ b/crates/sonde-protocol/src/modem.rs
@@ -78,6 +78,11 @@ pub const MODEM_MSG_BLE_DISCONNECTED: u8 = 0xA2;
 /// Numeric Comparison pin display request; gateway must show the pin to the operator.
 pub const MODEM_MSG_BLE_PAIRING_CONFIRM: u8 = 0xA3;
 
+// -- GPIO / hardware events: Modem → Gateway --
+
+/// A debounced button press was detected on the 1-Wire data line (MD-0603).
+pub const MODEM_MSG_EVENT_BUTTON: u8 = 0xB0;
+
 // -- Modem → Gateway (events / responses) --
 
 /// Modem initialized and ready (sent on boot and after `RESET`).
@@ -142,6 +147,9 @@ pub const BLE_PAIRING_CONFIRM_BODY_SIZE: usize = 4;
 
 /// BLE_PAIRING_CONFIRM_REPLY body: accept (1B).
 pub const BLE_PAIRING_CONFIRM_REPLY_BODY_SIZE: usize = 1;
+
+/// EVENT_BUTTON body: button_type (1B).
+pub const EVENT_BUTTON_BODY_SIZE: usize = 1;
 
 /// Maximum valid BLE Numeric Comparison passkey value (6 digits, 0–999 999).
 pub const BLE_PASSKEY_MAX: u32 = 999_999;
@@ -271,6 +279,9 @@ pub enum ModemMessage {
     BleDisconnected(BleDisconnected),
     BlePairingConfirm(BlePairingConfirm),
 
+    // -- GPIO / hardware events: Modem → Gateway --
+    EventButton(EventButton),
+
     /// A message with a recognized framing but unknown type code.
     /// Kept for forward compatibility — receivers should silently discard.
     Unknown {
@@ -377,6 +388,19 @@ pub struct BlePairingConfirmReply {
     /// `true` = accept (operator confirmed pin matches), `false` = reject.
     pub accept: bool,
 }
+
+/// EVENT_BUTTON (Modem → Gateway): a debounced button press was detected (MD-0603).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventButton {
+    /// `0x00` = BUTTON_SHORT (press < 1 s), `0x01` = BUTTON_LONG (press ≥ 1 s).
+    pub button_type: u8,
+}
+
+/// BUTTON_SHORT: press duration < 1 second.
+pub const BUTTON_TYPE_SHORT: u8 = 0x00;
+
+/// BUTTON_LONG: press duration ≥ 1 second.
+pub const BUTTON_TYPE_LONG: u8 = 0x01;
 
 // ---------------------------------------------------------------------------
 // Frame encoding
@@ -553,6 +577,16 @@ fn encode_body(msg: &ModemMessage) -> Result<(u8, Vec<u8>), ModemCodecError> {
             let mut body = Vec::with_capacity(BLE_PAIRING_CONFIRM_BODY_SIZE);
             body.extend_from_slice(&pc.passkey.to_be_bytes());
             Ok((MODEM_MSG_BLE_PAIRING_CONFIRM, body))
+        }
+        ModemMessage::EventButton(eb) => {
+            if eb.button_type > BUTTON_TYPE_LONG {
+                return Err(ModemCodecError::InvalidFieldValue {
+                    msg_type: MODEM_MSG_EVENT_BUTTON,
+                    field: "button_type",
+                    value: eb.button_type as usize,
+                });
+            }
+            Ok((MODEM_MSG_EVENT_BUTTON, alloc::vec![eb.button_type]))
         }
         ModemMessage::Unknown { msg_type, body } => Ok((*msg_type, body.clone())),
     }
@@ -860,6 +894,19 @@ fn decode_typed_message(msg_type: u8, body: &[u8]) -> Result<ModemMessage, Modem
             Ok(ModemMessage::BlePairingConfirm(BlePairingConfirm {
                 passkey,
             }))
+        }
+
+        MODEM_MSG_EVENT_BUTTON => {
+            check_exact_body(msg_type, body, EVENT_BUTTON_BODY_SIZE)?;
+            let button_type = body[0];
+            if button_type > BUTTON_TYPE_LONG {
+                return Err(ModemCodecError::InvalidFieldValue {
+                    msg_type,
+                    field: "button_type",
+                    value: button_type as usize,
+                });
+            }
+            Ok(ModemMessage::EventButton(EventButton { button_type }))
         }
 
         _ => Ok(ModemMessage::Unknown {
@@ -1821,5 +1868,70 @@ mod tests {
                 value: 100,
             }
         );
+    }
+
+    // -- EVENT_BUTTON tests (T-0808) --
+
+    #[test]
+    fn event_button_short_roundtrip() {
+        let msg = ModemMessage::EventButton(EventButton {
+            button_type: BUTTON_TYPE_SHORT,
+        });
+        let frame = encode_modem_frame(&msg).unwrap();
+        let (decoded, consumed) = decode_modem_frame(&frame).unwrap();
+        assert_eq!(consumed, frame.len());
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn event_button_long_roundtrip() {
+        let msg = ModemMessage::EventButton(EventButton {
+            button_type: BUTTON_TYPE_LONG,
+        });
+        let frame = encode_modem_frame(&msg).unwrap();
+        let (decoded, consumed) = decode_modem_frame(&frame).unwrap();
+        assert_eq!(consumed, frame.len());
+        assert_eq!(decoded, msg);
+    }
+
+    #[test]
+    fn event_button_invalid_type_encode_error() {
+        let msg = ModemMessage::EventButton(EventButton { button_type: 0x02 });
+        let err = encode_modem_frame(&msg).unwrap_err();
+        assert_eq!(
+            err,
+            ModemCodecError::InvalidFieldValue {
+                msg_type: MODEM_MSG_EVENT_BUTTON,
+                field: "button_type",
+                value: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn event_button_invalid_type_decode_error() {
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&2u16.to_be_bytes()); // len = 2 (TYPE + 1 body)
+        frame.push(MODEM_MSG_EVENT_BUTTON);
+        frame.push(0x02); // invalid button_type
+        let err = decode_modem_frame(&frame).unwrap_err();
+        assert_eq!(
+            err,
+            ModemCodecError::InvalidFieldValue {
+                msg_type: MODEM_MSG_EVENT_BUTTON,
+                field: "button_type",
+                value: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn event_button_wire_format() {
+        let msg = ModemMessage::EventButton(EventButton {
+            button_type: BUTTON_TYPE_SHORT,
+        });
+        let frame = encode_modem_frame(&msg).unwrap();
+        // LEN = 2 (TYPE + 1 body), TYPE = 0xB0, BODY = 0x00
+        assert_eq!(frame, &[0x00, 0x02, 0xB0, 0x00]);
     }
 }

--- a/docs/modem-design.md
+++ b/docs/modem-design.md
@@ -60,6 +60,7 @@ The firmware is intentionally minimal — no application- or protocol-layer cryp
 | **BLE GATT service** | Gateway Pairing Service + Gateway Command characteristic; indication pacing; Write Long reassembly | MD-0400, MD-0401, MD-0403, MD-0408, MD-0409 |
 | **BLE lifecycle** | `BLE_ENABLE`/`BLE_DISABLE` handling, connection/disconnection events, `BLE_CONNECTED`/`BLE_DISCONNECTED` notifications, idle timeout | MD-0405, MD-0410, MD-0411, MD-0413, MD-0414, MD-0415 |
 | **Watchdog** *(cross-cutting)* | Task watchdog feed in main loop; hardware reset on stall | MD-0302 |
+| **Button scanner** | GPIO2 polling, debounce, press classification, `EVENT_BUTTON` emission | MD-0600, MD-0601, MD-0602, MD-0603, MD-0604, MD-0605 |
 
 ---
 
@@ -236,11 +237,14 @@ loop {
     // ESP-NOW receive callback writes RECV_FRAME to USB
     // asynchronously from the WiFi task — no polling needed.
 
+    // Poll button GPIO; bridge emits EVENT_BUTTON if a press is classified.
+    button_scanner.poll();
+
     feed_watchdog();
 }
 ```
 
-The main loop polls the USB receive buffer and drains the ESP-NOW RX ring buffer. ESP-NOW frames arrive via callback into the ring; the main loop constructs `RECV_FRAME` messages and writes them to USB.
+The main loop polls the USB receive buffer, drains the ESP-NOW RX ring buffer, and polls the button GPIO. ESP-NOW frames arrive via callback into the ring; the main loop constructs `RECV_FRAME` messages and writes them to USB. Button press/release is detected via non-blocking GPIO reads and classified by duration.
 
 > **Per-poll processing caps (D9-2):** BLE events are drained up to `MAX_BLE_EVENTS_PER_POLL` (16) per main-loop iteration to prevent sustained BLE traffic from starving serial decode and ESP-NOW radio processing.
 
@@ -509,3 +513,71 @@ On BLE client disconnection (MD-0405, MD-0413, MD-0414):
 On `BLE_DISABLE`, the modem disconnects the active client (if any) and stops advertising. On `RESET`, BLE is disabled as part of the full reinitialisation sequence.
 
 > **`advertise_on_disconnect` interaction (D10-5):** During GATT server initialization the modem calls `ble_server.advertise_on_disconnect(true)` so that advertising resumes automatically after a client disconnect (MD-0407). This is a NimBLE stack-level setting that persists for the lifetime of the BLE server. When `BLE_DISABLE` is received, the modem explicitly stops advertising and clears its internal `advertising` flag, but does *not* clear the stack-level `advertise_on_disconnect` policy. If `disable()` disconnects an active client while `advertise_on_disconnect(true)` is still in effect, NimBLE may restart advertising in response to that disconnect and keep it enabled even though the gateway has issued `BLE_DISABLE`. Implementations **must** provide a mitigation in code (for example, clearing `advertise_on_disconnect` before initiating the disconnect, or ensuring that the post-disconnect path performs a final `ble_advertising.stop()` when BLE is disabled) so that advertising is guaranteed to remain off after `BLE_DISABLE`, as required by MD-0407/MD-0413.
+
+---
+
+## 16  Button scanner
+
+The modem detects button presses on the 1-Wire data line (GPIO2 / XIAO ESP32-S3 silk label D1) and emits `EVENT_BUTTON` messages to the gateway. The modem does not interpret button semantics.
+
+### 16.1  GPIO configuration
+
+At boot, GPIO2 is configured as an input pin with active-low logic. The carrier board provides an external pull-up resistor; the firmware enables the ESP32-S3 internal pull-up as a fallback only if the external pull-up is absent.
+
+### 16.2  Debounce and classification state machine
+
+The button scanner is a polling-based state machine called once per main-loop iteration. It uses `Instant::now()` for timing (ESP-IDF monotonic clock).
+
+```
+         ┌──────────┐
+         │  Idle    │◄──────── GPIO HIGH (not pressed)
+         │          │
+         └────┬─────┘
+              │ GPIO LOW detected
+              ▼
+         ┌──────────┐
+         │ Debounce │  wait 30 ms with GPIO continuously LOW
+         │ Press    │
+         └────┬─────┘
+              │ 30 ms elapsed, still LOW
+              ▼
+         ┌──────────┐
+         │ Pressed  │  record press_start = now()
+         │          │
+         └────┬─────┘
+              │ GPIO HIGH detected (release)
+              ▼
+         ┌──────────┐
+         │ Debounce │  wait 30 ms with GPIO continuously HIGH
+         │ Release  │
+         └────┬─────┘
+              │ 30 ms elapsed, still HIGH
+              ▼
+         ┌──────────┐
+         │ Classify │  duration = now() - press_start
+         │ & Emit   │  < 1 s → BUTTON_SHORT (0x00)
+         │          │  ≥ 1 s → BUTTON_LONG  (0x01)
+         └────┬─────┘
+              │ EVENT_BUTTON emitted
+              ▼
+         ┌──────────┐
+         │  Idle    │
+         └──────────┘
+```
+
+If during the debounce-press phase the GPIO returns HIGH before 30 ms elapse, the state machine resets to Idle (glitch rejected). Similarly, if during debounce-release the GPIO returns LOW before 30 ms elapse, the state machine returns to Pressed (bounce rejected).
+
+### 16.3  Module structure
+
+The button scanner is split into two layers:
+
+- **`ButtonScanner`** (platform-independent, in `bridge.rs` or a new `button.rs` module): Implements the state machine and classification logic. Generic over a GPIO read function. Testable on the host.
+- **ESP GPIO wrapper** (ESP-IDF, in `bin/modem.rs`): Configures GPIO2 via `esp-idf-hal` and provides the read function to `ButtonScanner`.
+
+### 16.4  Integration with Bridge
+
+The `ButtonScanner::poll()` method returns `Option<u8>` — `Some(0x00)` for BUTTON_SHORT, `Some(0x01)` for BUTTON_LONG, or `None` if no event occurred. The bridge calls `poll()` each main-loop iteration and, when `Some(button_type)` is returned, encodes and sends an `EVENT_BUTTON` frame over USB-CDC.
+
+### 16.5  Non-interference
+
+Button polling is a single non-blocking GPIO read per main-loop iteration — no interrupts, no dedicated FreeRTOS task, no blocking waits. The polling cost is negligible compared to the existing USB and ESP-NOW processing in the loop.

--- a/docs/modem-design.md
+++ b/docs/modem-design.md
@@ -229,22 +229,17 @@ The firmware runs a single-threaded event loop (no RTOS tasks beyond the WiFi/US
 
 ```
 loop {
-    if usb_has_data() {
-        frame = serial_codec.decode();
-        dispatch(frame);
-    }
-
-    // ESP-NOW receive callback writes RECV_FRAME to USB
-    // asynchronously from the WiFi task — no polling needed.
-
-    // Poll button GPIO; bridge emits EVENT_BUTTON if a press is classified.
-    button_scanner.poll();
+    // bridge.poll() handles:
+    //   - USB serial decode + dispatch
+    //   - BLE event drain
+    //   - Button GPIO poll → EVENT_BUTTON on classified release
+    bridge.poll();
 
     feed_watchdog();
 }
 ```
 
-The main loop polls the USB receive buffer, drains the ESP-NOW RX ring buffer, and polls the button GPIO. ESP-NOW frames arrive via callback into the ring; the main loop constructs `RECV_FRAME` messages and writes them to USB. Button press/release is detected via non-blocking GPIO reads and classified by duration.
+The main loop delegates all I/O to `Bridge::poll()`, which decodes USB serial frames, drains BLE events, and polls the button GPIO. ESP-NOW frames arrive via callback into the ring; the bridge constructs `RECV_FRAME` messages and writes them to USB. Button press/release is detected via non-blocking GPIO reads and classified by duration (see §16).
 
 > **Per-poll processing caps (D9-2):** BLE events are drained up to `MAX_BLE_EVENTS_PER_POLL` (16) per main-loop iteration to prevent sustained BLE traffic from starving serial decode and ESP-NOW radio processing.
 

--- a/docs/modem-design.md
+++ b/docs/modem-design.md
@@ -522,7 +522,7 @@ The modem detects button presses on the 1-Wire data line (GPIO2 / XIAO ESP32-S3 
 
 ### 16.1  GPIO configuration
 
-At boot, GPIO2 is configured as an input pin with active-low logic. The carrier board provides an external pull-up resistor; the firmware enables the ESP32-S3 internal pull-up as a fallback only if the external pull-up is absent.
+At boot, GPIO2 is configured as an input pin with active-low logic. The firmware unconditionally enables the ESP32-S3 internal pull-up; this is safe alongside the carrier board's external pull-up (parallel pull-ups simply lower the effective resistance).
 
 ### 16.2  Debounce and classification state machine
 

--- a/docs/modem-protocol.md
+++ b/docs/modem-protocol.md
@@ -559,7 +559,7 @@ The modem may send `RECV_FRAME`, `ERROR`, or `EVENT_BUTTON` at any time, interle
 
 - `RECV_FRAME` → deliver to the `Transport::recv()` caller.
 - `ERROR` → log and optionally trigger recovery.
-- `EVENT_BUTTON` → deliver to the button-event handler (e.g., registration window activation).
+- `EVENT_BUTTON` → deliver to the button-event handler (e.g., registration window activation). **Note:** gateway-side consumption of `EVENT_BUTTON` is not yet implemented; the message is currently logged and otherwise ignored.
 - Expected response (e.g., `STATUS`, `SET_CHANNEL_ACK`) → deliver to the waiting command.
 
 ---

--- a/docs/modem-protocol.md
+++ b/docs/modem-protocol.md
@@ -109,6 +109,7 @@ Message types are partitioned by direction:
 | 0xA1 | `BLE_CONNECTED` | §4.11 | A BLE client connected to the Gateway Pairing Service. |
 | 0xA2 | `BLE_DISCONNECTED` | §4.12 | The BLE client disconnected. |
 | 0xA3 | `BLE_PAIRING_CONFIRM` | §4.15 | Numeric Comparison pin display request — gateway must show the pin to the operator. |
+| 0xB0 | `EVENT_BUTTON` | §4.17 | A debounced button press was detected on the 1-Wire data line. |
 
 ---
 
@@ -364,6 +365,22 @@ The `BLE_PAIRING_CONFIRM_REPLY` body is a single 1-byte `accept` field: `0x01` m
 |-------|------|------|-------------|
 | `accept` | Unsigned integer | 1 byte | `0x01` = accept (operator confirmed pin matches), `0x00` = reject (operator rejected or timeout). |
 
+### 4.17  EVENT_BUTTON (Modem → Gateway)
+
+A debounced button press was detected on the 1-Wire data line (GPIO2 / XIAO D1). The modem classifies presses by duration and emits this event on button release. The modem does not interpret button meaning — all semantics (pairing, menus, UX) are handled by the gateway.
+
+The `EVENT_BUTTON` body is a single 1-byte `button_type` field.
+
+```
+┌──────────────────┐
+│  button_type (1B)│
+└──────────────────┘
+```
+
+| Field | Type | Size | Description |
+|-------|------|------|-------------|
+| `button_type` | Unsigned integer | 1 byte | `0x00` = BUTTON_SHORT (press < 1 s), `0x01` = BUTTON_LONG (press ≥ 1 s). |
+
 ---
 
 ## 5  Message flows
@@ -538,10 +555,11 @@ If the USB-CDC link drops:
 
 ### 6.4  Unsolicited messages
 
-The modem may send `RECV_FRAME` or `ERROR` at any time, interleaved with responses to gateway commands. The gateway's serial reader must demultiplex:
+The modem may send `RECV_FRAME`, `ERROR`, or `EVENT_BUTTON` at any time, interleaved with responses to gateway commands. The gateway's serial reader must demultiplex:
 
 - `RECV_FRAME` → deliver to the `Transport::recv()` caller.
 - `ERROR` → log and optionally trigger recovery.
+- `EVENT_BUTTON` → deliver to the button-event handler (e.g., registration window activation).
 - Expected response (e.g., `STATUS`, `SET_CHANNEL_ACK`) → deliver to the waiting command.
 
 ---
@@ -582,4 +600,5 @@ The `firmware_version` field in `MODEM_READY` allows the gateway to detect the m
 | 0x81 – 0x8F | Core modem events/responses |
 | 0x90 – 0x9F | Reserved |
 | 0xA0 – 0xAF | BLE relay events (BLE_RECV, BLE_CONNECTED, BLE_DISCONNECTED, BLE_PAIRING_CONFIRM) |
-| 0xB0 – 0xFF | Reserved for future modem → gateway messages |
+| 0xB0 – 0xBF | GPIO / hardware events (EVENT_BUTTON) |
+| 0xC0 – 0xFF | Reserved for future modem → gateway messages |

--- a/docs/modem-requirements.md
+++ b/docs/modem-requirements.md
@@ -741,6 +741,109 @@ When the modem encountersan error at an operator-visible boundary (BLE GATT oper
 
 ---
 
+## 9  Button input
+
+### MD-0600  Button GPIO configuration
+
+**Priority:** Must
+**Source:** modem-protocol.md §4.17, Issue #756
+
+**Description:**
+The modem firmware MUST configure GPIO2 (XIAO ESP32-S3 silk label D1, 1-Wire data line) as a GPIO input, active-low. The carrier board provides an external pull-up resistor. The firmware SHOULD enable the ESP32-S3 internal pull-up as a fallback only if the external pull-up is absent.
+
+**Acceptance criteria:**
+
+1. GPIO2 is configured as input at boot.
+2. The pin reads HIGH when the button is not pressed.
+3. The pin reads LOW when the button is pressed.
+
+---
+
+### MD-0601  Button debounce
+
+**Priority:** Must
+**Source:** modem-protocol.md §4.17, Issue #756
+
+**Description:**
+The modem firmware MUST debounce the button input with a 30 ms window. Transitions shorter than 30 ms MUST be ignored.
+
+**Acceptance criteria:**
+
+1. A LOW pulse shorter than 30 ms does not generate an event.
+2. A LOW pulse of 30 ms or longer is recognized as a valid press.
+
+---
+
+### MD-0602  Button press classification
+
+**Priority:** Must
+**Source:** modem-protocol.md §4.17, Issue #756
+
+**Description:**
+The modem firmware MUST classify button presses by their duration, measured from the debounced press to the debounced release:
+
+- **BUTTON_SHORT**: press duration < 1 second.
+- **BUTTON_LONG**: press duration ≥ 1 second.
+
+The classification MUST be determined on release — no event is emitted while the button is held.
+
+**Acceptance criteria:**
+
+1. A 500 ms press emits BUTTON_SHORT.
+2. A 999 ms press emits BUTTON_SHORT.
+3. A 1000 ms press emits BUTTON_LONG.
+4. A 1500 ms press emits BUTTON_LONG.
+5. No event is emitted while the button remains held.
+
+---
+
+### MD-0603  EVENT_BUTTON emission
+
+**Priority:** Must
+**Source:** modem-protocol.md §4.17, Issue #756
+
+**Description:**
+On button release, the modem firmware MUST emit an `EVENT_BUTTON` message (serial type `0xB0`) over USB-CDC. The message body contains a single `button_type` byte: `0x00` for BUTTON_SHORT, `0x01` for BUTTON_LONG. No state is retained between events. No acknowledgement from the gateway is expected.
+
+**Acceptance criteria:**
+
+1. `EVENT_BUTTON` is sent within one main-loop poll cycle of the debounced release.
+2. The `button_type` byte is `0x00` for short presses and `0x01` for long presses.
+3. No state persists between successive button events.
+
+---
+
+### MD-0604  Button non-interference
+
+**Priority:** Must
+**Source:** Issue #756
+
+**Description:**
+Button scanning MUST NOT block or delay ESP-NOW RX/TX, BLE callbacks, or USB-CDC framing. The firmware MUST use non-blocking GPIO polling in the main loop — no dedicated FreeRTOS task, no GPIO interrupts that could preempt radio callbacks.
+
+**Acceptance criteria:**
+
+1. ESP-NOW frame forwarding latency is not measurably increased when button events are occurring.
+2. BLE pairing operations complete successfully during concurrent button presses.
+3. No GPIO interrupt service routines are registered for the button pin.
+
+---
+
+### MD-0605  No button-semantic logic in modem
+
+**Priority:** Must
+**Source:** Issue #756
+
+**Description:**
+The modem MUST NOT interpret button meaning. Specifically, the modem MUST NOT: enter pairing mode based on button presses, update any display, change BLE advertising state, or maintain any button-related state beyond the debounce and classification logic required by MD-0601 and MD-0602. All button semantics are handled by the gateway.
+
+**Acceptance criteria:**
+
+1. No code path in the modem firmware maps button events to pairing, display, BLE, or any other subsystem action.
+2. `EVENT_BUTTON` is a pure, stateless notification.
+
+---
+
 ## Appendix A  Requirement index
 
 | ID | Title | Priority |
@@ -788,3 +891,9 @@ When the modem encountersan error at an operator-visible boundary (BLE GATT oper
 | MD-0504 | BLE pairing event logging | Must |
 | MD-0505 | Build-type–aware log levels | Must |
 | MD-0506 | Error diagnostic observability | Must |
+| MD-0600 | Button GPIO configuration | Must |
+| MD-0601 | Button debounce | Must |
+| MD-0602 | Button press classification | Must |
+| MD-0603 | EVENT_BUTTON emission | Must |
+| MD-0604 | Button non-interference | Must |
+| MD-0605 | No button-semantic logic in modem | Must |

--- a/docs/modem-requirements.md
+++ b/docs/modem-requirements.md
@@ -749,7 +749,7 @@ When the modem encountersan error at an operator-visible boundary (BLE GATT oper
 **Source:** modem-protocol.md §4.17, Issue #756
 
 **Description:**
-The modem firmware MUST configure GPIO2 (XIAO ESP32-S3 silk label D1, 1-Wire data line) as a GPIO input, active-low. The carrier board provides an external pull-up resistor. The firmware SHOULD enable the ESP32-S3 internal pull-up as a fallback only if the external pull-up is absent.
+The modem firmware MUST configure GPIO2 (XIAO ESP32-S3 silk label D1, 1-Wire data line) as a GPIO input, active-low. The firmware MUST enable the ESP32-S3 internal pull-up unconditionally; this is safe to use alongside the carrier board's external pull-up (parallel pull-ups simply lower the effective resistance).
 
 **Acceptance criteria:**
 

--- a/docs/modem-validation.md
+++ b/docs/modem-validation.md
@@ -1033,6 +1033,151 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 
 ---
 
+## 10  Button input tests
+
+### T-0800  Button GPIO reads HIGH when idle
+
+**Validates:** MD-0600
+
+**Procedure:**
+1. Boot the modem with no button pressed.
+2. Read GPIO2 value.
+3. Assert: GPIO2 reads HIGH.
+
+---
+
+### T-0801  Short press emits BUTTON_SHORT
+
+**Validates:** MD-0601, MD-0602, MD-0603
+
+**Procedure:**
+1. Simulate a 500 ms button press (GPIO LOW for 500 ms, then HIGH).
+2. Wait for `EVENT_BUTTON` on the serial link.
+3. Assert: `EVENT_BUTTON` (type `0xB0`) is received.
+4. Assert: `button_type` = `0x00` (BUTTON_SHORT).
+
+---
+
+### T-0802  Long press emits BUTTON_LONG
+
+**Validates:** MD-0601, MD-0602, MD-0603
+
+**Procedure:**
+1. Simulate a 1500 ms button press (GPIO LOW for 1500 ms, then HIGH).
+2. Wait for `EVENT_BUTTON` on the serial link.
+3. Assert: `EVENT_BUTTON` (type `0xB0`) is received.
+4. Assert: `button_type` = `0x01` (BUTTON_LONG).
+
+---
+
+### T-0803  Boundary — 999 ms press is SHORT, 1000 ms press is LONG
+
+**Validates:** MD-0602
+
+**Procedure:**
+1. Simulate a 999 ms button press, then release.
+2. Assert: `button_type` = `0x00` (BUTTON_SHORT).
+3. Simulate a 1000 ms button press, then release.
+4. Assert: `button_type` = `0x01` (BUTTON_LONG).
+
+---
+
+### T-0804  Debounce rejects glitches shorter than 30 ms
+
+**Validates:** MD-0601
+
+**Procedure:**
+1. Simulate a 20 ms LOW pulse (press), then return HIGH.
+2. Wait 100 ms.
+3. Assert: no `EVENT_BUTTON` is emitted.
+
+---
+
+### T-0805  No event emitted while button is held
+
+**Validates:** MD-0602
+
+**Procedure:**
+1. Simulate button press (GPIO LOW) and hold for 3 seconds without releasing.
+2. Assert: no `EVENT_BUTTON` is emitted during the hold.
+3. Release the button (GPIO HIGH).
+4. Assert: `EVENT_BUTTON` with `button_type` = `0x01` (BUTTON_LONG) is emitted on release.
+
+---
+
+### T-0806  Button events do not interfere with ESP-NOW
+
+**Validates:** MD-0604
+
+**Procedure:**
+1. Establish a baseline ESP-NOW forwarding rate (frames per second) with no button activity.
+2. Repeat the same traffic load while simultaneously simulating rapid button presses (short and long).
+3. Assert: ESP-NOW forwarding rate and latency show no measurable regression attributable to button polling.
+4. Assert: `EVENT_BUTTON` messages are received correctly during the load.
+
+---
+
+### T-0806a  Button events do not interfere with BLE pairing
+
+**Validates:** MD-0604
+
+**Procedure:**
+1. Enable BLE advertising via `BLE_ENABLE`.
+2. Initiate a BLE LESC pairing from a phone while simultaneously simulating rapid button presses.
+3. Assert: BLE pairing completes successfully.
+4. Assert: `BLE_CONNECTED` and `EVENT_BUTTON` messages are both received on USB-CDC.
+
+---
+
+### T-0807  No button-semantic logic in modem
+
+**Validates:** MD-0605
+
+**Procedure:**
+1. Simulate a BUTTON_LONG press (≥ 1 s).
+2. Assert: `EVENT_BUTTON` is emitted.
+3. Assert: BLE advertising state is unchanged.
+4. Assert: no pairing mode is entered.
+5. Assert: no display output is triggered.
+
+---
+
+### T-0808  EVENT_BUTTON round-trip codec
+
+**Validates:** MD-0603
+
+**Procedure:**
+1. Construct an `EVENT_BUTTON` message with `button_type` = `0x00`.
+2. Encode to serial frame.
+3. Decode the frame.
+4. Assert: decoded message matches the original.
+5. Repeat with `button_type` = `0x01`.
+
+---
+
+### T-0809  Release-bounce rejected
+
+**Validates:** MD-0601
+
+**Procedure:**
+1. Simulate a valid button press (GPIO LOW for 500 ms).
+2. On release, bounce: GPIO HIGH for 15 ms, LOW for 10 ms, then HIGH sustained.
+3. Assert: exactly one `EVENT_BUTTON` is emitted (the bounce does not create a second event).
+
+---
+
+### T-0810  Back-to-back presses emit independent events
+
+**Validates:** MD-0603
+
+**Procedure:**
+1. Simulate a short press (300 ms), release, wait 100 ms, then simulate a long press (1200 ms), release.
+2. Assert: two `EVENT_BUTTON` messages are received.
+3. Assert: first `button_type` = `0x00` (SHORT), second `button_type` = `0x01` (LONG).
+4. Assert: no state from the first press leaks into the second.
+
+---
+
 ## Appendix A  Test index
 
 | ID | Title | Validates |
@@ -1112,3 +1257,15 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 | T-0709 | Build-type verbose retains INFO and DEBUG | MD-0505 |
 | T-0710 | Error diagnostic — BLE indication failure | MD-0506 |
 | T-0711 | Error diagnostic — ESP-NOW send failure | MD-0506 |
+| T-0800 | Button GPIO reads HIGH when idle | MD-0600 |
+| T-0801 | Short press emits BUTTON_SHORT | MD-0601, MD-0602, MD-0603 |
+| T-0802 | Long press emits BUTTON_LONG | MD-0601, MD-0602, MD-0603 |
+| T-0803 | Boundary — 999 ms SHORT, 1000 ms LONG | MD-0602 |
+| T-0804 | Debounce rejects glitches shorter than 30 ms | MD-0601 |
+| T-0805 | No event emitted while button is held | MD-0602 |
+| T-0806 | Button events do not interfere with ESP-NOW | MD-0604 |
+| T-0806a | Button events do not interfere with BLE pairing | MD-0604 |
+| T-0807 | No button-semantic logic in modem | MD-0605 |
+| T-0808 | EVENT_BUTTON round-trip codec | MD-0603 |
+| T-0809 | Release-bounce rejected | MD-0601 |
+| T-0810 | Back-to-back presses emit independent events | MD-0603 |


### PR DESCRIPTION
## Summary

Extends the modem firmware to detect button presses on the 1-Wire data line (GPIO2 / XIAO ESP32-S3 D1). The modem debounces input (30 ms), classifies presses as \BUTTON_SHORT\ (< 1 s) or \BUTTON_LONG\ (≥ 1 s) on release, and emits \EVENT_BUTTON\ (type \