### PR TITLE
fix(ci): repair gateway container startup defaults

### DIFF
--- a/.github/docker/Dockerfile.gateway
+++ b/.github/docker/Dockerfile.gateway
@@ -17,8 +17,7 @@
 #     -e SONDE_MASTER_KEY=<64-hex-chars> \
 #     --device /dev/ttyACM0 \
 #     --group-add <host-dialout-gid> \
-#     sonde-gateway \
-#       --port /dev/ttyACM0 --key-provider env
+#     sonde-gateway
 
 # ── Stage 1: build ──────────────────────────────────────────────────────────
 # rust:alpine — pinned by digest for reproducible builds.
@@ -57,4 +56,4 @@ VOLUME /var/lib/sonde
 USER sonde
 
 ENTRYPOINT ["sonde-gateway"]
-CMD ["--db", "/var/lib/sonde/sonde.db"]
+CMD ["--db", "/var/lib/sonde/sonde.db", "--port", "/dev/ttyACM0", "--key-provider", "env"]

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Smoke test — static musl linkage
         run: |
           docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
-            'ldd /usr/local/bin/sonde-gateway 2>&1 | grep -q "not a dynamic executable"'
+            'ldd /usr/local/bin/sonde-gateway 2>&1 | grep -Eiq "not a dynamic executable|not a valid dynamic program"'
 
       - name: Smoke test — non-root user and writable volume
         run: |

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -70,6 +70,11 @@ jobs:
           docker run --rm --entrypoint sonde-sht40-handler ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
           docker run --rm --entrypoint sonde-tmp102-handler ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
 
+      - name: Smoke test — runtime defaults
+        run: |
+          test "$(docker inspect -f '{{json .Config.Entrypoint}}' ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }})" = '["sonde-gateway"]'
+          test "$(docker inspect -f '{{json .Config.Cmd}}' ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }})" = '["--db","/var/lib/sonde/sonde.db","--port","/dev/ttyACM0","--key-provider","env"]'
+
       - name: Smoke test — static musl linkage
         run: |
           docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1816,11 +1816,11 @@ Public tags are created only after both architectures pass smoke tests.
 | Property | Value |
 |----------|-------|
 | `ENTRYPOINT` | `sonde-gateway` |
-| `CMD` | `--db /var/lib/sonde/sonde.db` |
+| `CMD` | `--db /var/lib/sonde/sonde.db --port /dev/ttyACM0 --key-provider env` |
 | `VOLUME` | `/var/lib/sonde` |
 | `USER` | `sonde` (non-root) |
 
-Serial device access requires the operator to pass `--device=/dev/ttyACM0` and `--group-add <host-dialout-gid>` at `docker run` time.
+Serial device access requires the operator to pass `--device=/dev/ttyACM0` and `--group-add <host-dialout-gid>` at `docker run` time. The container defaults assume `/dev/ttyACM0`; operators using a different modem path must override `--port`.
 
 ### 22.6  CI integration
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2097,12 +2097,12 @@ Container images MUST follow a consistent tagging strategy. Release builds (git 
 **Source:** Issue #780
 
 **Description:**  
-The container image MUST be configured for production use. The `ENTRYPOINT` is `sonde-gateway` with a default `CMD` that points the database to the declared volume. A `VOLUME` at `/var/lib/sonde` is declared for database persistence. The gateway runs as a non-root `sonde` user inside the container. The `--key-provider file` and `--key-provider env` backends work without D-Bus.
+The container image MUST be configured for production use. The `ENTRYPOINT` is `sonde-gateway` with a default `CMD` that points the database to the declared volume, selects `/dev/ttyACM0` as the default modem path, and uses the `env` key provider that is suitable for container deployments. A `VOLUME` at `/var/lib/sonde` is declared for database persistence. The gateway runs as a non-root `sonde` user inside the container. The `--key-provider file` and `--key-provider env` backends work without D-Bus.
 
 **Acceptance criteria:**
 
 1. `ENTRYPOINT` is `sonde-gateway`.
-2. `CMD` defaults to `--db /var/lib/sonde/sonde.db`.
+2. `CMD` defaults to `--db /var/lib/sonde/sonde.db --port /dev/ttyACM0 --key-provider env`.
 3. `VOLUME /var/lib/sonde` is declared for database persistence.
 4. The gateway runs as a non-root `sonde` user inside the container.
 5. `--key-provider file` and `--key-provider env` work without D-Bus.

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -3247,21 +3247,23 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
-### T-1802  Container runs as non-root with writable volume
+### T-1802  Container runtime defaults, non-root user, and writable volume
 
 **Traces to:** GW-1802 (AC-2, AC-3, AC-4)
 
 **Preconditions:** Container image built.
 
 **Steps:**
-1. Run `docker run --rm --entrypoint sh <image> -c 'whoami'`.
-2. Run `docker run --rm --entrypoint sh <image> -c 'touch /var/lib/sonde/test && rm /var/lib/sonde/test'`.
-3. Run `docker run --rm <image> --help` and verify `--key-provider env` appears in the output.
+1. Run `docker inspect <image>` and inspect `Config.Entrypoint` and `Config.Cmd`.
+2. Run `docker run --rm --entrypoint sh <image> -c 'whoami'`.
+3. Run `docker run --rm --entrypoint sh <image> -c 'touch /var/lib/sonde/test && rm /var/lib/sonde/test'`.
+4. Run `docker run --rm <image> --help` and verify `--key-provider env` appears in the output.
 
 **Expected:**
-1. `whoami` outputs `sonde`.
-2. File creation in `/var/lib/sonde` succeeds (writable by `sonde` user).
-3. `--key-provider env` is accepted by the CLI help path.
+1. `ENTRYPOINT` is `["sonde-gateway"]` and `CMD` is `["--db", "/var/lib/sonde/sonde.db", "--port", "/dev/ttyACM0", "--key-provider", "env"]`.
+2. `whoami` outputs `sonde`.
+3. File creation in `/var/lib/sonde` succeeds (writable by `sonde` user).
+4. `--key-provider env` is accepted by the CLI help path.
 
 ---
 


### PR DESCRIPTION
## Summary
- accept both musl ldd messages in the static-linkage smoke test so arm64 builds do not fail on wording alone
- fix the gateway container defaults so the image starts with --db /var/lib/sonde/sonde.db --port /dev/ttyACM0 --key-provider env`n- update the gateway container design doc to match the corrected runtime defaults

## Validation
- reproduced the arm64 ldd output on real hardware: Not a valid dynamic program`n- confirmed the previous container defaults failed immediately because --port was missing
- confirmed the gateway process stays up and retries serial-port open when started with a complete command line on arm64