### PR TITLE
Add button pairing display flow

### DIFF
--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -1203,14 +1203,19 @@ impl GatewayAdmin for AdminService {
         let duration_s = request.into_inner().duration_s;
         let duration_s = if duration_s == 0 { 120 } else { duration_s };
 
-        // Enable BLE advertising first — if this fails, don't open the window.
-        transport
-            .send_ble_enable()
+        if !controller
+            .open_window(duration_s, crate::ble_pairing::PairingOrigin::Admin)
             .await
-            .map_err(|e| Status::internal(format!("failed to enable BLE: {e}")))?;
+        {
+            return Err(Status::failed_precondition(
+                "BLE pairing session already active",
+            ));
+        }
 
-        // Open the registration window only after BLE is enabled.
-        controller.open_window(duration_s).await;
+        if let Err(e) = transport.send_ble_enable().await {
+            controller.close_window().await;
+            return Err(Status::internal(format!("failed to enable BLE: {e}")));
+        }
 
         let (tx, rx) = tokio::sync::mpsc::channel(16);
         let _ = tx

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -135,6 +135,28 @@ async fn handle_button_short_event(
     true
 }
 
+async fn handle_button_pairing_timeout(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    display_generation: &Arc<AtomicU64>,
+    window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
+) {
+    if controller.session_origin_raw().await
+        != Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
+    {
+        return;
+    }
+    info!("button-initiated BLE pairing timed out");
+    close_button_pairing_session(
+        transport,
+        controller,
+        display_generation,
+        window,
+        &["Timed out"],
+    )
+    .await;
+}
+
 async fn show_button_pairing_connected(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
@@ -750,17 +772,13 @@ async fn run_gateway(
                 let event = tokio::select! {
                     _ = &mut button_timeout, if button_timeout_armed => {
                         button_timeout_armed = false;
-                        if ble_ctrl.session_origin().await == Some(PairingOrigin::Button) {
-                            info!("button-initiated BLE pairing timed out");
-                            close_button_pairing_session(
-                                &ble_transport,
-                                &ble_ctrl,
-                                &button_display_generation,
-                                &mut window,
-                                &["Timed out"],
-                            )
-                            .await;
-                        }
+                        handle_button_pairing_timeout(
+                            &ble_transport,
+                            &ble_ctrl,
+                            &button_display_generation,
+                            &mut window,
+                        )
+                        .await;
                         continue;
                     }
                     event = &mut recv_ble_event => event,
@@ -1685,6 +1703,41 @@ mod tests {
             framebuffer,
             render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
         );
+    }
+
+    #[tokio::test]
+    async fn button_timeout_cleanup_still_runs_after_controller_deadline_expires() {
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        assert!(controller.open_window(0, PairingOrigin::Button).await);
+        let task = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let display_generation = Arc::clone(&display_generation);
+            async move {
+                let mut window = RegistrationWindow::new();
+                window.open(BUTTON_PAIRING_DURATION_S);
+                handle_button_pairing_timeout(
+                    &transport,
+                    &controller,
+                    &display_generation,
+                    &mut window,
+                )
+                .await;
+                window
+            }
+        });
+
+        let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+        assert!(matches!(msg, ModemMessage::BleDisable));
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Timed out"]));
+        let _window = task.await.unwrap();
+        assert_eq!(controller.session_origin_raw().await, None);
     }
 
     #[tokio::test]

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1388,6 +1388,7 @@ fn spawn_shutdown_watchdog() {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
     use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream};

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -96,12 +96,12 @@ async fn open_button_pairing_session(
     {
         return false;
     }
-    invalidate_button_display_restore(display_generation);
     if let Err(e) = transport.send_ble_enable().await {
         controller.close_window().await;
         error!("BLE_ENABLE send error for button pairing: {e}");
         return false;
     }
+    invalidate_button_display_restore(display_generation);
     window.open(BUTTON_PAIRING_DURATION_S);
     *display_state = ButtonDisplayState::Generic;
     info!("button-initiated BLE pairing opened");
@@ -795,6 +795,7 @@ async fn run_gateway(
                 tokio::pin!(recv_ble_event);
 
                 let event = tokio::select! {
+                    biased;
                     _ = &mut button_timeout, if button_timeout_armed => {
                         button_timeout_armed = false;
                         handle_button_pairing_timeout(
@@ -839,7 +840,8 @@ async fn run_gateway(
                                 };
 
                             if sent
-                                && ble_ctrl.session_origin().await == Some(PairingOrigin::Button)
+                                && ble_ctrl.session_origin_raw().await
+                                    == Some(PairingOrigin::Button)
                                 && ble_ctrl.take_successful_registration().await
                             {
                                 complete_button_pairing_success(
@@ -1663,6 +1665,7 @@ mod tests {
         )
         .await;
 
+        tokio::time::pause();
         let task = tokio::spawn({
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
@@ -1689,7 +1692,8 @@ mod tests {
         let (cancelled, mut window) = task.await.unwrap();
         assert!(cancelled);
         assert_eq!(controller.session_origin().await, None);
-        tokio::time::sleep(BUTTON_EXIT_REASON_DISPLAY_DURATION + Duration::from_millis(100)).await;
+        tokio::time::advance(BUTTON_EXIT_REASON_DISPLAY_DURATION + Duration::from_millis(100))
+            .await;
         let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
         assert_eq!(
             framebuffer,
@@ -1732,6 +1736,7 @@ mod tests {
         )
         .await;
 
+        tokio::time::pause();
         let task = tokio::spawn({
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
@@ -1757,7 +1762,8 @@ mod tests {
         let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
         assert_eq!(framebuffer, render_display_message(&["Timed out"]));
         let _window = task.await.unwrap();
-        tokio::time::sleep(BUTTON_EXIT_REASON_DISPLAY_DURATION + Duration::from_millis(100)).await;
+        tokio::time::advance(BUTTON_EXIT_REASON_DISPLAY_DURATION + Duration::from_millis(100))
+            .await;
         let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
         assert_eq!(
             framebuffer,
@@ -1886,6 +1892,7 @@ mod tests {
         .await;
 
         controller.mark_phone_registered().await;
+        tokio::time::pause();
         let task = tokio::spawn({
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
@@ -1913,7 +1920,8 @@ mod tests {
         assert_eq!(framebuffer, render_display_message(&["Done"]));
         let _window = task.await.unwrap();
         assert_eq!(controller.session_origin().await, None);
-        tokio::time::sleep(BUTTON_EXIT_REASON_DISPLAY_DURATION + Duration::from_millis(100)).await;
+        tokio::time::advance(BUTTON_EXIT_REASON_DISPLAY_DURATION + Duration::from_millis(100))
+            .await;
         let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
         assert_eq!(
             framebuffer,

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::Duration;
 
 use clap::Parser;
@@ -36,6 +36,12 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const BUTTON_PAIRING_DURATION_S: u32 = 120;
 const BUTTON_EXIT_REASON_DISPLAY_DURATION: Duration = Duration::from_secs(2);
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ButtonDisplayState {
+    Generic,
+    Passkey,
+}
+
 async fn update_pairing_display(transport: &Arc<UsbEspNowTransport>, lines: &[&str]) {
     if let Err(e) = send_display_message(transport, lines).await {
         warn!(error = %e, ?lines, "failed to update pairing display");
@@ -52,7 +58,7 @@ fn schedule_gateway_version_restore(
     display_generation: &Arc<AtomicU64>,
 ) {
     let generation = display_generation.fetch_add(1, Ordering::SeqCst) + 1;
-    let transport = Arc::clone(transport);
+    let transport: Weak<UsbEspNowTransport> = Arc::downgrade(transport);
     let controller = Arc::clone(controller);
     let display_generation = Arc::clone(display_generation);
     tokio::spawn(async move {
@@ -63,6 +69,9 @@ fn schedule_gateway_version_restore(
         if controller.session_origin().await.is_some() {
             return;
         }
+        let Some(transport) = transport.upgrade() else {
+            return;
+        };
         if let Err(e) = send_gateway_version_banner(&transport).await {
             warn!(error = %e, "failed to restore gateway version banner");
         }
@@ -73,6 +82,7 @@ async fn open_button_pairing_session(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
 ) -> bool {
     use sonde_gateway::ble_pairing::PairingOrigin;
@@ -93,6 +103,7 @@ async fn open_button_pairing_session(
         return false;
     }
     window.open(BUTTON_PAIRING_DURATION_S);
+    *display_state = ButtonDisplayState::Generic;
     info!("button-initiated BLE pairing opened");
     update_pairing_display(transport, &["Pairing"]).await;
     true
@@ -102,11 +113,13 @@ async fn close_button_pairing_session(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
     status_lines: &[&str],
 ) {
     controller.close_window().await;
     window.close();
+    *display_state = ButtonDisplayState::Generic;
     if let Err(e) = transport.send_ble_disable().await {
         error!("BLE_DISABLE send error: {e}");
     }
@@ -118,6 +131,7 @@ async fn handle_button_short_event(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
 ) -> bool {
     if controller.session_origin().await != Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
@@ -128,6 +142,7 @@ async fn handle_button_short_event(
         transport,
         controller,
         display_generation,
+        display_state,
         window,
         &["Cancelled"],
     )
@@ -139,6 +154,7 @@ async fn handle_button_pairing_timeout(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
 ) {
     if controller.session_origin_raw().await
@@ -151,6 +167,7 @@ async fn handle_button_pairing_timeout(
         transport,
         controller,
         display_generation,
+        display_state,
         window,
         &["Timed out"],
     )
@@ -160,8 +177,10 @@ async fn handle_button_pairing_timeout(
 async fn show_button_pairing_connected(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    display_state: ButtonDisplayState,
 ) {
     if controller.session_origin().await == Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
+        && display_state != ButtonDisplayState::Passkey
     {
         update_pairing_display(transport, &["Phone connected"]).await;
     }
@@ -170,12 +189,14 @@ async fn show_button_pairing_connected(
 async fn confirm_button_pairing_passkey(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    display_state: &mut ButtonDisplayState,
     passkey: u32,
 ) -> bool {
     if controller.session_origin().await != Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
     {
         return false;
     }
+    *display_state = ButtonDisplayState::Passkey;
     let passkey_text = format!("{passkey:06}");
     update_pairing_display(transport, &["Pin", &passkey_text]).await;
     if let Err(e) = transport.send_ble_pairing_confirm_reply(true).await {
@@ -189,11 +210,13 @@ async fn complete_button_pairing_success(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
 ) {
     update_pairing_display(transport, &["Provisioned"]).await;
     controller.close_window().await;
     window.close();
+    *display_state = ButtonDisplayState::Generic;
     if let Err(e) = transport.send_ble_disable().await {
         error!("BLE_DISABLE send error after phone registration: {e}");
     }
@@ -754,6 +777,7 @@ async fn run_gateway(
             let button_timeout = tokio::time::sleep(Duration::from_secs(24 * 60 * 60));
             tokio::pin!(button_timeout);
             let mut button_timeout_armed = false;
+            let mut button_display_state = ButtonDisplayState::Generic;
 
             loop {
                 // Sync the local window state from the controller on each iteration.
@@ -764,6 +788,7 @@ async fn run_gateway(
                 } else if !controller_open && window.is_open() {
                     window.close();
                     button_timeout_armed = false;
+                    button_display_state = ButtonDisplayState::Generic;
                 }
 
                 let recv_ble_event = ble_transport.recv_ble_event();
@@ -776,6 +801,7 @@ async fn run_gateway(
                             &ble_transport,
                             &ble_ctrl,
                             &button_display_generation,
+                            &mut button_display_state,
                             &mut window,
                         )
                         .await;
@@ -820,6 +846,7 @@ async fn run_gateway(
                                     &ble_transport,
                                     &ble_ctrl,
                                     &button_display_generation,
+                                    &mut button_display_state,
                                     &mut window,
                                 )
                                 .await;
@@ -839,7 +866,12 @@ async fn run_gateway(
                                 mtu: bc.mtu,
                             },
                         );
-                        show_button_pairing_connected(&ble_transport, &ble_ctrl).await;
+                        show_button_pairing_connected(
+                            &ble_transport,
+                            &ble_ctrl,
+                            button_display_state,
+                        )
+                        .await;
                     }
                     Some(BleEvent::Disconnected(bd)) => {
                         info!(
@@ -866,8 +898,13 @@ async fn run_gateway(
                                 passkey = pc.passkey,
                                 "BLE Numeric Comparison passkey — auto-accepting button pairing"
                             );
-                            confirm_button_pairing_passkey(&ble_transport, &ble_ctrl, pc.passkey)
-                                .await
+                            confirm_button_pairing_passkey(
+                                &ble_transport,
+                                &ble_ctrl,
+                                &mut button_display_state,
+                                pc.passkey,
+                            )
+                            .await
                         } else {
                             info!(
                                 passkey = pc.passkey,
@@ -900,6 +937,7 @@ async fn run_gateway(
                                 &ble_transport,
                                 &ble_ctrl,
                                 &button_display_generation,
+                                &mut button_display_state,
                                 &mut window,
                             )
                             .await
@@ -920,6 +958,7 @@ async fn run_gateway(
                                     &ble_transport,
                                     &ble_ctrl,
                                     &button_display_generation,
+                                    &mut button_display_state,
                                     &mut window,
                                 )
                                 .await;
@@ -1523,10 +1562,12 @@ mod tests {
             let display_generation = Arc::clone(&display_generation);
             async move {
                 let mut window = RegistrationWindow::new();
+                let mut display_state = ButtonDisplayState::Generic;
                 let opened = open_button_pairing_session(
                     &transport,
                     &controller,
                     &display_generation,
+                    &mut display_state,
                     &mut window,
                 )
                 .await;
@@ -1585,9 +1626,16 @@ mod tests {
         )
         .await;
 
+        let mut display_state = ButtonDisplayState::Generic;
         assert!(
-            !open_button_pairing_session(&transport, &controller, &display_generation, &mut window)
-                .await
+            !open_button_pairing_session(
+                &transport,
+                &controller,
+                &display_generation,
+                &mut display_state,
+                &mut window,
+            )
+            .await
         );
         assert!(
             tokio::time::timeout(Duration::from_millis(200), server.read(&mut buf))
@@ -1621,10 +1669,12 @@ mod tests {
             let display_generation = Arc::clone(&display_generation);
             async move {
                 let mut window = window;
+                let mut display_state = ButtonDisplayState::Generic;
                 let cancelled = handle_button_short_event(
                     &transport,
                     &controller,
                     &display_generation,
+                    &mut display_state,
                     &mut window,
                 )
                 .await;
@@ -1647,9 +1697,16 @@ mod tests {
         );
 
         assert!(controller.open_window(120, PairingOrigin::Admin).await);
+        let mut display_state = ButtonDisplayState::Generic;
         assert!(
-            !handle_button_short_event(&transport, &controller, &display_generation, &mut window)
-                .await
+            !handle_button_short_event(
+                &transport,
+                &controller,
+                &display_generation,
+                &mut display_state,
+                &mut window,
+            )
+            .await
         );
         assert_eq!(
             controller.session_origin().await,
@@ -1681,10 +1738,12 @@ mod tests {
             let display_generation = Arc::clone(&display_generation);
             async move {
                 let mut window = window;
+                let mut display_state = ButtonDisplayState::Generic;
                 close_button_pairing_session(
                     &transport,
                     &controller,
                     &display_generation,
+                    &mut display_state,
                     &mut window,
                     &["Timed out"],
                 )
@@ -1721,11 +1780,13 @@ mod tests {
             let display_generation = Arc::clone(&display_generation);
             async move {
                 let mut window = RegistrationWindow::new();
+                let mut display_state = ButtonDisplayState::Generic;
                 window.open(BUTTON_PAIRING_DURATION_S);
                 handle_button_pairing_timeout(
                     &transport,
                     &controller,
                     &display_generation,
+                    &mut display_state,
                     &mut window,
                 )
                 .await;
@@ -1763,7 +1824,8 @@ mod tests {
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
             async move {
-                show_button_pairing_connected(&transport, &controller).await;
+                show_button_pairing_connected(&transport, &controller, ButtonDisplayState::Generic)
+                    .await;
             }
         });
         let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
@@ -1773,7 +1835,11 @@ mod tests {
         let confirm_task = tokio::spawn({
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
-            async move { confirm_button_pairing_passkey(&transport, &controller, 123456).await }
+            async move {
+                let mut display_state = ButtonDisplayState::Generic;
+                confirm_button_pairing_passkey(&transport, &controller, &mut display_state, 123456)
+                    .await
+            }
         });
         let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
         assert_eq!(framebuffer, render_display_message(&["Pin", "123456"]));
@@ -1782,6 +1848,22 @@ mod tests {
             ModemMessage::BlePairingConfirmReply(reply) => assert!(reply.accept),
             other => panic!("expected BLE pairing confirm reply, got {other:?}"),
         }
+        let suppressed_connected = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            async move {
+                show_button_pairing_connected(&transport, &controller, ButtonDisplayState::Passkey)
+                    .await;
+            }
+        });
+        suppressed_connected.await.unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), server.read(&mut buf))
+                .await
+                .is_err(),
+            "connected updates must not overwrite the passkey screen"
+        );
+
         assert!(confirm_task.await.unwrap());
     }
 
@@ -1810,10 +1892,12 @@ mod tests {
             let display_generation = Arc::clone(&display_generation);
             async move {
                 let mut window = window;
+                let mut display_state = ButtonDisplayState::Passkey;
                 complete_button_pairing_success(
                     &transport,
                     &controller,
                     &display_generation,
+                    &mut display_state,
                     &mut window,
                 )
                 .await;

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -3,16 +3,18 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
 #[cfg(windows)]
 use clap::Subcommand;
+use sonde_protocol::modem::{BUTTON_TYPE_LONG, BUTTON_TYPE_SHORT};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
-use sonde_gateway::display_banner::send_gateway_version_banner;
+use sonde_gateway::display_banner::{send_display_message, send_gateway_version_banner};
 use sonde_gateway::engine::{resolve_espnow_channel, Gateway, PendingCommand};
 use sonde_gateway::handler::{load_handler_configs, HandlerRouter};
 use sonde_gateway::key_provider::{EnvKeyProvider, FileKeyProvider, KeyProvider, KeyProviderError};
@@ -31,6 +33,151 @@ const DEFAULT_ADMIN_SOCKET: &str = r"\\.\pipe\sonde-admin";
 
 /// Maximum time to wait for graceful shutdown before force-exiting (GW-1400).
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const BUTTON_PAIRING_DURATION_S: u32 = 120;
+const BUTTON_EXIT_REASON_DISPLAY_DURATION: Duration = Duration::from_secs(2);
+
+async fn update_pairing_display(transport: &Arc<UsbEspNowTransport>, lines: &[&str]) {
+    if let Err(e) = send_display_message(transport, lines).await {
+        warn!(error = %e, ?lines, "failed to update pairing display");
+    }
+}
+
+fn invalidate_button_display_restore(display_generation: &Arc<AtomicU64>) {
+    display_generation.fetch_add(1, Ordering::SeqCst);
+}
+
+fn schedule_gateway_version_restore(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    display_generation: &Arc<AtomicU64>,
+) {
+    let generation = display_generation.fetch_add(1, Ordering::SeqCst) + 1;
+    let transport = Arc::clone(transport);
+    let controller = Arc::clone(controller);
+    let display_generation = Arc::clone(display_generation);
+    tokio::spawn(async move {
+        tokio::time::sleep(BUTTON_EXIT_REASON_DISPLAY_DURATION).await;
+        if display_generation.load(Ordering::SeqCst) != generation {
+            return;
+        }
+        if controller.session_origin().await.is_some() {
+            return;
+        }
+        if let Err(e) = send_gateway_version_banner(&transport).await {
+            warn!(error = %e, "failed to restore gateway version banner");
+        }
+    });
+}
+
+async fn open_button_pairing_session(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    display_generation: &Arc<AtomicU64>,
+    window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
+) -> bool {
+    use sonde_gateway::ble_pairing::PairingOrigin;
+
+    if controller.session_origin().await.is_some() {
+        return false;
+    }
+    if !controller
+        .open_window(BUTTON_PAIRING_DURATION_S, PairingOrigin::Button)
+        .await
+    {
+        return false;
+    }
+    invalidate_button_display_restore(display_generation);
+    if let Err(e) = transport.send_ble_enable().await {
+        controller.close_window().await;
+        error!("BLE_ENABLE send error for button pairing: {e}");
+        return false;
+    }
+    window.open(BUTTON_PAIRING_DURATION_S);
+    info!("button-initiated BLE pairing opened");
+    update_pairing_display(transport, &["Pairing"]).await;
+    true
+}
+
+async fn close_button_pairing_session(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    display_generation: &Arc<AtomicU64>,
+    window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
+    status_lines: &[&str],
+) {
+    controller.close_window().await;
+    window.close();
+    if let Err(e) = transport.send_ble_disable().await {
+        error!("BLE_DISABLE send error: {e}");
+    }
+    update_pairing_display(transport, status_lines).await;
+    schedule_gateway_version_restore(transport, controller, display_generation);
+}
+
+async fn handle_button_short_event(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    display_generation: &Arc<AtomicU64>,
+    window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
+) -> bool {
+    if controller.session_origin().await != Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
+    {
+        return false;
+    }
+    close_button_pairing_session(
+        transport,
+        controller,
+        display_generation,
+        window,
+        &["Cancelled"],
+    )
+    .await;
+    true
+}
+
+async fn show_button_pairing_connected(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+) {
+    if controller.session_origin().await == Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
+    {
+        update_pairing_display(transport, &["Phone connected"]).await;
+    }
+}
+
+async fn confirm_button_pairing_passkey(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    passkey: u32,
+) -> bool {
+    if controller.session_origin().await != Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
+    {
+        return false;
+    }
+    let passkey_text = format!("{passkey:06}");
+    update_pairing_display(transport, &["Pin", &passkey_text]).await;
+    if let Err(e) = transport.send_ble_pairing_confirm_reply(true).await {
+        error!("BLE_PAIRING_CONFIRM_REPLY send error: {e}");
+        return false;
+    }
+    true
+}
+
+async fn complete_button_pairing_success(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    display_generation: &Arc<AtomicU64>,
+    window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
+) {
+    update_pairing_display(transport, &["Provisioned"]).await;
+    controller.close_window().await;
+    window.close();
+    if let Err(e) = transport.send_ble_disable().await {
+        error!("BLE_DISABLE send error after phone registration: {e}");
+    }
+    update_pairing_display(transport, &["Done"]).await;
+    schedule_gateway_version_restore(transport, controller, display_generation);
+}
 
 // ── Windows NT service constants ─────────────────────────────────────────────
 #[cfg(windows)]
@@ -561,8 +708,9 @@ async fn run_gateway(
         // rather than capturing the CLI startup value.
         let ble_channel = channel_for_transport;
         let ble_ctrl = Arc::clone(&ble_controller);
+        let button_display_generation = Arc::new(AtomicU64::new(0));
         let mut ble_loop = tokio::spawn(async move {
-            use sonde_gateway::ble_pairing::handle_ble_recv;
+            use sonde_gateway::ble_pairing::{handle_ble_recv, PairingOrigin};
             use sonde_gateway::modem::BleEvent;
             use tracing::{debug, warn};
 
@@ -581,17 +729,44 @@ async fn run_gateway(
 
             // Use the shared registration window via the controller.
             let mut window = sonde_gateway::ble_pairing::RegistrationWindow::new();
+            let button_timeout = tokio::time::sleep(Duration::from_secs(24 * 60 * 60));
+            tokio::pin!(button_timeout);
+            let mut button_timeout_armed = false;
 
             loop {
                 // Sync the local window state from the controller on each iteration.
-                let controller_open = ble_ctrl.is_window_open().await;
+                let controller_origin = ble_ctrl.session_origin().await;
+                let controller_open = controller_origin.is_some();
                 if controller_open && !window.is_open() {
                     window.open(3600);
                 } else if !controller_open && window.is_open() {
                     window.close();
+                    button_timeout_armed = false;
                 }
 
-                match ble_transport.recv_ble_event().await {
+                let recv_ble_event = ble_transport.recv_ble_event();
+                tokio::pin!(recv_ble_event);
+
+                let event = tokio::select! {
+                    _ = &mut button_timeout, if button_timeout_armed => {
+                        button_timeout_armed = false;
+                        if ble_ctrl.session_origin().await == Some(PairingOrigin::Button) {
+                            info!("button-initiated BLE pairing timed out");
+                            close_button_pairing_session(
+                                &ble_transport,
+                                &ble_ctrl,
+                                &button_display_generation,
+                                &mut window,
+                                &["Timed out"],
+                            )
+                            .await;
+                        }
+                        continue;
+                    }
+                    event = &mut recv_ble_event => event,
+                };
+
+                match event {
                     Some(BleEvent::Recv(br)) => {
                         // GW-0808: read the current channel from the database
                         // so BLE pairing always returns the latest persisted
@@ -611,8 +786,26 @@ async fn run_gateway(
                         )
                         .await
                         {
-                            if let Err(e) = ble_transport.send_ble_indicate(&response).await {
-                                error!("BLE_INDICATE send error: {e}");
+                            let sent =
+                                if let Err(e) = ble_transport.send_ble_indicate(&response).await {
+                                    error!("BLE_INDICATE send error: {e}");
+                                    false
+                                } else {
+                                    true
+                                };
+
+                            if sent
+                                && ble_ctrl.session_origin().await == Some(PairingOrigin::Button)
+                                && ble_ctrl.take_successful_registration().await
+                            {
+                                complete_button_pairing_success(
+                                    &ble_transport,
+                                    &ble_ctrl,
+                                    &button_display_generation,
+                                    &mut window,
+                                )
+                                .await;
+                                button_timeout_armed = false;
                             }
                         }
                     }
@@ -628,6 +821,7 @@ async fn run_gateway(
                                 mtu: bc.mtu,
                             },
                         );
+                        show_button_pairing_connected(&ble_transport, &ble_ctrl).await;
                     }
                     Some(BleEvent::Disconnected(bd)) => {
                         info!(
@@ -642,35 +836,88 @@ async fn run_gateway(
                         );
                     }
                     Some(BleEvent::PairingConfirm(pc)) => {
-                        info!(
-                            passkey = pc.passkey,
-                            "BLE Numeric Comparison passkey — awaiting operator confirmation"
-                        );
                         ble_ctrl.broadcast_event(
                             sonde_gateway::ble_pairing::BlePairingEventKind::PasskeyRequest {
                                 passkey: pc.passkey,
                             },
                         );
-                        let (tx, rx) = tokio::sync::oneshot::channel();
-                        ble_ctrl.set_passkey_responder(tx).await;
-
-                        let accept = match tokio::time::timeout(
-                            std::time::Duration::from_secs(30),
-                            rx,
-                        )
-                        .await
+                        let accept = if ble_ctrl.session_origin().await
+                            == Some(PairingOrigin::Button)
                         {
-                            Ok(Ok(v)) => v,
-                            _ => {
-                                warn!("passkey confirmation timed out — rejecting");
-                                false
+                            info!(
+                                passkey = pc.passkey,
+                                "BLE Numeric Comparison passkey — auto-accepting button pairing"
+                            );
+                            confirm_button_pairing_passkey(&ble_transport, &ble_ctrl, pc.passkey)
+                                .await
+                        } else {
+                            info!(
+                                passkey = pc.passkey,
+                                "BLE Numeric Comparison passkey — awaiting operator confirmation"
+                            );
+                            let (tx, rx) = tokio::sync::oneshot::channel();
+                            ble_ctrl.set_passkey_responder(tx).await;
+
+                            match tokio::time::timeout(std::time::Duration::from_secs(30), rx).await
+                            {
+                                Ok(Ok(v)) => v,
+                                _ => {
+                                    warn!("passkey confirmation timed out — rejecting");
+                                    false
+                                }
                             }
                         };
+
+                        if ble_ctrl.session_origin().await == Some(PairingOrigin::Button) {
+                            continue;
+                        }
 
                         if let Err(e) = ble_transport.send_ble_pairing_confirm_reply(accept).await {
                             error!("BLE_PAIRING_CONFIRM_REPLY send error: {e}");
                         }
                     }
+                    Some(BleEvent::Button(button)) => match button.button_type {
+                        BUTTON_TYPE_LONG => {
+                            if !open_button_pairing_session(
+                                &ble_transport,
+                                &ble_ctrl,
+                                &button_display_generation,
+                                &mut window,
+                            )
+                            .await
+                            {
+                                debug!("ignoring BUTTON_LONG while BLE pairing session is active");
+                                continue;
+                            }
+                            button_timeout.as_mut().reset(
+                                tokio::time::Instant::now()
+                                    + Duration::from_secs(BUTTON_PAIRING_DURATION_S as u64),
+                            );
+                            button_timeout_armed = true;
+                        }
+                        BUTTON_TYPE_SHORT => match ble_ctrl.session_origin().await {
+                            Some(PairingOrigin::Button) => {
+                                info!("button-initiated BLE pairing cancelled");
+                                handle_button_short_event(
+                                    &ble_transport,
+                                    &ble_ctrl,
+                                    &button_display_generation,
+                                    &mut window,
+                                )
+                                .await;
+                                button_timeout_armed = false;
+                            }
+                            Some(PairingOrigin::Admin) => {
+                                debug!("ignoring BUTTON_SHORT during admin-initiated BLE pairing");
+                            }
+                            None => {
+                                debug!("ignoring BUTTON_SHORT with no BLE pairing session active");
+                            }
+                        },
+                        other => {
+                            debug!(button_type = other, "ignoring unknown button event");
+                        }
+                    },
                     None => {
                         debug!("BLE event channel closed");
                         break;
@@ -1120,6 +1367,421 @@ fn spawn_shutdown_watchdog() {
         );
         std::process::exit(0);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream};
+
+    use sonde_gateway::ble_pairing::{BlePairingController, PairingOrigin, RegistrationWindow};
+    use sonde_gateway::display_banner::{render_display_message, render_gateway_version_banner};
+    use sonde_protocol::modem::{
+        encode_modem_frame, DisplayFrameAck, FrameDecoder, ModemMessage, ModemReady,
+        DISPLAY_FRAME_BODY_SIZE, DISPLAY_FRAME_CHUNK_COUNT, DISPLAY_FRAME_CHUNK_SIZE,
+    };
+
+    async fn read_next_message(
+        stream: &mut DuplexStream,
+        decoder: &mut FrameDecoder,
+        buf: &mut [u8],
+    ) -> ModemMessage {
+        loop {
+            match decoder.decode() {
+                Ok(Some(msg)) => return msg,
+                Ok(None) => {}
+                Err(e) => panic!("decode error: {e}"),
+            }
+            let n = stream.read(buf).await.expect("read failed");
+            assert!(n > 0, "stream closed unexpectedly");
+            decoder.push(&buf[..n]);
+        }
+    }
+
+    async fn do_startup_handshake(server: &mut DuplexStream, expected_channel: u8) {
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 256];
+
+        let msg = read_next_message(server, &mut decoder, &mut buf).await;
+        assert!(matches!(msg, ModemMessage::Reset));
+
+        server
+            .write_all(
+                &encode_modem_frame(&ModemMessage::ModemReady(ModemReady {
+                    firmware_version: [1, 0, 0, 0],
+                    mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+                }))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let msg = read_next_message(server, &mut decoder, &mut buf).await;
+        let requested_channel = match msg {
+            ModemMessage::SetChannel(ch) => ch,
+            other => panic!("expected SetChannel, got {other:?}"),
+        };
+        assert_eq!(requested_channel, expected_channel);
+
+        server
+            .write_all(
+                &encode_modem_frame(&ModemMessage::SetChannelAck(requested_channel)).unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn create_transport_and_server(channel: u8) -> (Arc<UsbEspNowTransport>, DuplexStream) {
+        let (client, mut server) = duplex(4096);
+        let transport_handle =
+            tokio::spawn(async move { UsbEspNowTransport::new(client, channel).await.unwrap() });
+        do_startup_handshake(&mut server, channel).await;
+        let transport = Arc::new(transport_handle.await.unwrap());
+        (transport, server)
+    }
+
+    async fn receive_display_transfer(
+        server: &mut DuplexStream,
+        decoder: &mut FrameDecoder,
+        buf: &mut [u8],
+    ) -> [u8; DISPLAY_FRAME_BODY_SIZE] {
+        let mut framebuffer = [0u8; DISPLAY_FRAME_BODY_SIZE];
+
+        let begin = read_next_message(server, decoder, buf).await;
+        let transfer_id = match begin {
+            ModemMessage::DisplayFrameBegin(begin) => begin.transfer_id,
+            other => panic!("expected DisplayFrameBegin, got {other:?}"),
+        };
+        server
+            .write_all(
+                &encode_modem_frame(&ModemMessage::DisplayFrameAck(DisplayFrameAck {
+                    transfer_id,
+                    next_chunk_index: 0,
+                }))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        for expected_chunk_index in 0..DISPLAY_FRAME_CHUNK_COUNT {
+            let msg = read_next_message(server, decoder, buf).await;
+            match msg {
+                ModemMessage::DisplayFrameChunk(chunk) => {
+                    assert_eq!(chunk.transfer_id, transfer_id);
+                    assert_eq!(chunk.chunk_index, expected_chunk_index);
+                    let start = usize::from(expected_chunk_index) * DISPLAY_FRAME_CHUNK_SIZE;
+                    let end = start + DISPLAY_FRAME_CHUNK_SIZE;
+                    framebuffer[start..end].copy_from_slice(&chunk.chunk_data);
+                }
+                other => panic!("expected DisplayFrameChunk, got {other:?}"),
+            }
+            server
+                .write_all(
+                    &encode_modem_frame(&ModemMessage::DisplayFrameAck(DisplayFrameAck {
+                        transfer_id,
+                        next_chunk_index: expected_chunk_index + 1,
+                    }))
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+        }
+
+        framebuffer
+    }
+
+    async fn open_button_pairing_for_test(
+        transport: Arc<UsbEspNowTransport>,
+        controller: Arc<BlePairingController>,
+        display_generation: Arc<AtomicU64>,
+        server: &mut DuplexStream,
+        decoder: &mut FrameDecoder,
+        buf: &mut [u8],
+    ) -> RegistrationWindow {
+        let task = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let display_generation = Arc::clone(&display_generation);
+            async move {
+                let mut window = RegistrationWindow::new();
+                let opened = open_button_pairing_session(
+                    &transport,
+                    &controller,
+                    &display_generation,
+                    &mut window,
+                )
+                .await;
+                (opened, window)
+            }
+        });
+
+        let msg = read_next_message(server, decoder, buf).await;
+        assert!(matches!(msg, ModemMessage::BleEnable));
+        let framebuffer = receive_display_transfer(server, decoder, buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Pairing"]));
+
+        let (opened, window) = task.await.unwrap();
+        assert!(opened);
+        assert_eq!(
+            controller.session_origin().await,
+            Some(PairingOrigin::Button)
+        );
+        window
+    }
+
+    #[tokio::test]
+    async fn button_long_opens_pairing_and_updates_display() {
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        let _window = open_button_pairing_for_test(
+            Arc::clone(&transport),
+            Arc::clone(&controller),
+            Arc::clone(&display_generation),
+            &mut server,
+            &mut decoder,
+            &mut buf,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn second_button_long_is_ignored_while_active() {
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        let mut window = open_button_pairing_for_test(
+            Arc::clone(&transport),
+            Arc::clone(&controller),
+            Arc::clone(&display_generation),
+            &mut server,
+            &mut decoder,
+            &mut buf,
+        )
+        .await;
+
+        assert!(
+            !open_button_pairing_session(&transport, &controller, &display_generation, &mut window)
+                .await
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), server.read(&mut buf))
+                .await
+                .is_err(),
+            "ignored long press must not emit modem traffic"
+        );
+    }
+
+    #[tokio::test]
+    async fn button_short_cancels_button_pairing_but_not_admin_pairing() {
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        let window = open_button_pairing_for_test(
+            Arc::clone(&transport),
+            Arc::clone(&controller),
+            Arc::clone(&display_generation),
+            &mut server,
+            &mut decoder,
+            &mut buf,
+        )
+        .await;
+
+        let task = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let display_generation = Arc::clone(&display_generation);
+            async move {
+                let mut window = window;
+                let cancelled = handle_button_short_event(
+                    &transport,
+                    &controller,
+                    &display_generation,
+                    &mut window,
+                )
+                .await;
+                (cancelled, window)
+            }
+        });
+
+        let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+        assert!(matches!(msg, ModemMessage::BleDisable));
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Cancelled"]));
+        let (cancelled, mut window) = task.await.unwrap();
+        assert!(cancelled);
+        assert_eq!(controller.session_origin().await, None);
+        tokio::time::sleep(BUTTON_EXIT_REASON_DISPLAY_DURATION + Duration::from_millis(100)).await;
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(
+            framebuffer,
+            render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+        );
+
+        assert!(controller.open_window(120, PairingOrigin::Admin).await);
+        assert!(
+            !handle_button_short_event(&transport, &controller, &display_generation, &mut window)
+                .await
+        );
+        assert_eq!(
+            controller.session_origin().await,
+            Some(PairingOrigin::Admin)
+        );
+    }
+
+    #[tokio::test]
+    async fn button_timeout_closes_pairing_and_shows_timed_out() {
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        let window = open_button_pairing_for_test(
+            Arc::clone(&transport),
+            Arc::clone(&controller),
+            Arc::clone(&display_generation),
+            &mut server,
+            &mut decoder,
+            &mut buf,
+        )
+        .await;
+
+        let task = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let display_generation = Arc::clone(&display_generation);
+            async move {
+                let mut window = window;
+                close_button_pairing_session(
+                    &transport,
+                    &controller,
+                    &display_generation,
+                    &mut window,
+                    &["Timed out"],
+                )
+                .await;
+                window
+            }
+        });
+
+        let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+        assert!(matches!(msg, ModemMessage::BleDisable));
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Timed out"]));
+        let _window = task.await.unwrap();
+        tokio::time::sleep(BUTTON_EXIT_REASON_DISPLAY_DURATION + Duration::from_millis(100)).await;
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(
+            framebuffer,
+            render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    #[tokio::test]
+    async fn button_pairing_connected_and_passkey_are_rendered_and_auto_confirmed() {
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        let _window = open_button_pairing_for_test(
+            Arc::clone(&transport),
+            Arc::clone(&controller),
+            Arc::clone(&display_generation),
+            &mut server,
+            &mut decoder,
+            &mut buf,
+        )
+        .await;
+
+        let connected_task = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            async move {
+                show_button_pairing_connected(&transport, &controller).await;
+            }
+        });
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Phone connected"]));
+        connected_task.await.unwrap();
+
+        let confirm_task = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            async move { confirm_button_pairing_passkey(&transport, &controller, 123456).await }
+        });
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Pin", "123456"]));
+        let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+        match msg {
+            ModemMessage::BlePairingConfirmReply(reply) => assert!(reply.accept),
+            other => panic!("expected BLE pairing confirm reply, got {other:?}"),
+        }
+        assert!(confirm_task.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn successful_button_pairing_shows_provisioned_then_done_and_disables_ble() {
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        let window = open_button_pairing_for_test(
+            Arc::clone(&transport),
+            Arc::clone(&controller),
+            Arc::clone(&display_generation),
+            &mut server,
+            &mut decoder,
+            &mut buf,
+        )
+        .await;
+
+        controller.mark_phone_registered().await;
+        let task = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let display_generation = Arc::clone(&display_generation);
+            async move {
+                let mut window = window;
+                complete_button_pairing_success(
+                    &transport,
+                    &controller,
+                    &display_generation,
+                    &mut window,
+                )
+                .await;
+                window
+            }
+        });
+
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Provisioned"]));
+        let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+        assert!(matches!(msg, ModemMessage::BleDisable));
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Done"]));
+        let _window = task.await.unwrap();
+        assert_eq!(controller.session_origin().await, None);
+        tokio::time::sleep(BUTTON_EXIT_REASON_DISPLAY_DURATION + Duration::from_millis(100)).await;
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(
+            framebuffer,
+            render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+        );
+    }
 }
 
 #[tokio::main]

--- a/crates/sonde-gateway/src/ble_pairing.rs
+++ b/crates/sonde-gateway/src/ble_pairing.rs
@@ -186,20 +186,12 @@ impl BlePairingController {
 
     /// Check whether the window is currently open.
     pub async fn is_window_open(&self) -> bool {
-        let mut session = self.session.lock().await;
-        let open = session.window.is_open();
-        if !open {
-            session.origin = None;
-            session.successful_registration = false;
-        }
-        open
+        self.session.lock().await.window.is_open()
     }
 
     pub async fn session_origin(&self) -> Option<PairingOrigin> {
         let mut session = self.session.lock().await;
         if !session.window.is_open() {
-            session.origin = None;
-            session.successful_registration = false;
             return None;
         }
         session.origin
@@ -387,7 +379,13 @@ async fn handle_register_phone(
 ) -> Option<Vec<u8>> {
     const ERROR_GENERIC: u8 = 0x01;
 
-    if !window.is_open() {
+    let window_open = if let Some(ctrl) = controller {
+        ctrl.is_window_open().await
+    } else {
+        window.is_open()
+    };
+
+    if !window_open {
         info!("REGISTER_PHONE (AEAD) rejected: registration window closed");
         return encode_ble_envelope(BLE_MSG_ERROR, &[ERROR_WINDOW_CLOSED]);
     }
@@ -498,6 +496,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pairing_controller_preserves_origin_until_explicit_close() {
+        let controller = BlePairingController::new();
+        assert!(controller.open_window(0, PairingOrigin::Button).await);
+        assert_eq!(controller.session_origin().await, None);
+        assert_eq!(
+            controller.session_origin_raw().await,
+            Some(PairingOrigin::Button)
+        );
+        assert!(!controller.is_window_open().await);
+        assert_eq!(
+            controller.session_origin_raw().await,
+            Some(PairingOrigin::Button)
+        );
+        controller.close_window().await;
+        assert_eq!(controller.session_origin_raw().await, None);
+    }
+
+    #[tokio::test]
     async fn pairing_controller_rejects_second_open_while_active() {
         let controller = BlePairingController::new();
         assert!(controller.open_window(120, PairingOrigin::Admin).await);
@@ -506,6 +522,28 @@ mod tests {
             controller.session_origin().await,
             Some(PairingOrigin::Admin)
         );
+    }
+
+    #[tokio::test]
+    async fn register_phone_uses_controller_window_when_available() {
+        let storage: Arc<dyn Storage> = Arc::new(
+            crate::sqlite_storage::SqliteStorage::in_memory(zeroize::Zeroizing::new([0x42u8; 32]))
+                .expect("open in-memory storage"),
+        );
+        let controller = BlePairingController::new();
+        let mut window = RegistrationWindow::new();
+        window.open(120);
+
+        let mut body = vec![0x42u8; 32];
+        body.push(5);
+        body.extend_from_slice(b"phone");
+
+        let response = handle_register_phone(&body, &storage, &mut window, 3, Some(&controller))
+            .await
+            .expect("window-closed response");
+        let (msg_type, payload) = parse_ble_envelope(&response).expect("valid BLE envelope");
+        assert_eq!(msg_type, BLE_MSG_ERROR);
+        assert_eq!(payload, [ERROR_WINDOW_CLOSED]);
     }
 
     // -- T-1203: REQUEST_GW_INFO happy path --

--- a/crates/sonde-gateway/src/ble_pairing.rs
+++ b/crates/sonde-gateway/src/ble_pairing.rs
@@ -101,13 +101,25 @@ impl RegistrationWindow {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairingOrigin {
+    Admin,
+    Button,
+}
+
+struct PairingSessionState {
+    window: RegistrationWindow,
+    origin: Option<PairingOrigin>,
+    successful_registration: bool,
+}
+
 /// Shared BLE pairing controller accessible from the admin gRPC service.
 ///
 /// Wraps the registration window and provides methods to open/close it.
 /// The actual BLE commands (BLE_ENABLE/BLE_DISABLE) are sent by the caller
 /// through the modem transport.
 pub struct BlePairingController {
-    window: tokio::sync::Mutex<RegistrationWindow>,
+    session: tokio::sync::Mutex<PairingSessionState>,
     /// Channel for forwarding passkey confirmation requests to the admin CLI.
     passkey_tx: tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<bool>>>,
     /// Cancel token for the auto-close timeout task.
@@ -137,7 +149,11 @@ impl BlePairingController {
     pub fn new() -> Self {
         let (event_tx, _) = tokio::sync::broadcast::channel(64);
         Self {
-            window: tokio::sync::Mutex::new(RegistrationWindow::new()),
+            session: tokio::sync::Mutex::new(PairingSessionState {
+                window: RegistrationWindow::new(),
+                origin: None,
+                successful_registration: false,
+            }),
             passkey_tx: tokio::sync::Mutex::new(None),
             timeout_cancel: tokio::sync::Mutex::new(None),
             event_task: tokio::sync::Mutex::new(None),
@@ -146,18 +162,61 @@ impl BlePairingController {
     }
 
     /// Open the registration window for `duration_s` seconds.
-    pub async fn open_window(&self, duration_s: u32) {
-        self.window.lock().await.open(duration_s);
+    pub async fn open_window(&self, duration_s: u32, origin: PairingOrigin) -> bool {
+        let mut session = self.session.lock().await;
+        if session.window.is_open() {
+            return false;
+        }
+        session.window.open(duration_s);
+        session.origin = Some(origin);
+        session.successful_registration = false;
+        true
     }
 
     /// Close the registration window.
     pub async fn close_window(&self) {
-        self.window.lock().await.close();
+        {
+            let mut session = self.session.lock().await;
+            session.window.close();
+            session.origin = None;
+            session.successful_registration = false;
+        }
+        self.passkey_tx.lock().await.take();
     }
 
     /// Check whether the window is currently open.
     pub async fn is_window_open(&self) -> bool {
-        self.window.lock().await.is_open()
+        let mut session = self.session.lock().await;
+        let open = session.window.is_open();
+        if !open {
+            session.origin = None;
+            session.successful_registration = false;
+        }
+        open
+    }
+
+    pub async fn session_origin(&self) -> Option<PairingOrigin> {
+        let mut session = self.session.lock().await;
+        if !session.window.is_open() {
+            session.origin = None;
+            session.successful_registration = false;
+            return None;
+        }
+        session.origin
+    }
+
+    pub async fn mark_phone_registered(&self) {
+        let mut session = self.session.lock().await;
+        if session.window.is_open() {
+            session.successful_registration = true;
+        }
+    }
+
+    pub async fn take_successful_registration(&self) -> bool {
+        let mut session = self.session.lock().await;
+        let value = session.successful_registration;
+        session.successful_registration = false;
+        value
     }
 
     /// Register a oneshot channel for passkey confirmation from the admin CLI.
@@ -387,6 +446,7 @@ async fn handle_register_phone(
     );
 
     if let Some(ctrl) = controller {
+        ctrl.mark_phone_registered().await;
         ctrl.broadcast_event(BlePairingEventKind::PhoneRegistered {
             label,
             phone_key_hint,
@@ -410,6 +470,33 @@ mod tests {
 
     fn test_identity() -> GatewayIdentity {
         GatewayIdentity::generate().unwrap()
+    }
+
+    #[tokio::test]
+    async fn pairing_controller_tracks_origin_and_registration_state() {
+        let controller = BlePairingController::new();
+        assert!(controller.open_window(120, PairingOrigin::Button).await);
+        assert_eq!(
+            controller.session_origin().await,
+            Some(PairingOrigin::Button)
+        );
+        controller.mark_phone_registered().await;
+        assert!(controller.take_successful_registration().await);
+        assert!(!controller.take_successful_registration().await);
+        controller.close_window().await;
+        assert_eq!(controller.session_origin().await, None);
+        assert!(!controller.is_window_open().await);
+    }
+
+    #[tokio::test]
+    async fn pairing_controller_rejects_second_open_while_active() {
+        let controller = BlePairingController::new();
+        assert!(controller.open_window(120, PairingOrigin::Admin).await);
+        assert!(!controller.open_window(120, PairingOrigin::Button).await);
+        assert_eq!(
+            controller.session_origin().await,
+            Some(PairingOrigin::Admin)
+        );
     }
 
     // -- T-1203: REQUEST_GW_INFO happy path --

--- a/crates/sonde-gateway/src/ble_pairing.rs
+++ b/crates/sonde-gateway/src/ble_pairing.rs
@@ -205,6 +205,15 @@ impl BlePairingController {
         session.origin
     }
 
+    /// Return the stored session origin without auto-expiring the window state.
+    ///
+    /// Used by timeout-cleanup paths that must distinguish "expired button session
+    /// that still needs transport/display teardown" from "a newer non-button
+    /// session replaced the old one".
+    pub async fn session_origin_raw(&self) -> Option<PairingOrigin> {
+        self.session.lock().await.origin
+    }
+
     pub async fn mark_phone_registered(&self) {
         let mut session = self.session.lock().await;
         if session.window.is_open() {

--- a/crates/sonde-gateway/src/display_banner.rs
+++ b/crates/sonde-gateway/src/display_banner.rs
@@ -80,22 +80,40 @@ fn centered_text_x(text: &str) -> i32 {
     ((FRAMEBUFFER_WIDTH as i32 - text_width).max(0)) / 2
 }
 
-pub fn render_gateway_version_banner(version: &str) -> [u8; DISPLAY_FRAME_BODY_SIZE] {
-    let line1 = "Sonde Gateway";
-    let line2 = format!("v{version}");
-    let line_height = FONT_8X13_BOLD.character_size.height as i32;
-    let block_height = line_height * 2 + LINE_SPACING;
-    let top = ((FRAMEBUFFER_HEIGHT as i32 - block_height).max(0)) / 2;
-    let line1_y = top + FONT_8X13_BOLD.baseline as i32;
-    let line2_y = top + line_height + LINE_SPACING + FONT_8X13_BOLD.baseline as i32;
+pub fn render_display_message(lines: &[&str]) -> [u8; DISPLAY_FRAME_BODY_SIZE] {
+    if lines.is_empty() {
+        return [0u8; DISPLAY_FRAME_BODY_SIZE];
+    }
 
+    let line_height = FONT_8X13_BOLD.character_size.height as i32;
+    let block_height =
+        line_height * lines.len() as i32 + LINE_SPACING * (lines.len().saturating_sub(1) as i32);
+    let top = ((FRAMEBUFFER_HEIGHT as i32 - block_height).max(0)) / 2;
     let style = MonoTextStyle::new(&FONT_8X13_BOLD, BinaryColor::On);
     let mut framebuffer = Framebuffer::new();
-    let _ =
-        Text::new(line1, Point::new(centered_text_x(line1), line1_y), style).draw(&mut framebuffer);
-    let _ = Text::new(&line2, Point::new(centered_text_x(&line2), line2_y), style)
-        .draw(&mut framebuffer);
+
+    for (index, line) in lines.iter().enumerate() {
+        let baseline =
+            top + index as i32 * (line_height + LINE_SPACING) + FONT_8X13_BOLD.baseline as i32;
+        let _ = Text::new(line, Point::new(centered_text_x(line), baseline), style)
+            .draw(&mut framebuffer);
+    }
+
     framebuffer.into_bytes()
+}
+
+pub fn render_gateway_version_banner(version: &str) -> [u8; DISPLAY_FRAME_BODY_SIZE] {
+    let line2 = format!("v{version}");
+    render_display_message(&["Sonde Gateway", &line2])
+}
+
+pub async fn send_display_message(
+    transport: &UsbEspNowTransport,
+    lines: &[&str],
+) -> Result<(), TransportError> {
+    transport
+        .send_display_frame(render_display_message(lines))
+        .await
 }
 
 pub async fn send_gateway_version_banner(
@@ -143,6 +161,29 @@ mod tests {
     #[test]
     fn gateway_banner_renders_across_two_vertical_regions() {
         let framebuffer = render_gateway_version_banner("0.4.0");
+        let half = framebuffer.len() / 2;
+        assert!(
+            framebuffer[..half].iter().any(|byte| *byte != 0),
+            "top half should contain the first line"
+        );
+        assert!(
+            framebuffer[half..].iter().any(|byte| *byte != 0),
+            "bottom half should contain the second line"
+        );
+    }
+
+    #[test]
+    fn pairing_message_renders_visible_pixels() {
+        let framebuffer = render_display_message(&["Pairing"]);
+        assert!(
+            framebuffer.iter().any(|byte| *byte != 0),
+            "rendered pairing message must set at least one pixel"
+        );
+    }
+
+    #[test]
+    fn passkey_message_renders_across_two_vertical_regions() {
+        let framebuffer = render_display_message(&["Pin", "123456"]);
         let half = framebuffer.len() / 2;
         assert!(
             framebuffer[..half].iter().any(|byte| *byte != 0),

--- a/crates/sonde-gateway/src/modem.rs
+++ b/crates/sonde-gateway/src/modem.rs
@@ -18,8 +18,8 @@ use tracing::{debug, error, info, warn};
 use sonde_protocol::modem::{
     encode_modem_frame, BleConnected, BleDisconnected, BleIndicate, BlePairingConfirm,
     BlePairingConfirmReply, BleRecv, DisplayFrameAck, DisplayFrameBegin, DisplayFrameChunk,
-    EventError, FrameDecoder, ModemMessage, ModemReady, ModemStatus, ScanResult, SendFrame,
-    DISPLAY_FRAME_BODY_SIZE, DISPLAY_FRAME_CHUNK_COUNT, DISPLAY_FRAME_CHUNK_SIZE,
+    EventButton, EventError, FrameDecoder, ModemMessage, ModemReady, ModemStatus, ScanResult,
+    SendFrame, DISPLAY_FRAME_BODY_SIZE, DISPLAY_FRAME_CHUNK_COUNT, DISPLAY_FRAME_CHUNK_SIZE,
 };
 
 use sonde_protocol::constants::{
@@ -93,6 +93,8 @@ pub enum BleEvent {
     Disconnected(BleDisconnected),
     /// Numeric Comparison passkey from the modem for operator confirmation.
     PairingConfirm(BlePairingConfirm),
+    /// Debounced button event from the modem.
+    Button(EventButton),
 }
 
 /// Type-erased async writer behind a shared mutex.
@@ -979,6 +981,16 @@ async fn dispatch_message(
                 debug!("BLE event channel full/closed, dropping BLE_PAIRING_CONFIRM");
             }
         }
+        ModemMessage::EventButton(button) => {
+            let send_result = tokio::time::timeout(
+                std::time::Duration::from_millis(500),
+                ble_tx.send(BleEvent::Button(button)),
+            )
+            .await;
+            if send_result.is_err() || matches!(send_result, Ok(Err(_))) {
+                debug!("BLE event channel full/closed, dropping EVENT_BUTTON");
+            }
+        }
         ModemMessage::ModemReady(mr) => {
             if let Some(tx) = ready_tx.take() {
                 let _ = tx.send(mr);
@@ -1320,6 +1332,34 @@ mod tests {
         assert_eq!(received[0], 0x80);
         assert_eq!(received[DISPLAY_FRAME_BODY_SIZE - 1], 0x01);
         send_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn event_button_is_forwarded_to_ble_event_channel() {
+        let (client, mut server) = duplex(1024);
+
+        let startup = tokio::spawn(async move {
+            do_startup_handshake(&mut server, 6).await;
+            server
+        });
+
+        let transport = UsbEspNowTransport::new(client, 6).await.unwrap();
+        let mut server = startup.await.unwrap();
+
+        let button_msg = ModemMessage::EventButton(sonde_protocol::modem::EventButton {
+            button_type: sonde_protocol::modem::BUTTON_TYPE_LONG,
+        });
+        server
+            .write_all(&encode_modem_frame(&button_msg).unwrap())
+            .await
+            .unwrap();
+
+        match transport.recv_ble_event().await {
+            Some(BleEvent::Button(button)) => {
+                assert_eq!(button.button_type, sonde_protocol::modem::BUTTON_TYPE_LONG);
+            }
+            other => panic!("expected button event, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -76,7 +76,7 @@ The gateway is composed of ten functional modules grouped in two tiers. The uppe
 | **Handler Process** | Manage handler stdin/stdout lifecycle | GW-0502, GW-0503, GW-0506 |
 | **Storage** | Persist node registry, program library, configuration | GW-0700, GW-1000, GW-1001 |
 | **Admin API** | gRPC admin interface, CLI tool | GW-0800, GW-0801, GW-0802, GW-0803, GW-0804, GW-0805, GW-0806 |
-| **BLE Pairing Handler** | BLE pairing protocol logic via modem relay | GW-1200–GW-1222 |
+| **BLE Pairing Handler** | BLE pairing protocol logic via modem relay | GW-1200–GW-1222a |
 
 ---
 
@@ -940,9 +940,9 @@ The gRPC server runs on a local socket: a **Unix domain socket** on Linux/macOS 
 | Modem status | `GetModemStatus` | Returns modem status: radio channel, TX/RX/fail counters, uptime. |
 | Set modem channel | `SetModemChannel` | Sets the ESP-NOW radio channel (1–14). Persists the new channel in the database (GW-0808). |
 | Scan channels | `ScanModemChannels` | Scans all WiFi channels for AP activity, returns AP counts and RSSI per channel. |
-| Open BLE pairing | `OpenBlePairing` | Opens the phone registration window and sends `BLE_ENABLE` to modem. Server-streaming RPC returning events (passkey, phone connected/disconnected/registered, window closed). |
-| Close BLE pairing | `CloseBlePairing` | Closes the registration window and sends `BLE_DISABLE` to modem. |
-| Confirm BLE pairing | `ConfirmBlePairing` | Accepts or rejects a Numeric Comparison passkey during BLE pairing. |
+| Open BLE pairing | `OpenBlePairing` | Opens an admin-initiated phone registration window and sends `BLE_ENABLE` to the modem. Server-streaming RPC returning pairing events (passkey, phone connected/disconnected/registered, window closed). |
+| Close BLE pairing | `CloseBlePairing` | Closes the active BLE pairing session and sends `BLE_DISABLE` to the modem. |
+| Confirm BLE pairing | `ConfirmBlePairing` | Accepts or rejects a Numeric Comparison passkey during an admin-initiated BLE pairing session. |
 | List phones | `ListPhones` | Lists all registered phones with PSK metadata (ID, key hint, label, issue time, status). |
 | Revoke phone | `RevokePhone` | Revokes a phone's PSK by phone ID. |
 | Add handler | `AddHandler` | Registers a handler for a `program_hash` (GW-1402). Validates hash format. Returns `ALREADY_EXISTS` on duplicate. Triggers live reload. |
@@ -1101,7 +1101,7 @@ regardless of serial port state (Issue #551).
 
 ## 17  BLE pairing protocol handler
 
-> **Requirements:** GW-1200–GW-1222.
+> **Requirements:** GW-1200–GW-1222a.
 
 The gateway implements the pairing protocol logic defined in [ble-pairing-protocol.md](ble-pairing-protocol.md). The physical BLE layer (GATT service, advertising, ATT MTU negotiation, indication fragmentation) is hosted by the USB modem (GW-1204, GW-1205); the gateway processes pairing messages relayed over the modem serial protocol: inbound messages arrive as `BLE_RECV` and responses are sent as `BLE_INDICATE` (see §4.2 `UsbEspNowTransport`). `PEER_REQUEST` / `PEER_ACK` frames travel over ESP-NOW, not BLE, and follow the standard transport path.
 
@@ -1111,7 +1111,7 @@ The gateway implements the pairing protocol logic defined in [ble-pairing-protoc
 
 ### 17.2  BLE message relay
 
-The modem hosts the Gateway Pairing Service GATT service (UUID `0000FE60-…`) and controls BLE advertising. The gateway controls advertising lifetime by sending `BLE_ENABLE` / `BLE_DISABLE` to the modem when the registration window opens or closes (GW-1208). When a phone writes to the Gateway Command characteristic, the modem forwards the raw bytes to the gateway as a `BLE_RECV` serial message. The gateway processes the command and sends any response back via `BLE_INDICATE`; the modem handles fragmentation to fit within the negotiated ATT MTU (GW-1205). Numeric Comparison passkeys are relayed from the modem via `BLE_PAIRING_CONFIRM` and surfaced to the operator through the admin API streaming RPC (GW-1222).
+The modem hosts the Gateway Pairing Service GATT service (UUID `0000FE60-…`) and controls BLE advertising. The gateway controls advertising lifetime by sending `BLE_ENABLE` / `BLE_DISABLE` to the modem when the registration window opens or closes (GW-1208). When a phone writes to the Gateway Command characteristic, the modem forwards the raw bytes to the gateway as a `BLE_RECV` serial message. The gateway processes the command and sends any response back via `BLE_INDICATE`; the modem handles fragmentation to fit within the negotiated ATT MTU (GW-1205). Numeric Comparison passkeys are relayed from the modem via `BLE_PAIRING_CONFIRM`. Modem button events are relayed as `EVENT_BUTTON` and interpreted only by the gateway; the modem remains a dumb button classifier and framebuffer sink.
 
 ### 17.3  `REQUEST_GW_INFO` handling — RETIRED
 
@@ -1119,9 +1119,30 @@ The modem hosts the Gateway Pairing Service GATT service (UUID `0000FE60-…`) a
 
 ### 17.4  Registration window and `REGISTER_PHONE`
 
-The registration window is opened by a physical button hold (≥ 2 s) or by the admin API `OpenBlePairing` RPC. Opening sends `BLE_ENABLE` to the modem; closing (explicit or auto-close after a configurable duration, default 120 s) sends `BLE_DISABLE` (GW-1207, GW-1208). `REGISTER_PHONE` commands received while the window is closed are rejected with `ERROR(0x02)` (GW-1207).
+The gateway maintains a single BLE pairing session controller with:
 
-When the window is open and a `REGISTER_PHONE` command arrives (BLE command `0x02`), the gateway: receives a phone-generated 256-bit PSK from the phone; derives `phone_key_hint` = `u16::from_be_bytes(SHA-256(psk)[30..32])` (big-endian u16 from the last two bytes of the hash); stores the PSK with its label, issuance timestamp, and active status; and responds with a plaintext `PHONE_REGISTERED` indication containing `status`, `rf_channel`, and `phone_key_hint` via `BLE_INDICATE` (GW-1209). No additional encryption of the BLE response is needed — the BLE LESC link provides confidentiality. Operators can revoke phone PSKs through the admin API; revoked PSKs are excluded from AES-256-GCM decryption (GW-1210).
+- `window_open: bool`
+- `deadline: Option<Instant>`
+- `origin: Option<PairingOrigin>` where `PairingOrigin = Admin | Button`
+- `successful_registration: bool`
+
+The registration window opens either when the admin API calls `OpenBlePairing` or when the modem relays `EVENT_BUTTON(BUTTON_LONG)` while no BLE pairing session is active. In both cases the gateway sends `BLE_ENABLE` to the modem and records the session origin. A `BUTTON_LONG` received while a session is already active is ignored. A `BUTTON_SHORT` closes the session only when `origin == Button`; `BUTTON_SHORT` has no defined effect outside pairing and does not close an admin-initiated session. Auto-close uses the same timeout machinery for both origins (default 120 s). `REGISTER_PHONE` commands received while the window is closed are rejected with `ERROR(0x02)` (GW-1207).
+
+When the window is open and a `REGISTER_PHONE` command arrives (BLE command `0x02`), the gateway: receives a phone-generated 256-bit PSK from the phone; derives `phone_key_hint = u16::from_be_bytes(SHA-256(psk)[30..32])`; stores the PSK with its label, issuance timestamp, and active status; and responds with a plaintext `PHONE_REGISTERED` indication containing `status`, `rf_channel`, and `phone_key_hint` via `BLE_INDICATE` (GW-1209). No additional encryption of the BLE response is needed — the BLE LESC link provides confidentiality. Operators can revoke phone PSKs through the admin API; revoked PSKs are excluded from AES-256-GCM decryption (GW-1210).
+
+### 17.4a  Button-initiated display lifecycle
+
+Gateway-owned display policy lives above the modem transport. During a button-initiated BLE pairing session, the gateway renders pairing status into a 128×64 framebuffer and sends it using the same reliable display-transfer protocol as the modem-ready banner (§4.2, GW-1101a). The display state machine is:
+
+1. **Window opened by `BUTTON_LONG`** → display `Pairing`.
+2. **`BLE_CONNECTED`** → display `Phone connected`.
+3. **`BLE_PAIRING_CONFIRM(passkey)`** → display `Pin` plus the actual passkey.
+4. **`PHONE_REGISTERED` / successful `REGISTER_PHONE`** → display `Provisioned`.
+5. **Normal post-success close** → display `Done`.
+6. **`BUTTON_SHORT` cancellation** → display `Cancelled`.
+7. **Timeout close** → display `Timed out`.
+
+The passkey screen has priority over the generic connected state until Numeric Comparison is resolved. `Done`, `Cancelled`, and `Timed out` are terminal status screens: the gateway keeps each one visible for 2 seconds, then restores the normal Sonde Gateway version banner if no newer pairing session has claimed the display. Display updates are driven by state transitions; repeated identical events do not need to re-send the same framebuffer.
 
 ### 17.5  `PEER_REQUEST` processing
 
@@ -1140,9 +1161,11 @@ When the window is open and a `REGISTER_PHONE` command arrives (BLE command `0x0
 
 After successful registration **or** duplicate detection with matching PSK, the gateway builds a `PEER_ACK` CBOR message `{1: 0}` (status = success), encrypts the frame with AES-256-GCM using `node_psk` (GCM nonce = `SHA-256(node_psk)[0..3] ‖ msg_type ‖ frame_nonce`, AAD = 11-byte header), and echoes the `nonce` from the `PEER_REQUEST` header (GW-1219).
 
-### 17.7  Admin session
+### 17.7  Admin and button sessions
 
-The admin API exposes `OpenBlePairing` (server-streaming RPC) to open the registration window and enable BLE advertising, `CloseBlePairing` to close it, `ConfirmBlePairing` for Numeric Comparison passkey confirmation, `ListPhones` to enumerate registered phones, and `RevokePhone` to revoke a phone PSK (GW-1222). See §13 for the full gRPC service definition.
+The admin API exposes `OpenBlePairing` (server-streaming RPC) to open an admin-initiated registration window and enable BLE advertising, `CloseBlePairing` to close the active pairing session, `ConfirmBlePairing` for Numeric Comparison confirmation during admin-initiated pairing, `ListPhones` to enumerate registered phones, and `RevokePhone` to revoke a phone PSK (GW-1222).
+
+When Numeric Comparison is requested during an admin-initiated session, the gateway broadcasts the passkey to admin-stream subscribers and waits up to 30 seconds for `ConfirmBlePairing`. When Numeric Comparison is requested during a button-initiated session, the gateway skips the admin confirmation wait, updates the display with the passkey screen, and immediately sends `BLE_PAIRING_CONFIRM_REPLY(accept=true)` (GW-1222a). The existing admin-stream events (`PhoneConnected`, `PhoneDisconnected`, `PasskeyRequest`, `PhoneRegistered`) remain available for both origins; button-initiated mode adds automatic confirmation and display transitions, not a different pairing protocol.
 
 ---
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -1317,16 +1317,19 @@ The gateway MUST reject `REGISTER_PHONE` commands when the registration window i
 **Source:** ble-pairing-protocol.md §5.4.1, modem-protocol.md §4.13
 
 **Description:**  
-The gateway MUST open the registration window via a physical button hold (≥2 s) or the admin API and auto-close it after a configurable duration (default 120 s). When the registration window is opened via admin API, the gateway MUST also send `BLE_ENABLE` to the modem. When the window closes (auto-close or explicit close), the gateway MUST send `BLE_DISABLE` to the modem.
+The gateway MUST open the registration window either via a modem `EVENT_BUTTON(BUTTON_LONG)` event or via the admin API and auto-close it after a configurable duration (default 120 s). The gateway MUST track whether the active BLE pairing session was opened by `BUTTON_LONG` (`button` origin) or by `OpenBlePairing` (`admin` origin). A `BUTTON_LONG` event received while a BLE pairing session is already active MUST be ignored. A `BUTTON_SHORT` event MUST close the registration window only when the active session origin is `button`. When the registration window opens, the gateway MUST send `BLE_ENABLE` to the modem. When the window closes (auto-close, explicit admin close, or button cancel), the gateway MUST send `BLE_DISABLE` to the modem.
 
 **Acceptance criteria:**
 
-1. A button hold of ≥2 s opens the registration window.
-2. The admin API can open the registration window.
-3. The window auto-closes after the configured duration.
-4. The default duration is 120 s.
-5. Opening the window sends `BLE_ENABLE` to the modem.
-6. Closing the window (auto-close or explicit) sends `BLE_DISABLE` to the modem.
+1. A `BUTTON_LONG` event opens the registration window when no BLE pairing session is active.
+2. An `OpenBlePairing` admin API call opens the registration window when no BLE pairing session is active.
+3. A `BUTTON_LONG` event received while a BLE pairing session is already active leaves the existing session unchanged.
+4. A `BUTTON_SHORT` event closes a button-initiated BLE pairing session.
+5. A `BUTTON_SHORT` event received during an admin-initiated BLE pairing session does not close the session.
+6. The window auto-closes after the configured duration.
+7. The default duration is 120 s.
+8. Opening the window sends `BLE_ENABLE` to the modem.
+9. Closing the window (auto-close, explicit admin close, or button cancel) sends `BLE_DISABLE` to the modem.
 
 ---
 
@@ -1528,15 +1531,38 @@ The gateway MUST NOT apply sequence-number anti-replay checks to `msg_type` `0x0
 **Source:** ble-pairing-protocol.md §5.4.1, modem-protocol.md §4.13
 
 **Description:**  
-The admin API MUST expose an `OpenBlePairing` RPC (and corresponding `sonde-admin pairing start` CLI command) that opens the phone registration window AND sends `BLE_ENABLE` to the modem. A corresponding `CloseBlePairing` RPC (`sonde-admin pairing stop`) MUST close the window and send `BLE_DISABLE`. The admin CLI MUST display any Numeric Comparison passkey relayed from the modem via `BLE_PAIRING_CONFIRM` and prompt the operator to confirm.
+The admin API MUST expose an `OpenBlePairing` RPC (and corresponding `sonde-admin pairing start` CLI command) that opens an admin-initiated phone registration window and streams pairing events to the admin client. A corresponding `CloseBlePairing` RPC (`sonde-admin pairing stop`) MUST close the active BLE pairing session. During an admin-initiated session, the admin CLI MUST display any Numeric Comparison passkey relayed from the modem via `BLE_PAIRING_CONFIRM` and prompt the operator to confirm.
 
 **Acceptance criteria:**
 
-1. `sonde-admin pairing start` opens the registration window and enables BLE advertising.
-2. `sonde-admin pairing stop` closes the window and disables BLE advertising.
+1. `sonde-admin pairing start` opens an admin-initiated registration window and enables BLE advertising.
+2. `sonde-admin pairing stop` closes the active BLE pairing session and disables BLE advertising.
 3. Numeric Comparison passkey is displayed to the operator.
 4. Operator can accept or reject the passkey.
 5. Registration window auto-close also sends `BLE_DISABLE`.
+
+---
+
+### GW-1222a  Button-initiated BLE pairing feedback and confirmation
+
+**Priority:** Must  
+**Source:** modem-protocol.md §4.7a, §4.17, User request
+
+**Description:**  
+During a button-initiated BLE pairing session, the gateway MUST keep the modem display updated with pairing progress and MUST automatically accept Numeric Comparison requests. On entry to button-initiated pairing mode, the gateway MUST update the display to `Pairing`. When the modem reports a phone connection, the gateway MUST update the display to `Phone connected`. When the modem relays `BLE_PAIRING_CONFIRM(passkey=P)`, the gateway MUST update the display to show `Pin` and the actual passkey `P`, and MUST send `BLE_PAIRING_CONFIRM_REPLY(accept=true)` without waiting for admin confirmation. When phone registration completes, the gateway MUST update the display to `Provisioned`, followed by `Done` when the pairing session closes normally. If the session is closed by `BUTTON_SHORT`, the gateway MUST update the display to `Cancelled`. If the session auto-closes due to timeout, the gateway MUST update the display to `Timed out`. Each terminal button-pairing state (`Done`, `Cancelled`, `Timed out`) MUST remain on the display for 2 seconds before the gateway restores the normal Sonde Gateway version banner, unless a newer button-pairing session has already replaced it.
+
+**Acceptance criteria:**
+
+1. Entering a button-initiated BLE pairing session triggers a display update showing `Pairing`.
+2. A modem `BLE_CONNECTED` event during a button-initiated session triggers a display update showing `Phone connected`.
+3. A modem `BLE_PAIRING_CONFIRM(passkey=P)` event during a button-initiated session triggers a display update showing the actual passkey `P`.
+4. A modem `BLE_PAIRING_CONFIRM(passkey=P)` event during a button-initiated session causes the gateway to send `BLE_PAIRING_CONFIRM_REPLY(accept=true)` without waiting for `ConfirmBlePairing`.
+5. Successful phone registration during a button-initiated session triggers a display update showing `Provisioned`.
+6. Normal closure of a button-initiated session after successful registration triggers a display update showing `Done`.
+7. `BUTTON_SHORT` cancellation of a button-initiated session triggers a display update showing `Cancelled`.
+8. Auto-close timeout of a button-initiated session triggers a display update showing `Timed out`.
+9. After `Done`, `Cancelled`, or `Timed out`, the gateway restores the normal Sonde Gateway version banner after 2 seconds unless a newer pairing session has already taken over the display.
+10. Admin-initiated sessions continue to require explicit operator confirmation for Numeric Comparison.
 
 ---
 
@@ -2239,6 +2265,7 @@ The `secret-service` (D-Bus keyring) dependency MUST be behind a cargo feature f
 | GW-1220 | Silent-discard error model for PEER_REQUEST | Must |
 | GW-1221 | Random nonces for PEER_REQUEST/PEER_ACK | Must |
 | GW-1222 | Admin API — BLE pairing session | Must |
+| GW-1222a | Button-initiated BLE pairing feedback and confirmation | Must |
 | GW-1223 | Admin API — phone listing | Must |
 | GW-1224 | Admin API — phone revocation | Must |
 | GW-1303 | Build metadata in host binaries | Must |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -2105,14 +2105,72 @@ A configurable stub handler process (or in-process mock) that:
 **Procedure:**
 1. Call `OpenBlePairing` via admin API.
 2. Assert: registration window is open.
-3. Assert: `BLE_ENABLE` sent to modem.
-4. Wait for window timeout.
-5. Assert: `BLE_DISABLE` sent to modem.
-6. Assert: registration window is closed.
+3. Assert: session origin is `admin`.
+4. Assert: `BLE_ENABLE` sent to modem.
+5. Inject `EVENT_BUTTON(BUTTON_SHORT)` from the modem.
+6. Assert: the registration window remains open.
+7. Wait for window timeout.
+8. Assert: `BLE_DISABLE` sent to modem.
+9. Assert: registration window is closed.
 
 ---
 
-### T-1222  Numeric Comparison passkey display
+### T-1221a  Button long press opens pairing session
+
+**Validates:** GW-1208, GW-1222a
+
+**Procedure:**
+1. Ensure no BLE pairing session is active.
+2. Inject `EVENT_BUTTON(BUTTON_LONG)` from the mock modem.
+3. Assert: the registration window opens.
+4. Assert: session origin is `button`.
+5. Assert: the modem receives `BLE_ENABLE`.
+6. Assert: the gateway sends a display update rendering `Pairing`.
+
+---
+
+### T-1221b  Long press ignored while pairing active
+
+**Validates:** GW-1208
+
+**Procedure:**
+1. Open a button-initiated BLE pairing session via `EVENT_BUTTON(BUTTON_LONG)`.
+2. Record the session deadline and count of outbound `BLE_ENABLE` messages.
+3. Inject a second `EVENT_BUTTON(BUTTON_LONG)`.
+4. Assert: the existing session remains open with the same origin and deadline.
+5. Assert: no additional `BLE_ENABLE` is sent.
+
+---
+
+### T-1221c  Button short press cancels button pairing
+
+**Validates:** GW-1208, GW-1222a
+
+**Procedure:**
+1. Open a button-initiated BLE pairing session via `EVENT_BUTTON(BUTTON_LONG)`.
+2. Inject `EVENT_BUTTON(BUTTON_SHORT)`.
+3. Assert: the registration window closes.
+4. Assert: the modem receives `BLE_DISABLE`.
+5. Assert: the gateway sends a display update rendering `Cancelled`.
+6. Assert: about 2 seconds later, the gateway restores the normal Sonde Gateway version banner.
+
+---
+
+### T-1221d  Button pairing timeout closes window
+
+**Validates:** GW-1208, GW-1222a
+
+**Procedure:**
+1. Open a button-initiated BLE pairing session with a short timeout.
+2. Wait for the timeout to expire.
+3. Assert: the registration window closes.
+4. Assert: the modem receives `BLE_DISABLE`.
+5. Assert: the gateway sends a display update rendering `Timed out`.
+6. Assert: about 2 seconds later, the gateway restores the normal Sonde Gateway version banner.
+
+---
+
+### T-1222  Admin Numeric Comparison requires explicit confirmation
 
 **Validates:** GW-1222
 
@@ -2120,9 +2178,41 @@ A configurable stub handler process (or in-process mock) that:
 1. Start a BLE pairing session via admin API (`OpenBlePairing`).
 2. Connect phone via BLE. Modem sends `BLE_PAIRING_CONFIRM(passkey=123456)`.
 3. Assert: gateway forwards the passkey to the admin API client (e.g., as a streaming gRPC event or CLI prompt).
-4. Admin client accepts. Assert: gateway sends `BLE_PAIRING_CONFIRM_REPLY(0x01)` to modem.
+4. Assert: no `BLE_PAIRING_CONFIRM_REPLY` is sent until the admin client responds.
+5. Admin client accepts.
+6. Assert: gateway sends `BLE_PAIRING_CONFIRM_REPLY(accept=true)` to the modem.
 
 > **Note:** In automated integration tests, run `sonde-admin pairing start` against a mock modem that injects `BLE_PAIRING_CONFIRM`, capture stdout, and assert the passkey appears. Operator confirmation is simulated by piping `y` to stdin.
+
+---
+
+### T-1222a  Button pairing Numeric Comparison auto-confirms and shows passkey
+
+**Validates:** GW-1222a
+
+**Procedure:**
+1. Open a button-initiated BLE pairing session via `EVENT_BUTTON(BUTTON_LONG)`.
+2. Inject `BLE_CONNECTED`.
+3. Assert: the gateway sends a display update rendering `Phone connected`.
+4. Inject `BLE_PAIRING_CONFIRM(passkey=123456)`.
+5. Assert: the gateway sends a display update rendering `Pin` and `123456`.
+6. Assert: the gateway sends `BLE_PAIRING_CONFIRM_REPLY(accept=true)` without any admin confirmation RPC.
+
+---
+
+### T-1222b  Button pairing success display progression
+
+**Validates:** GW-1222a
+
+**Procedure:**
+1. Open a button-initiated BLE pairing session via `EVENT_BUTTON(BUTTON_LONG)`.
+2. Inject `BLE_CONNECTED`.
+3. Inject `BLE_PAIRING_CONFIRM(passkey=123456)`.
+4. Inject a successful `REGISTER_PHONE` flow and `PHONE_REGISTERED` event.
+5. Assert: the gateway sends a display update rendering `Provisioned`.
+6. Close the session normally after the successful registration path completes.
+7. Assert: the gateway sends a display update rendering `Done`.
+8. Assert: about 2 seconds later, the gateway restores the normal Sonde Gateway version banner.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -2161,8 +2161,8 @@ A configurable stub handler process (or in-process mock) that:
 **Validates:** GW-1208, GW-1222a
 
 **Procedure:**
-1. Open a button-initiated BLE pairing session with a short timeout.
-2. Wait for the timeout to expire.
+1. Open a button-initiated BLE pairing session.
+2. Wait for the implementation-defined button-pairing timeout to expire. In the current gateway implementation, this timeout is fixed at 120 seconds rather than shortened specifically for validation.
 3. Assert: the registration window closes.
 4. Assert: the modem receives `BLE_DISABLE`.
 5. Assert: the gateway sends a display update rendering `Timed out`.


### PR DESCRIPTION
## Summary
- add gateway-owned button pairing session tracking and modem button event handling
- drive pairing display transitions, auto-confirm numeric comparison for button sessions, and restore the version banner after terminal states
- update gateway requirements, design, and validation docs for the button pairing display lifecycle

Closes #795