### PR TITLE
Disable gateway Docker build record upload

### DIFF
--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -53,6 +53,8 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
       - name: Build container image
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .


### PR DESCRIPTION
## Summary
- disable the automatic Docker build record artifact in the gateway container workflow
- stop nightly runs from publishing stray .dockerbuild artifacts that break bulk gh run download`n
## Testing
- git diff --check