### PR TITLE
fix(ci): repair gateway container workflow and startup defaults

### DIFF
--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
       - name: Build container image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198e19c816612f # v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: .github/docker/Dockerfile.gateway


### PR DESCRIPTION
## Summary
- replace the unresolved `docker/build-push-action` pin in `.github/workflows/gateway-container.yml`
- accept both musl `ldd` messages in the static-linkage smoke test so arm64 builds do not fail on wording alone
- fix the gateway container defaults so the image starts with `--db /var/lib/sonde/sonde.db --port /dev/ttyACM0 --key-provider env`
- update the gateway container design doc to match the corrected runtime defaults

## Validation
- confirmed the original failing job was blocked by an unresolvable action pin
- reproduced the arm64 `ldd` output on real hardware: `Not a valid dynamic program`
- confirmed the previous container defaults failed immediately because `--port` was missing
- confirmed the gateway process stays up and retries serial-port open when started with a complete command line on arm64