### PR TITLE
fix(ci): grant packages:write to gateway-container caller job

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -29,6 +29,9 @@ jobs:
   gateway-container:
     name: Gateway container
     uses: ./.github/workflows/gateway-container.yml
+    permissions:
+      contents: read
+      packages: write
 
   node-firmware:
     name: Node firmware


### PR DESCRIPTION
## Problem

The nightly release workflow fails with \\startup_failure\\:

\\\
Error calling workflow gateway-container.yml: The nested job 'build' is
requesting 'packages: write', but is only allowed 'packages: read'.
\\\

\\gateway-container.yml\\ needs \\packages: write\\ to push images to GHCR, but the calling job in \\
ightly-release.yml\\ didn't declare any permissions, so it inherited default read-only.

## Fix

Add explicit \\permissions: { contents: read, packages: write }\\ to the \\gateway-container\\ caller job in \\
ightly-release.yml\\.

Fixes the \\startup_failure\\ at https://github.com/Alan-Jowett/sonde/actions/runs/24787599001