### PR TITLE
Add transient modem display command for headless login prompts

### DIFF
--- a/crates/sonde-admin/src/grpc_client.rs
+++ b/crates/sonde-admin/src/grpc_client.rs
@@ -272,6 +272,16 @@ impl AdminClient {
         Ok(resp.into_inner().entries)
     }
 
+    pub async fn show_modem_display_message(
+        &mut self,
+        lines: Vec<String>,
+    ) -> Result<(), tonic::Status> {
+        self.inner
+            .show_modem_display_message(ShowModemDisplayMessageRequest { lines })
+            .await?;
+        Ok(())
+    }
+
     // -- BLE phone pairing --
 
     pub async fn open_ble_pairing(

--- a/crates/sonde-admin/src/main.rs
+++ b/crates/sonde-admin/src/main.rs
@@ -217,6 +217,12 @@ enum ModemAction {
     },
     /// Scan all WiFi channels for AP activity.
     Scan,
+    /// Display 1 to 4 lines of text on the modem for 60 seconds.
+    Display {
+        /// Text lines to render; each argument becomes one display line.
+        #[arg(num_args = 1..=4)]
+        lines: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -673,6 +679,17 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
                             e.channel, e.ap_count, e.strongest_rssi
                         );
                     }
+                }
+            }
+            ModemAction::Display { lines } => {
+                client.show_modem_display_message(lines.clone()).await?;
+                if json {
+                    print_json(&serde_json::json!({
+                        "lines": lines,
+                        "duration_s": 60,
+                    }))?;
+                } else {
+                    println!("Displayed modem message for 60s");
                 }
             }
         },

--- a/crates/sonde-admin/tests/cli.rs
+++ b/crates/sonde-admin/tests/cli.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+use std::process::Command;
+
+#[test]
+fn modem_display_rejects_more_than_four_lines() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args(["modem", "display", "one", "two", "three", "four", "five"])
+        .output()
+        .expect("failed to run sonde-admin");
+
+    assert!(
+        !output.status.success(),
+        "clap should reject more than four display lines"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("five")
+            || stderr.contains("too many")
+            || stderr.contains("unexpected argument"),
+        "stderr should mention the rejected extra argument: {stderr}"
+    );
+}

--- a/crates/sonde-admin/tests/integration.rs
+++ b/crates/sonde-admin/tests/integration.rs
@@ -201,6 +201,17 @@ async fn grpc_revoke_nonexistent_phone() {
     assert!(result.is_err(), "revoking non-existent phone should fail");
 }
 
+/// Test: transient modem display fails cleanly when no modem transport exists.
+#[tokio::test]
+async fn grpc_show_modem_display_message_no_modem() {
+    let mut client = start_server_and_connect("show_modem_display_message_no_modem").await;
+    let result = client
+        .show_modem_display_message(vec!["Device login".to_string()])
+        .await;
+    let status = result.expect_err("missing modem transport should fail");
+    assert_eq!(status.code(), tonic::Code::Unavailable);
+}
+
 // ── State export/import ─────────────────────────────────────────────────────
 
 /// Test: export empty state and import it back.

--- a/crates/sonde-gateway/proto/admin.proto
+++ b/crates/sonde-gateway/proto/admin.proto
@@ -21,6 +21,7 @@ service GatewayAdmin {
     rpc GetModemStatus(Empty) returns (ModemStatus);
     rpc SetModemChannel(SetModemChannelRequest) returns (Empty);
     rpc ScanModemChannels(Empty) returns (ScanModemChannelsResponse);
+    rpc ShowModemDisplayMessage(ShowModemDisplayMessageRequest) returns (Empty);
 
     // BLE phone pairing — Phase 1 (GW-1222).
     // OpenBlePairing is server-streaming: it opens the registration window
@@ -122,6 +123,7 @@ message ChannelSurveyEntry {
     int32 strongest_rssi = 3;
 }
 message ScanModemChannelsResponse { repeated ChannelSurveyEntry entries = 1; }
+message ShowModemDisplayMessageRequest { repeated string lines = 1; }
 
 // BLE phone pairing messages (GW-1222).
 message OpenBlePairingRequest {

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -163,6 +163,22 @@ fn schedule_admin_display_restore(
     });
 }
 
+async fn restore_admin_display_failure(
+    transport: &Arc<UsbEspNowTransport>,
+    display_generation: &Arc<AtomicU64>,
+    generation: u64,
+) {
+    if !try_claim_display_restore(display_generation.as_ref(), generation) {
+        return;
+    }
+    if let Err(e) = send_gateway_version_banner(transport).await {
+        warn!(
+            error = %e,
+            "failed to restore gateway version banner after admin display error"
+        );
+    }
+}
+
 /// Convert a [`HandlerRecord`] into a [`HandlerConfig`].
 ///
 /// Returns `None` for records with invalid `program_hash` values so that
@@ -1275,9 +1291,12 @@ impl GatewayAdmin for AdminService {
         reset_status_page_cycle(status_page_cycle).await;
 
         let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
-        send_display_message(transport, &line_refs)
-            .await
-            .map_err(|e| Status::internal(format!("show modem display message failed: {e}")))?;
+        if let Err(e) = send_display_message(transport, &line_refs).await {
+            restore_admin_display_failure(transport, display_generation, generation).await;
+            return Err(Status::internal(format!(
+                "show modem display message failed: {e}"
+            )));
+        }
 
         schedule_admin_display_restore(
             transport,

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::UNIX_EPOCH;
 
 use tokio::sync::RwLock;
@@ -141,7 +141,7 @@ fn schedule_admin_display_restore(
     status_page_scroll_task: &StatusPageScrollTask,
     generation: u64,
 ) {
-    let transport = Arc::clone(transport);
+    let transport: Weak<UsbEspNowTransport> = Arc::downgrade(transport);
     let controller = Arc::clone(controller);
     let display_generation = Arc::clone(display_generation);
     let status_page_cycle = Arc::clone(status_page_cycle);
@@ -157,6 +157,9 @@ fn schedule_admin_display_restore(
         }
         cancel_status_page_scroll(&status_page_scroll_task).await;
         reset_status_page_cycle(&status_page_cycle).await;
+        let Some(transport) = transport.upgrade() else {
+            return;
+        };
         if let Err(e) = send_gateway_version_banner(&transport).await {
             warn!(error = %e, "failed to restore gateway version banner after admin display");
         }
@@ -1259,7 +1262,7 @@ impl GatewayAdmin for AdminService {
         let controller = self
             .ble_controller
             .as_ref()
-            .ok_or_else(|| Status::unavailable("no modem transport configured"))?;
+            .ok_or_else(|| Status::unavailable("no BLE controller configured"))?;
         let display_generation = self
             .display_generation
             .as_ref()

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 sonde contributors
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
@@ -11,6 +12,11 @@ use tracing::warn;
 use zeroize::Zeroizing;
 
 use crate::ble_pairing::BlePairingController;
+use crate::display_banner::{send_display_message, send_gateway_version_banner};
+use crate::display_control::{
+    cancel_status_page_scroll, claim_display_generation, reset_status_page_cycle,
+    try_claim_display_restore, StatusPageCycle, StatusPageScrollTask, STATUS_PAGE_TIMEOUT,
+};
 use crate::engine::PendingCommand;
 use crate::handler::HandlerConfig;
 use crate::handler::HandlerRouter;
@@ -36,6 +42,9 @@ pub struct AdminService {
     session_manager: Arc<SessionManager>,
     ble_controller: Option<Arc<BlePairingController>>,
     transport: Option<Arc<UsbEspNowTransport>>,
+    display_generation: Option<Arc<AtomicU64>>,
+    status_page_cycle: Option<Arc<tokio::sync::Mutex<StatusPageCycle>>>,
+    status_page_scroll_task: Option<StatusPageScrollTask>,
     handler_configs: RwLock<Vec<HandlerConfig>>,
     /// Shared handler router for live reload (GW-1404, GW-1407).
     handler_router: Option<Arc<tokio::sync::RwLock<HandlerRouter>>>,
@@ -54,6 +63,9 @@ impl AdminService {
             session_manager,
             ble_controller: None,
             transport: None,
+            display_generation: None,
+            status_page_cycle: None,
+            status_page_scroll_task: None,
             handler_configs: RwLock::new(Vec::new()),
             handler_router: None,
         }
@@ -67,6 +79,18 @@ impl AdminService {
     ) -> Self {
         self.ble_controller = Some(controller);
         self.transport = Some(transport);
+        self
+    }
+
+    pub fn with_display_state(
+        mut self,
+        display_generation: Arc<AtomicU64>,
+        status_page_cycle: Arc<tokio::sync::Mutex<StatusPageCycle>>,
+        status_page_scroll_task: StatusPageScrollTask,
+    ) -> Self {
+        self.display_generation = Some(display_generation);
+        self.status_page_cycle = Some(status_page_cycle);
+        self.status_page_scroll_task = Some(status_page_scroll_task);
         self
     }
 
@@ -107,6 +131,36 @@ impl AdminService {
             }
         }
     }
+}
+
+fn schedule_admin_display_restore(
+    transport: &Arc<UsbEspNowTransport>,
+    controller: &Arc<BlePairingController>,
+    display_generation: &Arc<AtomicU64>,
+    status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
+    status_page_scroll_task: &StatusPageScrollTask,
+    generation: u64,
+) {
+    let transport = Arc::clone(transport);
+    let controller = Arc::clone(controller);
+    let display_generation = Arc::clone(display_generation);
+    let status_page_cycle = Arc::clone(status_page_cycle);
+    let status_page_scroll_task = Arc::clone(status_page_scroll_task);
+
+    tokio::spawn(async move {
+        tokio::time::sleep(STATUS_PAGE_TIMEOUT).await;
+        if controller.session_origin().await.is_some() {
+            return;
+        }
+        if !try_claim_display_restore(display_generation.as_ref(), generation) {
+            return;
+        }
+        cancel_status_page_scroll(&status_page_scroll_task).await;
+        reset_status_page_cycle(&status_page_cycle).await;
+        if let Err(e) = send_gateway_version_banner(&transport).await {
+            warn!(error = %e, "failed to restore gateway version banner after admin display");
+        }
+    });
 }
 
 /// Convert a [`HandlerRecord`] into a [`HandlerConfig`].
@@ -1176,6 +1230,65 @@ impl GatewayAdmin for AdminService {
                 })
                 .collect(),
         }))
+    }
+
+    async fn show_modem_display_message(
+        &self,
+        request: Request<ShowModemDisplayMessageRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let transport = self
+            .transport
+            .as_ref()
+            .ok_or_else(|| Status::unavailable("no modem transport configured"))?;
+        let controller = self
+            .ble_controller
+            .as_ref()
+            .ok_or_else(|| Status::unavailable("no modem transport configured"))?;
+        let display_generation = self
+            .display_generation
+            .as_ref()
+            .ok_or_else(|| Status::internal("modem display control not configured"))?;
+        let status_page_cycle = self
+            .status_page_cycle
+            .as_ref()
+            .ok_or_else(|| Status::internal("modem display control not configured"))?;
+        let status_page_scroll_task = self
+            .status_page_scroll_task
+            .as_ref()
+            .ok_or_else(|| Status::internal("modem display control not configured"))?;
+
+        if controller.session_origin().await.is_some() {
+            return Err(Status::failed_precondition(
+                "BLE pairing session owns the modem display",
+            ));
+        }
+
+        let lines = request.into_inner().lines;
+        if lines.is_empty() || lines.len() > 4 {
+            return Err(Status::invalid_argument(
+                "lines must contain between 1 and 4 entries",
+            ));
+        }
+
+        cancel_status_page_scroll(status_page_scroll_task).await;
+        let generation = claim_display_generation(display_generation);
+        reset_status_page_cycle(status_page_cycle).await;
+
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        send_display_message(transport, &line_refs)
+            .await
+            .map_err(|e| Status::internal(format!("show modem display message failed: {e}")))?;
+
+        schedule_admin_display_restore(
+            transport,
+            controller,
+            display_generation,
+            status_page_cycle,
+            status_page_scroll_task,
+            generation,
+        );
+
+        Ok(Response::new(Empty {}))
     }
 
     // -- BLE phone pairing (GW-1222) ----------------------------------------

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -19,6 +19,12 @@ use sonde_gateway::display_banner::{
     render_display_message, render_status_text_page, send_display_message,
     send_gateway_version_banner, ScrollableFramebuffer, STATUS_TEXT_COLUMNS,
 };
+use sonde_gateway::display_control::{
+    cancel_status_page_scroll, invalidate_display_restore, reset_status_page_cycle,
+    try_claim_display_restore, ActiveStatusPageScroll, StatusPageCycle, StatusPageScrollTask,
+    BUTTON_EXIT_REASON_DISPLAY_DURATION, NODE_STATUS_SCROLL_INTERVAL, NODE_STATUS_SCROLL_STEP_PX,
+    STATUS_PAGE_TIMEOUT,
+};
 use sonde_gateway::engine::{resolve_espnow_channel, Gateway, PendingCommand};
 use sonde_gateway::handler::{load_handler_configs, HandlerRouter};
 use sonde_gateway::key_provider::{EnvKeyProvider, FileKeyProvider, KeyProvider, KeyProviderError};
@@ -39,11 +45,6 @@ const DEFAULT_ADMIN_SOCKET: &str = r"\\.\pipe\sonde-admin";
 /// Maximum time to wait for graceful shutdown before force-exiting (GW-1400).
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 const BUTTON_PAIRING_DURATION_S: u32 = 120;
-const BUTTON_EXIT_REASON_DISPLAY_DURATION: Duration = Duration::from_secs(2);
-const STATUS_PAGE_TIMEOUT: Duration = Duration::from_secs(60);
-const NODE_STATUS_SCROLL_INTERVAL: Duration = Duration::from_millis(50);
-const NODE_STATUS_SCROLL_STEP_PX: u32 = 3;
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ButtonDisplayState {
     Generic,
@@ -59,18 +60,6 @@ enum StatusPage {
 impl StatusPage {
     const ALL: [StatusPage; 2] = [StatusPage::Channel, StatusPage::Nodes];
 }
-
-#[derive(Debug, Default)]
-struct StatusPageCycle {
-    next_page_index: usize,
-}
-
-struct ActiveStatusPageScroll {
-    stop_requested: Arc<AtomicBool>,
-    handle: tokio::task::JoinHandle<()>,
-}
-
-type StatusPageScrollTask = Arc<tokio::sync::Mutex<Option<ActiveStatusPageScroll>>>;
 
 enum RenderedStatusPage {
     Static(Box<[u8; DISPLAY_FRAME_BODY_SIZE]>),
@@ -97,25 +86,6 @@ async fn update_display_message(transport: &Arc<UsbEspNowTransport>, lines: &[&s
     if let Err(e) = send_display_message(transport, lines).await {
         warn!(error = %e, ?lines, "failed to update display");
     }
-}
-
-fn invalidate_display_restore(display_generation: &Arc<AtomicU64>) {
-    display_generation.fetch_add(1, Ordering::SeqCst);
-}
-
-fn try_claim_display_restore(display_generation: &AtomicU64, generation: u64) -> bool {
-    display_generation
-        .compare_exchange(
-            generation,
-            generation.saturating_add(1),
-            Ordering::SeqCst,
-            Ordering::SeqCst,
-        )
-        .is_ok()
-}
-
-async fn reset_status_page_cycle(status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>) {
-    status_page_cycle.lock().await.next_page_index = 0;
 }
 
 fn format_epoch_ms(ms: u64) -> String {
@@ -273,14 +243,6 @@ fn schedule_button_pairing_banner_restore(
             warn!(error = %e, "failed to restore gateway version banner");
         }
     });
-}
-
-async fn cancel_status_page_scroll(scroll_task: &StatusPageScrollTask) {
-    let active = scroll_task.lock().await.take();
-    if let Some(active) = active {
-        active.stop_requested.store(true, Ordering::SeqCst);
-        let _ = active.handle.await;
-    }
 }
 
 fn schedule_status_page_banner_restore(
@@ -1070,12 +1032,20 @@ async fn run_gateway(
         // Re-create the admin service and spawn a fresh gRPC server on each
         // reconnect iteration to bind to the new transport reference.
         let ble_controller = Arc::new(sonde_gateway::ble_pairing::BlePairingController::new());
+        let button_display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
+        let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
         let admin_service = AdminService::new(
             storage.clone(),
             pending_commands.clone(),
             session_manager.clone(),
         )
         .with_ble(Arc::clone(&ble_controller), Arc::clone(&transport))
+        .with_display_state(
+            Arc::clone(&button_display_generation),
+            Arc::clone(&status_page_cycle),
+            Arc::clone(&status_page_scroll_task),
+        )
         .with_handler_configs(handler_configs_from_db.clone())
         .with_handler_router(handler_router.clone());
         let admin_socket = cli.admin_socket.clone();
@@ -1119,9 +1089,6 @@ async fn run_gateway(
         // rather than capturing the CLI startup value.
         let ble_channel = channel_for_transport;
         let ble_ctrl = Arc::clone(&ble_controller);
-        let button_display_generation = Arc::new(AtomicU64::new(0));
-        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
-        let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
         let mut ble_loop = tokio::spawn(async move {
             use sonde_gateway::ble_pairing::{handle_ble_recv, PairingOrigin};
             use sonde_gateway::modem::BleEvent;

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1032,7 +1032,7 @@ async fn run_gateway(
         // Re-create the admin service and spawn a fresh gRPC server on each
         // reconnect iteration to bind to the new transport reference.
         let ble_controller = Arc::new(sonde_gateway::ble_pairing::BlePairingController::new());
-        let button_display_generation = Arc::new(AtomicU64::new(0));
+        let display_generation = Arc::new(AtomicU64::new(0));
         let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
         let admin_service = AdminService::new(
@@ -1042,7 +1042,7 @@ async fn run_gateway(
         )
         .with_ble(Arc::clone(&ble_controller), Arc::clone(&transport))
         .with_display_state(
-            Arc::clone(&button_display_generation),
+            Arc::clone(&display_generation),
             Arc::clone(&status_page_cycle),
             Arc::clone(&status_page_scroll_task),
         )
@@ -1122,7 +1122,7 @@ async fn run_gateway(
                     window.open(3600);
                     if controller_origin == Some(PairingOrigin::Admin) {
                         cancel_status_page_scroll(&status_page_scroll_task).await;
-                        invalidate_display_restore(&button_display_generation);
+                        invalidate_display_restore(&display_generation);
                         reset_status_page_cycle(&status_page_cycle).await;
                         if let Err(e) = send_gateway_version_banner(&ble_transport).await {
                             warn!(
@@ -1147,7 +1147,7 @@ async fn run_gateway(
                         handle_button_pairing_timeout(
                             &ble_transport,
                             &ble_ctrl,
-                            &button_display_generation,
+                            &display_generation,
                             &status_page_cycle,
                             &mut button_display_state,
                             &mut window,
@@ -1194,7 +1194,7 @@ async fn run_gateway(
                                 complete_button_pairing_success(
                                     &ble_transport,
                                     &ble_ctrl,
-                                    &button_display_generation,
+                                    &display_generation,
                                     &status_page_cycle,
                                     &mut button_display_state,
                                     &mut window,
@@ -1286,7 +1286,7 @@ async fn run_gateway(
                             if !open_button_pairing_session(
                                 &ble_transport,
                                 &ble_ctrl,
-                                &button_display_generation,
+                                &display_generation,
                                 &status_page_cycle,
                                 &status_page_scroll_task,
                                 &mut button_display_state,
@@ -1309,7 +1309,7 @@ async fn run_gateway(
                                 handle_button_short_event(
                                     &ble_transport,
                                     &ble_ctrl,
-                                    &button_display_generation,
+                                    &display_generation,
                                     &status_page_cycle,
                                     &mut button_display_state,
                                     &mut window,
@@ -1326,7 +1326,7 @@ async fn run_gateway(
                                     &ble_ctrl,
                                     &ble_storage,
                                     ble_channel,
-                                    &button_display_generation,
+                                    &display_generation,
                                     &status_page_cycle,
                                     &status_page_scroll_task,
                                 )

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -20,10 +20,10 @@ use sonde_gateway::display_banner::{
     send_gateway_version_banner, ScrollableFramebuffer, STATUS_TEXT_COLUMNS,
 };
 use sonde_gateway::display_control::{
-    cancel_status_page_scroll, invalidate_display_restore, reset_status_page_cycle,
-    try_claim_display_restore, ActiveStatusPageScroll, StatusPageCycle, StatusPageScrollTask,
-    BUTTON_EXIT_REASON_DISPLAY_DURATION, NODE_STATUS_SCROLL_INTERVAL, NODE_STATUS_SCROLL_STEP_PX,
-    STATUS_PAGE_TIMEOUT,
+    cancel_status_page_scroll, claim_display_generation, invalidate_display_restore,
+    reset_status_page_cycle, try_claim_display_restore, ActiveStatusPageScroll, StatusPageCycle,
+    StatusPageScrollTask, BUTTON_EXIT_REASON_DISPLAY_DURATION, NODE_STATUS_SCROLL_INTERVAL,
+    NODE_STATUS_SCROLL_STEP_PX, STATUS_PAGE_TIMEOUT,
 };
 use sonde_gateway::engine::{resolve_espnow_channel, Gateway, PendingCommand};
 use sonde_gateway::handler::{load_handler_configs, HandlerRouter};
@@ -224,7 +224,7 @@ fn schedule_button_pairing_banner_restore(
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     display_generation: &Arc<AtomicU64>,
 ) {
-    let generation = display_generation.fetch_add(1, Ordering::SeqCst) + 1;
+    let generation = claim_display_generation(display_generation);
     let transport: Weak<UsbEspNowTransport> = Arc::downgrade(transport);
     let controller = Arc::clone(controller);
     let display_generation = Arc::clone(display_generation);
@@ -252,7 +252,7 @@ fn schedule_status_page_banner_restore(
     status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
     scroll_task: &StatusPageScrollTask,
 ) -> u64 {
-    let generation = display_generation.fetch_add(1, Ordering::SeqCst) + 1;
+    let generation = claim_display_generation(display_generation);
     let transport: Weak<UsbEspNowTransport> = Arc::downgrade(transport);
     let controller = Arc::clone(controller);
     let display_generation = Arc::clone(display_generation);

--- a/crates/sonde-gateway/src/display_control.rs
+++ b/crates/sonde-gateway/src/display_control.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Time a terminal button-pairing status screen remains visible before restore.
+pub const BUTTON_EXIT_REASON_DISPLAY_DURATION: Duration = Duration::from_secs(2);
+/// Idle timeout for gateway-owned temporary/status display screens.
+pub const STATUS_PAGE_TIMEOUT: Duration = Duration::from_secs(60);
+/// Scroll cadence for oversized node status pages.
+pub const NODE_STATUS_SCROLL_INTERVAL: Duration = Duration::from_millis(50);
+/// Vertical scroll increment per tick for oversized node status pages.
+pub const NODE_STATUS_SCROLL_STEP_PX: u32 = 3;
+
+#[derive(Debug, Default)]
+pub struct StatusPageCycle {
+    pub next_page_index: usize,
+}
+
+pub struct ActiveStatusPageScroll {
+    pub stop_requested: Arc<AtomicBool>,
+    pub handle: tokio::task::JoinHandle<()>,
+}
+
+pub type StatusPageScrollTask = Arc<tokio::sync::Mutex<Option<ActiveStatusPageScroll>>>;
+
+pub fn claim_display_generation(display_generation: &Arc<AtomicU64>) -> u64 {
+    display_generation.fetch_add(1, Ordering::SeqCst) + 1
+}
+
+pub fn invalidate_display_restore(display_generation: &Arc<AtomicU64>) {
+    let _ = claim_display_generation(display_generation);
+}
+
+pub fn try_claim_display_restore(display_generation: &AtomicU64, generation: u64) -> bool {
+    display_generation
+        .compare_exchange(
+            generation,
+            generation.saturating_add(1),
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        )
+        .is_ok()
+}
+
+pub async fn reset_status_page_cycle(status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>) {
+    status_page_cycle.lock().await.next_page_index = 0;
+}
+
+pub async fn cancel_status_page_scroll(scroll_task: &StatusPageScrollTask) {
+    let active = scroll_task.lock().await.take();
+    if let Some(active) = active {
+        active.stop_requested.store(true, Ordering::SeqCst);
+        let _ = active.handle.await;
+    }
+}

--- a/crates/sonde-gateway/src/display_control.rs
+++ b/crates/sonde-gateway/src/display_control.rs
@@ -27,7 +27,9 @@ pub struct ActiveStatusPageScroll {
 pub type StatusPageScrollTask = Arc<tokio::sync::Mutex<Option<ActiveStatusPageScroll>>>;
 
 pub fn claim_display_generation(display_generation: &Arc<AtomicU64>) -> u64 {
-    display_generation.fetch_add(1, Ordering::SeqCst) + 1
+    display_generation
+        .fetch_add(1, Ordering::SeqCst)
+        .wrapping_add(1)
 }
 
 pub fn invalidate_display_restore(display_generation: &Arc<AtomicU64>) {
@@ -38,7 +40,7 @@ pub fn try_claim_display_restore(display_generation: &AtomicU64, generation: u64
     display_generation
         .compare_exchange(
             generation,
-            generation.saturating_add(1),
+            generation.wrapping_add(1),
             Ordering::SeqCst,
             Ordering::SeqCst,
         )
@@ -54,5 +56,24 @@ pub async fn cancel_status_page_scroll(scroll_task: &StatusPageScrollTask) {
     if let Some(active) = active {
         active.stop_requested.store(true, Ordering::SeqCst);
         let _ = active.handle.await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claim_display_generation_wraps_without_panicking() {
+        let generation = Arc::new(AtomicU64::new(u64::MAX));
+        assert_eq!(claim_display_generation(&generation), 0);
+        assert_eq!(generation.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn try_claim_display_restore_wraps_generation() {
+        let generation = AtomicU64::new(u64::MAX);
+        assert!(try_claim_display_restore(&generation, u64::MAX));
+        assert_eq!(generation.load(Ordering::SeqCst), 0);
     }
 }

--- a/crates/sonde-gateway/src/lib.rs
+++ b/crates/sonde-gateway/src/lib.rs
@@ -6,6 +6,7 @@ pub mod aead;
 pub mod ble_pairing;
 pub mod crypto;
 pub mod display_banner;
+pub mod display_control;
 pub mod engine;
 pub mod gateway_identity;
 pub mod handler;

--- a/crates/sonde-gateway/tests/admin_display.rs
+++ b/crates/sonde-gateway/tests/admin_display.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Admin transient display tests (T-0815f through T-0815j).
+
+mod common;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+use tokio::sync::RwLock;
+use tonic::{Code, Request};
+
+use sonde_gateway::admin::pb::gateway_admin_server::GatewayAdmin;
+use sonde_gateway::admin::pb::*;
+use sonde_gateway::admin::AdminService;
+use sonde_gateway::ble_pairing::PairingOrigin;
+use sonde_gateway::display_banner::{render_display_message, render_gateway_version_banner};
+use sonde_gateway::engine::PendingCommand;
+use sonde_gateway::session::SessionManager;
+use sonde_gateway::storage::InMemoryStorage;
+
+use sonde_protocol::modem::{
+    encode_modem_frame, DisplayFrameAck, FrameDecoder, ModemMessage, DISPLAY_FRAME_BODY_SIZE,
+    DISPLAY_FRAME_CHUNK_COUNT, DISPLAY_FRAME_CHUNK_SIZE,
+};
+
+use common::{build_admin_with_modem, read_modem_msg};
+
+async fn receive_display_transfer(
+    server: &mut DuplexStream,
+    decoder: &mut FrameDecoder,
+    buf: &mut [u8],
+) -> [u8; DISPLAY_FRAME_BODY_SIZE] {
+    let mut framebuffer = [0u8; DISPLAY_FRAME_BODY_SIZE];
+
+    let begin = read_modem_msg(server, decoder, buf).await;
+    let transfer_id = match begin {
+        ModemMessage::DisplayFrameBegin(begin) => begin.transfer_id,
+        other => panic!("expected DisplayFrameBegin, got {other:?}"),
+    };
+    server
+        .write_all(
+            &encode_modem_frame(&ModemMessage::DisplayFrameAck(DisplayFrameAck {
+                transfer_id,
+                next_chunk_index: 0,
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    for expected_chunk_index in 0..DISPLAY_FRAME_CHUNK_COUNT {
+        let msg = read_modem_msg(server, decoder, buf).await;
+        match msg {
+            ModemMessage::DisplayFrameChunk(chunk) => {
+                assert_eq!(chunk.transfer_id, transfer_id);
+                assert_eq!(chunk.chunk_index, expected_chunk_index);
+                let start = usize::from(expected_chunk_index) * DISPLAY_FRAME_CHUNK_SIZE;
+                let end = start + DISPLAY_FRAME_CHUNK_SIZE;
+                framebuffer[start..end].copy_from_slice(&chunk.chunk_data);
+            }
+            other => panic!("expected DisplayFrameChunk, got {other:?}"),
+        }
+        server
+            .write_all(
+                &encode_modem_frame(&ModemMessage::DisplayFrameAck(DisplayFrameAck {
+                    transfer_id,
+                    next_chunk_index: expected_chunk_index + 1,
+                }))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    framebuffer
+}
+
+async fn assert_no_stream_data_while_time_paused(
+    server: &mut DuplexStream,
+    buf: &mut [u8],
+    duration: Duration,
+    message: &str,
+) {
+    let no_data = tokio::time::timeout(duration, server.read(buf));
+    tokio::pin!(no_data);
+    tokio::time::advance(duration).await;
+    assert!(no_data.await.is_err(), "{message}");
+}
+
+#[tokio::test]
+async fn t0815f_transient_modem_display_via_admin_api() {
+    tokio::time::pause();
+
+    let (admin, mut server, _controller, _storage) = build_admin_with_modem(6).await;
+    let admin = Arc::new(admin);
+    let mut decoder = FrameDecoder::new();
+    let mut buf = [0u8; 2048];
+
+    let single_line = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec!["Device login".to_string()],
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(framebuffer, render_display_message(&["Device login"]));
+    single_line.await.unwrap().unwrap();
+
+    let four_line = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec![
+                        "Device login".to_string(),
+                        "Use browser".to_string(),
+                        "Code".to_string(),
+                        "ABCD-EFGH".to_string(),
+                    ],
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(
+        framebuffer,
+        render_display_message(&["Device login", "Use browser", "Code", "ABCD-EFGH"])
+    );
+    four_line.await.unwrap().unwrap();
+
+    tokio::time::advance(Duration::from_secs(60) + Duration::from_millis(100)).await;
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(
+        framebuffer,
+        render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[tokio::test]
+async fn t0815g_new_transient_display_request_replaces_older_one() {
+    let (admin, mut server, _controller, _storage) = build_admin_with_modem(6).await;
+    let admin = Arc::new(admin);
+    let mut decoder = FrameDecoder::new();
+    let mut buf = [0u8; 2048];
+
+    tokio::time::pause();
+
+    let first = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec!["First".to_string()],
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(framebuffer, render_display_message(&["First"]));
+    first.await.unwrap().unwrap();
+
+    tokio::time::advance(Duration::from_secs(30)).await;
+
+    let second = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec!["Second".to_string()],
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(framebuffer, render_display_message(&["Second"]));
+    second.await.unwrap().unwrap();
+
+    assert_no_stream_data_while_time_paused(
+        &mut server,
+        &mut buf,
+        Duration::from_secs(30) + Duration::from_millis(100),
+        "first timer must not restore the banner after replacement",
+    )
+    .await;
+
+    tokio::time::advance(Duration::from_secs(30) + Duration::from_millis(100)).await;
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(
+        framebuffer,
+        render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[tokio::test]
+async fn t0815h_transient_display_rejected_during_ble_pairing() {
+    let (admin, mut server, controller, _storage) = build_admin_with_modem(6).await;
+    assert!(controller.open_window(120, PairingOrigin::Admin).await);
+
+    let err = admin
+        .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+            lines: vec!["Blocked".to_string()],
+        }))
+        .await
+        .expect_err("display request must fail during active BLE pairing");
+    assert_eq!(err.code(), Code::FailedPrecondition);
+
+    let mut buf = [0u8; 256];
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), server.read(&mut buf))
+            .await
+            .is_err(),
+        "rejected display request must not emit modem traffic"
+    );
+}
+
+#[tokio::test]
+async fn t0815i_transient_display_rejects_invalid_line_count() {
+    let (admin, mut server, _controller, _storage) = build_admin_with_modem(6).await;
+
+    let err = admin
+        .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+            lines: vec![],
+        }))
+        .await
+        .expect_err("empty line set must be rejected");
+    assert_eq!(err.code(), Code::InvalidArgument);
+
+    let err = admin
+        .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+            lines: vec![
+                "1".to_string(),
+                "2".to_string(),
+                "3".to_string(),
+                "4".to_string(),
+                "5".to_string(),
+            ],
+        }))
+        .await
+        .expect_err("more than four lines must be rejected");
+    assert_eq!(err.code(), Code::InvalidArgument);
+
+    let mut buf = [0u8; 256];
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), server.read(&mut buf))
+            .await
+            .is_err(),
+        "invalid requests must not emit modem traffic"
+    );
+}
+
+#[tokio::test]
+async fn t0815j_transient_display_without_modem_transport_is_unavailable() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let pending: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
+        Arc::new(RwLock::new(HashMap::new()));
+    let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+    let admin = AdminService::new(storage, pending, session_manager);
+
+    let err = admin
+        .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+            lines: vec!["Unavailable".to_string()],
+        }))
+        .await
+        .expect_err("missing modem transport must produce UNAVAILABLE");
+    assert_eq!(err.code(), Code::Unavailable);
+}

--- a/crates/sonde-gateway/tests/admin_display.rs
+++ b/crates/sonde-gateway/tests/admin_display.rs
@@ -91,6 +91,17 @@ async fn assert_no_stream_data_while_time_paused(
     assert!(no_data.await.is_err(), "{message}");
 }
 
+async fn receive_display_begin_transfer_id(
+    server: &mut DuplexStream,
+    decoder: &mut FrameDecoder,
+    buf: &mut [u8],
+) -> u8 {
+    match read_modem_msg(server, decoder, buf).await {
+        ModemMessage::DisplayFrameBegin(begin) => begin.transfer_id,
+        other => panic!("expected DisplayFrameBegin, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn t0815f_transient_modem_display_via_admin_api() {
     tokio::time::pause();
@@ -271,4 +282,47 @@ async fn t0815j_transient_display_without_modem_transport_is_unavailable() {
         .await
         .expect_err("missing modem transport must produce UNAVAILABLE");
     assert_eq!(err.code(), Code::Unavailable);
+}
+
+#[tokio::test]
+async fn admin_display_failure_restores_gateway_banner() {
+    let (admin, mut server, _controller, _storage) = build_admin_with_modem(6).await;
+    let admin = Arc::new(admin);
+    let mut decoder = FrameDecoder::new();
+    let mut buf = [0u8; 2048];
+
+    let request = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec!["Device login".to_string()],
+                }))
+                .await
+        }
+    });
+
+    let transfer_id = receive_display_begin_transfer_id(&mut server, &mut decoder, &mut buf).await;
+    server
+        .write_all(
+            &encode_modem_frame(&ModemMessage::DisplayFrameAck(DisplayFrameAck {
+                transfer_id: transfer_id.wrapping_add(1),
+                next_chunk_index: 0,
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(
+        framebuffer,
+        render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+    );
+
+    let err = request
+        .await
+        .unwrap()
+        .expect_err("mismatched ACK must fail the admin display request");
+    assert_eq!(err.code(), Code::Internal);
 }

--- a/crates/sonde-gateway/tests/common/mod.rs
+++ b/crates/sonde-gateway/tests/common/mod.rs
@@ -4,9 +4,9 @@
 //! Shared mock-modem helpers for gateway integration tests.
 
 use std::collections::HashMap;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream};
 use tokio::sync::RwLock;
@@ -21,13 +21,43 @@ use sonde_gateway::storage::{InMemoryStorage, Storage};
 
 use sonde_protocol::modem::{encode_modem_frame, FrameDecoder, ModemMessage, ModemReady};
 
+async fn read_with_wall_clock_timeout(
+    stream: &mut DuplexStream,
+    buf: &mut [u8],
+    timeout: Duration,
+) -> usize {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let cancelled_bg = Arc::clone(&cancelled);
+    tokio::task::spawn_blocking(move || {
+        let deadline = std::time::Instant::now() + timeout;
+        while !cancelled_bg.load(Ordering::SeqCst) {
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                let _ = tx.send(());
+                return;
+            }
+            std::thread::sleep((deadline - now).min(Duration::from_millis(10)));
+        }
+    });
+
+    tokio::select! {
+        read = stream.read(buf) => {
+            cancelled.store(true, Ordering::SeqCst);
+            read.expect("read failed")
+        }
+        _ = async {
+            let _ = rx.await;
+        } => panic!("timed out waiting for modem message"),
+    }
+}
+
 /// Read the next decoded modem message from a mock server stream.
 pub async fn read_modem_msg(
     stream: &mut DuplexStream,
     decoder: &mut FrameDecoder,
     buf: &mut [u8],
 ) -> ModemMessage {
-    let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         match decoder.decode() {
             Ok(Some(msg)) => return msg,
@@ -36,19 +66,7 @@ pub async fn read_modem_msg(
         }
         // Use a wall-clock deadline so paused Tokio time does not turn a
         // missing modem frame into a hung test.
-        let n = loop {
-            tokio::select! {
-                read = stream.read(buf) => {
-                    break read.expect("read failed");
-                }
-                _ = tokio::task::yield_now() => {
-                    assert!(
-                        Instant::now() < deadline,
-                        "timed out waiting for modem message"
-                    );
-                }
-            }
-        };
+        let n = read_with_wall_clock_timeout(stream, buf, Duration::from_secs(10)).await;
         assert!(n > 0, "stream closed unexpectedly");
         decoder.push(&buf[..n]);
     }

--- a/crates/sonde-gateway/tests/common/mod.rs
+++ b/crates/sonde-gateway/tests/common/mod.rs
@@ -4,6 +4,7 @@
 //! Shared mock-modem helpers for gateway integration tests.
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -12,6 +13,7 @@ use tokio::sync::RwLock;
 
 use sonde_gateway::admin::AdminService;
 use sonde_gateway::ble_pairing::BlePairingController;
+use sonde_gateway::display_control::{StatusPageCycle, StatusPageScrollTask};
 use sonde_gateway::engine::PendingCommand;
 use sonde_gateway::modem::UsbEspNowTransport;
 use sonde_gateway::session::SessionManager;
@@ -109,9 +111,17 @@ pub async fn build_admin_with_modem(
     let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
     let pending: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
         Arc::new(RwLock::new(HashMap::new()));
+    let display_generation = Arc::new(AtomicU64::new(0));
+    let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
+    let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
 
     let admin = AdminService::new(storage.clone(), pending, session_manager)
-        .with_ble(controller.clone(), transport);
+        .with_ble(controller.clone(), transport)
+        .with_display_state(
+            display_generation,
+            status_page_cycle,
+            status_page_scroll_task,
+        );
 
     (admin, server, controller, storage)
 }

--- a/crates/sonde-gateway/tests/common/mod.rs
+++ b/crates/sonde-gateway/tests/common/mod.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream};
 use tokio::sync::RwLock;
@@ -27,16 +27,28 @@ pub async fn read_modem_msg(
     decoder: &mut FrameDecoder,
     buf: &mut [u8],
 ) -> ModemMessage {
+    let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         match decoder.decode() {
             Ok(Some(msg)) => return msg,
             Ok(None) => {}
             Err(e) => panic!("decode error: {e}"),
         }
-        let n = tokio::time::timeout(Duration::from_secs(10), stream.read(buf))
-            .await
-            .expect("timed out waiting for modem message")
-            .expect("read failed");
+        // Use a wall-clock deadline so paused Tokio time does not turn a
+        // missing modem frame into a hung test.
+        let n = loop {
+            tokio::select! {
+                read = stream.read(buf) => {
+                    break read.expect("read failed");
+                }
+                _ = tokio::task::yield_now() => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "timed out waiting for modem message"
+                    );
+                }
+            }
+        };
         assert!(n > 0, "stream closed unexpectedly");
         decoder.push(&buf[..n]);
     }

--- a/docs/admin-design.md
+++ b/docs/admin-design.md
@@ -135,7 +135,7 @@ sonde-admin
 │   ├── status
 │   ├── set-channel <channel:1-14>
 │   ├── scan
-│   └── display <line> [line...]
+│   └── display <line> [<line> ...]
 ├── pairing
 │   ├── start [--duration-s <seconds>]
 │   ├── stop

--- a/docs/admin-design.md
+++ b/docs/admin-design.md
@@ -134,7 +134,8 @@ sonde-admin
 ├── modem
 │   ├── status
 │   ├── set-channel <channel:1-14>
-│   └── scan
+│   ├── scan
+│   └── display <line> [line...]
 ├── pairing
 │   ├── start [--duration-s <seconds>]
 │   ├── stop
@@ -155,6 +156,7 @@ The CLI validates the following inputs before sending RPCs:
 | `psk-hex` | `hex::decode` + length == 32 bytes | ADMIN-0202 |
 | `program-hash` | `hex::decode` for commands that send a binary hash (`program assign`, `program remove`, `ephemeral`); handler commands pass through `*` or the provided string without local validation (gateway enforces) | ADMIN-0302, ADMIN-0800 |
 | `channel` | clap `value_parser!(u32).range(1..=14)` | ADMIN-0601 |
+| `display` lines | variadic positional argument with clap `num_args = 1..=4`; each argument maps to one display line | ADMIN-0603 |
 | `passphrase` | Non-empty check | ADMIN-0502 |
 
 ---
@@ -214,6 +216,7 @@ interval. Optional fields are omitted when absent.
 | `modem status` | `GetModemStatus` | — | `{channel, tx_count, ...}` | Multi-line status |
 | `modem set-channel` | `SetModemChannel` | — | `{channel}` | "Set modem channel to {ch}" |
 | `modem scan` | `ScanModemChannels` | — | `[{channel, ap_count, strongest_rssi}]` | Table with headers |
+| `modem display` | `ShowModemDisplayMessage` | — | `{lines, duration_s}` | "Displayed modem message for 60s" |
 | `pairing start` | `OpenBlePairing` (stream) | — | N/A (interactive) | Event-by-event text |
 | `pairing stop` | `CloseBlePairing` | Yes | `{status}` | "BLE pairing window closed" |
 | `pairing list-phones` | `ListPhones` | — | `[{phone_id, ...}]` | Table with headers |

--- a/docs/admin-requirements.md
+++ b/docs/admin-requirements.md
@@ -537,6 +537,28 @@ display a tabular summary with channel, AP count, and strongest RSSI.
 
 ---
 
+### ADMIN-0603  modem display
+
+**Priority:** Must
+**Source:** GW-0809
+
+**Description:**
+`sonde-admin modem display <line> [<line> ...]` MUST request a transient modem
+display message using 1 to 4 positional text lines. The command returns as
+soon as the gateway accepts the request; it does not wait for the 60-second
+display interval to complete. The gateway is responsible for restoring the
+normal banner after the timeout.
+
+**Acceptance criteria:**
+
+1. One to four text lines are accepted and sent to the gateway.
+2. Supplying more than four text lines is rejected locally by clap.
+3. Text output reports that the transient display request was accepted for 60 seconds.
+4. JSON output returns the requested lines and `duration_s = 60`.
+5. The command exits after the request is accepted, without waiting for the timeout.
+
+---
+
 ## 9  BLE pairing subcommands
 
 ### ADMIN-0700  pairing start

--- a/docs/admin-validation.md
+++ b/docs/admin-validation.md
@@ -412,6 +412,32 @@ to avoid collisions when tests run in parallel.
 
 ---
 
+### T-0603  Modem display — line-count validation
+
+**Validates:** ADMIN-0603
+**Category:** New automated (CLI process test)
+
+**Procedure:**
+1. Invoke `sonde-admin modem display one two three four five`.
+2. Assert: clap rejects the command locally.
+3. Assert: stderr indicates that too many positional arguments were supplied.
+
+---
+
+### T-0604  Modem display — RPC mapping and output
+
+**Validates:** ADMIN-0603
+**Category:** Structural/manual until a display-capable modem harness is documented
+
+**Procedure:**
+1. Perform structural verification of the CLI path in `main.rs` and `grpc_client.rs`.
+2. Assert: the `modem display` subcommand accepts between 1 and 4 positional line arguments, forwards the provided lines unchanged to the `ShowModemDisplayMessage` RPC wrapper, and does not block for 60 seconds after the RPC succeeds.
+3. Assert: text output reports a 60-second transient display request.
+4. Assert: JSON output contains the requested lines and `duration_s = 60`.
+5. If a modem-equipped manual setup is available, invoke both `sonde-admin modem display "Device login"` and `sonde-admin modem display "Device login" "Use browser" "Code" "ABCD-EFGH"` and verify that the requested text appears on the modem display and the CLI returns immediately in both cases.
+
+---
+
 ## 9  BLE pairing tests
 
 ### T-0700  List phones — empty

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -907,6 +907,7 @@ service GatewayAdmin {
     rpc GetModemStatus(Empty) returns (ModemStatus);
     rpc SetModemChannel(SetModemChannelRequest) returns (Empty);
     rpc ScanModemChannels(Empty) returns (ScanModemChannelsResponse);
+    rpc ShowModemDisplayMessage(ShowModemDisplayMessageRequest) returns (Empty);
 
     // BLE phone pairing
     rpc OpenBlePairing(OpenBlePairingRequest) returns (stream BlePairingEvent);
@@ -940,6 +941,7 @@ The gRPC server runs on a local socket: a **Unix domain socket** on Linux/macOS 
 | Modem status | `GetModemStatus` | Returns modem status: radio channel, TX/RX/fail counters, uptime. |
 | Set modem channel | `SetModemChannel` | Sets the ESP-NOW radio channel (1–14). Persists the new channel in the database (GW-0808). |
 | Scan channels | `ScanModemChannels` | Scans all WiFi channels for AP activity, returns AP counts and RSSI per channel. |
+| Show transient modem display text | `ShowModemDisplayMessage` | Renders 1–4 gateway-supplied text lines on the modem display for 60 s, then restores the normal gateway banner (GW-0809). |
 | Open BLE pairing | `OpenBlePairing` | Opens an admin-initiated phone registration window and sends `BLE_ENABLE` to the modem. Server-streaming RPC returning pairing events (passkey, phone connected/disconnected/registered, window closed). |
 | Close BLE pairing | `CloseBlePairing` | Closes the active BLE pairing session and sends `BLE_DISABLE` to the modem. |
 | Confirm BLE pairing | `ConfirmBlePairing` | Accepts or rejects a Numeric Comparison passkey during an admin-initiated BLE pairing session. |
@@ -978,6 +980,7 @@ sonde-admin status <node-id>
 sonde-admin modem status
 sonde-admin modem set-channel <channel>
 sonde-admin modem scan
+sonde-admin modem display <line> [<line> ...]
 
 sonde-admin pairing start [--duration-s <seconds>]
 sonde-admin pairing stop
@@ -1161,6 +1164,32 @@ Each `BUTTON_SHORT` while no pairing session is active:
 If the selected page is `Nodes`, the gateway first renders the complete page into an off-screen 1-bit framebuffer sized to the rendered text height. For oversized content, the gateway prepends one full display height of blank rows before the first rendered text row, so the initial transfer uses a blank 128×64 window and the text enters from the bottom edge as scrolling begins. If the rendered height exceeds 64 pixels, the gateway starts a 50 ms ticker that advances the visible window downward by 3 pixels per update, producing upward text motion on the OLED. The ticker reuses the same reliable display-transfer path as other display updates. It continues advancing past the last fully populated 128×64 window so the bottom of the rendered content scrolls completely off the top of the display before the next tick restarts from offset 0 at the start of the blank lead-in region. If the operator leaves the `Nodes` page and later returns, the page restarts from offset 0 rather than resuming from the previous offset. If the rendered height is 64 pixels or less, the gateway sends a single static page and does not start the ticker.
 
 If another `BUTTON_SHORT` arrives before the timeout fires, the gateway advances again, increments `display_generation`, and leaves the older timeout task stale. Any existing `Nodes` page scroll ticker observes the generation change or an explicit stop request and exits without sending further updates. When a timeout task fires, it first stops any active `Nodes` page scroll task, then restores the default `Sonde Gateway v<semver>` banner only if its captured generation still matches the current `display_generation` and no BLE pairing session is active; otherwise it does nothing because a newer display update or pairing session has already claimed the screen. Autonomous `Nodes` page scroll updates do not increment `display_generation` and therefore do not extend the 60 s idle timeout.
+
+### 17.4c  Admin-triggered transient display override
+
+The admin API also exposes a gateway-owned transient display override for
+operator prompts such as headless device-login codes. The
+`ShowModemDisplayMessage` RPC accepts 1 to 4 text lines. The gateway validates
+the line count before rendering and rejects the request with
+`FAILED_PRECONDITION` if a BLE pairing session currently owns the display, so
+pairing passkeys and terminal status screens remain visible.
+
+On success, the gateway renders the supplied lines with the same centered
+128×64 text renderer used for the startup banner and button-pairing status
+screens, then sends the resulting framebuffer through the existing reliable
+display-transfer path. The RPC returns after that initial display update
+completes; the caller does not remain connected for the 60-second dwell time.
+
+The transient-display path reuses the same display-ownership machinery as
+button-driven status pages: it cancels any active `Nodes` scroll task, resets
+the status-page cycle to the normal starting position, increments
+`display_generation`, and spawns a 60-second restore task tied to the captured
+generation. When that task fires, it restores the default
+`Sonde Gateway v<semver>` banner only if its generation is still current and no
+BLE pairing session owns the display. A newer transient-display request, a
+button-driven status-page update, or a pairing display transition invalidates
+the older generation, causing the stale restore task to exit without
+overwriting the newer screen.
 
 ### 17.5  `PEER_REQUEST` processing
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -957,6 +957,36 @@ The gateway MUST persist the current ESP-NOW radio channel in the database so th
 
 ---
 
+### GW-0809  Admin API — transient modem display message
+
+**Priority:** Must  
+**Source:** Issue #771
+
+**Description:**  
+The admin API MUST support a gateway-owned transient display override for the
+modem-attached OLED. The operation accepts 1 to 4 text lines, renders them
+using the gateway's existing centered text renderer, displays the result for 60
+seconds, then restores the normal `Sonde Gateway v<semver>` banner.
+
+The RPC MUST return after the initial display update succeeds; it MUST NOT wait
+for the 60-second timeout to expire. A later successful transient-display
+request replaces any earlier one and restarts the 60-second timer.
+
+To avoid obscuring pairing prompts, the operation MUST fail with
+`FAILED_PRECONDITION` while a BLE pairing session owns the display. If no modem
+transport is configured, it MUST fail with `UNAVAILABLE`.
+
+**Acceptance criteria:**
+
+1. `ShowModemDisplayMessage` with 1 to 4 lines updates the modem display and returns before the 60-second timeout expires.
+2. `ShowModemDisplayMessage` with fewer than 1 line or more than 4 lines returns `INVALID_ARGUMENT`.
+3. If no newer display owner claims the screen, the normal `Sonde Gateway v<semver>` banner is restored after 60 seconds.
+4. A second successful `ShowModemDisplayMessage` received before the first timeout expires replaces the earlier text and restarts the 60-second timeout window.
+5. While a BLE pairing session owns the display, `ShowModemDisplayMessage` returns `FAILED_PRECONDITION`.
+6. Without a configured modem transport, `ShowModemDisplayMessage` returns `UNAVAILABLE`.
+
+---
+
 ## 10  Operational requirements
 
 ### GW-1000  Gateway failover / replaceability

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1481,6 +1481,75 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-0815f  Transient modem display via admin API
+
+**Validates:** GW-0809
+
+**Procedure:**
+1. Start the gateway with a mock or real modem transport that captures display frames.
+2. Call `ShowModemDisplayMessage` with a single-line message.
+3. Assert: the RPC returns successfully before the 60-second timeout expires.
+4. Assert: the modem transport receives a display update corresponding to the requested text.
+5. Call `ShowModemDisplayMessage` with four lines.
+6. Assert: the RPC returns successfully before the 60-second timeout expires.
+7. Assert: the modem transport receives a display update corresponding to all four requested lines.
+8. Wait for the 60-second restore timeout associated with the four-line request (or advance paused test time).
+9. Assert: the modem transport receives the normal `Sonde Gateway v<semver>` banner after the timeout.
+
+---
+
+### T-0815g  New transient display request replaces older one
+
+**Validates:** GW-0809
+
+**Procedure:**
+1. Start the gateway with a mock or real modem transport that captures display frames.
+2. Call `ShowModemDisplayMessage` with an initial message.
+3. Before 60 seconds elapse, call `ShowModemDisplayMessage` again with a different message.
+4. Assert: the second message is rendered to the modem display.
+5. Wait until 60 seconds have elapsed from the first request but not from the second.
+6. Assert: the gateway does not restore the default banner yet.
+7. Wait until 60 seconds have elapsed from the second request.
+8. Assert: the gateway restores the default banner exactly once after the second timeout window.
+
+---
+
+### T-0815h  Transient display rejected during BLE pairing
+
+**Validates:** GW-0809
+
+**Procedure:**
+1. Start the gateway with a modem transport and an active BLE pairing session.
+2. Call `ShowModemDisplayMessage`.
+3. Assert: the RPC returns `FAILED_PRECONDITION`.
+4. Assert: no transient admin display update is sent to the modem.
+
+---
+
+### T-0815i  Transient display rejects invalid line count
+
+**Validates:** GW-0809
+
+**Procedure:**
+1. Start the gateway with a modem transport.
+2. Call `ShowModemDisplayMessage` with zero lines.
+3. Assert: the RPC returns `INVALID_ARGUMENT`.
+4. Call `ShowModemDisplayMessage` with five lines.
+5. Assert: the RPC returns `INVALID_ARGUMENT`.
+
+---
+
+### T-0815j  Transient display without modem transport
+
+**Validates:** GW-0809
+
+**Procedure:**
+1. Start the gateway without a modem transport.
+2. Call `ShowModemDisplayMessage`.
+3. Assert: the RPC returns `UNAVAILABLE`.
+
+---
+
 ### T-0816  Admin CLI JSON output
 
 **Validates:** GW-0806


### PR DESCRIPTION
## Summary
- add a gateway admin RPC for showing a transient 1-4 line modem display message for 60 seconds
- add `sonde-admin modem display <line> [<line> ...]` for headless operator prompts such as Azure device-login codes
- share gateway display control state so admin-triggered messages coordinate with the existing button/status-page flows and restore the normal banner afterward

## Spec changes
- add `GW-0809` for the transient modem display override
- add `ADMIN-0603` for the new admin CLI command and RPC mapping

## Validation
- `cargo fmt --all --check`
- `cargo test -p sonde-admin`
- `cargo test -p sonde-gateway --test admin_display`

Prerequisite for #771