### PR TITLE
fix(modem): default ESP32-S3 image to 8MB flash

### DIFF
--- a/.github/workflows/esp32-modem.yml
+++ b/.github/workflows/esp32-modem.yml
@@ -146,7 +146,7 @@ jobs:
 
           FLASH_MODE=$(grep -oP '(?<=CONFIG_ESPTOOLPY_FLASHMODE=").*(?=")' "$SDKCONFIG" 2>/dev/null || echo "dio")
           FLASH_FREQ=$(grep -oP '(?<=CONFIG_ESPTOOLPY_FLASHFREQ=").*(?=")' "$SDKCONFIG" 2>/dev/null || echo "80m")
-          FLASH_SIZE=$(grep -oP '(?<=CONFIG_ESPTOOLPY_FLASHSIZE=").*(?=")' "$SDKCONFIG" 2>/dev/null || echo "16MB")
+          FLASH_SIZE=$(grep -oP '(?<=CONFIG_ESPTOOLPY_FLASHSIZE=").*(?=")' "$SDKCONFIG" 2>/dev/null || echo "8MB")
           echo "Flash mode=$FLASH_MODE freq=$FLASH_FREQ size=$FLASH_SIZE"
 
           # Convert ELF → flat binary.

--- a/docs/modem-design.md
+++ b/docs/modem-design.md
@@ -403,14 +403,14 @@ The ESP32-S3 modem firmware requires specific flash parameters in `sdkconfig.def
 ```ini
 CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
 CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
-CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
 ```
 
 `CONFIG_ESPTOOLPY_FLASHMODE_DIO=y` selects Dual I/O (DIO) SPI mode. DIO uses 2 data lines for both address and data phases and is widely compatible across flash chips found on ESP32-S3 modules. It is more conservative than QIO (Quad I/O) and avoids pin-multiplexing issues on boards that do not route all four QSPI data lines.
 
 `CONFIG_ESPTOOLPY_FLASHFREQ_80M=y` sets the SPI flash clock to 80 MHz, which is the maximum supported by the ESP32-S3 in DIO mode and improves firmware load performance.
 
-`CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y` declares the installed flash capacity. This must match the actual hardware. The partition table is sized accordingly; using a mismatched value causes the bootloader to reject the partition table at boot.
+`CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y` keeps the merged modem image compatible with both 8 MB and 16 MB ESP32-S3 boards, since the current partition layout fits within the first 8 MB. Using a value larger than the installed flash causes the bootloader to reject the image header at boot.
 
 ---
 

--- a/sdkconfig.defaults.esp32s3
+++ b/sdkconfig.defaults.esp32s3
@@ -33,9 +33,11 @@ CONFIG_ESP_WIFI_ENABLED=y
 
 # --- Flash configuration ---
 # Pin flash parameters so elf2image in CI uses matching values.
+# Default to 8 MB so the merged modem image boots on both 8 MB and 16 MB
+# ESP32-S3 boards, as long as the partition layout stays within the first 8 MB.
 CONFIG_ESPTOOLPY_FLASHMODE_DIO=y
 CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
-CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
 
 # --- Bluetooth / NimBLE (MD-0400) ---
 # Use NimBLE (BLE-only, lightweight) instead of Bluedroid.


### PR DESCRIPTION
## Summary
- change the ESP32-S3 modem default flash size from 16 MB to 8 MB
- update the modem CI fallback flash-size value to match the sdkconfig default
- update the modem design doc to explain why 8 MB is the safe default for both 8 MB and 16 MB boards

## Validation
- matched the boot failure against the image-header flash-size mismatch in the serial log
- verified the repo previously hard-coded 16 MB in both `sdkconfig.defaults.esp32s3` and the modem CI workflow fallback
- confirmed the current partition layout fits within the first 8 MB, so the 8 MB image remains valid on 16 MB boards