### PR TITLE
Implement issue #798 modem display lifecycle

### DIFF
--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -138,9 +138,7 @@ fn schedule_status_page_banner_restore(
         if display_generation.load(Ordering::SeqCst) != generation {
             return;
         }
-        if controller.session_origin().await
-            == Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
-        {
+        if controller.session_origin().await.is_some() {
             return;
         }
         reset_status_page_cycle(&status_page_cycle).await;
@@ -2169,6 +2167,52 @@ mod tests {
             render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
         );
         assert_eq!(status_page_cycle.lock().await.next_page_index, 0);
+    }
+
+    #[tokio::test]
+    async fn status_page_timeout_does_not_restore_banner_during_admin_pairing() {
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
+        let storage = Arc::new(InMemoryStorage::new());
+        storage.set_config("espnow_channel", "11").await.unwrap();
+        let storage: Arc<dyn Storage> = storage;
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        tokio::time::pause();
+        let short_press = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let storage = Arc::clone(&storage);
+            let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
+            async move {
+                handle_idle_button_short_event(
+                    &transport,
+                    &controller,
+                    &storage,
+                    6,
+                    &display_generation,
+                    &status_page_cycle,
+                )
+                .await
+            }
+        });
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Channel", "11"]));
+        assert!(short_press.await.unwrap());
+
+        assert!(controller.open_window(120, PairingOrigin::Admin).await);
+        tokio::time::advance(STATUS_PAGE_TIMEOUT + Duration::from_millis(100)).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), server.read(&mut buf))
+                .await
+                .is_err(),
+            "status-page timeout must not restore the banner during admin pairing"
+        );
+        assert_eq!(status_page_cycle.lock().await.next_page_index, 1);
     }
 }
 

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -35,6 +35,7 @@ const DEFAULT_ADMIN_SOCKET: &str = r"\\.\pipe\sonde-admin";
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const BUTTON_PAIRING_DURATION_S: u32 = 120;
 const BUTTON_EXIT_REASON_DISPLAY_DURATION: Duration = Duration::from_secs(2);
+const STATUS_PAGE_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ButtonDisplayState {
@@ -42,17 +43,60 @@ enum ButtonDisplayState {
     Passkey,
 }
 
-async fn update_pairing_display(transport: &Arc<UsbEspNowTransport>, lines: &[&str]) {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StatusPage {
+    Channel,
+    Nodes,
+}
+
+impl StatusPage {
+    const ALL: [StatusPage; 2] = [StatusPage::Channel, StatusPage::Nodes];
+}
+
+#[derive(Debug, Default)]
+struct StatusPageCycle {
+    next_page_index: usize,
+}
+
+async fn update_display_message(transport: &Arc<UsbEspNowTransport>, lines: &[&str]) {
     if let Err(e) = send_display_message(transport, lines).await {
-        warn!(error = %e, ?lines, "failed to update pairing display");
+        warn!(error = %e, ?lines, "failed to update display");
     }
 }
 
-fn invalidate_button_display_restore(display_generation: &Arc<AtomicU64>) {
+fn invalidate_display_restore(display_generation: &Arc<AtomicU64>) {
     display_generation.fetch_add(1, Ordering::SeqCst);
 }
 
-fn schedule_gateway_version_restore(
+async fn reset_status_page_cycle(status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>) {
+    status_page_cycle.lock().await.next_page_index = 0;
+}
+
+async fn render_status_page_lines(
+    storage: &Arc<dyn Storage>,
+    default_channel: u8,
+    page: StatusPage,
+) -> [String; 2] {
+    match page {
+        StatusPage::Channel => match storage.get_config("espnow_channel").await {
+            Ok(Some(channel)) => ["Channel".to_string(), channel],
+            Ok(None) => ["Channel".to_string(), default_channel.to_string()],
+            Err(e) => {
+                warn!(error = %e, "failed to load espnow_channel for status page");
+                ["Channel".to_string(), "Error".to_string()]
+            }
+        },
+        StatusPage::Nodes => match storage.list_nodes().await {
+            Ok(nodes) => ["Nodes".to_string(), nodes.len().to_string()],
+            Err(e) => {
+                warn!(error = %e, "failed to load node count for status page");
+                ["Nodes".to_string(), "Error".to_string()]
+            }
+        },
+    }
+}
+
+fn schedule_button_pairing_banner_restore(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
@@ -78,10 +122,42 @@ fn schedule_gateway_version_restore(
     });
 }
 
+fn schedule_status_page_banner_restore(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    display_generation: &Arc<AtomicU64>,
+    status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
+) {
+    let generation = display_generation.fetch_add(1, Ordering::SeqCst) + 1;
+    let transport: Weak<UsbEspNowTransport> = Arc::downgrade(transport);
+    let controller = Arc::clone(controller);
+    let display_generation = Arc::clone(display_generation);
+    let status_page_cycle = Arc::clone(status_page_cycle);
+    tokio::spawn(async move {
+        tokio::time::sleep(STATUS_PAGE_TIMEOUT).await;
+        if display_generation.load(Ordering::SeqCst) != generation {
+            return;
+        }
+        if controller.session_origin().await
+            == Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
+        {
+            return;
+        }
+        reset_status_page_cycle(&status_page_cycle).await;
+        let Some(transport) = transport.upgrade() else {
+            return;
+        };
+        if let Err(e) = send_gateway_version_banner(&transport).await {
+            warn!(error = %e, "failed to restore gateway version banner");
+        }
+    });
+}
+
 async fn open_button_pairing_session(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
     display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
 ) -> bool {
@@ -101,11 +177,12 @@ async fn open_button_pairing_session(
         error!("BLE_ENABLE send error for button pairing: {e}");
         return false;
     }
-    invalidate_button_display_restore(display_generation);
+    invalidate_display_restore(display_generation);
+    reset_status_page_cycle(status_page_cycle).await;
     window.open(BUTTON_PAIRING_DURATION_S);
     *display_state = ButtonDisplayState::Generic;
     info!("button-initiated BLE pairing opened");
-    update_pairing_display(transport, &["Pairing"]).await;
+    update_display_message(transport, &["Pairing"]).await;
     true
 }
 
@@ -113,6 +190,7 @@ async fn close_button_pairing_session(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
     display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
     status_lines: &[&str],
@@ -123,14 +201,16 @@ async fn close_button_pairing_session(
     if let Err(e) = transport.send_ble_disable().await {
         error!("BLE_DISABLE send error: {e}");
     }
-    update_pairing_display(transport, status_lines).await;
-    schedule_gateway_version_restore(transport, controller, display_generation);
+    reset_status_page_cycle(status_page_cycle).await;
+    update_display_message(transport, status_lines).await;
+    schedule_button_pairing_banner_restore(transport, controller, display_generation);
 }
 
 async fn handle_button_short_event(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
     display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
 ) -> bool {
@@ -142,6 +222,7 @@ async fn handle_button_short_event(
         transport,
         controller,
         display_generation,
+        status_page_cycle,
         display_state,
         window,
         &["Cancelled"],
@@ -154,6 +235,7 @@ async fn handle_button_pairing_timeout(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
     display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
 ) {
@@ -167,6 +249,7 @@ async fn handle_button_pairing_timeout(
         transport,
         controller,
         display_generation,
+        status_page_cycle,
         display_state,
         window,
         &["Timed out"],
@@ -182,7 +265,7 @@ async fn show_button_pairing_connected(
     if controller.session_origin().await == Some(sonde_gateway::ble_pairing::PairingOrigin::Button)
         && display_state != ButtonDisplayState::Passkey
     {
-        update_pairing_display(transport, &["Phone connected"]).await;
+        update_display_message(transport, &["Phone connected"]).await;
     }
 }
 
@@ -198,7 +281,7 @@ async fn confirm_button_pairing_passkey(
     }
     *display_state = ButtonDisplayState::Passkey;
     let passkey_text = format!("{passkey:06}");
-    update_pairing_display(transport, &["Pin", &passkey_text]).await;
+    update_display_message(transport, &["Pin", &passkey_text]).await;
     if let Err(e) = transport.send_ble_pairing_confirm_reply(true).await {
         error!("BLE_PAIRING_CONFIRM_REPLY send error: {e}");
         return false;
@@ -210,18 +293,51 @@ async fn complete_button_pairing_success(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
+    status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
     display_state: &mut ButtonDisplayState,
     window: &mut sonde_gateway::ble_pairing::RegistrationWindow,
 ) {
-    update_pairing_display(transport, &["Provisioned"]).await;
+    update_display_message(transport, &["Provisioned"]).await;
     controller.close_window().await;
     window.close();
     *display_state = ButtonDisplayState::Generic;
     if let Err(e) = transport.send_ble_disable().await {
         error!("BLE_DISABLE send error after phone registration: {e}");
     }
-    update_pairing_display(transport, &["Done"]).await;
-    schedule_gateway_version_restore(transport, controller, display_generation);
+    reset_status_page_cycle(status_page_cycle).await;
+    update_display_message(transport, &["Done"]).await;
+    schedule_button_pairing_banner_restore(transport, controller, display_generation);
+}
+
+async fn handle_idle_button_short_event(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
+    storage: &Arc<dyn Storage>,
+    default_channel: u8,
+    display_generation: &Arc<AtomicU64>,
+    status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
+) -> bool {
+    if controller.session_origin().await.is_some() {
+        return false;
+    }
+
+    invalidate_display_restore(display_generation);
+    let page = {
+        let mut cycle = status_page_cycle.lock().await;
+        let page = StatusPage::ALL[cycle.next_page_index % StatusPage::ALL.len()];
+        cycle.next_page_index = (cycle.next_page_index + 1) % StatusPage::ALL.len();
+        page
+    };
+    let lines = render_status_page_lines(storage, default_channel, page).await;
+    let line_refs = [lines[0].as_str(), lines[1].as_str()];
+    update_display_message(transport, &line_refs).await;
+    schedule_status_page_banner_restore(
+        transport,
+        controller,
+        display_generation,
+        status_page_cycle,
+    );
+    true
 }
 
 // ── Windows NT service constants ─────────────────────────────────────────────
@@ -754,6 +870,7 @@ async fn run_gateway(
         let ble_channel = channel_for_transport;
         let ble_ctrl = Arc::clone(&ble_controller);
         let button_display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let mut ble_loop = tokio::spawn(async move {
             use sonde_gateway::ble_pairing::{handle_ble_recv, PairingOrigin};
             use sonde_gateway::modem::BleEvent;
@@ -785,6 +902,16 @@ async fn run_gateway(
                 let controller_open = controller_origin.is_some();
                 if controller_open && !window.is_open() {
                     window.open(3600);
+                    if controller_origin == Some(PairingOrigin::Admin) {
+                        invalidate_display_restore(&button_display_generation);
+                        reset_status_page_cycle(&status_page_cycle).await;
+                        if let Err(e) = send_gateway_version_banner(&ble_transport).await {
+                            warn!(
+                                error = %e,
+                                "failed to restore gateway version banner for admin BLE pairing"
+                            );
+                        }
+                    }
                 } else if !controller_open && window.is_open() {
                     window.close();
                     button_timeout_armed = false;
@@ -802,6 +929,7 @@ async fn run_gateway(
                             &ble_transport,
                             &ble_ctrl,
                             &button_display_generation,
+                            &status_page_cycle,
                             &mut button_display_state,
                             &mut window,
                         )
@@ -848,6 +976,7 @@ async fn run_gateway(
                                     &ble_transport,
                                     &ble_ctrl,
                                     &button_display_generation,
+                                    &status_page_cycle,
                                     &mut button_display_state,
                                     &mut window,
                                 )
@@ -939,6 +1068,7 @@ async fn run_gateway(
                                 &ble_transport,
                                 &ble_ctrl,
                                 &button_display_generation,
+                                &status_page_cycle,
                                 &mut button_display_state,
                                 &mut window,
                             )
@@ -960,6 +1090,7 @@ async fn run_gateway(
                                     &ble_transport,
                                     &ble_ctrl,
                                     &button_display_generation,
+                                    &status_page_cycle,
                                     &mut button_display_state,
                                     &mut window,
                                 )
@@ -970,7 +1101,15 @@ async fn run_gateway(
                                 debug!("ignoring BUTTON_SHORT during admin-initiated BLE pairing");
                             }
                             None => {
-                                debug!("ignoring BUTTON_SHORT with no BLE pairing session active");
+                                let _ = handle_idle_button_short_event(
+                                    &ble_transport,
+                                    &ble_ctrl,
+                                    &ble_storage,
+                                    ble_channel,
+                                    &button_display_generation,
+                                    &status_page_cycle,
+                                )
+                                .await;
                             }
                         },
                         other => {
@@ -1436,6 +1575,8 @@ mod tests {
 
     use sonde_gateway::ble_pairing::{BlePairingController, PairingOrigin, RegistrationWindow};
     use sonde_gateway::display_banner::{render_display_message, render_gateway_version_banner};
+    use sonde_gateway::registry::NodeRecord;
+    use sonde_gateway::storage::{InMemoryStorage, Storage};
     use sonde_protocol::modem::{
         encode_modem_frame, DisplayFrameAck, FrameDecoder, ModemMessage, ModemReady,
         DISPLAY_FRAME_BODY_SIZE, DISPLAY_FRAME_CHUNK_COUNT, DISPLAY_FRAME_CHUNK_SIZE,
@@ -1554,6 +1695,7 @@ mod tests {
         transport: Arc<UsbEspNowTransport>,
         controller: Arc<BlePairingController>,
         display_generation: Arc<AtomicU64>,
+        status_page_cycle: Arc<tokio::sync::Mutex<StatusPageCycle>>,
         server: &mut DuplexStream,
         decoder: &mut FrameDecoder,
         buf: &mut [u8],
@@ -1562,6 +1704,7 @@ mod tests {
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
             let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
             async move {
                 let mut window = RegistrationWindow::new();
                 let mut display_state = ButtonDisplayState::Generic;
@@ -1569,6 +1712,7 @@ mod tests {
                     &transport,
                     &controller,
                     &display_generation,
+                    &status_page_cycle,
                     &mut display_state,
                     &mut window,
                 )
@@ -1596,6 +1740,7 @@ mod tests {
         let (transport, mut server) = create_transport_and_server(6).await;
         let controller = Arc::new(BlePairingController::new());
         let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let mut decoder = FrameDecoder::new();
         let mut buf = [0u8; 2048];
 
@@ -1603,6 +1748,7 @@ mod tests {
             Arc::clone(&transport),
             Arc::clone(&controller),
             Arc::clone(&display_generation),
+            Arc::clone(&status_page_cycle),
             &mut server,
             &mut decoder,
             &mut buf,
@@ -1615,6 +1761,7 @@ mod tests {
         let (transport, mut server) = create_transport_and_server(6).await;
         let controller = Arc::new(BlePairingController::new());
         let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let mut decoder = FrameDecoder::new();
         let mut buf = [0u8; 2048];
 
@@ -1622,6 +1769,7 @@ mod tests {
             Arc::clone(&transport),
             Arc::clone(&controller),
             Arc::clone(&display_generation),
+            Arc::clone(&status_page_cycle),
             &mut server,
             &mut decoder,
             &mut buf,
@@ -1634,6 +1782,7 @@ mod tests {
                 &transport,
                 &controller,
                 &display_generation,
+                &status_page_cycle,
                 &mut display_state,
                 &mut window,
             )
@@ -1652,6 +1801,7 @@ mod tests {
         let (transport, mut server) = create_transport_and_server(6).await;
         let controller = Arc::new(BlePairingController::new());
         let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let mut decoder = FrameDecoder::new();
         let mut buf = [0u8; 2048];
 
@@ -1659,6 +1809,7 @@ mod tests {
             Arc::clone(&transport),
             Arc::clone(&controller),
             Arc::clone(&display_generation),
+            Arc::clone(&status_page_cycle),
             &mut server,
             &mut decoder,
             &mut buf,
@@ -1670,6 +1821,7 @@ mod tests {
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
             let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
             async move {
                 let mut window = window;
                 let mut display_state = ButtonDisplayState::Generic;
@@ -1677,6 +1829,7 @@ mod tests {
                     &transport,
                     &controller,
                     &display_generation,
+                    &status_page_cycle,
                     &mut display_state,
                     &mut window,
                 )
@@ -1707,6 +1860,7 @@ mod tests {
                 &transport,
                 &controller,
                 &display_generation,
+                &status_page_cycle,
                 &mut display_state,
                 &mut window,
             )
@@ -1723,6 +1877,7 @@ mod tests {
         let (transport, mut server) = create_transport_and_server(6).await;
         let controller = Arc::new(BlePairingController::new());
         let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let mut decoder = FrameDecoder::new();
         let mut buf = [0u8; 2048];
 
@@ -1730,6 +1885,7 @@ mod tests {
             Arc::clone(&transport),
             Arc::clone(&controller),
             Arc::clone(&display_generation),
+            Arc::clone(&status_page_cycle),
             &mut server,
             &mut decoder,
             &mut buf,
@@ -1741,6 +1897,7 @@ mod tests {
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
             let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
             async move {
                 let mut window = window;
                 let mut display_state = ButtonDisplayState::Generic;
@@ -1748,6 +1905,7 @@ mod tests {
                     &transport,
                     &controller,
                     &display_generation,
+                    &status_page_cycle,
                     &mut display_state,
                     &mut window,
                     &["Timed out"],
@@ -1776,6 +1934,7 @@ mod tests {
         let (transport, mut server) = create_transport_and_server(6).await;
         let controller = Arc::new(BlePairingController::new());
         let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let mut decoder = FrameDecoder::new();
         let mut buf = [0u8; 2048];
 
@@ -1784,6 +1943,7 @@ mod tests {
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
             let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
             async move {
                 let mut window = RegistrationWindow::new();
                 let mut display_state = ButtonDisplayState::Generic;
@@ -1792,6 +1952,7 @@ mod tests {
                     &transport,
                     &controller,
                     &display_generation,
+                    &status_page_cycle,
                     &mut display_state,
                     &mut window,
                 )
@@ -1813,6 +1974,7 @@ mod tests {
         let (transport, mut server) = create_transport_and_server(6).await;
         let controller = Arc::new(BlePairingController::new());
         let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let mut decoder = FrameDecoder::new();
         let mut buf = [0u8; 2048];
 
@@ -1820,6 +1982,7 @@ mod tests {
             Arc::clone(&transport),
             Arc::clone(&controller),
             Arc::clone(&display_generation),
+            Arc::clone(&status_page_cycle),
             &mut server,
             &mut decoder,
             &mut buf,
@@ -1878,6 +2041,7 @@ mod tests {
         let (transport, mut server) = create_transport_and_server(6).await;
         let controller = Arc::new(BlePairingController::new());
         let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let mut decoder = FrameDecoder::new();
         let mut buf = [0u8; 2048];
 
@@ -1885,6 +2049,7 @@ mod tests {
             Arc::clone(&transport),
             Arc::clone(&controller),
             Arc::clone(&display_generation),
+            Arc::clone(&status_page_cycle),
             &mut server,
             &mut decoder,
             &mut buf,
@@ -1897,6 +2062,7 @@ mod tests {
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
             let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
             async move {
                 let mut window = window;
                 let mut display_state = ButtonDisplayState::Passkey;
@@ -1904,6 +2070,7 @@ mod tests {
                     &transport,
                     &controller,
                     &display_generation,
+                    &status_page_cycle,
                     &mut display_state,
                     &mut window,
                 )
@@ -1927,6 +2094,81 @@ mod tests {
             framebuffer,
             render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
         );
+    }
+
+    #[tokio::test]
+    async fn idle_button_short_cycles_status_pages_and_restores_banner() {
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
+        let storage = Arc::new(InMemoryStorage::new());
+        storage.set_config("espnow_channel", "11").await.unwrap();
+        storage
+            .upsert_node(&NodeRecord::new("node-a".to_string(), 0x1001, [0x42; 32]))
+            .await
+            .unwrap();
+        storage
+            .upsert_node(&NodeRecord::new("node-b".to_string(), 0x1002, [0x24; 32]))
+            .await
+            .unwrap();
+        let storage: Arc<dyn Storage> = storage;
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        tokio::time::pause();
+        let first_press = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let storage = Arc::clone(&storage);
+            let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
+            async move {
+                handle_idle_button_short_event(
+                    &transport,
+                    &controller,
+                    &storage,
+                    6,
+                    &display_generation,
+                    &status_page_cycle,
+                )
+                .await
+            }
+        });
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Channel", "11"]));
+        assert!(first_press.await.unwrap());
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+        let second_press = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let storage = Arc::clone(&storage);
+            let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
+            async move {
+                handle_idle_button_short_event(
+                    &transport,
+                    &controller,
+                    &storage,
+                    6,
+                    &display_generation,
+                    &status_page_cycle,
+                )
+                .await
+            }
+        });
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_display_message(&["Nodes", "2"]));
+        assert!(second_press.await.unwrap());
+
+        tokio::time::advance(STATUS_PAGE_TIMEOUT + Duration::from_millis(100)).await;
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(
+            framebuffer,
+            render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+        );
+        assert_eq!(status_page_cycle.lock().await.next_page_index, 0);
     }
 }
 

--- a/crates/sonde-modem/src/display.rs
+++ b/crates/sonde-modem/src/display.rs
@@ -3,6 +3,8 @@
 
 //! SSD1306 OLED display driver for the ESP32-S3 modem target.
 
+use std::time::{Duration, Instant};
+
 use esp_idf_hal::delay::TICK_RATE_HZ;
 
 use crate::bridge::{Display, DisplayError};
@@ -13,11 +15,100 @@ const I2C_TIMEOUT_MS: u32 = 25;
 const OLED_ADDR: u8 = 0x3C;
 const OLED_SDA_GPIO: i32 = esp_idf_sys::gpio_num_t_GPIO_NUM_5;
 const OLED_SCL_GPIO: i32 = esp_idf_sys::gpio_num_t_GPIO_NUM_6;
+const DISPLAY_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+const SSD1306_DISPLAY_OFF: u8 = 0xAE;
+const SSD1306_DISPLAY_ON: u8 = 0xAF;
 
 const SSD1306_INIT: &[u8] = &[
-    0xAE, 0x20, 0x02, 0xB0, 0xC8, 0x00, 0x10, 0x40, 0x81, 0x7F, 0xA1, 0xA6, 0xA8, 0x3F, 0xA4, 0xD3,
-    0x00, 0xD5, 0x80, 0xD9, 0xF1, 0xDA, 0x12, 0xDB, 0x20, 0x8D, 0x14, 0xAF,
+    SSD1306_DISPLAY_OFF,
+    0x20,
+    0x02,
+    0xB0,
+    0xC8,
+    0x00,
+    0x10,
+    0x40,
+    0x81,
+    0x7F,
+    0xA1,
+    0xA6,
+    0xA8,
+    0x3F,
+    0xA4,
+    0xD3,
+    0x00,
+    0xD5,
+    0x80,
+    0xD9,
+    0xF1,
+    0xDA,
+    0x12,
+    0xDB,
+    0x20,
+    0x8D,
+    0x14,
+    SSD1306_DISPLAY_ON,
 ];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PanelPowerCommand {
+    None,
+    Wake,
+    Sleep,
+}
+
+#[derive(Debug, Clone)]
+struct IdlePowerState {
+    panel_awake: bool,
+    last_frame_at: Option<Instant>,
+}
+
+impl Default for IdlePowerState {
+    fn default() -> Self {
+        Self {
+            panel_awake: false,
+            last_frame_at: None,
+        }
+    }
+}
+
+impl IdlePowerState {
+    fn note_frame_accepted_at(&mut self, now: Instant) {
+        self.last_frame_at = Some(now);
+    }
+
+    fn mark_initialized(&mut self) {
+        self.panel_awake = true;
+    }
+
+    fn reset(&mut self) {}
+
+    fn poll_at(
+        &mut self,
+        now: Instant,
+        flush_pending: bool,
+        initialized: bool,
+    ) -> PanelPowerCommand {
+        if flush_pending {
+            if initialized && !self.panel_awake {
+                self.panel_awake = true;
+                return PanelPowerCommand::Wake;
+            }
+            return PanelPowerCommand::None;
+        }
+
+        if self.panel_awake
+            && self.last_frame_at.is_some_and(|last_frame_at| {
+                now.duration_since(last_frame_at) >= DISPLAY_IDLE_TIMEOUT
+            })
+        {
+            self.panel_awake = false;
+            return PanelPowerCommand::Sleep;
+        }
+
+        PanelPowerCommand::None
+    }
+}
 
 pub struct EspSsd1306Display {
     framebuffer: [u8; DISPLAY_FRAME_BODY_SIZE],
@@ -25,6 +116,7 @@ pub struct EspSsd1306Display {
     flush_page: u8,
     flush_pending: bool,
     initialized: bool,
+    idle_power: IdlePowerState,
 }
 
 /// Display wrapper that degrades to recoverable write failures if the display
@@ -65,6 +157,7 @@ impl EspSsd1306Display {
             flush_page: 0,
             flush_pending: false,
             initialized: false,
+            idle_power: IdlePowerState::default(),
         })
     }
 
@@ -158,15 +251,22 @@ impl Display for EspSsd1306Display {
         self.framebuffer = framebuffer;
         self.flush_page = 0;
         self.flush_pending = true;
+        self.idle_power.note_frame_accepted_at(Instant::now());
     }
 
     fn reset(&mut self) {
         self.flush_page = 0;
         self.flush_pending = false;
+        self.idle_power.reset();
     }
 
     fn poll(&mut self) -> Result<(), DisplayError> {
+        let now = Instant::now();
+
         if !self.flush_pending {
+            if self.idle_power.poll_at(now, false, self.initialized) == PanelPowerCommand::Sleep {
+                self.write_commands(&[SSD1306_DISPLAY_OFF])?;
+            }
             return Ok(());
         }
 
@@ -176,6 +276,15 @@ impl Display for EspSsd1306Display {
                 return Err(err);
             }
             self.initialized = true;
+            self.idle_power.mark_initialized();
+            return Ok(());
+        }
+
+        if self.idle_power.poll_at(now, true, self.initialized) == PanelPowerCommand::Wake {
+            if let Err(err) = self.write_commands(&[SSD1306_DISPLAY_ON]) {
+                self.flush_pending = false;
+                return Err(err);
+            }
             return Ok(());
         }
 
@@ -232,5 +341,77 @@ impl Drop for EspSsd1306Display {
         unsafe {
             let _ = esp_idf_sys::i2c_driver_delete(esp_idf_sys::i2c_port_t_I2C_NUM_0);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn idle_power_state_sleeps_after_timeout() {
+        let mut idle_power = IdlePowerState::default();
+        let t0 = Instant::now();
+        idle_power.mark_initialized();
+        idle_power.note_frame_accepted_at(t0);
+
+        assert_eq!(
+            idle_power.poll_at(
+                t0 + DISPLAY_IDLE_TIMEOUT - Duration::from_secs(1),
+                false,
+                true
+            ),
+            PanelPowerCommand::None
+        );
+        assert_eq!(
+            idle_power.poll_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
+            PanelPowerCommand::Sleep
+        );
+        assert_eq!(
+            idle_power.poll_at(
+                t0 + DISPLAY_IDLE_TIMEOUT + Duration::from_secs(1),
+                false,
+                true
+            ),
+            PanelPowerCommand::None
+        );
+    }
+
+    #[test]
+    fn idle_power_state_wakes_on_new_frame_after_sleep() {
+        let mut idle_power = IdlePowerState::default();
+        let t0 = Instant::now();
+        idle_power.mark_initialized();
+        idle_power.note_frame_accepted_at(t0);
+        assert_eq!(
+            idle_power.poll_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
+            PanelPowerCommand::Sleep
+        );
+
+        let t1 = t0 + DISPLAY_IDLE_TIMEOUT + Duration::from_secs(5);
+        idle_power.note_frame_accepted_at(t1);
+        assert_eq!(idle_power.poll_at(t1, true, true), PanelPowerCommand::Wake);
+        assert_eq!(
+            idle_power.poll_at(
+                t1 + DISPLAY_IDLE_TIMEOUT - Duration::from_secs(1),
+                false,
+                true
+            ),
+            PanelPowerCommand::None
+        );
+    }
+
+    #[test]
+    fn idle_power_state_reset_preserves_sleep_deadline() {
+        let mut idle_power = IdlePowerState::default();
+        let t0 = Instant::now();
+        idle_power.mark_initialized();
+        idle_power.note_frame_accepted_at(t0);
+        idle_power.reset();
+
+        assert_eq!(
+            idle_power.poll_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
+            PanelPowerCommand::Sleep
+        );
     }
 }

--- a/crates/sonde-modem/src/display.rs
+++ b/crates/sonde-modem/src/display.rs
@@ -83,15 +83,14 @@ impl IdlePowerState {
 
     fn reset(&mut self) {}
 
-    fn poll_at(
-        &mut self,
+    fn desired_command_at(
+        &self,
         now: Instant,
         flush_pending: bool,
         initialized: bool,
     ) -> PanelPowerCommand {
         if flush_pending {
             if initialized && !self.panel_awake {
-                self.panel_awake = true;
                 return PanelPowerCommand::Wake;
             }
             return PanelPowerCommand::None;
@@ -102,11 +101,18 @@ impl IdlePowerState {
                 now.duration_since(last_frame_at) >= DISPLAY_IDLE_TIMEOUT
             })
         {
-            self.panel_awake = false;
             return PanelPowerCommand::Sleep;
         }
 
         PanelPowerCommand::None
+    }
+
+    fn mark_wake_succeeded(&mut self) {
+        self.panel_awake = true;
+    }
+
+    fn mark_sleep_succeeded(&mut self) {
+        self.panel_awake = false;
     }
 }
 
@@ -264,8 +270,13 @@ impl Display for EspSsd1306Display {
         let now = Instant::now();
 
         if !self.flush_pending {
-            if self.idle_power.poll_at(now, false, self.initialized) == PanelPowerCommand::Sleep {
+            if self
+                .idle_power
+                .desired_command_at(now, false, self.initialized)
+                == PanelPowerCommand::Sleep
+            {
                 self.write_commands(&[SSD1306_DISPLAY_OFF])?;
+                self.idle_power.mark_sleep_succeeded();
             }
             return Ok(());
         }
@@ -280,11 +291,16 @@ impl Display for EspSsd1306Display {
             return Ok(());
         }
 
-        if self.idle_power.poll_at(now, true, self.initialized) == PanelPowerCommand::Wake {
+        if self
+            .idle_power
+            .desired_command_at(now, true, self.initialized)
+            == PanelPowerCommand::Wake
+        {
             if let Err(err) = self.write_commands(&[SSD1306_DISPLAY_ON]) {
                 self.flush_pending = false;
                 return Err(err);
             }
+            self.idle_power.mark_wake_succeeded();
             return Ok(());
         }
 
@@ -384,15 +400,20 @@ mod tests {
         idle_power.mark_initialized();
         idle_power.note_frame_accepted_at(t0);
         assert_eq!(
-            idle_power.poll_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
+            idle_power.desired_command_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
             PanelPowerCommand::Sleep
         );
+        idle_power.mark_sleep_succeeded();
 
         let t1 = t0 + DISPLAY_IDLE_TIMEOUT + Duration::from_secs(5);
         idle_power.note_frame_accepted_at(t1);
-        assert_eq!(idle_power.poll_at(t1, true, true), PanelPowerCommand::Wake);
         assert_eq!(
-            idle_power.poll_at(
+            idle_power.desired_command_at(t1, true, true),
+            PanelPowerCommand::Wake
+        );
+        idle_power.mark_wake_succeeded();
+        assert_eq!(
+            idle_power.desired_command_at(
                 t1 + DISPLAY_IDLE_TIMEOUT - Duration::from_secs(1),
                 false,
                 true
@@ -410,8 +431,38 @@ mod tests {
         idle_power.reset();
 
         assert_eq!(
-            idle_power.poll_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
+            idle_power.desired_command_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
             PanelPowerCommand::Sleep
+        );
+    }
+
+    #[test]
+    fn idle_power_state_does_not_mark_awake_until_wake_succeeds() {
+        let mut idle_power = IdlePowerState::default();
+        let t0 = Instant::now();
+        idle_power.mark_initialized();
+        idle_power.note_frame_accepted_at(t0);
+        assert_eq!(
+            idle_power.desired_command_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
+            PanelPowerCommand::Sleep
+        );
+        idle_power.mark_sleep_succeeded();
+
+        let t1 = t0 + DISPLAY_IDLE_TIMEOUT + Duration::from_secs(5);
+        idle_power.note_frame_accepted_at(t1);
+        assert_eq!(
+            idle_power.desired_command_at(t1, true, true),
+            PanelPowerCommand::Wake
+        );
+        assert_eq!(
+            idle_power.desired_command_at(t1 + Duration::from_secs(1), true, true),
+            PanelPowerCommand::Wake
+        );
+
+        idle_power.mark_wake_succeeded();
+        assert_eq!(
+            idle_power.desired_command_at(t1 + Duration::from_secs(1), true, true),
+            PanelPowerCommand::None
         );
     }
 }

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -148,7 +148,7 @@ pub struct UsbEspNowTransport {
 7. Wait for `SET_CHANNEL_ACK` (timeout: 2 seconds).
 8. Start the health monitor task.
 
-The transport adapter stops at the modem handshake boundary. Gateway-owned display policy lives above the transport: once the handshake completes, the gateway runtime renders `Sonde Gateway v<semver>` into a 128×64 1-bit framebuffer and sends it using the reliable display-transfer subprotocol (`DISPLAY_FRAME_BEGIN` plus eight acknowledged `DISPLAY_FRAME_CHUNK` messages) (GW-1101a). This keeps text layout and version-string selection in the gateway while preserving the modem's role as a dumb framebuffer sink.
+The transport adapter stops at the modem handshake boundary. Gateway-owned display policy lives above the transport: once the handshake completes, the gateway runtime renders `Sonde Gateway v<semver>` into a 128×64 1-bit framebuffer and sends it using the reliable display-transfer subprotocol (`DISPLAY_FRAME_BEGIN` plus eight acknowledged `DISPLAY_FRAME_CHUNK` messages) (GW-1101a). The same gateway-owned rendering path also produces the short-press status pages and the timeout-driven return to the default banner (GW-1101b, GW-1101c). This keeps text layout, page selection, and banner policy in the gateway while preserving the modem's role as a dumb framebuffer sink with local panel power management only.
 
 **Health monitor (GW-1102):**
 
@@ -1126,7 +1126,7 @@ The gateway maintains a single BLE pairing session controller with:
 - `origin: Option<PairingOrigin>` where `PairingOrigin = Admin | Button`
 - `successful_registration: bool`
 
-The registration window opens either when the admin API calls `OpenBlePairing` or when the modem relays `EVENT_BUTTON(BUTTON_LONG)` while no BLE pairing session is active. In both cases the gateway sends `BLE_ENABLE` to the modem and records the session origin. A `BUTTON_LONG` received while a session is already active is ignored. A `BUTTON_SHORT` closes the session only when `origin == Button`; `BUTTON_SHORT` has no defined effect outside pairing and does not close an admin-initiated session. Auto-close uses the same timeout machinery for both origins (default 120 s). `REGISTER_PHONE` commands received while the window is closed are rejected with `ERROR(0x02)` (GW-1207).
+The registration window opens either when the admin API calls `OpenBlePairing` or when the modem relays `EVENT_BUTTON(BUTTON_LONG)` while no BLE pairing session is active. In both cases the gateway sends `BLE_ENABLE` to the modem and records the session origin. A `BUTTON_LONG` received while a session is already active is ignored. A `BUTTON_SHORT` closes the session only when `origin == Button`; `BUTTON_SHORT` does not close an admin-initiated session. When no BLE pairing session is active, `BUTTON_SHORT` is routed instead to the display-page navigation policy described below. Auto-close uses the same timeout machinery for both origins (default 120 s). `REGISTER_PHONE` commands received while the window is closed are rejected with `ERROR(0x02)` (GW-1207).
 
 When the window is open and a `REGISTER_PHONE` command arrives (BLE command `0x02`), the gateway: receives a phone-generated 256-bit PSK from the phone; derives `phone_key_hint = u16::from_be_bytes(SHA-256(psk)[30..32])`; stores the PSK with its label, issuance timestamp, and active status; and responds with a plaintext `PHONE_REGISTERED` indication containing `status`, `rf_channel`, and `phone_key_hint` via `BLE_INDICATE` (GW-1209). No additional encryption of the BLE response is needed — the BLE LESC link provides confidentiality. Operators can revoke phone PSKs through the admin API; revoked PSKs are excluded from AES-256-GCM decryption (GW-1210).
 
@@ -1143,6 +1143,23 @@ Gateway-owned display policy lives above the modem transport. During a button-in
 7. **Timeout close** → display `Timed out`.
 
 The passkey screen has priority over the generic connected state until Numeric Comparison is resolved. `Done`, `Cancelled`, and `Timed out` are terminal status screens: the gateway keeps each one visible for 2 seconds, then restores the normal Sonde Gateway version banner if no newer pairing session has claimed the display. Display updates are driven by state transitions; repeated identical events do not need to re-send the same framebuffer.
+
+### 17.4b  Short-press status-page navigation
+
+Outside an active BLE pairing session, `EVENT_BUTTON(BUTTON_SHORT)` advances the modem display through a gateway-owned sequence of status pages. The gateway chooses the sequence contents and renders each page into the same 128×64 framebuffer format used for the default banner and pairing screens.
+
+The display controller keeps:
+
+- `current_page: DisplayPage`
+- `page_deadline: Option<Instant>`
+
+Each `BUTTON_SHORT` while no pairing session is active:
+
+1. Advances `current_page` to the next configured status page.
+2. Sends the corresponding framebuffer via the reliable display-transfer path.
+3. Sets `page_deadline = now + 60 s`.
+
+If another `BUTTON_SHORT` arrives before the deadline, the gateway advances again and resets the deadline. If the deadline expires with no further short press, the gateway restores the default `Sonde Gateway v<semver>` banner and clears `current_page` back to the idle banner state.
 
 ### 17.5  `PEER_REQUEST` processing
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1148,18 +1148,15 @@ The passkey screen has priority over the generic connected state until Numeric C
 
 Outside an active BLE pairing session, `EVENT_BUTTON(BUTTON_SHORT)` advances the modem display through a gateway-owned sequence of status pages. The gateway chooses the sequence contents and renders each page into the same 128×64 framebuffer format used for the default banner and pairing screens.
 
-The display controller keeps:
-
-- `current_page: DisplayPage`
-- `page_deadline: Option<Instant>`
+The gateway tracks the status-page cycle as a cursor over the configured page sequence (`StatusPageCycle { next_page_index }` in `bin/gateway.rs`) together with a monotonically increasing `display_generation` used to invalidate older timeout tasks.
 
 Each `BUTTON_SHORT` while no pairing session is active:
 
-1. Advances `current_page` to the next configured status page.
-2. Sends the corresponding framebuffer via the reliable display-transfer path.
-3. Sets `page_deadline = now + 60 s`.
+1. Selects the page indicated by the current cycle cursor and sends the corresponding framebuffer via the reliable display-transfer path.
+2. Advances `next_page_index` so the next short press shows the following configured status page, wrapping at the end of the sequence.
+3. Increments `display_generation` and spawns a 60 s timeout task associated with that generation.
 
-If another `BUTTON_SHORT` arrives before the deadline, the gateway advances again and resets the deadline. If the deadline expires with no further short press, the gateway restores the default `Sonde Gateway v<semver>` banner and clears `current_page` back to the idle banner state.
+If another `BUTTON_SHORT` arrives before the timeout fires, the gateway advances again, increments `display_generation`, and leaves the older timeout task stale. When a timeout task fires, it restores the default `Sonde Gateway v<semver>` banner only if its captured generation still matches the current `display_generation` and no BLE pairing session is active; otherwise it does nothing because a newer display update or pairing session has already claimed the screen.
 
 ### 17.5  `PEER_REQUEST` processing
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -1108,6 +1108,38 @@ Whenever the gateway re-initializes the modem after a serial reconnect or warm r
 
 ---
 
+### GW-1101b  Short-press display page navigation
+
+**Priority:** Should
+**Source:** Issue #798
+
+**Description:**
+While no BLE pairing session is active, the gateway SHOULD interpret `EVENT_BUTTON(BUTTON_SHORT)` as a request to advance the modem display to the next gateway-owned status page. The gateway owns status-page selection and framebuffer rendering; the modem continues to render only the received framebuffer bytes.
+
+**Acceptance criteria:**
+
+1. A `BUTTON_SHORT` event received while no BLE pairing session is active causes the gateway to send a new reliable display transfer for the next status page.
+2. Consecutive short presses advance through the configured status-page sequence in order.
+3. Status-page framebuffer generation remains gateway-owned; the modem receives only opaque framebuffer data.
+
+---
+
+### GW-1101c  Idle return to default display banner
+
+**Priority:** Should
+**Source:** Issue #798
+
+**Description:**
+After the gateway switches the modem display away from the default `Sonde Gateway v<semver>` banner for a short-press status page, it SHOULD restore the default banner after 60 seconds without further short-press navigation activity.
+
+**Acceptance criteria:**
+
+1. The idle timeout for returning from a status page to the default banner is 60 seconds.
+2. A new short press received before the timeout expires resets the 60-second timeout against the newly selected status page.
+3. When the timeout expires, the gateway sends the same default version banner format defined by GW-1101a.
+
+---
+
 ### GW-1102  Modem health monitoring
 
 **Priority:** Should
@@ -1330,6 +1362,7 @@ The gateway MUST open the registration window either via a modem `EVENT_BUTTON(B
 7. The default duration is 120 s.
 8. Opening the window sends `BLE_ENABLE` to the modem.
 9. Closing the window (auto-close, explicit admin close, or button cancel) sends `BLE_DISABLE` to the modem.
+10. A `BUTTON_SHORT` event received while no BLE pairing session is active does not open or close the registration window; display-page navigation is governed separately by GW-1101b / GW-1101c.
 
 ---
 
@@ -2240,6 +2273,9 @@ The `secret-service` (D-Bus keyring) dependency MUST be behind a cargo feature f
 | GW-1003 | Concurrent node handling | Should |
 | GW-1100 | Modem transport trait implementation | Must |
 | GW-1101 | Modem startup sequence | Must |
+| GW-1101a | Modem-ready display banner | Must |
+| GW-1101b | Short-press display page navigation | Should |
+| GW-1101c | Idle return to default display banner | Should |
 | GW-1102 | Modem health monitoring | Should |
 | GW-1103 | Modem error handling | Must |
 | GW-1200 | Ed25519 keypair generation — RETIRED | Must |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1681,6 +1681,35 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1103b  Short press advances display status page when pairing is inactive
+
+**Validates:** GW-1101b, GW-1208
+
+**Procedure:**
+1. Start a full gateway instance with a mock modem and complete the startup handshake.
+2. Record the framebuffer sent for the default `Sonde Gateway v<semver>` banner.
+3. Inject `EVENT_BUTTON(BUTTON_SHORT)` while no BLE pairing session is active.
+4. Assert: the gateway sends a new reliable display transfer.
+5. Reassemble the new framebuffer and assert: it differs from the default banner framebuffer.
+6. Assert: no `BLE_ENABLE` or `BLE_DISABLE` message is sent as a result of the short press.
+
+---
+
+### T-1103c  Repeated short presses reset the status-page timeout and eventually restore the banner
+
+**Validates:** GW-1101b, GW-1101c
+
+**Procedure:**
+1. Start a gateway instance with a mock modem and complete the startup handshake.
+2. Inject `EVENT_BUTTON(BUTTON_SHORT)` while no BLE pairing session is active and capture the resulting status-page framebuffer.
+3. Before 60 seconds elapse, inject a second `EVENT_BUTTON(BUTTON_SHORT)`.
+4. Assert: the gateway sends another reliable display transfer for the next status page and resets the page timeout.
+5. Advance time by just under 60 seconds from the second short press and assert: the default banner has not yet been restored.
+6. Advance time past the 60-second timeout.
+7. Assert: the gateway sends the default `Sonde Gateway v<semver>` banner again.
+
+---
+
 ### T-1104a  Serial disconnect — reconnection with backoff
 
 **Validates:** GW-1103 (criteria 3–5)
@@ -2153,6 +2182,7 @@ A configurable stub handler process (or in-process mock) that:
 4. Assert: the modem receives `BLE_DISABLE`.
 5. Assert: the gateway sends a display update rendering `Cancelled`.
 6. Assert: about 2 seconds later, the gateway restores the normal Sonde Gateway version banner.
+7. Assert: the short press does not navigate to a status page while the button pairing session is active.
 
 ---
 

--- a/docs/modem-design.md
+++ b/docs/modem-design.md
@@ -63,7 +63,7 @@ The firmware is intentionally minimal — no application- or protocol-layer cryp
 | **BLE lifecycle** | `BLE_ENABLE`/`BLE_DISABLE` handling, connection/disconnection events, `BLE_CONNECTED`/`BLE_DISCONNECTED` notifications, idle timeout | MD-0405, MD-0410, MD-0411, MD-0413, MD-0414, MD-0415 |
 | **Watchdog** *(cross-cutting)* | Task watchdog feed in main loop; hardware reset on stall | MD-0302 |
 | **Button scanner** | GPIO2 polling, debounce, press classification, `EVENT_BUTTON` emission | MD-0600, MD-0601, MD-0602, MD-0603, MD-0604, MD-0605 |
-| **Display driver** | Validate reliable display transfers, reassemble framebuffer chunks, convert row-major pixels to SSD1306 page writes, incremental I²C flush, `EVENT_ERROR` emission | MD-0700, MD-0701, MD-0702, MD-0703, MD-0704 |
+| **Display driver** | Validate reliable display transfers, reassemble framebuffer chunks, convert row-major pixels to SSD1306 page writes, incremental I²C flush, local OLED sleep/wake, `EVENT_ERROR` emission | MD-0700, MD-0701, MD-0702, MD-0703, MD-0704, MD-0705 |
 
 ---
 
@@ -291,7 +291,18 @@ To preserve modem responsiveness (MD-0702), `display.poll()` performs at most on
 
 If a newer display transfer completes while an older one is still flushing, the pending buffer is replaced and the next flush restarts from page 0 so the display converges to the latest gateway-supplied image.
 
-### 9a.4  Failure handling
+### 9a.4  Local OLED power state
+
+The modem owns only OLED panel power state, not display-page semantics. The display driver tracks the monotonic deadline for panel idle sleep:
+
+1. Each newly accepted complete display transfer records `last_frame_at = now`.
+2. If the panel is currently off when a new complete transfer is accepted, the driver sends SSD1306 `display on` before resuming page flush.
+3. If 300 seconds elapse with no newly accepted complete display transfer, the driver sends SSD1306 `display off` and marks the panel as asleep.
+4. A sleeping panel keeps the last framebuffer in memory; the next complete display transfer wakes the panel and renders the new framebuffer.
+
+This preserves the modem's dumb-framebuffer role: gateway software still decides *what* to show and *when* to change pages, while the modem only decides whether the OLED glass should currently be powered.
+
+### 9a.5  Failure handling
 
 If any OLED I²C transaction fails during initialization or page flush:
 
@@ -570,7 +581,7 @@ On `BLE_DISABLE`, the modem disconnects the active client (if any) and stops adv
 
 ## 16  Button scanner
 
-The modem detects button presses on the 1-Wire data line (GPIO2 / XIAO ESP32-S3 silk label D1) and emits `EVENT_BUTTON` messages to the gateway. The modem does not interpret button semantics.
+The modem detects button presses on the 1-Wire data line (GPIO2 / XIAO ESP32-S3 silk label D1) and emits `EVENT_BUTTON` messages to the gateway. The modem does not interpret button semantics; gateway software decides whether a short press navigates status pages or a long press opens pairing.
 
 ### 16.1  GPIO configuration
 

--- a/docs/modem-requirements.md
+++ b/docs/modem-requirements.md
@@ -903,13 +903,14 @@ Reliable display transfer and rendering MUST NOT block or materially delay ESP-N
 **Source:** Issue #757
 
 **Description:**
-The modem firmware MUST NOT generate text, menus, pairing screens, status overlays, or any other display content on its own. The modem MUST NOT interpret framebuffer meaning. Its only display responsibility is to render the exact gateway-supplied framebuffer, reassembled from the reliable display-transfer subprotocol, onto the OLED.
+The modem firmware MUST NOT generate text, menus, pairing screens, status overlays, or any other display content on its own. The modem MUST NOT interpret framebuffer meaning. Its display responsibilities are limited to rendering the exact gateway-supplied framebuffer, reassembled from the reliable display-transfer subprotocol, onto the OLED and controlling panel power state for idle sleep/wake behavior.
 
 **Acceptance criteria:**
 
 1. No code path synthesizes display pixels from button state, BLE state, pairing state, radio state, or any other modem-local state.
 2. The same completed display transfer produces the same rendered output regardless of modem runtime state.
 3. The modem does not implement text rendering, menu generation, or display-side pairing UX.
+4. Any modem-local display behavior is limited to panel power state transitions and does not alter framebuffer contents.
 
 ---
 
@@ -926,6 +927,23 @@ Display-related faults MUST be reported via `EVENT_ERROR`, not the unrecoverable
 1. Invalid `DISPLAY_FRAME_BEGIN` or `DISPLAY_FRAME_CHUNK` metadata produces `EVENT_ERROR(INVALID_FRAME)`.
 2. An I²C write failure during display update produces `EVENT_ERROR(DISPLAY_WRITE_FAILED)`.
 3. After either error, the modem remains operational for ESP-NOW, BLE, USB-CDC, and future reliable display transfers.
+
+---
+
+### MD-0705  OLED idle power management
+
+**Priority:** Should
+**Source:** Issue #798
+
+**Description:**
+The modem firmware SHOULD manage SSD1306 panel power locally. If no new complete display transfer is accepted for 300 seconds, the modem SHOULD switch the OLED panel off using the controller's native display-off command. When the next complete display transfer is accepted, the modem SHOULD wake the panel if necessary, render the new framebuffer, and restart the 300-second idle timer.
+
+**Acceptance criteria:**
+
+1. The idle timeout before the panel is switched off is 300 seconds with no newly accepted complete display transfer.
+2. Idle expiry uses the SSD1306 display-off command rather than only clearing the framebuffer.
+3. The next accepted complete display transfer wakes the panel if it was off, renders the framebuffer, and restarts the 300-second idle timer.
+4. Panel sleep/wake behavior does not emit `EVENT_BUTTON`, change BLE advertising state, or otherwise introduce local display semantics.
 
 ---
 
@@ -987,3 +1005,4 @@ Display-related faults MUST be reported via `EVENT_ERROR`, not the unrecoverable
 | MD-0702 | Display-path non-interference | Must |
 | MD-0703 | No firmware-generated display UI | Must |
 | MD-0704 | Recoverable display error reporting | Must |
+| MD-0705 | OLED idle power management | Should |

--- a/docs/modem-validation.md
+++ b/docs/modem-validation.md
@@ -1268,6 +1268,33 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 1. Configure the display transport to inject an I²C write failure during a completed display update.
 2. Send a valid reliable display transfer.
 3. Assert: `EVENT_ERROR(DISPLAY_WRITE_FAILED)` is received.
+
+---
+
+### T-0906  Idle timeout switches the OLED panel off
+
+**Validates:** MD-0705
+
+**Procedure:**
+1. Send a valid reliable display transfer and allow it to render fully.
+2. Wait 300 seconds with no further accepted display transfer.
+3. Observe the display driver's command stream (or instrument the mock).
+4. Assert: the SSD1306 native display-off command is sent.
+5. Assert: no `EVENT_ERROR` is emitted solely because the panel was idled.
+
+---
+
+### T-0907  New display transfer wakes the panel and restarts the idle timer
+
+**Validates:** MD-0705, MD-0703
+
+**Procedure:**
+1. Render a valid display transfer, then allow the 300-second idle timeout to switch the panel off.
+2. Send a second valid reliable display transfer with different framebuffer contents.
+3. Assert: the display driver sends the SSD1306 display-on command before or as part of rendering the new frame.
+4. Assert: the new framebuffer is rendered correctly.
+5. Wait less than 300 seconds and send a third valid display transfer.
+6. Assert: the panel does not sleep between the second and third updates because the idle timer was restarted by the second accepted transfer.
 4. Send `GET_STATUS` and an ESP-NOW or BLE command afterward.
 5. Assert: the modem remains operational after the display failure.
 
@@ -1371,3 +1398,5 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 | T-0903 | Display updates do not interfere with BLE pairing | MD-0702 |
 | T-0904 | No modem-generated display UI | MD-0703, MD-0605 |
 | T-0905 | OLED write failure emits recoverable error | MD-0704 |
+| T-0906 | Idle timeout switches the OLED panel off | MD-0705 |
+| T-0907 | New display transfer wakes the panel and restarts the idle timer | MD-0705, MD-0703 |


### PR DESCRIPTION
## Summary
- add gateway-owned short-press status pages with a 60s return to the default banner
- keep BUTTON_SHORT as cancel for button-origin BLE pairing while admin pairing still ignores it
- add modem-owned 300s SSD1306 idle sleep/wake behavior without introducing modem-generated UI

## Traceability
- GW-1101b / GW-1101c
- GW-1208
- MD-0703 / MD-0705

## Validation
- cargo build --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

## Notes
- current status-page sequence is Channel then Nodes
- implementation audit found and fixed a reset/idle-timer interaction in the modem OLED power path