### PR TITLE
Add provisioned node board layouts

### DIFF
--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -405,6 +405,7 @@ pub struct MockNodeStorage {
     channel: Option<u8>,
     peer_payload: Option<Vec<u8>>,
     reg_complete: bool,
+    last_battery_mv: Option<u32>,
 }
 
 impl MockNodeStorage {
@@ -418,6 +419,7 @@ impl MockNodeStorage {
             channel: None,
             peer_payload: None,
             reg_complete: false,
+            last_battery_mv: None,
         }
     }
 
@@ -433,6 +435,7 @@ impl MockNodeStorage {
             channel: None,
             peer_payload: None,
             reg_complete: false,
+            last_battery_mv: None,
         }
     }
 
@@ -453,6 +456,7 @@ impl MockNodeStorage {
             channel: Some(channel),
             peer_payload: Some(peer_payload),
             reg_complete: false,
+            last_battery_mv: None,
         }
     }
 }
@@ -550,6 +554,15 @@ impl PlatformStorage for MockNodeStorage {
     }
     fn write_reg_complete(&mut self, complete: bool) -> NodeResult<()> {
         self.reg_complete = complete;
+        Ok(())
+    }
+
+    fn read_last_battery_mv(&self) -> Option<u32> {
+        self.last_battery_mv
+    }
+
+    fn write_last_battery_mv(&mut self, battery_mv: u32) -> NodeResult<()> {
+        self.last_battery_mv = Some(battery_mv);
         Ok(())
     }
 }

--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -25,7 +25,7 @@ use sonde_node::async_queue::AsyncQueue;
 use sonde_node::bpf_helpers::SondeContext;
 use sonde_node::bpf_runtime::{BpfError, BpfInterpreter, HelperFn};
 use sonde_node::error::NodeResult;
-use sonde_node::hal::{BatteryReader, Hal};
+use sonde_node::hal::Hal;
 use sonde_node::map_storage::MapStorage;
 use sonde_node::traits::{Clock, PlatformStorage, Rng, Transport as NodeTransport};
 use sonde_node::wake_cycle::WakeCycleOutcome;
@@ -233,7 +233,6 @@ impl NodeProxy {
 
         let mut hal = MockHal;
         let clock = MockClock::new();
-        let battery = MockBattery;
         let sha = TestSha256;
         let aead = NodeAead;
 
@@ -249,7 +248,7 @@ impl NodeProxy {
             &mut hal,
             &mut self.rng,
             &clock,
-            &battery,
+            &sonde_protocol::BoardLayout::LEGACY_COMPAT,
             interpreter,
             &mut self.map_storage,
             &sha,
@@ -578,14 +577,6 @@ impl Hal for MockHal {
     }
     fn adc_read(&mut self, _ch: u32) -> i32 {
         0
-    }
-}
-
-struct MockBattery;
-
-impl BatteryReader for MockBattery {
-    fn battery_mv(&self) -> u32 {
-        3300
     }
 }
 

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -103,8 +103,8 @@ async fn t_e2e_001_nop_wake_cycle() {
 /// T-E2E-002b — Consecutive AEAD wake cycles (state persistence).
 ///
 /// Runs two AEAD wake cycles on the same `NodeProxy` to verify that
-/// persistent storage and monotonic RNG state work correctly across
-/// multiple AES-256-GCM exchanges.
+/// persistent storage, battery telemetry propagation, and monotonic RNG
+/// state work correctly across multiple AES-256-GCM exchanges.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_002b_consecutive_wake_cycles() {
     let env = E2eTestEnv::new();
@@ -116,10 +116,14 @@ async fn t_e2e_002b_consecutive_wake_cycles() {
     let stats1 = node.run_wake_cycle(&env);
     assert_eq!(stats1.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(stats1.response_count > 0);
+    let record_after_first = env.storage.get_node("aead-multi").await.unwrap().unwrap();
+    assert_eq!(record_after_first.last_battery_mv, Some(0));
 
     let stats2 = node.run_wake_cycle(&env);
     assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(stats2.response_count > 0);
+    let record_after_second = env.storage.get_node("aead-multi").await.unwrap().unwrap();
+    assert_eq!(record_after_second.last_battery_mv, Some(3300));
 
     // Verify nonce uniqueness across cycles.
     assert!(

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -92,7 +92,7 @@ async fn t_e2e_001_nop_wake_cycle() {
 
     // Verify gateway updated node telemetry.
     let record = env.storage.get_node("aead-nop").await.unwrap().unwrap();
-    assert_eq!(record.last_battery_mv, Some(3300));
+    assert_eq!(record.last_battery_mv, Some(0));
     assert!(record.last_seen.is_some());
     assert_eq!(
         record.firmware_abi_version,
@@ -704,7 +704,7 @@ async fn t_e2e_002_aead_authentication_round_trip() {
         "gateway must respond to valid AEAD frame"
     );
     let rec = env.storage.get_node("aead-002").await.unwrap().unwrap();
-    assert_eq!(rec.last_battery_mv, Some(3300));
+    assert_eq!(rec.last_battery_mv, Some(0));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -188,7 +188,7 @@ async fn t_e2e_062_node_ble_provisioning() {
         psk: node_psk,
         rf_channel,
         encrypted_payload: encrypted_payload.clone(),
-        pin_config: None,
+        board_layout: sonde_node::ble_pairing::ProvisionedBoardLayout::Absent,
     };
     let mut node = NodeProxy::new_unpaired();
     let status = handle_node_provision(
@@ -614,7 +614,7 @@ async fn t_e2e_068_factory_reset_reprovision() {
         psk: new_node_psk,
         rf_channel,
         encrypted_payload: new_encrypted_payload,
-        pin_config: None,
+        board_layout: sonde_node::ble_pairing::ProvisionedBoardLayout::Absent,
     };
     let status = handle_node_provision(
         &provision,

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -23,9 +23,10 @@ fn main() {
     use esp_idf_svc::nvs::EspDefaultNvsPartition;
     use log::{info, warn};
 
+    use sonde_node::board_layout::stage_runtime_board_layout;
     use sonde_node::crypto::{EspRng, SoftwareSha256};
     use sonde_node::esp_ble_pairing::run_ble_pairing_mode;
-    use sonde_node::esp_hal::{EspBatteryReader, EspClock, EspHal};
+    use sonde_node::esp_hal::{EspClock, EspHal};
     use sonde_node::esp_sleep::EspSleepController;
     use sonde_node::esp_storage::NvsStorage;
     use sonde_node::esp_transport::EspNowTransport;
@@ -187,10 +188,11 @@ fn main() {
     let aead = sonde_node::node_aead::NodeAead;
     let mut rng = EspRng;
     let clock = EspClock;
-    // Read I2C pin config from NVS (ND-0608), falling back to defaults.
-    let (i2c0_sda, i2c0_scl) = storage.read_i2c0_pins();
-    let mut hal = EspHal::new(i2c0_sda, i2c0_scl);
-    let battery = EspBatteryReader;
+    let board_layout = storage
+        .read_board_layout()
+        .unwrap_or(sonde_protocol::BoardLayout::LEGACY_COMPAT);
+    stage_runtime_board_layout(&board_layout);
+    let mut hal = EspHal::new(board_layout);
 
     // Read the stored WiFi channel (falls back to channel 1 if not yet set).
     let channel = storage.read_channel().unwrap_or(1);
@@ -211,7 +213,7 @@ fn main() {
         &mut hal,
         &mut rng,
         &clock,
-        &battery,
+        &board_layout,
         &mut interpreter,
         &mut map_storage,
         &sha,

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -16,6 +16,7 @@
 use crate::key_store::KeyStore;
 use crate::map_storage::MapStorage;
 use crate::traits::PlatformStorage;
+use sonde_protocol::{decode_board_layout_cbor, BoardLayout};
 
 // ---------------------------------------------------------------------------
 // BLE message envelope constants (ble-pairing-protocol.md §4)
@@ -92,18 +93,14 @@ pub struct NodeProvision {
     pub rf_channel: u8,
     /// Opaque encrypted payload for the gateway (ble-pairing-protocol.md §6.4).
     pub encrypted_payload: Vec<u8>,
-    /// Optional I2C pin configuration (ND-0608).
-    /// `None` if the pairing tool did not include pin config (backward compatible).
-    pub pin_config: Option<PinConfig>,
+    /// Provisioned board layout, when the pairing tool included one.
+    pub board_layout: ProvisionedBoardLayout,
 }
 
-/// Board-specific I2C pin assignments (ND-0608).
 #[derive(Debug, Clone, PartialEq)]
-pub struct PinConfig {
-    /// I2C0 SDA GPIO number.
-    pub i2c0_sda: u8,
-    /// I2C0 SCL GPIO number.
-    pub i2c0_scl: u8,
+pub enum ProvisionedBoardLayout {
+    Absent,
+    Provided(BoardLayout),
 }
 
 // Re-export BLE envelope codec from sonde-protocol (shared with gateway).
@@ -134,14 +131,13 @@ pub fn parse_node_provision(body: &[u8]) -> Result<NodeProvision, &'static str> 
     }
     let encrypted_payload = body[37..37 + payload_len].to_vec();
 
-    // Parse optional trailing pin config CBOR (ND-0608).
-    // Best-effort: if trailing bytes exist but fail to decode as valid
-    // CBOR pin config, treat as "no pin config" so provisioning still
-    // succeeds (ND-0608 AC#6 backward compatibility).
-    let pin_config = if body.len() > expected_len {
-        parse_pin_config_cbor(&body[expected_len..]).ok()
+    let board_layout = if body.len() > expected_len {
+        ProvisionedBoardLayout::Provided(
+            decode_board_layout_cbor(&body[expected_len..])
+                .map_err(|_| "board_layout CBOR decode failed")?,
+        )
     } else {
-        None
+        ProvisionedBoardLayout::Absent
     };
 
     Ok(NodeProvision {
@@ -149,82 +145,7 @@ pub fn parse_node_provision(body: &[u8]) -> Result<NodeProvision, &'static str> 
         psk,
         rf_channel,
         encrypted_payload,
-        pin_config,
-    })
-}
-
-/// Parse a CBOR map of pin assignments from trailing NODE_PROVISION bytes (ND-0608).
-///
-/// CBOR integer keys: 1 = i2c0_sda, 2 = i2c0_scl. Unknown keys are ignored for
-/// forward compatibility (values of unknown keys are not validated). Returns
-/// `Err` if the CBOR is malformed, a known key has a non-integer value,
-/// trailing bytes remain after the map, SDA == SCL, or a pin exceeds the
-/// ESP32-C3 GPIO range (0–21); missing keys are allowed and fall back
-/// to defaults (`i2c0_sda = 0`, `i2c0_scl = 1`).
-fn parse_pin_config_cbor(data: &[u8]) -> Result<PinConfig, &'static str> {
-    // Decode from a mutable slice reference so ciborium advances it past
-    // the consumed bytes — lets us detect trailing data (ND-0608).
-    let mut remaining = data;
-    let value: ciborium::Value =
-        ciborium::from_reader(&mut remaining).map_err(|_| "pin_config CBOR decode failed")?;
-    if !remaining.is_empty() {
-        return Err("pin_config: trailing bytes after CBOR map");
-    }
-
-    let map = value.as_map().ok_or("pin_config: expected CBOR map")?;
-
-    let mut sda: Option<u8> = None;
-    let mut scl: Option<u8> = None;
-
-    for (k, v) in map {
-        // Parse keys as i128 so future keys >255 are silently ignored
-        // instead of erroring out (forward compatibility).
-        let key = k
-            .as_integer()
-            .map(i128::from)
-            .ok_or("pin_config: non-integer key")?;
-        match key {
-            1 => {
-                let val = v
-                    .as_integer()
-                    .and_then(|i| u8::try_from(i).ok())
-                    .ok_or("pin_config: non-integer value for key 1")?;
-                sda = Some(val);
-            }
-            2 => {
-                let val = v
-                    .as_integer()
-                    .and_then(|i| u8::try_from(i).ok())
-                    .ok_or("pin_config: non-integer value for key 2")?;
-                scl = Some(val);
-            }
-            _ => {
-                // Ignore unknown keys for forward compatibility without
-                // validating their value type.
-            }
-        }
-    }
-
-    // Apply defaults for missing keys (backward-compatible with older
-    // provisioners that omit the pin config entirely).
-    let sda = sda.unwrap_or(0);
-    let scl = scl.unwrap_or(1);
-
-    // Semantic validation: SDA and SCL must be distinct and within the
-    // ESP32-C3 GPIO range (0–21). Returning Err causes parse_node_provision
-    // to treat pin_config as absent rather than persisting an invalid,
-    // non-recoverable config (factory reset does not erase pin config).
-    const MAX_GPIO: u8 = 21;
-    if sda == scl {
-        return Err("pin_config: SDA and SCL must be different pins");
-    }
-    if sda > MAX_GPIO || scl > MAX_GPIO {
-        return Err("pin_config: GPIO number out of range (0-21)");
-    }
-
-    Ok(PinConfig {
-        i2c0_sda: sda,
-        i2c0_scl: scl,
+        board_layout,
     })
 }
 
@@ -320,17 +241,28 @@ pub fn handle_node_provision<S: PlatformStorage>(
         return NODE_ACK_STORAGE_ERROR;
     }
 
-    // Persist optional pin config (ND-0608) on a best-effort basis.
-    // Pin config is non-fatal: if the pairing tool provided a pin config
-    // but we fail to persist it, log a warning and continue with
-    // NODE_ACK_SUCCESS. The node is effectively provisioned (PSK + peer
-    // payload + channel persisted) and pin config falls back to defaults.
-    if let Some(ref pins) = provision.pin_config {
-        if storage
-            .write_i2c0_pins(pins.i2c0_sda, pins.i2c0_scl)
-            .is_err()
-        {
-            log::warn!("failed to persist I2C pin config during provisioning");
+    match &provision.board_layout {
+        ProvisionedBoardLayout::Provided(layout) => {
+            let previous_layout = storage.read_board_layout();
+            if storage.write_board_layout(layout).is_err() {
+                if let Some(previous_layout) = previous_layout {
+                    let _ = storage.write_board_layout(&previous_layout);
+                }
+                let _ = storage.erase_key();
+                let _ = storage.erase_peer_payload();
+                return NODE_ACK_STORAGE_ERROR;
+            }
+        }
+        ProvisionedBoardLayout::Absent => {
+            if storage.read_board_layout().is_none()
+                && storage
+                    .write_board_layout(&BoardLayout::LEGACY_COMPAT)
+                    .is_err()
+            {
+                let _ = storage.erase_key();
+                let _ = storage.erase_peer_payload();
+                return NODE_ACK_STORAGE_ERROR;
+            }
         }
     }
 
@@ -484,12 +416,12 @@ mod tests {
         channel: Option<u8>,
         peer_payload: Option<Vec<u8>>,
         reg_complete: bool,
-        i2c0_pins: Option<(u8, u8)>,
+        board_layout: Option<BoardLayout>,
         fail_write_key: bool,
         fail_write_channel: bool,
         fail_write_peer_payload: bool,
         fail_write_reg_complete: bool,
-        fail_write_i2c0_pins: bool,
+        fail_write_board_layout: bool,
     }
 
     impl MockStorage {
@@ -499,12 +431,12 @@ mod tests {
                 channel: None,
                 peer_payload: None,
                 reg_complete: false,
-                i2c0_pins: None,
+                board_layout: None,
                 fail_write_key: false,
                 fail_write_channel: false,
                 fail_write_peer_payload: false,
                 fail_write_reg_complete: false,
-                fail_write_i2c0_pins: false,
+                fail_write_board_layout: false,
             }
         }
 
@@ -598,14 +530,16 @@ mod tests {
             self.reg_complete = complete;
             Ok(())
         }
-        fn read_i2c0_pins(&self) -> (u8, u8) {
-            self.i2c0_pins.unwrap_or((0, 1))
+        fn read_board_layout(&self) -> Option<BoardLayout> {
+            self.board_layout
         }
-        fn write_i2c0_pins(&mut self, sda: u8, scl: u8) -> NodeResult<()> {
-            if self.fail_write_i2c0_pins {
-                return Err(NodeError::StorageError("injected write_i2c0_pins failure"));
+        fn write_board_layout(&mut self, layout: &BoardLayout) -> NodeResult<()> {
+            if self.fail_write_board_layout {
+                return Err(NodeError::StorageError(
+                    "injected write_board_layout failure",
+                ));
             }
-            self.i2c0_pins = Some((sda, scl));
+            self.board_layout = Some(*layout);
             Ok(())
         }
     }
@@ -618,7 +552,7 @@ mod tests {
             psk,
             rf_channel: channel,
             encrypted_payload: payload.to_vec(),
-            pin_config: None,
+            board_layout: ProvisionedBoardLayout::Absent,
         }
     }
 
@@ -743,198 +677,58 @@ mod tests {
     }
 
     #[test]
-    fn parse_node_provision_trailing_bytes_accepted_as_pin_config() {
-        // Valid 37-byte header + 0-byte payload + CBOR pin config
-        // CBOR: {1: 4, 2: 5} = A2 01 04 02 05
-        let pin_cbor = [0xA2, 0x01, 0x04, 0x02, 0x05];
-        let mut body = vec![0u8; 37 + pin_cbor.len()];
+    fn parse_node_provision_trailing_bytes_decode_board_layout() {
+        let board_layout_cbor =
+            sonde_protocol::encode_board_layout_cbor(&BoardLayout::SONDE_SENSOR_NODE_REV_A)
+                .unwrap();
+        let mut body = vec![0u8; 37 + board_layout_cbor.len()];
         body[2..34].fill(0x42); // psk
         body[34] = 1; // channel 1
         body[35] = 0x00;
         body[36] = 0x00; // payload_len = 0
-        body[37..].copy_from_slice(&pin_cbor);
+        body[37..].copy_from_slice(&board_layout_cbor);
         let provision = parse_node_provision(&body).unwrap();
-        let pins = provision.pin_config.expect("pin_config should be present");
-        assert_eq!(pins.i2c0_sda, 4);
-        assert_eq!(pins.i2c0_scl, 5);
+        assert_eq!(
+            provision.board_layout,
+            ProvisionedBoardLayout::Provided(BoardLayout::SONDE_SENSOR_NODE_REV_A)
+        );
     }
 
     #[test]
-    fn parse_node_provision_trailing_non_cbor_treated_as_no_pin_config() {
-        // Trailing bytes that aren't valid CBOR — best-effort parsing
-        // treats this as "no pin config" (ND-0608 AC#6 backward compat).
+    fn parse_node_provision_trailing_non_cbor_rejected() {
         let mut body = vec![0u8; 38];
         body[2..34].fill(0x42); // psk
         body[34] = 1; // channel 1
         body[35] = 0x00;
         body[36] = 0x00; // payload_len = 0
         body[37] = 0xFF; // invalid CBOR
+        assert!(parse_node_provision(&body).is_err());
+    }
+
+    #[test]
+    fn parse_node_provision_missing_board_layout_bytes_is_absent() {
+        let mut body = vec![0u8; 37];
+        body[2..34].fill(0x42);
+        body[34] = 1;
+        body[35] = 0x00;
+        body[36] = 0x00;
         let provision = parse_node_provision(&body).unwrap();
-        assert!(
-            provision.pin_config.is_none(),
-            "invalid trailing CBOR should be treated as no pin config"
-        );
+        assert_eq!(provision.board_layout, ProvisionedBoardLayout::Absent);
     }
 
     #[test]
-    fn parse_pin_config_cbor_trailing_bytes_rejected() {
-        // Valid CBOR map followed by extra bytes — now rejected because
-        // parse_pin_config_cbor enforces full consumption (ND-0608 wire
-        // format: trailing bytes are exactly the CBOR map, no junk).
-        // CBOR: {1: 4, 2: 5} = A2 01 04 02 05, then 0x00 trailing
-        let data = [0xA2, 0x01, 0x04, 0x02, 0x05, 0x00];
-        let result = parse_pin_config_cbor(&data);
-        assert!(
-            result.is_err(),
-            "trailing bytes after CBOR map should be rejected"
-        );
-    }
-
-    #[test]
-    fn parse_node_provision_cbor_trailing_junk_treated_as_no_pin_config() {
-        // Valid CBOR map + trailing junk at provision level — best-effort
-        // catches the error from parse_pin_config_cbor and sets pin_config=None.
-        // CBOR: {1: 4, 2: 5} = A2 01 04 02 05, then 0x00 trailing
-        let data = [0xA2, 0x01, 0x04, 0x02, 0x05, 0x00];
+    fn parse_node_provision_board_layout_with_trailing_junk_rejected() {
+        let mut data =
+            sonde_protocol::encode_board_layout_cbor(&BoardLayout::SONDE_SENSOR_NODE_REV_A)
+                .unwrap();
+        data.push(0x00);
         let mut body = vec![0u8; 37 + data.len()];
         body[2..34].fill(0x42); // psk
         body[34] = 1; // channel 1
         body[35] = 0x00;
         body[36] = 0x00; // payload_len = 0
         body[37..].copy_from_slice(&data);
-        let provision = parse_node_provision(&body).unwrap();
-        assert!(
-            provision.pin_config.is_none(),
-            "CBOR trailing junk should be treated as no pin config"
-        );
-    }
-
-    #[test]
-    fn parse_pin_config_cbor_unknown_key_non_integer_value_ignored() {
-        // Unknown key 99 with a text string value — should be ignored
-        // without failing, even though the value isn't an integer.
-        // CBOR: {1: 4, 2: 5, 99: "x"} — forward compatibility.
-        let mut buf = Vec::new();
-        ciborium::into_writer(
-            &ciborium::Value::Map(vec![
-                (
-                    ciborium::Value::Integer(1.into()),
-                    ciborium::Value::Integer(4.into()),
-                ),
-                (
-                    ciborium::Value::Integer(2.into()),
-                    ciborium::Value::Integer(5.into()),
-                ),
-                (
-                    ciborium::Value::Integer(99.into()),
-                    ciborium::Value::Text("x".into()),
-                ),
-            ]),
-            &mut buf,
-        )
-        .unwrap();
-        let result = parse_pin_config_cbor(&buf).unwrap();
-        assert_eq!(result.i2c0_sda, 4);
-        assert_eq!(result.i2c0_scl, 5);
-    }
-
-    #[test]
-    fn parse_pin_config_cbor_key_above_255_ignored() {
-        // Key 256 exceeds u8 range — should be silently ignored (forward
-        // compat), not cause a parse error.
-        let mut buf = Vec::new();
-        ciborium::into_writer(
-            &ciborium::Value::Map(vec![
-                (
-                    ciborium::Value::Integer(1.into()),
-                    ciborium::Value::Integer(4.into()),
-                ),
-                (
-                    ciborium::Value::Integer(2.into()),
-                    ciborium::Value::Integer(5.into()),
-                ),
-                (
-                    ciborium::Value::Integer(256.into()),
-                    ciborium::Value::Integer(42.into()),
-                ),
-            ]),
-            &mut buf,
-        )
-        .unwrap();
-        let result = parse_pin_config_cbor(&buf).unwrap();
-        assert_eq!(result.i2c0_sda, 4);
-        assert_eq!(result.i2c0_scl, 5);
-    }
-
-    #[test]
-    fn parse_pin_config_cbor_sda_equals_scl_rejected() {
-        // SDA == SCL is invalid — would disable I2C. Should return Err so
-        // parse_node_provision treats it as absent (backward-compatible).
-        // CBOR: {1: 4, 2: 4}
-        let mut buf = Vec::new();
-        ciborium::into_writer(
-            &ciborium::Value::Map(vec![
-                (
-                    ciborium::Value::Integer(1.into()),
-                    ciborium::Value::Integer(4.into()),
-                ),
-                (
-                    ciborium::Value::Integer(2.into()),
-                    ciborium::Value::Integer(4.into()),
-                ),
-            ]),
-            &mut buf,
-        )
-        .unwrap();
-        let err = parse_pin_config_cbor(&buf).unwrap_err();
-        assert_eq!(err, "pin_config: SDA and SCL must be different pins");
-    }
-
-    #[test]
-    fn parse_pin_config_cbor_gpio_out_of_range_rejected() {
-        // GPIO 22 is out of range for ESP32-C3 (0–21). Should return Err.
-        // CBOR: {1: 4, 2: 22}
-        let mut buf = Vec::new();
-        ciborium::into_writer(
-            &ciborium::Value::Map(vec![
-                (
-                    ciborium::Value::Integer(1.into()),
-                    ciborium::Value::Integer(4.into()),
-                ),
-                (
-                    ciborium::Value::Integer(2.into()),
-                    ciborium::Value::Integer(22.into()),
-                ),
-            ]),
-            &mut buf,
-        )
-        .unwrap();
-        let err = parse_pin_config_cbor(&buf).unwrap_err();
-        assert_eq!(err, "pin_config: GPIO number out of range (0-21)");
-    }
-
-    #[test]
-    fn parse_pin_config_cbor_boundary_gpio_21_accepted() {
-        // GPIO 21 is the maximum valid pin for ESP32-C3 — should succeed.
-        // CBOR: {1: 20, 2: 21}
-        let mut buf = Vec::new();
-        ciborium::into_writer(
-            &ciborium::Value::Map(vec![
-                (
-                    ciborium::Value::Integer(1.into()),
-                    ciborium::Value::Integer(20.into()),
-                ),
-                (
-                    ciborium::Value::Integer(2.into()),
-                    ciborium::Value::Integer(21.into()),
-                ),
-            ]),
-            &mut buf,
-        )
-        .unwrap();
-        let result = parse_pin_config_cbor(&buf).unwrap();
-        assert_eq!(result.i2c0_sda, 20);
-        assert_eq!(result.i2c0_scl, 21);
+        assert!(parse_node_provision(&body).is_err());
     }
 
     #[test]
@@ -1198,11 +992,11 @@ mod tests {
         assert!(storage.read_peer_payload().is_none());
     }
 
-    // --- handle_node_provision: pin config persistence (ND-0608) ---
+    // --- handle_node_provision: board layout persistence (ND-0608) ---
 
-    /// Pin config present → persisted to NVS and NODE_ACK_SUCCESS returned.
+    /// Board layout present → persisted to flash and NODE_ACK_SUCCESS returned.
     #[test]
-    fn handle_provision_with_pin_config_persists() {
+    fn handle_provision_with_board_layout_persists() {
         let mut storage = MockStorage::new();
         let mut maps = MapStorage::new(1024);
         let provision = NodeProvision {
@@ -1210,50 +1004,50 @@ mod tests {
             psk: [0x42u8; 32],
             rf_channel: 6,
             encrypted_payload: vec![0xAA],
-            pin_config: Some(PinConfig {
-                i2c0_sda: 4,
-                i2c0_scl: 5,
-            }),
+            board_layout: ProvisionedBoardLayout::Provided(BoardLayout::SONDE_SENSOR_NODE_REV_A),
         };
 
         let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
         assert_eq!(status, NODE_ACK_SUCCESS);
-        assert_eq!(storage.read_i2c0_pins(), (4, 5));
+        assert_eq!(
+            storage.read_board_layout(),
+            Some(BoardLayout::SONDE_SENSOR_NODE_REV_A)
+        );
     }
 
-    /// Pin config write failure → NODE_ACK_SUCCESS (non-fatal, ND-0608).
-    /// The node is effectively provisioned; pin config falls back to defaults.
+    /// Board layout write failure is fatal and rolls back critical provisioning state.
     #[test]
-    fn handle_provision_pin_config_write_failure() {
+    fn handle_provision_board_layout_write_failure() {
         let mut storage = MockStorage::new();
-        storage.fail_write_i2c0_pins = true;
+        storage.fail_write_board_layout = true;
         let mut maps = MapStorage::new(1024);
         let provision = NodeProvision {
             key_hint: 0x0001,
             psk: [0x42u8; 32],
             rf_channel: 6,
             encrypted_payload: vec![0xAA],
-            pin_config: Some(PinConfig {
-                i2c0_sda: 4,
-                i2c0_scl: 5,
-            }),
+            board_layout: ProvisionedBoardLayout::Provided(BoardLayout::SONDE_SENSOR_NODE_REV_A),
         };
 
         let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
-        assert_eq!(status, NODE_ACK_SUCCESS);
+        assert_eq!(status, NODE_ACK_STORAGE_ERROR);
+        assert!(storage.read_key().is_none());
+        assert!(storage.read_peer_payload().is_none());
     }
 
-    /// Pin config absent → NVS pins untouched, NODE_ACK_SUCCESS returned (backward compat).
+    /// Layout absent with no stored layout → legacy compatibility layout is synthesized.
     #[test]
-    fn handle_provision_without_pin_config_ok() {
+    fn handle_provision_without_board_layout_writes_legacy_compat() {
         let mut storage = MockStorage::new();
         let mut maps = MapStorage::new(1024);
         let provision = make_provision(0x0001, [0x42u8; 32], 6, &[0xAA]);
 
         let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
         assert_eq!(status, NODE_ACK_SUCCESS);
-        // No pin config → NVS pins should still be default
-        assert!(storage.i2c0_pins.is_none());
+        assert_eq!(
+            storage.read_board_layout(),
+            Some(BoardLayout::LEGACY_COMPAT)
+        );
     }
 
     // --- Full round-trip: parse envelope → handle → encode ACK ---

--- a/crates/sonde-node/src/board_layout.rs
+++ b/crates/sonde-node/src/board_layout.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+use sonde_protocol::BoardLayout;
+
+#[cfg(feature = "esp")]
+const RTC_LAYOUT_MAGIC: u32 = 0x534C_5954;
+
+#[cfg(feature = "esp")]
+#[repr(C)]
+struct RtcBoardLayout {
+    magic: u32,
+    i2c0_sda: i16,
+    i2c0_scl: i16,
+    one_wire_data: i16,
+    battery_adc: i16,
+    sensor_enable: i16,
+}
+
+#[cfg(feature = "esp")]
+#[link_section = ".rtc.data"]
+static mut RTC_BOARD_LAYOUT: RtcBoardLayout = RtcBoardLayout {
+    magic: 0,
+    i2c0_sda: -1,
+    i2c0_scl: -1,
+    one_wire_data: -1,
+    battery_adc: -1,
+    sensor_enable: -1,
+};
+
+#[cfg(feature = "esp")]
+const fn encode_pin(pin: Option<u8>) -> i16 {
+    match pin {
+        Some(pin) => pin as i16,
+        None => -1,
+    }
+}
+
+#[cfg(feature = "esp")]
+const fn decode_pin(pin: i16) -> Option<u8> {
+    if pin < 0 {
+        None
+    } else {
+        Some(pin as u8)
+    }
+}
+
+#[cfg(feature = "esp")]
+pub fn stage_runtime_board_layout(layout: &BoardLayout) {
+    unsafe {
+        RTC_BOARD_LAYOUT.magic = RTC_LAYOUT_MAGIC;
+        RTC_BOARD_LAYOUT.i2c0_sda = encode_pin(layout.i2c0_sda);
+        RTC_BOARD_LAYOUT.i2c0_scl = encode_pin(layout.i2c0_scl);
+        RTC_BOARD_LAYOUT.one_wire_data = encode_pin(layout.one_wire_data);
+        RTC_BOARD_LAYOUT.battery_adc = encode_pin(layout.battery_adc);
+        RTC_BOARD_LAYOUT.sensor_enable = encode_pin(layout.sensor_enable);
+    }
+}
+
+#[cfg(feature = "esp")]
+pub fn runtime_board_layout() -> Option<BoardLayout> {
+    unsafe {
+        if RTC_BOARD_LAYOUT.magic != RTC_LAYOUT_MAGIC {
+            return None;
+        }
+        Some(BoardLayout {
+            i2c0_sda: decode_pin(RTC_BOARD_LAYOUT.i2c0_sda),
+            i2c0_scl: decode_pin(RTC_BOARD_LAYOUT.i2c0_scl),
+            one_wire_data: decode_pin(RTC_BOARD_LAYOUT.one_wire_data),
+            battery_adc: decode_pin(RTC_BOARD_LAYOUT.battery_adc),
+            sensor_enable: decode_pin(RTC_BOARD_LAYOUT.sensor_enable),
+        })
+    }
+}
+
+#[cfg(not(feature = "esp"))]
+use std::sync::Mutex;
+
+#[cfg(not(feature = "esp"))]
+static RUNTIME_BOARD_LAYOUT: Mutex<Option<BoardLayout>> = Mutex::new(None);
+
+#[cfg(not(feature = "esp"))]
+pub fn stage_runtime_board_layout(layout: &BoardLayout) {
+    *RUNTIME_BOARD_LAYOUT.lock().unwrap() = Some(*layout);
+}
+
+#[cfg(not(feature = "esp"))]
+pub fn runtime_board_layout() -> Option<BoardLayout> {
+    *RUNTIME_BOARD_LAYOUT.lock().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_layout_round_trip() {
+        let layout = BoardLayout::SONDE_SENSOR_NODE_REV_A;
+        stage_runtime_board_layout(&layout);
+        assert_eq!(runtime_board_layout(), Some(layout));
+    }
+}

--- a/crates/sonde-node/src/esp_hal.rs
+++ b/crates/sonde-node/src/esp_hal.rs
@@ -14,6 +14,7 @@
 
 use crate::hal;
 use log::warn;
+use sonde_protocol::BoardLayout;
 
 const I2C0_FREQ_HZ: u32 = 100_000; // 100 kHz standard mode
 
@@ -61,10 +62,7 @@ impl crate::traits::Clock for EspClock {
 /// ESP-IDF calls with no pre-initialization.
 pub struct EspHal {
     i2c0_initialized: bool,
-    /// I2C0 SDA pin number (stored for sleep cleanup).
-    i2c0_sda: i32,
-    /// I2C0 SCL pin number (stored for sleep cleanup).
-    i2c0_scl: i32,
+    board_layout: BoardLayout,
     adc_width_configured: bool,
     /// Bitmask of GPIO pins already configured as output.
     gpio_output_configured: u64,
@@ -73,18 +71,20 @@ pub struct EspHal {
 }
 
 impl EspHal {
-    /// Create a new HAL with the given I2C0 pin assignments.
-    /// Call with `storage.read_i2c0_pins()` from the platform storage.
-    pub fn new(i2c0_sda: u8, i2c0_scl: u8) -> Self {
+    /// Create a new HAL with the current wake cycle's provisioned board layout.
+    pub fn new(board_layout: BoardLayout) -> Self {
         let mut hal = Self {
             i2c0_initialized: false,
-            i2c0_sda: i2c0_sda as i32,
-            i2c0_scl: i2c0_scl as i32,
+            board_layout,
             adc_width_configured: false,
             gpio_output_configured: 0,
             adc_channels_configured: 0,
         };
-        hal.init_i2c0(hal.i2c0_sda, hal.i2c0_scl);
+        if let (Some(i2c0_sda), Some(i2c0_scl)) =
+            (hal.board_layout.i2c0_sda, hal.board_layout.i2c0_scl)
+        {
+            hal.init_i2c0(i2c0_sda as i32, i2c0_scl as i32);
+        }
         hal
     }
 
@@ -122,6 +122,25 @@ impl EspHal {
         match bus {
             0 if self.i2c0_initialized => Some(esp_idf_sys::i2c_port_t_I2C_NUM_0),
             _ => None,
+        }
+    }
+
+    fn set_high_z_input(pin: i32) {
+        unsafe {
+            esp_idf_sys::gpio_reset_pin(pin);
+            let err =
+                esp_idf_sys::gpio_set_direction(pin, esp_idf_sys::gpio_mode_t_GPIO_MODE_INPUT);
+            if err != esp_idf_sys::ESP_OK as i32 {
+                warn!("gpio_set_direction({pin}, INPUT) failed: {err}");
+            }
+            let err = esp_idf_sys::gpio_pullup_dis(pin);
+            if err != esp_idf_sys::ESP_OK as i32 {
+                warn!("gpio_pullup_dis({pin}) failed: {err}");
+            }
+            let err = esp_idf_sys::gpio_pulldown_dis(pin);
+            if err != esp_idf_sys::ESP_OK as i32 {
+                warn!("gpio_pulldown_dis({pin}) failed: {err}");
+            }
         }
     }
 }
@@ -309,18 +328,6 @@ impl hal::Hal for EspHal {
     }
 
     fn prepare_for_sleep(&mut self) {
-        // GPIO hygiene for low-power deep sleep (issue #517).
-        //
-        // Every peripheral and GPIO touched during this wake cycle is
-        // placed into the lowest-leakage state:
-        //   • I2C driver deleted → SDA/SCL pins released
-        //   • BPF-configured output GPIOs → disabled (no I/O, no pulls)
-        //   • ADC tracking flags → cleared
-        //
-        // Pins are set to GPIO_MODE_DISABLE (input buffer off, output
-        // driver off) with pull-up and pull-down disabled. This is the
-        // lowest-current state for an ESP32 GPIO.
-
         // 1. Delete the I2C driver if it was installed.
         if self.i2c0_initialized {
             let err = unsafe { esp_idf_sys::i2c_driver_delete(esp_idf_sys::i2c_port_t_I2C_NUM_0) };
@@ -331,73 +338,21 @@ impl hal::Hal for EspHal {
             }
         }
 
-        // 2. Always reset I2C SDA/SCL pins regardless of driver state.
-        //    `i2c_param_config` enables internal pull-ups even when the
-        //    subsequent `i2c_driver_install` fails, so these pins must be
-        //    cleaned up unconditionally.
-        for pin in [self.i2c0_sda, self.i2c0_scl] {
-            unsafe {
-                // gpio_reset_pin detaches from the I2C peripheral (IOMUX)
-                // and returns the pin to GPIO function.
-                esp_idf_sys::gpio_reset_pin(pin);
-                let err = esp_idf_sys::gpio_set_direction(
-                    pin,
-                    esp_idf_sys::gpio_mode_t_GPIO_MODE_DISABLE,
-                );
-                if err != esp_idf_sys::ESP_OK as i32 {
-                    warn!("gpio_set_direction({pin}, DISABLE) failed: {err}");
-                }
-                let err = esp_idf_sys::gpio_pullup_dis(pin);
-                if err != esp_idf_sys::ESP_OK as i32 {
-                    warn!("gpio_pullup_dis({pin}) failed: {err}");
-                }
-                let err = esp_idf_sys::gpio_pulldown_dis(pin);
-                if err != esp_idf_sys::ESP_OK as i32 {
-                    warn!("gpio_pulldown_dis({pin}) failed: {err}");
-                }
-            }
-        }
-
-        // 3. Reset every GPIO that BPF programs configured as output.
+        // 2. Return all provisioned bus/control pins and any BPF-configured
+        //    outputs to a high-impedance input state.
         let mut mask = self.gpio_output_configured;
+        for pin in self.board_layout.assigned_pins().into_iter().flatten() {
+            mask |= 1u64 << pin;
+        }
         while mask != 0 {
             let pin = mask.trailing_zeros();
-            unsafe {
-                let err = esp_idf_sys::gpio_set_direction(
-                    pin as i32,
-                    esp_idf_sys::gpio_mode_t_GPIO_MODE_DISABLE,
-                );
-                if err != esp_idf_sys::ESP_OK as i32 {
-                    warn!("gpio_set_direction({pin}, DISABLE) failed: {err}");
-                }
-                let err = esp_idf_sys::gpio_pullup_dis(pin as i32);
-                if err != esp_idf_sys::ESP_OK as i32 {
-                    warn!("gpio_pullup_dis({pin}) failed: {err}");
-                }
-                let err = esp_idf_sys::gpio_pulldown_dis(pin as i32);
-                if err != esp_idf_sys::ESP_OK as i32 {
-                    warn!("gpio_pulldown_dis({pin}) failed: {err}");
-                }
-            }
+            Self::set_high_z_input(pin as i32);
             mask &= !(1u64 << pin);
         }
         self.gpio_output_configured = 0;
 
-        // 4. Clear ADC tracking so a fresh wake cycle re-configures.
+        // 3. Clear ADC tracking so a fresh wake cycle re-configures.
         self.adc_width_configured = false;
         self.adc_channels_configured = 0;
-    }
-}
-
-/// Battery reader using a fixed estimate.
-///
-/// On real hardware this would read an ADC channel connected to a
-/// voltage divider on the battery. For initial bring-up, return a
-/// fixed value indicating "battery OK".
-pub struct EspBatteryReader;
-
-impl hal::BatteryReader for EspBatteryReader {
-    fn battery_mv(&self) -> u32 {
-        3300 // Fixed estimate until ADC channel is configured
     }
 }

--- a/crates/sonde-node/src/esp_hal.rs
+++ b/crates/sonde-node/src/esp_hal.rs
@@ -299,8 +299,9 @@ impl hal::Hal for EspHal {
     }
 
     fn adc_read(&mut self, channel: u32) -> i32 {
-        // ESP32 ADC1 has channels 0-7.
-        if channel > 7 {
+        // ESP32-C3 exposes ADC1 channels 0-4 on GPIO0-4. GPIO5 is ADC2 and
+        // is not handled by this ADC1-only path.
+        if channel > 4 {
             return -1;
         }
         unsafe {

--- a/crates/sonde-node/src/esp_storage.rs
+++ b/crates/sonde-node/src/esp_storage.rs
@@ -88,6 +88,94 @@ impl NvsStorage {
         self.nvs.get_u32("i2c0_sda").ok().flatten().is_some()
             || self.nvs.get_u32("i2c0_scl").ok().flatten().is_some()
     }
+
+    fn legacy_i2c0_pin_state(&self) -> (Option<u8>, Option<u8>) {
+        const MAX_GPIO: u8 = 21;
+        let read_pin = |key: &str| {
+            self.nvs
+                .get_u32(key)
+                .ok()
+                .flatten()
+                .and_then(|v| u8::try_from(v).ok())
+                .filter(|&v| v <= MAX_GPIO)
+        };
+        (read_pin("i2c0_sda"), read_pin("i2c0_scl"))
+    }
+
+    fn restore_legacy_i2c0_pins(
+        &mut self,
+        i2c0_sda: Option<u8>,
+        i2c0_scl: Option<u8>,
+    ) -> NodeResult<()> {
+        match i2c0_sda {
+            Some(pin) => self
+                .nvs
+                .set_u32("i2c0_sda", pin as u32)
+                .map_err(|_| NodeError::StorageError("legacy i2c0_sda write failed"))?,
+            None => {
+                self.nvs
+                    .remove("i2c0_sda")
+                    .map_err(|_| NodeError::StorageError("legacy i2c0_sda erase failed"))?;
+            }
+        }
+        match i2c0_scl {
+            Some(pin) => self
+                .nvs
+                .set_u32("i2c0_scl", pin as u32)
+                .map_err(|_| NodeError::StorageError("legacy i2c0_scl write failed"))?,
+            None => {
+                self.nvs
+                    .remove("i2c0_scl")
+                    .map_err(|_| NodeError::StorageError("legacy i2c0_scl erase failed"))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_blob_exact(&self, key: &str) -> NodeResult<Option<Vec<u8>>> {
+        let Some(len) = self
+            .nvs
+            .blob_len(key)
+            .map_err(|_| NodeError::StorageError("blob length read failed"))?
+        else {
+            return Ok(None);
+        };
+
+        let mut buf = vec![0u8; len];
+        let slice_len = self
+            .nvs
+            .get_blob(key, &mut buf)
+            .map_err(|_| NodeError::StorageError("blob read failed"))?
+            .ok_or(NodeError::StorageError("blob disappeared during read"))?
+            .len();
+        buf.truncate(slice_len);
+        Ok(Some(buf))
+    }
+
+    fn restore_board_layout_blob(&mut self, blob: Option<&[u8]>) -> NodeResult<()> {
+        match blob {
+            Some(blob) => self
+                .nvs
+                .set_blob("board_layout", blob)
+                .map_err(|_| NodeError::StorageError("board_layout rollback failed"))?,
+            None => {
+                self.nvs
+                    .remove("board_layout")
+                    .map_err(|_| NodeError::StorageError("board_layout erase failed"))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn rollback_board_layout_update(
+        &mut self,
+        board_layout_blob: Option<&[u8]>,
+        legacy_i2c0_sda: Option<u8>,
+        legacy_i2c0_scl: Option<u8>,
+    ) -> NodeResult<()> {
+        self.restore_board_layout_blob(board_layout_blob)?;
+        self.restore_legacy_i2c0_pins(legacy_i2c0_sda, legacy_i2c0_scl)
+    }
 }
 
 impl crate::traits::PlatformStorage for NvsStorage {
@@ -330,10 +418,16 @@ impl crate::traits::PlatformStorage for NvsStorage {
     }
 
     fn read_board_layout(&self) -> Option<BoardLayout> {
-        let mut buf = [0u8; 32];
-        if let Ok(Some(slice)) = self.nvs.get_blob("board_layout", &mut buf) {
-            if let Ok(layout) = decode_board_layout_cbor(slice) {
-                return Some(layout);
+        match self.read_blob_exact("board_layout") {
+            Ok(Some(blob)) => match decode_board_layout_cbor(&blob) {
+                Ok(layout) => return Some(layout),
+                Err(err) => {
+                    log::warn!("failed to decode stored board_layout: {}", err);
+                }
+            },
+            Ok(None) => {}
+            Err(err) => {
+                log::warn!("failed to read stored board_layout: {}", err);
             }
         }
 
@@ -354,19 +448,30 @@ impl crate::traits::PlatformStorage for NvsStorage {
     fn write_board_layout(&mut self, layout: &BoardLayout) -> NodeResult<()> {
         let encoded = encode_board_layout_cbor(layout)
             .map_err(|_| NodeError::StorageError("board_layout encode failed"))?;
-        self.nvs
-            .set_blob("board_layout", &encoded)
-            .map_err(|_| NodeError::StorageError("board_layout write failed"))?;
+        let previous_board_layout = self.read_blob_exact("board_layout")?;
+        let (previous_i2c0_sda, previous_i2c0_scl) = self.legacy_i2c0_pin_state();
 
-        if let Some(i2c0_sda) = layout.i2c0_sda {
-            self.nvs
-                .set_u32("i2c0_sda", i2c0_sda as u32)
-                .map_err(|_| NodeError::StorageError("legacy i2c0_sda write failed"))?;
+        if let Err(err) = self
+            .nvs
+            .set_blob("board_layout", &encoded)
+            .map_err(|_| NodeError::StorageError("board_layout write failed"))
+        {
+            let _ = self.rollback_board_layout_update(
+                previous_board_layout.as_deref(),
+                previous_i2c0_sda,
+                previous_i2c0_scl,
+            );
+            return Err(err);
         }
-        if let Some(i2c0_scl) = layout.i2c0_scl {
-            self.nvs
-                .set_u32("i2c0_scl", i2c0_scl as u32)
-                .map_err(|_| NodeError::StorageError("legacy i2c0_scl write failed"))?;
+
+        if let Err(err) = self.restore_legacy_i2c0_pins(layout.i2c0_sda, layout.i2c0_scl) {
+            self.rollback_board_layout_update(
+                previous_board_layout.as_deref(),
+                previous_i2c0_sda,
+                previous_i2c0_scl,
+            )
+            .map_err(|_| NodeError::StorageError("board_layout rollback failed"))?;
+            return Err(err);
         }
         Ok(())
     }

--- a/crates/sonde-node/src/esp_storage.rs
+++ b/crates/sonde-node/src/esp_storage.rs
@@ -12,7 +12,7 @@
 //! - Programs: `"prog_a"` (blob, ≤4096 B), `"prog_b"` (blob, ≤4096 B)
 //! - WiFi channel: `"channel"` (u32, 1–13)
 //! - BLE pairing (ND-0916): `"peer_payload"` (blob, variable), `"reg_complete"` (u32, 0 or 1)
-//! - I2C pin config (ND-0608): `"i2c0_sda"` (u32, default 0), `"i2c0_scl"` (u32, default 1)
+//! - Board layout (ND-0608): `"board_layout"` (blob, deterministic CBOR)
 //!
 //! The early-wake flag is stored in RTC slow SRAM (`.rtc.data` section)
 //! rather than NVS, so it survives deep sleep without incurring flash wear.
@@ -22,6 +22,7 @@
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use esp_idf_svc::nvs::{EspNvs, EspNvsPartition, NvsDefault};
+use sonde_protocol::{decode_board_layout_cbor, encode_board_layout_cbor, BoardLayout};
 
 use crate::error::{NodeError, NodeResult};
 
@@ -40,6 +41,12 @@ const DEFAULT_INTERVAL_S: u32 = 300;
 #[link_section = ".rtc.data"]
 static EARLY_WAKE_FLAG: AtomicU32 = AtomicU32::new(0);
 
+#[link_section = ".rtc.data"]
+static LAST_BATTERY_MV: AtomicU32 = AtomicU32::new(0);
+
+#[link_section = ".rtc.data"]
+static LAST_BATTERY_VALID: AtomicU32 = AtomicU32::new(0);
+
 /// NVS-backed implementation of [`crate::traits::PlatformStorage`].
 pub struct NvsStorage {
     nvs: EspNvs<NvsDefault>,
@@ -51,6 +58,35 @@ impl NvsStorage {
         let nvs = EspNvs::new(partition, NVS_NAMESPACE, true)
             .map_err(|_| NodeError::StorageError("NVS open failed"))?;
         Ok(Self { nvs })
+    }
+
+    fn legacy_i2c0_pins(&self) -> (u8, u8) {
+        const MAX_GPIO: u8 = 21;
+        let sda = self
+            .nvs
+            .get_u32("i2c0_sda")
+            .ok()
+            .flatten()
+            .and_then(|v| u8::try_from(v).ok())
+            .filter(|&v| v <= MAX_GPIO)
+            .unwrap_or(0);
+        let scl = self
+            .nvs
+            .get_u32("i2c0_scl")
+            .ok()
+            .flatten()
+            .and_then(|v| u8::try_from(v).ok())
+            .filter(|&v| v <= MAX_GPIO)
+            .unwrap_or(1);
+        if sda == scl {
+            return (0, 1);
+        }
+        (sda, scl)
+    }
+
+    fn has_legacy_i2c0_pins(&self) -> bool {
+        self.nvs.get_u32("i2c0_sda").ok().flatten().is_some()
+            || self.nvs.get_u32("i2c0_scl").ok().flatten().is_some()
     }
 }
 
@@ -293,58 +329,59 @@ impl crate::traits::PlatformStorage for NvsStorage {
             .map_err(|_| NodeError::StorageError("reg_complete write failed"))
     }
 
-    fn read_i2c0_pins(&self) -> (u8, u8) {
-        const MAX_GPIO: u8 = 21;
-        let sda = self
-            .nvs
-            .get_u32("i2c0_sda")
-            .ok()
-            .flatten()
-            .and_then(|v| u8::try_from(v).ok())
-            .filter(|&v| v <= MAX_GPIO)
-            .unwrap_or(0);
-        let scl = self
-            .nvs
-            .get_u32("i2c0_scl")
-            .ok()
-            .flatten()
-            .and_then(|v| u8::try_from(v).ok())
-            .filter(|&v| v <= MAX_GPIO)
-            .unwrap_or(1);
-        // If both decoded to the same pin, fall back to defaults to
-        // avoid initializing I2C with SDA==SCL (ND-0608).
-        if sda == scl {
-            return (0, 1);
+    fn read_board_layout(&self) -> Option<BoardLayout> {
+        let mut buf = [0u8; 32];
+        if let Ok(Some(slice)) = self.nvs.get_blob("board_layout", &mut buf) {
+            if let Ok(layout) = decode_board_layout_cbor(slice) {
+                return Some(layout);
+            }
         }
-        (sda, scl)
+
+        if self.has_legacy_i2c0_pins() {
+            let (i2c0_sda, i2c0_scl) = self.legacy_i2c0_pins();
+            return Some(BoardLayout {
+                i2c0_sda: Some(i2c0_sda),
+                i2c0_scl: Some(i2c0_scl),
+                one_wire_data: None,
+                battery_adc: None,
+                sensor_enable: None,
+            });
+        }
+
+        None
     }
 
-    fn write_i2c0_pins(&mut self, sda: u8, scl: u8) -> NodeResult<()> {
-        // Validate before persisting — an invalid config survives factory
-        // reset (ND-0608 AC#4) and could permanently disable I2C.
-        const MAX_GPIO: u8 = 21;
-        if sda > MAX_GPIO || scl > MAX_GPIO {
-            return Err(NodeError::StorageError("i2c0 pin out of GPIO range"));
-        }
-        if sda == scl {
-            return Err(NodeError::StorageError("i2c0 SDA and SCL must differ"));
-        }
-
-        // Best-effort atomicity: if updating SCL fails after SDA was written,
-        // restore the previous SDA value to avoid leaving a mismatched pair.
-        let (old_sda, _old_scl) = self.read_i2c0_pins();
-
+    fn write_board_layout(&mut self, layout: &BoardLayout) -> NodeResult<()> {
+        let encoded = encode_board_layout_cbor(layout)
+            .map_err(|_| NodeError::StorageError("board_layout encode failed"))?;
         self.nvs
-            .set_u32("i2c0_sda", sda as u32)
-            .map_err(|_| NodeError::StorageError("i2c0_sda write failed"))?;
+            .set_blob("board_layout", &encoded)
+            .map_err(|_| NodeError::StorageError("board_layout write failed"))?;
 
-        if let Err(_e) = self.nvs.set_u32("i2c0_scl", scl as u32) {
-            // Attempt to roll back SDA; ignore rollback failure since we
-            // can't do better than best-effort here.
-            let _ = self.nvs.set_u32("i2c0_sda", old_sda as u32);
-            return Err(NodeError::StorageError("i2c0_scl write failed"));
+        if let Some(i2c0_sda) = layout.i2c0_sda {
+            self.nvs
+                .set_u32("i2c0_sda", i2c0_sda as u32)
+                .map_err(|_| NodeError::StorageError("legacy i2c0_sda write failed"))?;
         }
+        if let Some(i2c0_scl) = layout.i2c0_scl {
+            self.nvs
+                .set_u32("i2c0_scl", i2c0_scl as u32)
+                .map_err(|_| NodeError::StorageError("legacy i2c0_scl write failed"))?;
+        }
+        Ok(())
+    }
 
+    fn read_last_battery_mv(&self) -> Option<u32> {
+        if LAST_BATTERY_VALID.load(Ordering::Relaxed) == 0 {
+            None
+        } else {
+            Some(LAST_BATTERY_MV.load(Ordering::Relaxed))
+        }
+    }
+
+    fn write_last_battery_mv(&mut self, battery_mv: u32) -> NodeResult<()> {
+        LAST_BATTERY_MV.store(battery_mv, Ordering::Relaxed);
+        LAST_BATTERY_VALID.store(1, Ordering::Relaxed);
         Ok(())
     }
 }

--- a/crates/sonde-node/src/esp_storage.rs
+++ b/crates/sonde-node/src/esp_storage.rs
@@ -13,11 +13,13 @@
 //! - WiFi channel: `"channel"` (u32, 1–13)
 //! - BLE pairing (ND-0916): `"peer_payload"` (blob, variable), `"reg_complete"` (u32, 0 or 1)
 //! - Board layout (ND-0608): `"board_layout"` (blob, deterministic CBOR)
+//! - Legacy board-layout compatibility keys: `"i2c0_sda"` / `"i2c0_scl"` (u32)
 //!
 //! The early-wake flag is stored in RTC slow SRAM (`.rtc.data` section)
 //! rather than NVS, so it survives deep sleep without incurring flash wear.
 //! It is reset on power loss or hardware reset, which is acceptable — a
-//! missed early wake is harmless.
+//! missed early wake is harmless. The retained battery value used for the
+//! next `WAKE.battery_mv` is also stored in RTC slow SRAM via `LAST_BATTERY_*`.
 
 use core::sync::atomic::{AtomicU32, Ordering};
 

--- a/crates/sonde-node/src/lib.rs
+++ b/crates/sonde-node/src/lib.rs
@@ -10,6 +10,7 @@ compile_error!(
 
 pub mod async_queue;
 pub mod ble_pairing;
+pub mod board_layout;
 pub mod bpf_dispatch;
 pub mod bpf_helpers;
 pub mod bpf_runtime;

--- a/crates/sonde-node/src/traits.rs
+++ b/crates/sonde-node/src/traits.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 sonde contributors
 
 use crate::error::NodeResult;
+use sonde_protocol::BoardLayout;
 
 /// Radio transport for sending and receiving frames.
 pub trait Transport {
@@ -165,14 +166,23 @@ pub trait PlatformStorage {
         Ok(())
     }
 
-    /// Read I2C0 pin configuration from NVS (ND-0608).
-    /// Returns `(sda_gpio, scl_gpio)`. Defaults to `(0, 1)` if not set.
-    fn read_i2c0_pins(&self) -> (u8, u8) {
-        (0, 1)
+    /// Read the provisioned board layout from flash (ND-0608).
+    fn read_board_layout(&self) -> Option<BoardLayout> {
+        None
     }
 
-    /// Persist I2C0 pin configuration to NVS (ND-0608).
-    fn write_i2c0_pins(&mut self, _sda: u8, _scl: u8) -> NodeResult<()> {
+    /// Persist the provisioned board layout to flash (ND-0608).
+    fn write_board_layout(&mut self, _layout: &BoardLayout) -> NodeResult<()> {
+        Ok(())
+    }
+
+    /// Read the last battery value retained across deep sleep.
+    fn read_last_battery_mv(&self) -> Option<u32> {
+        None
+    }
+
+    /// Persist the current-cycle battery value for the next wake.
+    fn write_last_battery_mv(&mut self, _battery_mv: u32) -> NodeResult<()> {
         Ok(())
     }
 }

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -68,10 +68,16 @@ fn hash_hex_prefix(hash: &[u8]) -> HashHexPrefix<'_> {
     HashHexPrefix(hash)
 }
 
+// The ESP32-C3 ADC1 path used by this firmware exposes GPIO0-4 only.
+fn is_supported_battery_adc_gpio(pin: u8) -> bool {
+    matches!(pin, 0..=4)
+}
+
 fn gpio_to_adc_channel(pin: u8) -> Option<u32> {
-    match pin {
-        0..=4 => Some(pin as u32),
-        _ => None,
+    if is_supported_battery_adc_gpio(pin) {
+        Some(pin as u32)
+    } else {
+        None
     }
 }
 
@@ -1339,6 +1345,9 @@ mod tests {
 
     #[test]
     fn gpio_to_adc_channel_only_maps_esp32c3_adc1_pins() {
+        assert!(is_supported_battery_adc_gpio(0));
+        assert!(is_supported_battery_adc_gpio(4));
+        assert!(!is_supported_battery_adc_gpio(5));
         assert_eq!(gpio_to_adc_channel(0), Some(0));
         assert_eq!(gpio_to_adc_channel(4), Some(4));
         assert_eq!(gpio_to_adc_channel(5), None);

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -1859,6 +1859,75 @@ mod tests {
         }
 
         #[test]
+        fn run_wake_cycle_reports_previous_battery_on_next_wake() {
+            let psk = [0x42u8; 32];
+            let sha = crate::crypto::SoftwareSha256;
+            let aead = NodeAead;
+            let key_hint = sonde_protocol::key_hint_from_psk(&psk, &sha);
+            let clock = MockClock;
+            let mut storage = MockStorage::new().with_key(key_hint, psk);
+            let mut hal = MockHal;
+            let mut rng = MockRng(0);
+            let mut interp = MockBpfInterpreter::new();
+            let mut map_storage = MapStorage::new(DEFAULT_MAP_BUDGET);
+            let mut async_queue = AsyncQueue::new();
+
+            let mut transport_first = MockTransport::new();
+            transport_first.queue_response(Some(make_command(&psk, 1, &CommandPayload::Nop)));
+            let first_outcome = run_wake_cycle(
+                &mut transport_first,
+                &mut storage,
+                &mut hal,
+                &mut rng,
+                &clock,
+                &BoardLayout::LEGACY_COMPAT,
+                &mut interp,
+                &mut map_storage,
+                &sha,
+                &aead,
+                &mut async_queue,
+            );
+            assert_eq!(first_outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+            let first_wake = decode_frame(&transport_first.outbound[0]).unwrap();
+            let first_payload = open_frame(&first_wake, &psk, &aead, &sha).unwrap();
+            let first_battery_mv =
+                match sonde_protocol::NodeMessage::decode(MSG_WAKE, &first_payload).unwrap() {
+                    sonde_protocol::NodeMessage::Wake { battery_mv, .. } => battery_mv,
+                    _ => panic!("expected Wake message"),
+                };
+            assert_eq!(first_battery_mv, 0);
+            assert_eq!(storage.last_battery_mv, Some(BATTERY_FALLBACK_MV));
+
+            let mut transport_second = MockTransport::new();
+            transport_second.queue_response(Some(make_command(&psk, 2, &CommandPayload::Nop)));
+            let second_outcome = run_wake_cycle(
+                &mut transport_second,
+                &mut storage,
+                &mut hal,
+                &mut rng,
+                &clock,
+                &BoardLayout::LEGACY_COMPAT,
+                &mut interp,
+                &mut map_storage,
+                &sha,
+                &aead,
+                &mut async_queue,
+            );
+            assert_eq!(second_outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+            let second_wake = decode_frame(&transport_second.outbound[0]).unwrap();
+            let second_payload = open_frame(&second_wake, &psk, &aead, &sha).unwrap();
+            let second_battery_mv =
+                match sonde_protocol::NodeMessage::decode(MSG_WAKE, &second_payload).unwrap() {
+                    sonde_protocol::NodeMessage::Wake { battery_mv, .. } => battery_mv,
+                    _ => panic!("expected Wake message"),
+                };
+            assert_eq!(second_battery_mv, BATTERY_FALLBACK_MV);
+            assert_eq!(storage.last_battery_mv, Some(BATTERY_FALLBACK_MV));
+        }
+
+        #[test]
         fn run_wake_cycle_update_program() {
             let psk = [0x22u8; 32];
             let sha = crate::crypto::SoftwareSha256;

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -70,7 +70,7 @@ fn hash_hex_prefix(hash: &[u8]) -> HashHexPrefix<'_> {
 
 fn gpio_to_adc_channel(pin: u8) -> Option<u32> {
     match pin {
-        0..=5 => Some(pin as u32),
+        0..=4 => Some(pin as u32),
         _ => None,
     }
 }
@@ -1335,6 +1335,14 @@ mod tests {
         fn delay_ms(&self, _ms: u32) {
             // No-op in tests
         }
+    }
+
+    #[test]
+    fn gpio_to_adc_channel_only_maps_esp32c3_adc1_pins() {
+        assert_eq!(gpio_to_adc_channel(0), Some(0));
+        assert_eq!(gpio_to_adc_channel(4), Some(4));
+        assert_eq!(gpio_to_adc_channel(5), None);
+        assert_eq!(gpio_to_adc_channel(21), None);
     }
 
     // --- Mock BPF interpreter ---

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -7,16 +7,16 @@
 //! `boot → WAKE → COMMAND → dispatch → (transfer/execute) → sleep`
 
 use sonde_protocol::{
-    CommandPayload, DecodeError, FrameHeader, GatewayMessage, NodeMessage, Sha256Provider,
-    MSG_APP_DATA, MSG_APP_DATA_REPLY, MSG_CHUNK, MSG_COMMAND, MSG_GET_CHUNK, MSG_PROGRAM_ACK,
-    MSG_WAKE,
+    BoardLayout, CommandPayload, DecodeError, FrameHeader, GatewayMessage, NodeMessage,
+    Sha256Provider, MSG_APP_DATA, MSG_APP_DATA_REPLY, MSG_CHUNK, MSG_COMMAND, MSG_GET_CHUNK,
+    MSG_PROGRAM_ACK, MSG_WAKE,
 };
 
 use crate::async_queue::AsyncQueue;
 use crate::bpf_helpers::{ProgramClass, SondeContext};
 use crate::bpf_runtime::BpfInterpreter;
 use crate::error::{NodeError, NodeResult};
-use crate::hal::{BatteryReader, Hal};
+use crate::hal::Hal;
 use crate::key_store::NodeIdentity;
 use crate::map_storage::MapStorage;
 use crate::peer_request::peer_request_exchange;
@@ -33,6 +33,10 @@ const RESPONSE_TIMEOUT_MS: u32 = 200;
 
 /// Default instruction budget for BPF execution.
 const DEFAULT_INSTRUCTION_BUDGET: u64 = 100_000;
+const BATTERY_FALLBACK_MV: u32 = 3300;
+const SENSOR_SETTLE_MS: u32 = 10;
+const ADC_FULL_SCALE_MV: u32 = 2500;
+const BATTERY_DIVIDER_RATIO: u32 = 2;
 
 /// Default map budget in bytes (~4 KB for ESP32-C3 after firmware overhead).
 /// Used by tests; production code receives the budget via `MapStorage`.
@@ -62,6 +66,54 @@ impl<'a> core::fmt::Display for HashHexPrefix<'a> {
 /// This avoids heap allocation; use with formatting macros like `log::info!`.
 fn hash_hex_prefix(hash: &[u8]) -> HashHexPrefix<'_> {
     HashHexPrefix(hash)
+}
+
+fn gpio_to_adc_channel(pin: u8) -> Option<u32> {
+    match pin {
+        0..=5 => Some(pin as u32),
+        _ => None,
+    }
+}
+
+fn capture_current_cycle_battery(
+    hal: &mut dyn Hal,
+    board_layout: &BoardLayout,
+    clock: &dyn Clock,
+) -> u32 {
+    if let Some(sensor_enable) = board_layout.sensor_enable {
+        if hal.gpio_write(sensor_enable as u32, 0) < 0 {
+            log::warn!("failed to assert sensor_enable GPIO {}", sensor_enable);
+        } else {
+            clock.delay_ms(SENSOR_SETTLE_MS);
+        }
+    }
+
+    let Some(battery_pin) = board_layout.battery_adc else {
+        return BATTERY_FALLBACK_MV;
+    };
+
+    let Some(channel) = gpio_to_adc_channel(battery_pin) else {
+        log::warn!(
+            "battery_adc GPIO {} is not ADC-capable on ESP32-C3; using fallback {} mV",
+            battery_pin,
+            BATTERY_FALLBACK_MV
+        );
+        return BATTERY_FALLBACK_MV;
+    };
+
+    let raw = hal.adc_read(channel);
+    if raw < 0 {
+        log::warn!(
+            "battery ADC sample failed on GPIO {} (channel {}); using fallback {} mV",
+            battery_pin,
+            channel,
+            BATTERY_FALLBACK_MV
+        );
+        return BATTERY_FALLBACK_MV;
+    }
+
+    let sensed_mv = (raw as u32).saturating_mul(ADC_FULL_SCALE_MV) / 4095;
+    sensed_mv.saturating_mul(BATTERY_DIVIDER_RATIO)
 }
 
 /// Outcome of a wake cycle.
@@ -629,7 +681,7 @@ pub fn run_wake_cycle<T, S, I, A, H>(
     hal: &mut (dyn Hal + 'static),
     rng: &mut dyn Rng,
     clock: &(dyn Clock + 'static),
-    battery: &dyn BatteryReader,
+    board_layout: &BoardLayout,
     interpreter: &mut I,
     map_storage: &mut MapStorage,
     sha: &H,
@@ -717,7 +769,7 @@ where
 
     // 5. Generate WAKE nonce
     let wake_nonce = rng.random_u64();
-    let battery_mv = battery.battery_mv();
+    let wake_battery_mv = storage.read_last_battery_mv().unwrap_or(0);
 
     // 5a. Check async queue for WAKE piggybacking.
     // The queue persists across wake cycles in RTC slow SRAM (ESP) or
@@ -729,7 +781,7 @@ where
             let trial = NodeMessage::Wake {
                 firmware_abi_version: FIRMWARE_ABI_VERSION,
                 program_hash: program_hash.clone(),
-                battery_mv,
+                battery_mv: wake_battery_mv,
                 firmware_version: env!("CARGO_PKG_VERSION").into(),
                 blob: Some(blob.to_vec()),
             };
@@ -752,7 +804,7 @@ where
         &identity,
         wake_nonce,
         &program_hash,
-        battery_mv,
+        wake_battery_mv,
         clock,
         aead,
         sha,
@@ -788,6 +840,10 @@ where
     };
 
     let mut current_seq = starting_seq;
+    let current_battery_mv = capture_current_cycle_battery(hal, board_layout, clock);
+    if let Err(e) = storage.write_last_battery_mv(current_battery_mv) {
+        log::warn!("failed to persist battery reading for next wake: {}", e);
+    }
 
     // Log the received COMMAND (ND-1003).
     match &command_payload {
@@ -973,10 +1029,10 @@ where
         let map_ptrs = map_storage.map_pointers().to_vec();
 
         let elapsed_since_command = clock.elapsed_ms().saturating_sub(command_received_at);
-        let battery_mv_clamped = if battery_mv > u16::MAX as u32 {
+        let battery_mv_clamped = if current_battery_mv > u16::MAX as u32 {
             u16::MAX
         } else {
-            battery_mv as u16
+            current_battery_mv as u16
         };
         let ctx = SondeContext {
             timestamp: timestamp_ms.saturating_add(elapsed_since_command),
@@ -1008,7 +1064,7 @@ where
                 async_queue as *mut AsyncQueue,
                 timestamp_ms,
                 command_received_at,
-                battery_mv,
+                current_battery_mv,
                 aead as *const dyn AeadProvider,
                 sha as *const dyn Sha256Provider,
             );
@@ -1125,6 +1181,7 @@ mod tests {
         pub channel: Option<u8>,
         pub peer_payload: Option<Vec<u8>>,
         pub reg_complete: bool,
+        pub last_battery_mv: Option<u32>,
     }
 
     impl MockStorage {
@@ -1139,6 +1196,7 @@ mod tests {
                 channel: None,
                 peer_payload: None,
                 reg_complete: false,
+                last_battery_mv: None,
             }
         }
 
@@ -1223,6 +1281,13 @@ mod tests {
             self.reg_complete = c;
             Ok(())
         }
+        fn read_last_battery_mv(&self) -> Option<u32> {
+            self.last_battery_mv
+        }
+        fn write_last_battery_mv(&mut self, battery_mv: u32) -> NodeResult<()> {
+            self.last_battery_mv = Some(battery_mv);
+            Ok(())
+        }
     }
 
     // --- Mock HAL ---
@@ -1249,13 +1314,6 @@ mod tests {
         }
         fn adc_read(&mut self, _ch: u32) -> i32 {
             0
-        }
-    }
-
-    struct MockBattery;
-    impl BatteryReader for MockBattery {
-        fn battery_mv(&self) -> u32 {
-            3300
         }
     }
 
@@ -1779,7 +1837,7 @@ mod tests {
                 &mut hal,
                 &mut rng,
                 &clock,
-                &MockBattery,
+                &BoardLayout::LEGACY_COMPAT,
                 &mut interp,
                 &mut map_storage,
                 &sha,
@@ -1851,7 +1909,7 @@ mod tests {
                 &mut hal,
                 &mut rng,
                 &clock,
-                &MockBattery,
+                &BoardLayout::LEGACY_COMPAT,
                 &mut interp,
                 &mut map_storage,
                 &sha,
@@ -1909,7 +1967,7 @@ mod tests {
                 &mut hal,
                 &mut rng,
                 &clock,
-                &MockBattery,
+                &BoardLayout::LEGACY_COMPAT,
                 &mut interp,
                 &mut map_storage,
                 &sha,
@@ -1954,7 +2012,7 @@ mod tests {
                 &mut hal,
                 &mut rng,
                 &clock,
-                &MockBattery,
+                &BoardLayout::LEGACY_COMPAT,
                 &mut interp,
                 &mut map_storage,
                 &sha,
@@ -2032,7 +2090,7 @@ mod tests {
                 &mut hal,
                 &mut rng,
                 &clock,
-                &MockBattery,
+                &BoardLayout::LEGACY_COMPAT,
                 &mut interp,
                 &mut map_storage,
                 &sha,

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -18,11 +18,11 @@
 
 use std::sync::{Arc, Mutex};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sonde_pair::discovery::{service_type, DeviceScanner, ServiceType};
 use sonde_pair::phase1::PairingProgress;
 use sonde_pair::rng::OsRng;
-use sonde_pair::types::{PinConfig, ScannedDevice};
+use sonde_pair::types::{BoardLayout, ScannedDevice};
 use sonde_pair::{phase1, phase2};
 
 #[cfg(not(target_os = "android"))]
@@ -79,6 +79,16 @@ struct PairingStatus {
     gateway_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BoardLayoutInput {
+    i2c0_sda: Option<u8>,
+    i2c0_scl: Option<u8>,
+    one_wire_data: Option<u8>,
+    battery_adc: Option<u8>,
+    sensor_enable: Option<u8>,
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -103,21 +113,44 @@ fn parse_address(s: &str) -> Result<[u8; 6], String> {
     Ok(addr)
 }
 
-/// Resolve optional I2C pin parameters into a `PinConfig` (PT-1216 AC 7).
-///
-/// Both parameters must be present or both absent.  Providing exactly one
-/// is an error.
-fn resolve_pin_config(
+fn resolve_legacy_i2c_layout(
     i2c_sda: Option<u8>,
     i2c_scl: Option<u8>,
-) -> Result<Option<PinConfig>, String> {
+) -> Result<Option<BoardLayout>, String> {
     match (i2c_sda, i2c_scl) {
-        (Some(sda), Some(scl)) => Ok(Some(PinConfig {
-            i2c0_sda: sda,
-            i2c0_scl: scl,
+        (Some(sda), Some(scl)) => Ok(Some(BoardLayout {
+            i2c0_sda: Some(sda),
+            i2c0_scl: Some(scl),
+            one_wire_data: None,
+            battery_adc: None,
+            sensor_enable: None,
         })),
         (None, None) => Ok(None),
         _ => Err("Provide both I2C SDA and I2C SCL pins, or leave both empty.".into()),
+    }
+}
+
+fn resolve_board_layout(
+    board_layout: Option<BoardLayoutInput>,
+    legacy_i2c_sda: Option<u8>,
+    legacy_i2c_scl: Option<u8>,
+) -> Result<Option<BoardLayout>, String> {
+    let layout = match board_layout {
+        Some(layout) => Some(BoardLayout {
+            i2c0_sda: layout.i2c0_sda,
+            i2c0_scl: layout.i2c0_scl,
+            one_wire_data: layout.one_wire_data,
+            battery_adc: layout.battery_adc,
+            sensor_enable: layout.sensor_enable,
+        }),
+        None => resolve_legacy_i2c_layout(legacy_i2c_sda, legacy_i2c_scl)?,
+    };
+
+    if let Some(layout) = layout {
+        layout.validate().map_err(str::to_string)?;
+        Ok(Some(layout))
+    } else {
+        Ok(None)
     }
 }
 
@@ -269,6 +302,7 @@ async fn provision_node(
     state: tauri::State<'_, AppState>,
     address: String,
     node_id: String,
+    board_layout: Option<BoardLayoutInput>,
     i2c_sda: Option<u8>,
     i2c_scl: Option<u8>,
 ) -> Result<String, String> {
@@ -282,7 +316,7 @@ async fn provision_node(
         }
     };
 
-    let pin_config = resolve_pin_config(i2c_sda, i2c_scl)?;
+    let board_layout = resolve_board_layout(board_layout, i2c_sda, i2c_scl)?;
 
     // Load artifacts from in-memory cache, falling back to file store.
     let artifacts = {
@@ -315,7 +349,7 @@ async fn provision_node(
                 &addr,
                 &node_id,
                 &[],
-                pin_config,
+                board_layout,
             )
             .await
         })
@@ -512,6 +546,7 @@ async fn provision_node(
     state: tauri::State<'_, AppState>,
     address: String,
     node_id: String,
+    board_layout: Option<BoardLayoutInput>,
     i2c_sda: Option<u8>,
     i2c_scl: Option<u8>,
 ) -> Result<String, String> {
@@ -525,7 +560,7 @@ async fn provision_node(
         }
     };
 
-    let pin_config = resolve_pin_config(i2c_sda, i2c_scl)?;
+    let board_layout = resolve_board_layout(board_layout, i2c_sda, i2c_scl)?;
 
     // Load artifacts from in-memory cache, falling back to Android secure storage.
     let artifacts = {
@@ -558,7 +593,7 @@ async fn provision_node(
                 &addr,
                 &node_id,
                 &[],
-                pin_config,
+                board_layout,
             )
             .await
         })
@@ -789,38 +824,64 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_pin_config_both_present() {
-        let result = resolve_pin_config(Some(5), Some(6)).unwrap();
-        let pc = result.unwrap();
-        assert_eq!(pc.i2c0_sda, 5);
-        assert_eq!(pc.i2c0_scl, 6);
+    fn resolve_legacy_i2c_layout_both_present() {
+        let result = resolve_legacy_i2c_layout(Some(5), Some(6)).unwrap();
+        let layout = result.unwrap();
+        assert_eq!(layout.i2c0_sda, Some(5));
+        assert_eq!(layout.i2c0_scl, Some(6));
     }
 
     #[test]
-    fn resolve_pin_config_both_absent() {
-        let result = resolve_pin_config(None, None).unwrap();
+    fn resolve_legacy_i2c_layout_both_absent() {
+        let result = resolve_legacy_i2c_layout(None, None).unwrap();
         assert!(result.is_none());
     }
 
     #[test]
-    fn resolve_pin_config_only_sda_rejected() {
-        let result = resolve_pin_config(Some(5), None);
+    fn resolve_legacy_i2c_layout_only_sda_rejected() {
+        let result = resolve_legacy_i2c_layout(Some(5), None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("both"));
     }
 
     #[test]
-    fn resolve_pin_config_only_scl_rejected() {
-        let result = resolve_pin_config(None, Some(6));
+    fn resolve_legacy_i2c_layout_only_scl_rejected() {
+        let result = resolve_legacy_i2c_layout(None, Some(6));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("both"));
     }
 
     #[test]
-    fn resolve_pin_config_zero_one_values() {
-        let result = resolve_pin_config(Some(0), Some(1)).unwrap();
-        let pc = result.unwrap();
-        assert_eq!(pc.i2c0_sda, 0);
-        assert_eq!(pc.i2c0_scl, 1);
+    fn resolve_board_layout_validates_custom_board() {
+        let result = resolve_board_layout(
+            Some(BoardLayoutInput {
+                i2c0_sda: Some(6),
+                i2c0_scl: Some(7),
+                one_wire_data: Some(3),
+                battery_adc: Some(2),
+                sensor_enable: Some(4),
+            }),
+            None,
+            None,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(result, BoardLayout::SONDE_SENSOR_NODE_REV_A);
+    }
+
+    #[test]
+    fn resolve_board_layout_rejects_half_i2c_assignment() {
+        let result = resolve_board_layout(
+            Some(BoardLayoutInput {
+                i2c0_sda: Some(5),
+                i2c0_scl: None,
+                one_wire_data: None,
+                battery_adc: None,
+                sensor_enable: None,
+            }),
+            None,
+            None,
+        );
+        assert!(result.is_err());
     }
 }

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -130,6 +130,15 @@ fn resolve_legacy_i2c_layout(
     }
 }
 
+fn validate_supported_battery_adc(layout: &BoardLayout) -> Result<(), String> {
+    match layout.battery_adc {
+        Some(0..=4) | None => Ok(()),
+        Some(pin) => Err(format!(
+            "battery_adc GPIO {pin} is not ADC-capable on ESP32-C3; use GPIO 0-4 or leave it blank"
+        )),
+    }
+}
+
 fn resolve_board_layout(
     board_layout: Option<BoardLayoutInput>,
     legacy_i2c_sda: Option<u8>,
@@ -148,6 +157,7 @@ fn resolve_board_layout(
 
     if let Some(layout) = layout {
         layout.validate().map_err(str::to_string)?;
+        validate_supported_battery_adc(&layout)?;
         Ok(Some(layout))
     } else {
         Ok(None)
@@ -883,5 +893,22 @@ mod tests {
             None,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_board_layout_rejects_non_adc_battery_pin() {
+        let result = resolve_board_layout(
+            Some(BoardLayoutInput {
+                i2c0_sda: Some(6),
+                i2c0_scl: Some(7),
+                one_wire_data: None,
+                battery_adc: Some(7),
+                sensor_enable: None,
+            }),
+            None,
+            None,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("ADC-capable"));
     }
 }

--- a/crates/sonde-pair-ui/src/index.html
+++ b/crates/sonde-pair-ui/src/index.html
@@ -114,12 +114,28 @@
         <div id="custom-pins" class="custom-pins hidden">
           <div class="pin-row">
             <div class="pin-field">
-              <label for="custom-sda">I2C SDA GPIO</label>
-              <input id="custom-sda" type="number" min="0" max="21" placeholder="0" />
+              <label for="custom-i2c-sda">I2C SDA GPIO</label>
+              <input id="custom-i2c-sda" type="number" min="0" max="21" placeholder="leave blank to unassign" />
             </div>
             <div class="pin-field">
-              <label for="custom-scl">I2C SCL GPIO</label>
-              <input id="custom-scl" type="number" min="0" max="21" placeholder="1" />
+              <label for="custom-i2c-scl">I2C SCL GPIO</label>
+              <input id="custom-i2c-scl" type="number" min="0" max="21" placeholder="leave blank to unassign" />
+            </div>
+          </div>
+          <div class="pin-row">
+            <div class="pin-field">
+              <label for="custom-one-wire">1-Wire GPIO</label>
+              <input id="custom-one-wire" type="number" min="0" max="21" placeholder="leave blank to unassign" />
+            </div>
+            <div class="pin-field">
+              <label for="custom-battery-adc">Battery ADC GPIO</label>
+              <input id="custom-battery-adc" type="number" min="0" max="21" placeholder="leave blank to unassign" />
+            </div>
+          </div>
+          <div class="pin-row">
+            <div class="pin-field">
+              <label for="custom-sensor-enable">Sensor Enable GPIO (active low)</label>
+              <input id="custom-sensor-enable" type="number" min="0" max="21" placeholder="leave blank to unassign" />
             </div>
           </div>
         </div>

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -57,8 +57,11 @@ const btnToProvision = document.getElementById("btn-to-provision");
 const nodeId = document.getElementById("node-id");
 const boardSelect = document.getElementById("board-select");
 const customPins = document.getElementById("custom-pins");
-const customSda = document.getElementById("custom-sda");
-const customScl = document.getElementById("custom-scl");
+const customI2cSda = document.getElementById("custom-i2c-sda");
+const customI2cScl = document.getElementById("custom-i2c-scl");
+const customOneWire = document.getElementById("custom-one-wire");
+const customBatteryAdc = document.getElementById("custom-battery-adc");
+const customSensorEnable = document.getElementById("custom-sensor-enable");
 const btnProvision = document.getElementById("btn-provision");
 const provisionStatus = document.getElementById("provision-status");
 
@@ -89,8 +92,18 @@ let scanGeneration = 0;
 // ---------------------------------------------------------------------------
 
 const BOARD_PRESETS = {
-  devkitm1: { label: "Espressif ESP32-C3 DevKitM-1", sda: 0, scl: 1 },
-  sparkfun: { label: "SparkFun ESP32-C3 Pro Micro",   sda: 5, scl: 6 },
+  rev_a: {
+    label: "Sonde Sensor Node rev_a",
+    layout: { i2c0Sda: 6, i2c0Scl: 7, oneWireData: 3, batteryAdc: 2, sensorEnable: 4 },
+  },
+  devkitm1: {
+    label: "Espressif ESP32-C3 DevKitM-1",
+    layout: { i2c0Sda: 0, i2c0Scl: 1, oneWireData: null, batteryAdc: null, sensorEnable: null },
+  },
+  sparkfun: {
+    label: "SparkFun ESP32-C3 Pro Micro",
+    layout: { i2c0Sda: 5, i2c0Scl: 6, oneWireData: null, batteryAdc: null, sensorEnable: null },
+  },
 };
 
 function initBoardSelect() {
@@ -103,22 +116,41 @@ function initBoardSelect() {
     boardSelect.appendChild(option);
   }
   if (customOption) boardSelect.appendChild(customOption);
+  boardSelect.value = "rev_a";
   customPins.classList.toggle("hidden", boardSelect.value !== "custom");
 }
 
-function resolveI2cPins() {
+function parseOptionalPin(input, label) {
+  const raw = input.value.trim();
+  if (raw === "") return null;
+  const value = Number(raw);
+  if (!Number.isInteger(value)) { showError(`Enter a whole GPIO number for ${label}`); return undefined; }
+  if (value < 0 || value > 21) { showError(`${label} must be 0–21`); return undefined; }
+  return value;
+}
+
+function resolveBoardLayout() {
   const board = boardSelect.value;
   if (board === "custom") {
-    const sda = customSda.valueAsNumber;
-    const scl = customScl.valueAsNumber;
-    if (!Number.isInteger(sda) || !Number.isInteger(scl)) { showError("Enter SDA and SCL GPIO numbers"); return null; }
-    if (sda < 0 || sda > 21 || scl < 0 || scl > 21) { showError("GPIO must be 0–21"); return null; }
-    if (sda === scl) { showError("SDA and SCL must be different pins"); return null; }
-    return { sda, scl };
+    const i2c0Sda = parseOptionalPin(customI2cSda, "I2C SDA");
+    const i2c0Scl = parseOptionalPin(customI2cScl, "I2C SCL");
+    const oneWireData = parseOptionalPin(customOneWire, "1-Wire data");
+    const batteryAdc = parseOptionalPin(customBatteryAdc, "battery ADC");
+    const sensorEnable = parseOptionalPin(customSensorEnable, "sensor enable");
+    if ([i2c0Sda, i2c0Scl, oneWireData, batteryAdc, sensorEnable].includes(undefined)) return null;
+    if ((i2c0Sda === null) !== (i2c0Scl === null)) {
+      showError("I2C SDA and I2C SCL must both be assigned or both left blank");
+      return null;
+    }
+    if (i2c0Sda !== null && i2c0Sda === i2c0Scl) {
+      showError("I2C SDA and I2C SCL must be different pins");
+      return null;
+    }
+    return { i2c0Sda, i2c0Scl, oneWireData, batteryAdc, sensorEnable };
   }
   const preset = BOARD_PRESETS[board];
   if (!preset) { showError("Unknown board selection"); return null; }
-  return { sda: preset.sda, scl: preset.scl };
+  return preset.layout;
 }
 
 // ---------------------------------------------------------------------------
@@ -511,8 +543,8 @@ async function provisionNode() {
   if (!selectedAddressNode) return;
   const nid = nodeId.value.trim();
   if (!nid) { showError("Enter a Node ID"); return; }
-  const pins = resolveI2cPins();
-  if (!pins) return;
+  const boardLayout = resolveBoardLayout();
+  if (!boardLayout) return;
   clearError();
   if (scanning) await stopScan();
   setBusy(true);
@@ -522,8 +554,7 @@ async function provisionNode() {
     await invoke("provision_node", {
       address: selectedAddressNode,
       nodeId: nid,
-      i2cSda: pins.sda,
-      i2cScl: pins.scl,
+      boardLayout,
     });
     hideStatus(provisionStatus);
     provisionDetails.textContent = "Node \"" + nid + "\" provisioned.";

--- a/crates/sonde-pair/src/error.rs
+++ b/crates/sonde-pair/src/error.rs
@@ -145,8 +145,8 @@ pub enum PairingError {
     #[error("invalid node ID: {0}")]
     InvalidNodeId(String),
 
-    #[error("invalid pin config: {0}")]
-    InvalidPinConfig(String),
+    #[error("invalid board layout: {0}")]
+    InvalidBoardLayout(String),
 
     #[error("invalid RF channel {0}: must be 1-13")]
     InvalidRfChannel(u8),

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -29,6 +29,15 @@ fn msg_type_name(t: u8) -> &'static str {
     }
 }
 
+fn validate_supported_battery_adc(layout: &BoardLayout) -> Result<(), PairingError> {
+    match layout.battery_adc {
+        Some(0..=4) | None => Ok(()),
+        Some(pin) => Err(PairingError::InvalidBoardLayout(format!(
+            "battery_adc GPIO {pin} is not ADC-capable on ESP32-C3; use GPIO 0-4 or leave it unassigned"
+        ))),
+    }
+}
+
 /// Phase 2 (AEAD): Provision a node via BLE using simplified AEAD flow.
 ///
 /// The phone generates the node PSK, builds a PairingRequest CBOR, encrypts
@@ -54,6 +63,7 @@ pub async fn provision_node(
         if let Err(reason) = layout.validate() {
             return Err(PairingError::InvalidBoardLayout(reason.into()));
         }
+        validate_supported_battery_adc(layout)?;
     }
 
     // Step 2: Generate node PSK
@@ -680,6 +690,47 @@ mod tests {
                 i2c0_scl: Some(4),
                 one_wire_data: None,
                 battery_adc: None,
+                sensor_enable: None,
+            }),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(PairingError::InvalidBoardLayout(_))),
+            "expected InvalidBoardLayout, got {result:?}"
+        );
+        assert!(
+            transport.written.is_empty(),
+            "no BLE writes on validation failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn provision_node_board_layout_battery_adc_not_supported() {
+        use crate::phase1::PairingArtifacts;
+
+        let artifacts = PairingArtifacts {
+            phone_psk: Zeroizing::new([0x55u8; 32]),
+            phone_key_hint: compute_key_hint(&[0x55u8; 32]),
+            rf_channel: 6,
+            phone_label: "test".into(),
+        };
+
+        let rng = MockRng::new([0x42u8; 32]);
+        let mut transport = MockBleTransport::new(247);
+
+        let result = provision_node(
+            &mut transport,
+            &artifacts,
+            &rng,
+            &[0xAA; 6],
+            "test-node",
+            &[],
+            Some(BoardLayout {
+                i2c0_sda: Some(6),
+                i2c0_scl: Some(7),
+                one_wire_data: None,
+                battery_adc: Some(7),
                 sensor_enable: None,
             }),
         )

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -532,13 +532,13 @@ mod tests {
         let (_svc, _chr, data) = &transport.written[0];
         let body = &data[3..];
         let payload_len = u16::from_be_bytes([body[35], body[36]]) as usize;
-        let pin_cbor_start = 37 + payload_len;
+        let board_layout_cbor_start = 37 + payload_len;
         assert!(
-            body.len() > pin_cbor_start,
-            "body should have trailing CBOR"
+            body.len() > board_layout_cbor_start,
+            "body should have trailing board-layout CBOR"
         );
 
-        let trailing = &body[pin_cbor_start..];
+        let trailing = &body[board_layout_cbor_start..];
         let value: ciborium::Value = ciborium::from_reader(trailing).expect("valid CBOR");
         let map = value.as_map().expect("CBOR map");
         let expected = [

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -9,6 +9,7 @@ use crate::rng::RngProvider;
 use crate::transport::BleTransport;
 use crate::types::*;
 use crate::validation::{compute_key_hint, validate_node_id};
+use sonde_protocol::encode_board_layout_cbor;
 use tracing::{debug, info, trace};
 use zeroize::Zeroizing;
 
@@ -43,25 +44,15 @@ pub async fn provision_node(
     device_address: &[u8; 6],
     node_id: &str,
     sensors: &[crate::types::SensorDescriptor],
-    pin_config: Option<PinConfig>,
+    board_layout: Option<BoardLayout>,
 ) -> Result<NodeProvisionResult, PairingError> {
     // Step 1: Validate node_id
     validate_node_id(node_id)?;
 
-    // Step 1a: Validate pin config (PT-1214 AC 5, AC 6)
-    if let Some(ref pc) = pin_config {
-        const MAX_GPIO: u8 = 21;
-        if pc.i2c0_sda > MAX_GPIO || pc.i2c0_scl > MAX_GPIO {
-            return Err(PairingError::InvalidPinConfig(format!(
-                "GPIO pin number out of range (0–{}), got sda={}, scl={}",
-                MAX_GPIO, pc.i2c0_sda, pc.i2c0_scl
-            )));
-        }
-        if pc.i2c0_sda == pc.i2c0_scl {
-            return Err(PairingError::InvalidPinConfig(format!(
-                "i2c0_sda and i2c0_scl must be different GPIO pins, both are {}",
-                pc.i2c0_sda
-            )));
+    // Step 1a: Validate board layout (PT-1214, PT-1216).
+    if let Some(ref layout) = board_layout {
+        if let Err(reason) = layout.validate() {
+            return Err(PairingError::InvalidBoardLayout(reason.into()));
         }
     }
 
@@ -127,7 +118,7 @@ pub async fn provision_node(
         &node_psk,
         artifacts.rf_channel,
         &encrypted_frame,
-        pin_config,
+        board_layout,
     )
     .await;
 
@@ -142,7 +133,7 @@ async fn do_provision_node(
     node_psk: &[u8; 32],
     rf_channel: u8,
     encrypted_frame: &[u8],
-    pin_config: Option<PinConfig>,
+    board_layout: Option<BoardLayout>,
 ) -> Result<NodeProvisionResult, PairingError> {
     if encrypted_frame.len() > PEER_PAYLOAD_MAX_LEN {
         return Err(PairingError::PayloadTooLarge {
@@ -152,11 +143,16 @@ async fn do_provision_node(
     }
     let payload_len = encrypted_frame.len() as u16;
 
-    // Pin config CBOR {1: u8, 2: u8} is at most 7 bytes (map(2) + 2×(uint,uint)).
-    let pin_cbor_capacity = if pin_config.is_some() { 7 } else { 0 };
+    let board_layout_cbor = match board_layout {
+        Some(layout) => Some(
+            encode_board_layout_cbor(&layout)
+                .map_err(|e| PairingError::InvalidBoardLayout(e.to_string()))?,
+        ),
+        None => None,
+    };
 
     let mut provision_payload = Zeroizing::new(Vec::with_capacity(
-        2 + 32 + 1 + 2 + encrypted_frame.len() + pin_cbor_capacity,
+        2 + 32 + 1 + 2 + encrypted_frame.len() + board_layout_cbor.as_ref().map_or(0, Vec::len),
     ));
     provision_payload.extend_from_slice(&node_key_hint.to_be_bytes());
     provision_payload.extend_from_slice(node_psk);
@@ -164,24 +160,12 @@ async fn do_provision_node(
     provision_payload.extend_from_slice(&payload_len.to_be_bytes());
     provision_payload.extend_from_slice(encrypted_frame);
 
-    // Append optional pin config CBOR (PT-1214, ND-0608)
-    if let Some(pc) = pin_config {
-        let pin_cbor = ciborium::Value::Map(vec![
-            (
-                ciborium::Value::Integer(1.into()),
-                ciborium::Value::Integer(pc.i2c0_sda.into()),
-            ),
-            (
-                ciborium::Value::Integer(2.into()),
-                ciborium::Value::Integer(pc.i2c0_scl.into()),
-            ),
-        ]);
-        ciborium::into_writer(&pin_cbor, &mut *provision_payload)
-            .map_err(|e| PairingError::CborEncodeFailed(format!("pin_config: {e}")))?;
+    // Append optional board layout CBOR (PT-1214, ND-0608).
+    if let Some(board_layout_cbor) = board_layout_cbor {
+        provision_payload.extend_from_slice(&board_layout_cbor);
         trace!(
-            sda = pc.i2c0_sda,
-            scl = pc.i2c0_scl,
-            "appended pin config CBOR to NODE_PROVISION"
+            board_layout_len = board_layout_cbor.len(),
+            "appended board layout CBOR to NODE_PROVISION"
         );
     }
 
@@ -499,7 +483,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provision_node_pin_config_appended() {
+    async fn provision_node_board_layout_appended() {
         use crate::phase1::PairingArtifacts;
 
         let artifacts = PairingArtifacts {
@@ -520,9 +504,12 @@ mod tests {
         let mut transport = MockBleTransport::new(247);
         transport.queue_response(Ok(ack_envelope));
 
-        let pc = PinConfig {
-            i2c0_sda: 4,
-            i2c0_scl: 5,
+        let board_layout = BoardLayout {
+            i2c0_sda: Some(4),
+            i2c0_scl: Some(5),
+            one_wire_data: Some(3),
+            battery_adc: Some(2),
+            sensor_enable: Some(6),
         };
 
         let result = provision_node(
@@ -532,13 +519,13 @@ mod tests {
             &[0xAA; 6],
             "test-node",
             &[],
-            Some(pc),
+            Some(board_layout),
         )
         .await;
 
         assert!(
             result.is_ok(),
-            "provision with pin_config should succeed: {result:?}"
+            "provision with board_layout should succeed: {result:?}"
         );
 
         assert_eq!(transport.written.len(), 1);
@@ -554,26 +541,32 @@ mod tests {
         let trailing = &body[pin_cbor_start..];
         let value: ciborium::Value = ciborium::from_reader(trailing).expect("valid CBOR");
         let map = value.as_map().expect("CBOR map");
-        let sda = map
-            .iter()
-            .find(|(k, _)| *k == ciborium::Value::Integer(1.into()))
-            .expect("key 1")
-            .1
-            .as_integer()
-            .unwrap();
-        let scl = map
-            .iter()
-            .find(|(k, _)| *k == ciborium::Value::Integer(2.into()))
-            .expect("key 2")
-            .1
-            .as_integer()
-            .unwrap();
-        assert_eq!(i128::from(sda), 4);
-        assert_eq!(i128::from(scl), 5);
+        let expected = [
+            (1, Some(4)),
+            (2, Some(5)),
+            (3, Some(3)),
+            (4, Some(2)),
+            (5, Some(6)),
+        ];
+        for (key, expected_value) in expected {
+            let value = map
+                .iter()
+                .find(|(k, _)| *k == ciborium::Value::Integer(key.into()))
+                .unwrap_or_else(|| panic!("missing key {key}"))
+                .1
+                .clone();
+            match expected_value {
+                Some(expected_value) => {
+                    let actual = value.as_integer().expect("integer value");
+                    assert_eq!(i128::from(actual), expected_value);
+                }
+                None => assert_eq!(value, ciborium::Value::Null),
+            }
+        }
     }
 
     #[tokio::test]
-    async fn provision_node_pin_config_none_no_trailing() {
+    async fn provision_node_board_layout_none_no_trailing() {
         use crate::phase1::PairingArtifacts;
 
         let artifacts = PairingArtifacts {
@@ -607,7 +600,7 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "provision without pin_config should succeed: {result:?}"
+            "provision without board_layout should succeed: {result:?}"
         );
 
         let (_svc, _chr, data) = &transport.written[0];
@@ -616,12 +609,12 @@ mod tests {
         assert_eq!(
             body.len(),
             37 + payload_len,
-            "no trailing bytes when pin_config is None"
+            "no trailing bytes when board_layout is None"
         );
     }
 
     #[tokio::test]
-    async fn provision_node_pin_config_out_of_range() {
+    async fn provision_node_board_layout_out_of_range() {
         use crate::phase1::PairingArtifacts;
 
         let artifacts = PairingArtifacts {
@@ -641,16 +634,19 @@ mod tests {
             &[0xAA; 6],
             "test-node",
             &[],
-            Some(PinConfig {
-                i2c0_sda: 22,
-                i2c0_scl: 5,
+            Some(BoardLayout {
+                i2c0_sda: Some(6),
+                i2c0_scl: Some(7),
+                one_wire_data: None,
+                battery_adc: Some(22),
+                sensor_enable: None,
             }),
         )
         .await;
 
         assert!(
-            matches!(result, Err(PairingError::InvalidPinConfig(_))),
-            "expected InvalidPinConfig, got {result:?}"
+            matches!(result, Err(PairingError::InvalidBoardLayout(_))),
+            "expected InvalidBoardLayout, got {result:?}"
         );
         assert!(
             transport.written.is_empty(),
@@ -659,7 +655,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provision_node_pin_config_sda_equals_scl() {
+    async fn provision_node_board_layout_sda_equals_scl() {
         use crate::phase1::PairingArtifacts;
 
         let artifacts = PairingArtifacts {
@@ -679,16 +675,19 @@ mod tests {
             &[0xAA; 6],
             "test-node",
             &[],
-            Some(PinConfig {
-                i2c0_sda: 4,
-                i2c0_scl: 4,
+            Some(BoardLayout {
+                i2c0_sda: Some(4),
+                i2c0_scl: Some(4),
+                one_wire_data: None,
+                battery_adc: None,
+                sensor_enable: None,
             }),
         )
         .await;
 
         assert!(
-            matches!(result, Err(PairingError::InvalidPinConfig(_))),
-            "expected InvalidPinConfig, got {result:?}"
+            matches!(result, Err(PairingError::InvalidBoardLayout(_))),
+            "expected InvalidBoardLayout, got {result:?}"
         );
         assert!(
             transport.written.is_empty(),
@@ -754,43 +753,13 @@ mod tests {
         assert!(matches!(result, Err(PairingError::DiagnosticFailed(_))));
     }
 
-    /// Validates: PT-1214 AC2 — pin config CBOR deterministic encoding.
-    ///
-    /// The pin config CBOR map must use integer keys in ascending order
-    /// (key 1 = i2c0_sda, key 2 = i2c0_scl) with minimal-length encoding.
+    /// Validates: PT-1214 AC2 — board layout CBOR deterministic encoding.
     #[test]
-    fn pin_config_cbor_deterministic() {
-        let pc = PinConfig {
-            i2c0_sda: 5,
-            i2c0_scl: 6,
-        };
-        let pin_cbor = ciborium::Value::Map(vec![
-            (
-                ciborium::Value::Integer(1.into()),
-                ciborium::Value::Integer(pc.i2c0_sda.into()),
-            ),
-            (
-                ciborium::Value::Integer(2.into()),
-                ciborium::Value::Integer(pc.i2c0_scl.into()),
-            ),
-        ]);
-        let mut buf = Vec::new();
-        ciborium::into_writer(&pin_cbor, &mut buf).unwrap();
-
-        // Expected: A2 01 05 02 06
-        // A2 = map(2), 01 = key 1, 05 = value 5, 02 = key 2, 06 = value 6
-        assert_eq!(buf, [0xA2, 0x01, 0x05, 0x02, 0x06]);
-
-        // Verify keys are in ascending order (deterministic CBOR §4.2).
-        let decoded: ciborium::Value = ciborium::from_reader(buf.as_slice()).unwrap();
-        if let ciborium::Value::Map(pairs) = decoded {
-            let keys: Vec<u64> = pairs
-                .iter()
-                .map(|(k, _)| u64::try_from(k.as_integer().unwrap()).unwrap())
-                .collect();
-            assert_eq!(keys, vec![1, 2], "keys must be in ascending order");
-        } else {
-            panic!("expected CBOR map");
-        }
+    fn board_layout_cbor_deterministic() {
+        let buf = encode_board_layout_cbor(&BoardLayout::SONDE_SENSOR_NODE_REV_A).unwrap();
+        assert_eq!(
+            buf,
+            [0xA5, 0x01, 0x06, 0x02, 0x07, 0x03, 0x03, 0x04, 0x02, 0x05, 0x04]
+        );
     }
 }

--- a/crates/sonde-pair/src/types.rs
+++ b/crates/sonde-pair/src/types.rs
@@ -129,15 +129,4 @@ pub struct SensorDescriptor {
     pub label: Option<String>,
 }
 
-/// Board-specific I2C pin configuration for NODE_PROVISION (PT-1214).
-///
-/// When present, encoded as a deterministic CBOR map and appended to the
-/// NODE_PROVISION body after the encrypted payload.  The node persists
-/// these to NVS so a single firmware binary works across boards (ND-0608).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct PinConfig {
-    /// I2C0 SDA GPIO number (0–21 for ESP32-C3).
-    pub i2c0_sda: u8,
-    /// I2C0 SCL GPIO number (0–21 for ESP32-C3).
-    pub i2c0_scl: u8,
-}
+pub use sonde_protocol::BoardLayout;

--- a/crates/sonde-protocol/src/board_layout.rs
+++ b/crates/sonde-protocol/src/board_layout.rs
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use ciborium::Value;
+
+use crate::{DecodeError, EncodeError};
+
+pub const BOARD_LAYOUT_KEY_I2C0_SDA: u64 = 1;
+pub const BOARD_LAYOUT_KEY_I2C0_SCL: u64 = 2;
+pub const BOARD_LAYOUT_KEY_ONE_WIRE_DATA: u64 = 3;
+pub const BOARD_LAYOUT_KEY_BATTERY_ADC: u64 = 4;
+pub const BOARD_LAYOUT_KEY_SENSOR_ENABLE: u64 = 5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BoardLayout {
+    pub i2c0_sda: Option<u8>,
+    pub i2c0_scl: Option<u8>,
+    pub one_wire_data: Option<u8>,
+    pub battery_adc: Option<u8>,
+    pub sensor_enable: Option<u8>,
+}
+
+impl BoardLayout {
+    pub const LEGACY_COMPAT: Self = Self {
+        i2c0_sda: Some(0),
+        i2c0_scl: Some(1),
+        one_wire_data: None,
+        battery_adc: None,
+        sensor_enable: None,
+    };
+
+    pub const SONDE_SENSOR_NODE_REV_A: Self = Self {
+        i2c0_sda: Some(6),
+        i2c0_scl: Some(7),
+        one_wire_data: Some(3),
+        battery_adc: Some(2),
+        sensor_enable: Some(4),
+    };
+
+    pub const ESPRESSIF_ESP32_C3_DEVKIT_M1: Self = Self {
+        i2c0_sda: Some(0),
+        i2c0_scl: Some(1),
+        one_wire_data: None,
+        battery_adc: None,
+        sensor_enable: None,
+    };
+
+    pub const SPARKFUN_ESP32_C3_PRO_MICRO: Self = Self {
+        i2c0_sda: Some(5),
+        i2c0_scl: Some(6),
+        one_wire_data: None,
+        battery_adc: None,
+        sensor_enable: None,
+    };
+
+    pub fn is_legacy_compat(&self) -> bool {
+        self.i2c0_sda == Self::LEGACY_COMPAT.i2c0_sda
+            && self.i2c0_scl == Self::LEGACY_COMPAT.i2c0_scl
+            && self.one_wire_data == Self::LEGACY_COMPAT.one_wire_data
+            && self.battery_adc == Self::LEGACY_COMPAT.battery_adc
+            && self.sensor_enable == Self::LEGACY_COMPAT.sensor_enable
+    }
+
+    pub fn validate(&self) -> Result<(), &'static str> {
+        validate_gpio(self.i2c0_sda, "i2c0_sda")?;
+        validate_gpio(self.i2c0_scl, "i2c0_scl")?;
+        validate_gpio(self.one_wire_data, "one_wire_data")?;
+        validate_gpio(self.battery_adc, "battery_adc")?;
+        validate_gpio(self.sensor_enable, "sensor_enable")?;
+
+        match (self.i2c0_sda, self.i2c0_scl) {
+            (Some(sda), Some(scl)) if sda == scl => {
+                Err("i2c0_sda and i2c0_scl must be different pins")
+            }
+            (Some(_), None) | (None, Some(_)) => {
+                Err("i2c0_sda and i2c0_scl must both be assigned or both be unassigned")
+            }
+            _ => Ok(()),
+        }
+    }
+
+    pub fn assigned_pins(&self) -> [Option<u8>; 5] {
+        [
+            self.i2c0_sda,
+            self.i2c0_scl,
+            self.one_wire_data,
+            self.battery_adc,
+            self.sensor_enable,
+        ]
+    }
+}
+
+fn validate_gpio(pin: Option<u8>, field: &str) -> Result<(), &'static str> {
+    const MAX_GPIO: u8 = 21;
+    if matches!(pin, Some(value) if value > MAX_GPIO) {
+        return Err(match field {
+            "i2c0_sda" => "i2c0_sda must be in GPIO range 0-21",
+            "i2c0_scl" => "i2c0_scl must be in GPIO range 0-21",
+            "one_wire_data" => "one_wire_data must be in GPIO range 0-21",
+            "battery_adc" => "battery_adc must be in GPIO range 0-21",
+            "sensor_enable" => "sensor_enable must be in GPIO range 0-21",
+            _ => "GPIO value must be in range 0-21",
+        });
+    }
+    Ok(())
+}
+
+fn value_for_pin(pin: Option<u8>) -> Value {
+    match pin {
+        Some(pin) => Value::Integer(pin.into()),
+        None => Value::Null,
+    }
+}
+
+fn decode_pin(value: &Value, field: &'static str) -> Result<Option<u8>, DecodeError> {
+    match value {
+        Value::Null => Ok(None),
+        _ => value
+            .as_integer()
+            .and_then(|integer| u8::try_from(integer).ok())
+            .map(Some)
+            .ok_or_else(|| DecodeError::InvalidParameter(format!("{field} must be uint or null"))),
+    }
+}
+
+pub fn encode_board_layout_cbor(layout: &BoardLayout) -> Result<Vec<u8>, EncodeError> {
+    layout
+        .validate()
+        .map_err(|reason| EncodeError::InvalidParameter(reason.into()))?;
+
+    let value = Value::Map(vec![
+        (
+            Value::Integer(BOARD_LAYOUT_KEY_I2C0_SDA.into()),
+            value_for_pin(layout.i2c0_sda),
+        ),
+        (
+            Value::Integer(BOARD_LAYOUT_KEY_I2C0_SCL.into()),
+            value_for_pin(layout.i2c0_scl),
+        ),
+        (
+            Value::Integer(BOARD_LAYOUT_KEY_ONE_WIRE_DATA.into()),
+            value_for_pin(layout.one_wire_data),
+        ),
+        (
+            Value::Integer(BOARD_LAYOUT_KEY_BATTERY_ADC.into()),
+            value_for_pin(layout.battery_adc),
+        ),
+        (
+            Value::Integer(BOARD_LAYOUT_KEY_SENSOR_ENABLE.into()),
+            value_for_pin(layout.sensor_enable),
+        ),
+    ]);
+
+    let mut buf = Vec::new();
+    ciborium::into_writer(&value, &mut buf).map_err(|e| EncodeError::CborError(format!("{e}")))?;
+    Ok(buf)
+}
+
+pub fn decode_board_layout_cbor(data: &[u8]) -> Result<BoardLayout, DecodeError> {
+    let mut remaining = data;
+    let value: Value = ciborium::from_reader(&mut remaining)
+        .map_err(|e| DecodeError::CborError(format!("{e}")))?;
+    if !remaining.is_empty() {
+        return Err(DecodeError::InvalidParameter(
+            "board_layout has trailing bytes".into(),
+        ));
+    }
+
+    let map = value
+        .as_map()
+        .ok_or_else(|| DecodeError::InvalidParameter("board_layout must be a CBOR map".into()))?;
+
+    let mut i2c0_sda = None;
+    let mut i2c0_scl = None;
+    let mut one_wire_data = None;
+    let mut battery_adc = None;
+    let mut sensor_enable = None;
+
+    for (key, value) in map {
+        let Some(key) = key
+            .as_integer()
+            .and_then(|integer| u64::try_from(integer).ok())
+        else {
+            return Err(DecodeError::InvalidParameter(
+                "board_layout key must be an unsigned integer".into(),
+            ));
+        };
+
+        match key {
+            BOARD_LAYOUT_KEY_I2C0_SDA => i2c0_sda = Some(decode_pin(value, "i2c0_sda")?),
+            BOARD_LAYOUT_KEY_I2C0_SCL => i2c0_scl = Some(decode_pin(value, "i2c0_scl")?),
+            BOARD_LAYOUT_KEY_ONE_WIRE_DATA => {
+                one_wire_data = Some(decode_pin(value, "one_wire_data")?)
+            }
+            BOARD_LAYOUT_KEY_BATTERY_ADC => battery_adc = Some(decode_pin(value, "battery_adc")?),
+            BOARD_LAYOUT_KEY_SENSOR_ENABLE => {
+                sensor_enable = Some(decode_pin(value, "sensor_enable")?)
+            }
+            _ => {}
+        }
+    }
+
+    let layout = BoardLayout {
+        i2c0_sda: i2c0_sda
+            .ok_or_else(|| DecodeError::InvalidParameter("board_layout missing i2c0_sda".into()))?,
+        i2c0_scl: i2c0_scl
+            .ok_or_else(|| DecodeError::InvalidParameter("board_layout missing i2c0_scl".into()))?,
+        one_wire_data: one_wire_data.ok_or_else(|| {
+            DecodeError::InvalidParameter("board_layout missing one_wire_data".into())
+        })?,
+        battery_adc: battery_adc.ok_or_else(|| {
+            DecodeError::InvalidParameter("board_layout missing battery_adc".into())
+        })?,
+        sensor_enable: sensor_enable.ok_or_else(|| {
+            DecodeError::InvalidParameter("board_layout missing sensor_enable".into())
+        })?,
+    };
+
+    layout
+        .validate()
+        .map_err(|reason| DecodeError::InvalidParameter(reason.into()))?;
+    Ok(layout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn board_layout_round_trip() {
+        let layout = BoardLayout::SONDE_SENSOR_NODE_REV_A;
+        let encoded = encode_board_layout_cbor(&layout).unwrap();
+        let decoded = decode_board_layout_cbor(&encoded).unwrap();
+        assert_eq!(decoded, layout);
+    }
+
+    #[test]
+    fn board_layout_encoding_is_deterministic() {
+        let encoded = encode_board_layout_cbor(&BoardLayout {
+            i2c0_sda: Some(6),
+            i2c0_scl: Some(7),
+            one_wire_data: Some(3),
+            battery_adc: Some(2),
+            sensor_enable: Some(4),
+        })
+        .unwrap();
+        assert_eq!(
+            encoded,
+            [0xA5, 0x01, 0x06, 0x02, 0x07, 0x03, 0x03, 0x04, 0x02, 0x05, 0x04]
+        );
+    }
+
+    #[test]
+    fn board_layout_rejects_missing_known_key() {
+        let encoded = [0xA4, 0x01, 0x06, 0x02, 0x07, 0x03, 0x03, 0x05, 0x04];
+        let err = decode_board_layout_cbor(&encoded).unwrap_err();
+        assert_eq!(
+            err,
+            DecodeError::InvalidParameter("board_layout missing battery_adc".into())
+        );
+    }
+
+    #[test]
+    fn board_layout_rejects_half_i2c_assignment() {
+        let err = BoardLayout {
+            i2c0_sda: Some(6),
+            i2c0_scl: None,
+            one_wire_data: None,
+            battery_adc: None,
+            sensor_enable: None,
+        }
+        .validate()
+        .unwrap_err();
+        assert_eq!(
+            err,
+            "i2c0_sda and i2c0_scl must both be assigned or both be unassigned"
+        );
+    }
+}

--- a/crates/sonde-protocol/src/lib.rs
+++ b/crates/sonde-protocol/src/lib.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 
 pub mod aead_codec;
 pub mod ble_envelope;
+pub mod board_layout;
 pub mod chunk;
 pub mod constants;
 pub mod error;
@@ -20,6 +21,11 @@ pub use aead_codec::{build_gcm_nonce, decode_frame, encode_frame, open_frame, De
 pub use ble_envelope::{
     decode_diag_relay_request, decode_diag_relay_response, encode_ble_envelope,
     encode_diag_relay_request, encode_diag_relay_response, parse_ble_envelope,
+};
+pub use board_layout::{
+    decode_board_layout_cbor, encode_board_layout_cbor, BoardLayout, BOARD_LAYOUT_KEY_BATTERY_ADC,
+    BOARD_LAYOUT_KEY_I2C0_SCL, BOARD_LAYOUT_KEY_I2C0_SDA, BOARD_LAYOUT_KEY_ONE_WIRE_DATA,
+    BOARD_LAYOUT_KEY_SENSOR_ENABLE,
 };
 pub use chunk::{chunk_count, get_chunk};
 pub use constants::*;

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -159,7 +159,7 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
 
 ### 4.3  Phase 2 state machine — Node provisioning
 
-The Phase 2 state machine implements the node provisioning flow from [ble-pairing-protocol.md §6](ble-pairing-protocol.md).  `provision_node()` takes a `BleTransport`, `PairingArtifacts` (from Phase 1), `RngProvider`, device address, operator-supplied `node_id`, sensor descriptors, and an optional `PinConfig`, and returns `Result<NodeProvisionResult, PairingError>`.
+The Phase 2 state machine implements the node provisioning flow from [ble-pairing-protocol.md §6](ble-pairing-protocol.md).  `provision_node()` takes a `BleTransport`, `PairingArtifacts` (from Phase 1), `RngProvider`, device address, operator-supplied `node_id`, sensor descriptors, and an optional `BoardLayout`, and returns `Result<NodeProvisionResult, PairingError>`.
 
 ```
 ┌─────────────┐
@@ -217,19 +217,22 @@ Offset  Size           Field
 34      1              rf_channel        (1–13)
 35      2              payload_len       (BE u16, encrypted payload length)
 37      payload_len    encrypted_payload (opaque blob for gateway)
-37+N    remaining      pin_config_cbor   (optional, CBOR map — see below)
+37+N    remaining      board_layout_cbor (optional, CBOR map — see below)
 ```
 
-**Pin config (ND-0608):** If the NODE_PROVISION body is longer than `37 + payload_len`, the remaining bytes are a deterministic CBOR map (RFC 8949 §4.2) of board-specific pin assignments:
+**Board layout (ND-0608):** If the `NODE_PROVISION` body is longer than `37 + payload_len`, the remaining bytes are a deterministic CBOR map (RFC 8949 §4.2) of board-specific function assignments:
 
-| CBOR key | Field | Type | Default |
+| CBOR key | Field | Type | Meaning |
 |----------|-------|------|---------|
-| 1 | `i2c0_sda` | uint | 0 |
-| 2 | `i2c0_scl` | uint | 1 |
+| 1 | `i2c0_sda` | uint or null | I2C0 SDA GPIO, or explicitly unassigned |
+| 2 | `i2c0_scl` | uint or null | I2C0 SCL GPIO, or explicitly unassigned |
+| 3 | `one_wire_data` | uint or null | 1-Wire data GPIO, or explicitly unassigned |
+| 4 | `battery_adc` | uint or null | Battery ADC GPIO, or explicitly unassigned |
+| 5 | `sensor_enable` | uint or null | Active-low sensor-rail enable GPIO, or explicitly unassigned |
 
-The node persists these to NVS. If the map is absent (older pairing tool), the node uses compiled-in defaults. Future keys (SPI pins, pairing button GPIO) may be added without breaking backward compatibility.
+When the map is present, the five known keys are always emitted in ascending order with either a concrete GPIO number or `null`, so the receiver can distinguish "assigned" from "explicitly unassigned" without inference. If the map is absent entirely (older pairing tool / non-UI caller), the node retains any previously provisioned board layout; if none exists yet, it applies the legacy compatibility layout defined in the node specification.
 
-**Pin config source:** The pairing tool obtains `i2c0_sda` and `i2c0_scl` values from the board selector UI (see PT-1216).  The operator selects a named board preset (e.g., "Espressif ESP32-C3 DevKitM-1" or "SparkFun ESP32-C3 Pro Micro") or enters custom GPIO numbers.  The UI layer resolves the selection to a `PinConfig` and passes it to `provision_node()`.  This keeps provisioning simple — no separate board profile files or bundle manifests are required.
+**Board layout source:** The pairing tool obtains `BoardLayout` values from the board selector UI (see PT-1216).  The operator selects a named board preset (for example `Sonde Sensor Node rev_a`, `Espressif ESP32-C3 DevKitM-1`, or `SparkFun ESP32-C3 Pro Micro`) or enters a custom layout. The UI layer resolves the selection to a `BoardLayout` and passes it to `provision_node()`.
 
 ---
 
@@ -804,7 +807,7 @@ The mock RNG for testing returns deterministic bytes, enabling reproducible test
 
 ## 12  Input validation
 
-User inputs are validated before any BLE or cryptographic operation (PT-0403, PT-1205).  Validation is split across `validation.rs` (string and range checks for Phase 1/2 fields) and `phase2.rs` (payload size and pin configuration checks):
+User inputs are validated before any BLE or cryptographic operation (PT-0403, PT-1205).  Validation is split across `validation.rs` (string and range checks for Phase 1/2 fields) and `phase2.rs` (payload size and board-layout checks):
 
 | Input | Validation rule | Validated by | Error |
 |-------|----------------|-------------|-------|
@@ -812,8 +815,11 @@ User inputs are validated before any BLE or cryptographic operation (PT-0403, PT
 | `rf_channel` | 1–13 inclusive | `validation.rs` | `PairingError::InvalidRfChannel` |
 | `phone_label` | 0–64 bytes UTF-8 | `validation.rs` | `PairingError::InvalidLabel` |
 | Encrypted payload | ≤ 202 bytes | `phase2.rs` | `PairingError::PayloadTooLarge` |
-| `i2c0_sda` | 0–21, ≠ `i2c0_scl` | `phase2.rs` | `PairingError::InvalidPinConfig` |
-| `i2c0_scl` | 0–21, ≠ `i2c0_sda` | `phase2.rs` | `PairingError::InvalidPinConfig` |
+| `i2c0_sda` | 0–21 when assigned; if assigned then `i2c0_scl` must also be assigned and differ | `phase2.rs` | `PairingError::InvalidPinConfig` |
+| `i2c0_scl` | 0–21 when assigned; if assigned then `i2c0_sda` must also be assigned and differ | `phase2.rs` | `PairingError::InvalidPinConfig` |
+| `one_wire_data` | 0–21 when assigned, or null | `phase2.rs` | `PairingError::InvalidPinConfig` |
+| `battery_adc` | 0–21 when assigned, or null | `phase2.rs` | `PairingError::InvalidPinConfig` |
+| `sensor_enable` | 0–21 when assigned, or null | `phase2.rs` | `PairingError::InvalidPinConfig` |
 
 All validation occurs *before* any BLE write, ensuring that invalid inputs never reach the transport layer.
 
@@ -821,34 +827,35 @@ All validation occurs *before* any BLE write, ensuring that invalid inputs never
 
 ## 12.1  Board selector UI (PT-1216)
 
-The Tauri UI includes a board selector dropdown on the Phase 2 (Node Provisioning) card.  The selector is always visible (not collapsed behind an "Advanced" section) and determines the I2C `PinConfig` passed to `provision_node()`.
+The Tauri UI includes a board selector dropdown on the Phase 2 (Node Provisioning) card.  The selector is always visible (not collapsed behind an "Advanced" section) and determines the `BoardLayout` passed to `provision_node()`.
 
 ### Board presets
 
-Board presets are defined as a static table in the frontend JavaScript.  Each preset maps a human-readable board name to its I2C pin assignments:
+Board presets are defined as a static table in the frontend JavaScript. Each preset maps a human-readable board name to a full `BoardLayout`:
 
-| Preset label | `i2c0_sda` | `i2c0_scl` |
-|---|---|---|
-| Espressif ESP32-C3 DevKitM-1 | 0 | 1 |
-| SparkFun ESP32-C3 Pro Micro | 5 | 6 |
-| Custom | (user input) | (user input) |
+| Preset label | `i2c0_sda` | `i2c0_scl` | `one_wire_data` | `battery_adc` | `sensor_enable` |
+|---|---|---|---|---|---|
+| Sonde Sensor Node rev_a | 6 | 7 | 3 | 2 | 4 |
+| Espressif ESP32-C3 DevKitM-1 | 0 | 1 | `null` | `null` | `null` |
+| SparkFun ESP32-C3 Pro Micro | 5 | 6 | `null` | `null` | `null` |
+| Custom | (user input) | (user input) | (user input / blank) | (user input / blank) | (user input / blank) |
 
-The default selection is "Espressif ESP32-C3 DevKitM-1".  Adding a new board requires only a new entry in the frontend preset table — no backend or protocol changes.
+The default selection is `Sonde Sensor Node rev_a`. Adding a new board profile requires only a new entry in the frontend preset table — no backend or wire-format changes, because the full layout is already explicit in the provisioning payload.
 
 ### UI behavior
 
-- **Named preset selected:** The two GPIO values are resolved from the preset table.  No additional input fields are shown.
-- **"Custom" selected:** Two numeric `<input>` fields for SDA and SCL are revealed.  Values are validated client-side per PT-0409 (range 0–21, SDA ≠ SCL) before the Tauri command is invoked.  Validation errors are displayed in the existing error bar.
+- **Named preset selected:** The full `BoardLayout` is resolved from the preset table. No additional input fields are shown.
+- **"Custom" selected:** Editable fields for `i2c0_sda`, `i2c0_scl`, `one_wire_data`, `battery_adc`, and `sensor_enable` are revealed. Optional functions may be left blank to represent `null` / unassigned. Values are validated client-side per PT-0409 before the Tauri command is invoked. Validation errors are displayed in the existing error bar.
 
 ### Tauri command interface
 
-The `provision_node` Tauri command gains two optional parameters:
+The `provision_node` Tauri command gains an optional structured board-layout parameter:
 
 ```
-provision_node(address, nodeId, i2cSda?, i2cScl?)
+provision_node(address, nodeId, boardLayout?)
 ```
 
-When both `i2cSda` and `i2cScl` are provided, the backend constructs `Some(PinConfig { i2c0_sda, i2c0_scl })` and passes it to `phase2::provision_node()`.  When both are omitted, `None` is passed (backward compatible for non-UI callers).  Providing exactly one is an error.
+When provided, `boardLayout` contains nullable fields for `i2cSda`, `i2cScl`, `oneWireData`, `batteryAdc`, and `sensorEnable`. The backend validates the object, constructs `Some(BoardLayout { ... })`, and passes it to `phase2::provision_node()`. When omitted, `None` is passed for backward compatibility with non-UI callers.
 
 ---
 

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -459,14 +459,15 @@ After a successful `NODE_PROVISION` write, the tool MUST zero `node_psk` from me
 **Source:** PT-1214 (board layout), phase2.rs implementation
 
 **Description:**  
-Before provisioning, the tool MUST validate any board layout supplied by the operator or selected from a preset. Assigned GPIO pin numbers must be in range 0–21 (valid ESP32-C3 GPIOs). The I2C SDA and SCL functions form a pair: either both are assigned concrete GPIOs or both are explicitly unassigned, and when both are assigned they MUST NOT be identical. Optional functions such as 1-Wire data, battery ADC, and sensor-rail enable may be explicitly unassigned, but the encoding MUST preserve that state unambiguously. Invalid layouts MUST be rejected before any BLE transmission.
+Before provisioning, the tool MUST validate any board layout supplied by the operator or selected from a preset. Assigned GPIO pin numbers must be in range 0–21 (valid ESP32-C3 GPIOs). The I2C SDA and SCL functions form a pair: either both are assigned concrete GPIOs or both are explicitly unassigned, and when both are assigned they MUST NOT be identical. Optional functions such as 1-Wire data and sensor-rail enable may be explicitly unassigned; `battery_adc` may also be explicitly unassigned, but when assigned it MUST target an ADC-capable ESP32-C3 GPIO (currently GPIO0–GPIO4). The encoding MUST preserve unassigned state unambiguously. Invalid layouts MUST be rejected before any BLE transmission.
 
 **Acceptance criteria:**
 
 1. A board layout with any assigned GPIO number outside 0–21 is rejected with an actionable error identifying the out-of-range function.
 2. A board layout where `i2c0_sda == i2c0_scl` is rejected with an actionable error.
 3. A board layout where exactly one of `i2c0_sda` or `i2c0_scl` is assigned is rejected with an actionable error.
-4. A valid board layout with optional functions explicitly marked unassigned is accepted.
+4. A board layout where `battery_adc` is assigned to a non-ADC-capable GPIO is rejected with an actionable error.
+5. A valid board layout with optional functions explicitly marked unassigned is accepted.
 
 ---
 
@@ -1139,7 +1140,7 @@ Board layout is sourced from the board selector UI (see PT-1216). The operator s
 4. The CBOR map uses integer keys: 1 = `i2c0_sda`, 2 = `i2c0_scl`, 3 = `one_wire_data`, 4 = `battery_adc`, 5 = `sensor_enable`.
 5. Each known key in the board-layout map is encoded as either a concrete GPIO number (`uint`) or `null` to indicate "function explicitly unassigned on this board".
 6. The encoding makes "unassigned" unambiguous to the receiver; the receiver never has to guess whether a function is absent, unsupported, or accidentally omitted.
-7. GPIO values MUST be in the range 0–21 (ESP32-C3), and `i2c0_sda` / `i2c0_scl` MUST either both be assigned or both be `null`.
+7. GPIO values MUST be in the range 0–21 (ESP32-C3); when assigned, `battery_adc` MUST use an ADC-capable GPIO (currently GPIO0–GPIO4); and `i2c0_sda` / `i2c0_scl` MUST either both be assigned or both be `null`.
 
 ---
 

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -426,7 +426,7 @@ The encrypted payload MUST NOT exceed 202 bytes (the ESP-NOW frame budget). The 
 **Source:** ble-pairing-protocol.md §6.6, §6.7
 
 **Description:**  
-The tool MUST assemble the `NODE_PROVISION` body as `node_key_hint[2] ‖ node_psk[32] ‖ rf_channel[1] ‖ payload_len[2, BE u16] ‖ encrypted_payload`, write it to the Node Command characteristic, and wait for `NODE_ACK` (timeout: 5 s). The `encrypted_payload` is a complete ESP-NOW `PEER_REQUEST` frame (see ble-pairing-protocol.md §7.1) built by the phone in two AES-256-GCM layers using `phone_psk`: first, the inner PairingRequest CBOR is encrypted with AAD = `"sonde-pairing-v2"`; then that result is wrapped in the outer ESP-NOW `PEER_REQUEST` frame, whose AEAD AAD is the 11-byte ESP-NOW frame header. The node stores and forwards this frame verbatim — it does not decrypt or interpret the contents.
+The tool MUST assemble the `NODE_PROVISION` body as `node_key_hint[2] ‖ node_psk[32] ‖ rf_channel[1] ‖ payload_len[2, BE u16] ‖ encrypted_payload ‖ board_layout_cbor?`, write it to the Node Command characteristic, and wait for `NODE_ACK` (timeout: 5 s). The `encrypted_payload` is a complete ESP-NOW `PEER_REQUEST` frame (see ble-pairing-protocol.md §7.1) built by the phone in two AES-256-GCM layers using `phone_psk`: first, the inner PairingRequest CBOR is encrypted with AAD = `"sonde-pairing-v2"`; then that result is wrapped in the outer ESP-NOW `PEER_REQUEST` frame, whose AEAD AAD is the 11-byte ESP-NOW frame header. When present, `board_layout_cbor` is a deterministic CBOR map describing the provisioned board layout (PT-1214). The node stores and forwards the encrypted payload verbatim — it does not decrypt or interpret the contents.
 
 **Acceptance criteria:**
 
@@ -453,19 +453,20 @@ After a successful `NODE_PROVISION` write, the tool MUST zero `node_psk` from me
 
 ---
 
-### PT-0409  Pin configuration validation
+### PT-0409  Board layout validation
 
 **Priority:** Must  
-**Source:** PT-1214 (board pin configuration), phase2.rs implementation
+**Source:** PT-1214 (board layout), phase2.rs implementation
 
 **Description:**  
-Before provisioning, the tool MUST validate any pin configuration supplied by the operator.  GPIO pin numbers must be in range 0–21 (valid ESP32-C3 GPIOs), and the I²C SDA and SCL pins must not be identical.  Invalid configurations MUST be rejected before any BLE transmission.
+Before provisioning, the tool MUST validate any board layout supplied by the operator or selected from a preset. Assigned GPIO pin numbers must be in range 0–21 (valid ESP32-C3 GPIOs). The I2C SDA and SCL functions form a pair: either both are assigned concrete GPIOs or both are explicitly unassigned, and when both are assigned they MUST NOT be identical. Optional functions such as 1-Wire data, battery ADC, and sensor-rail enable may be explicitly unassigned, but the encoding MUST preserve that state unambiguously. Invalid layouts MUST be rejected before any BLE transmission.
 
 **Acceptance criteria:**
 
-1. A pin configuration with any GPIO number > 21 is rejected with an actionable error identifying the out-of-range pin.
-2. A pin configuration where SDA == SCL is rejected with an actionable error.
-3. A valid pin configuration (both pins in range, SDA ≠ SCL) is accepted.
+1. A board layout with any assigned GPIO number outside 0–21 is rejected with an actionable error identifying the out-of-range function.
+2. A board layout where `i2c0_sda == i2c0_scl` is rejected with an actionable error.
+3. A board layout where exactly one of `i2c0_sda` or `i2c0_scl` is assigned is rejected with an actionable error.
+4. A valid board layout with optional functions explicitly marked unassigned is accepted.
 
 ---
 
@@ -1120,24 +1121,25 @@ The pairing tool MUST apply build-type–aware log-level policies: compile-time 
 
 ---
 
-### PT-1214  Board pin configuration in NODE_PROVISION
+### PT-1214  Board layout in NODE_PROVISION
 
-**Priority:** Should  
+**Priority:** Must  
 **Source:** issue #490, issue #641, ND-0608
 
 **Description:**  
-The pairing tool SHOULD support including optional board-specific pin configuration (I2C SDA/SCL GPIO numbers) in the NODE_PROVISION message body so that a single firmware binary works across different ESP32-C3 boards.
+The pairing tool MUST support including an optional explicit board layout in the `NODE_PROVISION` message body so that a single firmware binary works across board revisions without hard-coding any specific layout in firmware. The board layout describes the GPIO assignment for each supported hardware function and whether that function is explicitly unassigned on the target board.
 
-Pin configuration is sourced from the board selector UI (see PT-1216).  The operator selects a named board preset or enters custom GPIO pin numbers.  The `provision_node` API accepts an optional pin config parameter; the UI layer extracts the selected board's pin assignments and passes them through.
+Board layout is sourced from the board selector UI (see PT-1216). The operator selects a named board preset or enters a custom layout. The `provision_node` API accepts an optional board-layout parameter; the UI layer extracts the selected board's layout and passes it through.
 
 **Acceptance criteria:**
 
-1. The `provision_node(...)` API (which constructs/sends NODE_PROVISION during Phase 2) accepts an optional pin config parameter.
-2. When provided, pin config is encoded as a deterministic CBOR map and appended to the NODE_PROVISION body after the encrypted payload.
-3. When not provided, the NODE_PROVISION body is identical to the existing format (backward compatible).
-4. The CBOR map uses integer keys: 1 = `i2c0_sda` (uint), 2 = `i2c0_scl` (uint).
-5. GPIO values MUST be in the range 0–21 (ESP32-C3).
-6. `i2c0_sda` MUST NOT equal `i2c0_scl`.
+1. The `provision_node(...)` API (which constructs/sends `NODE_PROVISION` during Phase 2) accepts an optional board-layout parameter.
+2. When provided, board layout is encoded as a deterministic CBOR map and appended to the `NODE_PROVISION` body after the encrypted payload.
+3. When not provided, the `NODE_PROVISION` body is identical to the existing format (backward compatible for older callers).
+4. The CBOR map uses integer keys: 1 = `i2c0_sda`, 2 = `i2c0_scl`, 3 = `one_wire_data`, 4 = `battery_adc`, 5 = `sensor_enable`.
+5. Each known key in the board-layout map is encoded as either a concrete GPIO number (`uint`) or `null` to indicate "function explicitly unassigned on this board".
+6. The encoding makes "unassigned" unambiguous to the receiver; the receiver never has to guess whether a function is absent, unsupported, or accidentally omitted.
+7. GPIO values MUST be in the range 0–21 (ESP32-C3), and `i2c0_sda` / `i2c0_scl` MUST either both be assigned or both be `null`.
 
 ---
 
@@ -1163,29 +1165,30 @@ When the pairing tool encounters an error at a user-facing boundary (BLE connect
 ### PT-1216  Board selector UI for node provisioning
 
 **Priority:** Must  
-**Source:** PT-1214 (board pin configuration), ND-0608
+**Source:** PT-1214 (board layout), ND-0608
 
 **Description:**  
-The pairing tool UI MUST present a board selector during Phase 2 (node provisioning) so the operator can specify the target board's I2C pin assignments without entering raw GPIO numbers. The selector is always visible on the provisioning card and determines the `PinConfig` passed to `provision_node()`.
+The pairing tool UI MUST present a board selector during Phase 2 (node provisioning) so the operator can choose a complete target-board layout without entering raw GPIO numbers for common cases. The selector is always visible on the provisioning card and determines the `BoardLayout` passed to `provision_node()`.
 
 The tool MUST include at least the following named presets:
 
-| Preset | `i2c0_sda` | `i2c0_scl` |
-|--------|-----------|-----------|
-| Espressif ESP32-C3 DevKitM-1 | 0 | 1 |
-| SparkFun ESP32-C3 Pro Micro | 5 | 6 |
+| Preset | `i2c0_sda` | `i2c0_scl` | `one_wire_data` | `battery_adc` | `sensor_enable` |
+|--------|-------------|-------------|------------------|---------------|-----------------|
+| Sonde Sensor Node rev_a | 6 | 7 | 3 | 2 | 4 |
+| Espressif ESP32-C3 DevKitM-1 | 0 | 1 | `null` | `null` | `null` |
+| SparkFun ESP32-C3 Pro Micro | 5 | 6 | `null` | `null` | `null` |
 
-A "Custom" option MUST also be available, which reveals two numeric input fields for arbitrary GPIO pin entry (validated per PT-0409).
+A "Custom" option MUST also be available, which reveals editable fields for the supported hardware functions. Optional functions may be left blank to encode `null` / unassigned (validated per PT-0409).
 
 **Acceptance criteria:**
 
 1. The Phase 2 provisioning card includes a board selector dropdown with the named presets above and a "Custom" option.
-2. The default selection is "Espressif ESP32-C3 DevKitM-1".
-3. Selecting a named preset sets the `PinConfig` to the preset's pin values — no additional input required.
-4. Selecting "Custom" reveals two numeric input fields for SDA and SCL GPIO numbers.
-5. Custom GPIO values are validated per PT-0409 (range 0–21, SDA ≠ SCL) before provisioning.
-6. The selected `PinConfig` is always passed to `provision_node()` — the tool never sends `None` when the UI is used.
-7. The Tauri `provision_node` command accepts optional `i2c_sda` and `i2c_scl` parameters and converts them to a `PinConfig`.
+2. The default selection is "Sonde Sensor Node rev_a".
+3. Selecting a named preset sets the complete `BoardLayout` to the preset's values — no additional input required.
+4. Selecting "Custom" reveals editable fields for `i2c0_sda`, `i2c0_scl`, `one_wire_data`, `battery_adc`, and `sensor_enable`, with optional functions allowed to remain blank / unassigned.
+5. Custom values are validated per PT-0409 before provisioning.
+6. The selected `BoardLayout` is always passed to `provision_node()` when the UI is used — the tool does not rely on implicit firmware defaults.
+7. The Tauri `provision_node` command accepts board-layout parameters sufficient to represent all supported functions and explicit unassigned state.
 
 ---
 
@@ -1391,7 +1394,7 @@ The UI SHOULD use CSS transitions for page changes.  Forward navigation slides t
 | PT-1211 | LESC pairing status logging | Active |
 | PT-1212 | Error logging with actionable context | Active |
 | PT-1213 | Build-type–aware log levels | Active |
-| PT-1214 | Board pin configuration in NODE_PROVISION | Active |
+| PT-1214 | Board layout in NODE_PROVISION | Active |
 | PT-1215 | Error diagnostic observability (extends PT-1212) | Active |
 | PT-1216 | Board selector UI for node provisioning | Active |
 | PT-1217 | Multi-page wizard navigation | Active |

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1181,84 +1181,97 @@ TestNode {
 
 ---
 
-### T-PT-1214a  Pin config included in NODE_PROVISION when provided
+### T-PT-1214a  Board layout included in NODE_PROVISION when provided
 
-**Validates:** PT-1214 (AC 1, 2, 4)
+**Validates:** PT-1214 (AC 1, 2, 4, 5)
 
 **Procedure:**
-1. Call `provision_node(...)` with pin config `Some(PinConfig { i2c0_sda: 4, i2c0_scl: 5 })`.
+1. Call `provision_node(...)` with board layout `Some(BoardLayout { i2c0_sda: Some(6), i2c0_scl: Some(7), one_wire_data: Some(3), battery_adc: Some(2), sensor_enable: Some(4) })`.
 2. Capture the NODE_PROVISION message body written to the mock BLE transport.
 3. Assert: the body contains the encrypted payload followed by a deterministic CBOR map.
-4. Decode the trailing CBOR map and assert: integer key 1 = 4 (`i2c0_sda`), integer key 2 = 5 (`i2c0_scl`).
+4. Decode the trailing CBOR map and assert: integer key 1 = 6 (`i2c0_sda`), key 2 = 7 (`i2c0_scl`), key 3 = 3 (`one_wire_data`), key 4 = 2 (`battery_adc`), key 5 = 4 (`sensor_enable`).
 5. Assert: the CBOR map uses deterministic encoding (RFC 8949 §4.2).
 
 ---
 
-### T-PT-1214c  Pin config with out-of-range GPIO rejected
+### T-PT-1214c  Board layout with out-of-range GPIO rejected
 
-**Validates:** PT-1214 (AC 5)
+**Validates:** PT-0409 (AC 1)
 
 **Procedure:**
-1. Call `provision_node(...)` with pin config `Some(PinConfig { i2c0_sda: 22, i2c0_scl: 5 })`.
-2. Assert: the call returns an error indicating GPIO number out of range (0–21).
+1. Call `provision_node(...)` with board layout `Some(BoardLayout { i2c0_sda: Some(6), i2c0_scl: Some(7), one_wire_data: Some(3), battery_adc: Some(22), sensor_enable: Some(4) })`.
+2. Assert: the call returns an error indicating that `battery_adc` is out of range (0–21).
 3. Assert: no NODE_PROVISION message is written to the BLE transport.
 
 ---
 
-### T-PT-1214d  Pin config with SDA equal to SCL rejected
+### T-PT-1214d  Board layout with invalid I2C pairing rejected
 
-**Validates:** PT-1214 (AC 6)
+**Validates:** PT-0409 (AC 2, AC 3)
 
 **Procedure:**
-1. Call `provision_node(...)` with pin config `Some(PinConfig { i2c0_sda: 4, i2c0_scl: 4 })`.
+1. Call `provision_node(...)` with board layout `Some(BoardLayout { i2c0_sda: Some(4), i2c0_scl: Some(4), one_wire_data: None, battery_adc: None, sensor_enable: None })`.
 2. Assert: the call returns an error indicating SDA and SCL must be different pins.
 3. Assert: no NODE_PROVISION message is written to the BLE transport.
 
 ---
 
-### T-PT-1214b  No pin config in NODE_PROVISION — backward compatible
+### T-PT-1214b  No board layout in NODE_PROVISION — backward compatible
 
 **Validates:** PT-1214 (AC 1, 3)
 
 **Procedure:**
-1. Call `provision_node(...)` with pin config `None`.
+1. Call `provision_node(...)` with board layout `None`.
 2. Capture the NODE_PROVISION message body written to the mock BLE transport.
 3. Assert: the body is identical to the existing format (encrypted payload only, no trailing bytes).
 4. Assert: provisioning completes successfully (NODE_ACK received).
 
 ---
 
-### T-PT-1216a  Board preset passes correct pin config
+### T-PT-1214e  Explicitly unassigned functions encoded as CBOR null
+
+**Validates:** PT-1214 (AC 5, 6), PT-0409 (AC 4)
+
+**Procedure:**
+1. Call `provision_node(...)` with board layout `Some(BoardLayout { i2c0_sda: Some(0), i2c0_scl: Some(1), one_wire_data: None, battery_adc: None, sensor_enable: None })`.
+2. Capture the NODE_PROVISION message body written to the mock BLE transport.
+3. Decode the trailing CBOR map.
+4. Assert: keys 3, 4, and 5 are present and encoded as CBOR `null`, not omitted.
+5. Assert: the receiver can distinguish those functions from concrete GPIO assignments.
+
+---
+
+### T-PT-1216a  Board preset passes correct board layout
 
 **Validates:** PT-1216 (AC 1, 3, 6), PT-1214 (AC 1, 2)
 
 **Procedure:**
-1. Call `phase2::provision_node(...)` with `MockBleTransport` and pin config `Some(PinConfig { i2c0_sda: 5, i2c0_scl: 6 })` (SparkFun preset values).
+1. Call `phase2::provision_node(...)` with `MockBleTransport` and board layout `Some(BoardLayout { i2c0_sda: Some(5), i2c0_scl: Some(6), one_wire_data: None, battery_adc: None, sensor_enable: None })` (SparkFun preset values).
 2. Capture the NODE_PROVISION message body written to the mock BLE transport.
-3. Assert: the trailing CBOR map contains integer key 1 = 5 (`i2c0_sda`), integer key 2 = 6 (`i2c0_scl`).
+3. Assert: the trailing CBOR map contains integer key 1 = 5 (`i2c0_sda`), key 2 = 6 (`i2c0_scl`), and keys 3, 4, 5 encoded as `null`.
 
 ---
 
-### T-PT-1216b  Default preset is Espressif DevKitM-1
+### T-PT-1216b  Default preset is Sonde Sensor Node rev_a
 
 **Validates:** PT-1216 (AC 2, 3)
 
 **Procedure:**
-1. Open the provisioning UI and verify the initial board selector value is "Espressif ESP32-C3 DevKitM-1".
-2. Without changing the board selection or manually overriding the I2C pins, trigger provisioning.
+1. Open the provisioning UI and verify the initial board selector value is "Sonde Sensor Node rev_a".
+2. Without changing the board selection, trigger provisioning.
 3. Capture the NODE_PROVISION message body written to the mock BLE transport.
-4. Assert: the trailing CBOR map contains integer key 1 = 0 (`i2c0_sda`), integer key 2 = 1 (`i2c0_scl`).
+4. Assert: the trailing CBOR map contains integer key 1 = 6 (`i2c0_sda`), key 2 = 7 (`i2c0_scl`), key 3 = 3 (`one_wire_data`), key 4 = 2 (`battery_adc`), and key 5 = 4 (`sensor_enable`).
 
 ---
 
-### T-PT-1216c  Custom board with valid GPIOs
+### T-PT-1216c  Custom board with valid layout
 
-**Validates:** PT-1216 (AC 4, 5, 6)
+**Validates:** PT-1216 (AC 4, 5, 6), PT-0409 (AC 4)
 
 **Procedure:**
-1. Call `phase2::provision_node(...)` with `MockBleTransport` and pin config `Some(PinConfig { i2c0_sda: 8, i2c0_scl: 9 })` (custom values).
+1. Call `phase2::provision_node(...)` with `MockBleTransport` and board layout `Some(BoardLayout { i2c0_sda: Some(8), i2c0_scl: Some(9), one_wire_data: Some(10), battery_adc: None, sensor_enable: Some(11) })`.
 2. Capture the NODE_PROVISION message body written to the mock BLE transport.
-3. Assert: the trailing CBOR map contains integer key 1 = 8 (`i2c0_sda`), integer key 2 = 9 (`i2c0_scl`).
+3. Assert: the trailing CBOR map contains integer key 1 = 8 (`i2c0_sda`), key 2 = 9 (`i2c0_scl`), key 3 = 10 (`one_wire_data`), key 4 = `null`, and key 5 = 11 (`sensor_enable`).
 
 ---
 
@@ -1267,19 +1280,43 @@ TestNode {
 **Validates:** PT-1216 (AC 5), PT-0409
 
 **Procedure:**
-1. Call `phase2::provision_node(...)` with `MockBleTransport` and pin config `Some(PinConfig { i2c0_sda: 25, i2c0_scl: 6 })`.
+1. Call `phase2::provision_node(...)` with `MockBleTransport` and board layout `Some(BoardLayout { i2c0_sda: Some(25), i2c0_scl: Some(6), one_wire_data: None, battery_adc: None, sensor_enable: None })`.
 2. Assert: the call returns `Err(PairingError::InvalidPinConfig(_))`.
 3. Assert: no NODE_PROVISION message is written to the mock BLE transport.
 
 ---
 
-### T-PT-1216e  Provision with only one pin parameter rejected
+### T-PT-1216e  Provision with partial I2C layout rejected
+
+**Validates:** PT-1216 (AC 5), PT-0409 (AC 3)
+
+**Procedure:**
+1. Call `resolve_board_layout(BoardLayoutInput { i2c0_sda: Some(5), i2c0_scl: None, one_wire_data: None, battery_adc: None, sensor_enable: None })`.
+2. Assert: the call returns an error indicating that both I2C pins must be provided together.
+
+---
+
+### T-PT-1216g  Tauri provision_node command accepts structured board layout
 
 **Validates:** PT-1216 (AC 7)
 
 **Procedure:**
-1. Call `resolve_pin_config(Some(5), None)`.
-2. Assert: the call returns an error indicating both pins must be provided.
+1. Invoke the Tauri `provision_node` command with a structured `boardLayout` object containing `i2cSda=6`, `i2cScl=7`, `oneWireData=3`, `batteryAdc=2`, and `sensorEnable=4`.
+2. Assert: the backend converts the object into `Some(BoardLayout { ... })` and passes it to `phase2::provision_node()`.
+3. Repeat with `oneWireData=null`, `batteryAdc=null`, and `sensorEnable=null`.
+4. Assert: the backend preserves explicit `null` values as unassigned functions rather than omitting them.
+
+---
+
+### T-PT-1216f  Espressif preset remains available
+
+**Validates:** PT-1216 (AC 1, 3)
+
+**Procedure:**
+1. Open the provisioning UI and select "Espressif ESP32-C3 DevKitM-1".
+2. Trigger provisioning.
+3. Capture the NODE_PROVISION message body written to the mock BLE transport.
+4. Assert: the trailing CBOR map contains integer key 1 = 0 (`i2c0_sda`), key 2 = 1 (`i2c0_scl`), and keys 3, 4, 5 encoded as `null`.
 
 ---
 
@@ -1643,15 +1680,18 @@ TestNode {
 | T-PT-1215c | PT-1215 | Connection dropped includes stale pairing hint |
 | T-PT-1215d | PT-1215 | Indication timeout includes device address |
 | T-PT-1215e | PT-1215 | `format_device_address` produces canonical format |
-| T-PT-1214a | PT-1214 | Pin config included in NODE_PROVISION when provided |
-| T-PT-1214b | PT-1214 | No pin config in NODE_PROVISION — backward compatible |
-| T-PT-1214c | PT-1214 | Pin config with out-of-range GPIO rejected |
-| T-PT-1214d | PT-1214 | Pin config with SDA equal to SCL rejected |
-| T-PT-1216a | PT-1216, PT-1214 | Board preset passes correct pin config |
-| T-PT-1216b | PT-1216 | Default preset is Espressif DevKitM-1 |
-| T-PT-1216c | PT-1216 | Custom board with valid GPIOs |
+| T-PT-1214a | PT-1214 | Board layout included in NODE_PROVISION when provided |
+| T-PT-1214b | PT-1214 | No board layout in NODE_PROVISION — backward compatible |
+| T-PT-1214c | PT-0409 | Board layout with out-of-range GPIO rejected |
+| T-PT-1214d | PT-0409 | Board layout with invalid I2C pairing rejected |
+| T-PT-1214e | PT-1214, PT-0409 | Explicitly unassigned functions encoded as CBOR null |
+| T-PT-1216a | PT-1216, PT-1214 | Board preset passes correct board layout |
+| T-PT-1216b | PT-1216 | Default preset is Sonde Sensor Node rev_a |
+| T-PT-1216c | PT-1216, PT-0409 | Custom board with valid layout |
 | T-PT-1216d | PT-1216, PT-0409 | Custom board with invalid GPIOs rejected |
-| T-PT-1216e | PT-1216 | Provision with only one pin parameter rejected |
+| T-PT-1216e | PT-1216, PT-0409 | Provision with partial I2C layout rejected |
+| T-PT-1216f | PT-1216 | Espressif preset remains available |
+| T-PT-1216g | PT-1216 | Tauri provision_node command accepts structured board layout |
 | T-PT-1217a | PT-1217 | Six pages rendered and only one visible at a time |
 | T-PT-1217b | PT-1217 | Forward navigation through all pages |
 | T-PT-1217c | PT-1217 | Existing functionality works through wizard flow |

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1228,9 +1228,20 @@ TestNode {
 
 ---
 
-### T-PT-1214e  Explicitly unassigned functions encoded as CBOR null
+### T-PT-1214e  Board layout with non-ADC-capable battery GPIO rejected
 
-**Validates:** PT-1214 (AC 5, 6), PT-0409 (AC 4)
+**Validates:** PT-0409 (AC 4)
+
+**Procedure:**
+1. Call `provision_node(...)` with board layout `Some(BoardLayout { i2c0_sda: Some(6), i2c0_scl: Some(7), one_wire_data: None, battery_adc: Some(7), sensor_enable: None })`.
+2. Assert: the call returns an error indicating that `battery_adc` must use an ADC-capable GPIO on ESP32-C3.
+3. Assert: no NODE_PROVISION message is written to the BLE transport.
+
+---
+
+### T-PT-1214f  Explicitly unassigned functions encoded as CBOR null
+
+**Validates:** PT-1214 (AC 5, 6), PT-0409 (AC 5)
 
 **Procedure:**
 1. Call `provision_node(...)` with board layout `Some(BoardLayout { i2c0_sda: Some(0), i2c0_scl: Some(1), one_wire_data: None, battery_adc: None, sensor_enable: None })`.
@@ -1684,7 +1695,8 @@ TestNode {
 | T-PT-1214b | PT-1214 | No board layout in NODE_PROVISION — backward compatible |
 | T-PT-1214c | PT-0409 | Board layout with out-of-range GPIO rejected |
 | T-PT-1214d | PT-0409 | Board layout with invalid I2C pairing rejected |
-| T-PT-1214e | PT-1214, PT-0409 | Explicitly unassigned functions encoded as CBOR null |
+| T-PT-1214e | PT-0409 | Board layout with non-ADC-capable battery GPIO rejected |
+| T-PT-1214f | PT-1214, PT-0409 | Explicitly unassigned functions encoded as CBOR null |
 | T-PT-1216a | PT-1216, PT-1214 | Board preset passes correct board layout |
 | T-PT-1216b | PT-1216 | Default preset is Sonde Sensor Node rev_a |
 | T-PT-1216c | PT-1216, PT-0409 | Custom board with valid layout |

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -69,12 +69,12 @@ The node firmware is divided into twelve functional modules arranged in two tier
 |---|---|---|
 | **Transport** | ESP-NOW send/receive, frame size enforcement | ND-0100, ND-0103 |
 | **Protocol Codec** | Frame serialization/deserialization, CBOR encoding | ND-0101, ND-0102 |
-| **Wake Cycle Engine** | State machine: WAKE → COMMAND → transfer/execute → sleep | ND-0200–0203, ND-0700–0702 |
+| **Wake Cycle Engine** | State machine: WAKE → COMMAND → transfer/execute → sleep | ND-0200–0203, ND-0608a, ND-0700–0702 |
 | **Key Store** | PSK storage in dedicated flash partition, pairing, factory reset | ND-0400, ND-0402 |
 | **Program Store** | A/B flash partitions, program image decoding, LDDW resolution | ND-0500–0503, ND-0501a |
 | **BPF Runtime** | `sonde-bpf` interpreter, helper dispatch, execution constraints | ND-0504–0506, ND-0600–0606 |
 | **Map Storage** | Sleep-persistent maps in RTC slow SRAM | ND-0603, ND-0606 |
-| **HAL** | I2C, SPI, GPIO, ADC bus access for BPF helpers | ND-0601 |
+| **HAL** | I2C, SPI, GPIO, ADC bus access for BPF helpers and provisioned board-layout expansion | ND-0601, ND-0608 |
 | **Sleep Manager** | Deep sleep entry, wake interval, RTC memory management, GPIO sleep preparation | ND-0203, ND-1013 |
 | **node_aead** | AES-256-GCM `AeadProvider` implementation (pure-Rust `aes-gcm` crate, `no_std`-compatible) | ND-0300 |
 | **Auth** | AES-256-GCM AEAD via `node_aead` provider, nonce generation, response verification | ND-0300–0304 |
@@ -132,18 +132,19 @@ The state machine has five main states plus two alternate boot paths. Starting f
 1. **Boot/wake**: Initialize hardware. Determine boot path per ND-0900: (1) no PSK or button held → BLE pairing mode, (2) PSK + no `reg_complete` → PEER_REQUEST registration, (3) PSK + `reg_complete` → proceed to step 2.
 2. **Generate nonce**: Hardware RNG produces a 64-bit random nonce.
 3. **Drain async queue**: Check the async queue (§8.6) from the previous cycle. If exactly 1 message is queued and it fits in the WAKE payload budget, include it as `blob` (CBOR key 10) in the WAKE message. Otherwise, `blob` is omitted and the queue is left intact for overflow drain in step 7 (NOP only).
-4. **Send WAKE**: Construct WAKE frame (`firmware_abi_version`, `program_hash`, `battery_mv`, `firmware_version`, and optionally `blob`). The `firmware_version` string is derived from `CARGO_PKG_VERSION` at compile time. AEAD-encrypt with PSK. Transmit via ESP-NOW.
+4. **Send WAKE**: Construct WAKE frame (`firmware_abi_version`, `program_hash`, `battery_mv`, `firmware_version`, and optionally `blob`). The `firmware_version` string is derived from `CARGO_PKG_VERSION` at compile time. `battery_mv` comes from the RTC-retained reading captured on the previous wake; if no value has been captured yet, it is `0`. AEAD-encrypt with PSK. Transmit via ESP-NOW.
 5. **Await COMMAND**: Wait up to 200 ms for a response. On timeout, back off for 400 ms before retrying, up to 4 total attempts. If all attempts fail, sleep.
 6. **Verify COMMAND**: Decrypt via AES-256-GCM. Verify echoed nonce matches. Decode CBOR. Extract `starting_seq` and `timestamp_ms`.
 6b. **Downlink data extraction**: If the COMMAND is NOP and contains a `blob` field (CBOR key 10), the firmware copies the blob into a RAM buffer and sets `sonde_context.data_start` / `data_end` to point to it. If no `blob` is present, both fields are set to 0.
-7. **Dispatch command**:
+7. **Capture current-cycle battery value**: Using the provisioned board layout (§10.3), optionally assert the active-low `sensor_enable` GPIO, wait for the sensor rail / bus settle time, capture the current-cycle battery value from the provisioned `battery_adc` pin (or use the fallback `3300` mV when no ADC pin is assigned), and store the value in RTC-retained state for the next wake.
+8. **Dispatch command**:
    - `NOP` → drain remaining async queue (previous-cycle blobs not piggybacked on WAKE) as individual APP_DATA frames, then proceed to BPF execution. Blobs queued by BPF in the current cycle remain in the queue for piggybacking on the next WAKE.
    - `UPDATE_PROGRAM` / `RUN_EPHEMERAL` → clear async queue (old program's blobs are invalid), enter chunked transfer.
    - `UPDATE_SCHEDULE` → store new base interval, proceed to BPF execution.
    - `REBOOT` → restart firmware.
    - Unknown → treat as NOP.
-8. **BPF execution**: Execute resident (or newly installed/ephemeral) program.
-9. **Sleep**: Enter deep sleep for `min(set_next_wake_value, base_interval)`.
+9. **BPF execution**: Execute resident (or newly installed/ephemeral) program.
+10. **Sleep**: Enter deep sleep for `min(set_next_wake_value, base_interval)`.
 
 ### 4.3  Chunked transfer sub-state
 
@@ -374,7 +375,7 @@ Before invoking the BPF program, the firmware populates:
 ```rust
 pub struct SondeContext {
     pub timestamp: u64,              // from gateway timestamp_ms + local elapsed
-    pub battery_mv: u16,             // current ADC reading
+    pub battery_mv: u16,             // current-cycle reading or fallback captured after COMMAND
     pub firmware_abi_version: u16,   // firmware ABI
     pub wake_reason: u8,             // 0x00=scheduled, 0x01=early, 0x02=program_update
     pub data_start: u64,             // pointer to downlink blob (0 if none)
@@ -493,22 +494,36 @@ Handles pack bus and address into a single `u32` (matching bpf-environment.md §
 
 All HAL helpers return `0` on success, negative on error. Errors include NACK, bus timeout, invalid pin/channel. The BPF program decides how to handle errors — the firmware does not retry.
 
-### 10.3  Configurable I2C pin assignments (ND-0608)
+### 10.3  Provisioned board layout (ND-0608, ND-0608a)
 
-I2C bus GPIO pin numbers are configurable via NVS to support different ESP32-C3 board layouts with a single firmware binary.
+Board-specific hardware layout is provisioned once and persisted in flash so that the firmware never hard-codes any particular board revision.
 
-**NVS keys** (namespace `"sonde"`):
+**Flash key** (namespace `"sonde"`):
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `"i2c0_sda"` | u32 | 0 | I2C0 SDA GPIO number |
-| `"i2c0_scl"` | u32 | 1 | I2C0 SCL GPIO number |
+| Key | Type | Description |
+|-----|------|-------------|
+| `"board_layout"` | blob | Serialized board-layout record containing `i2c0_sda`, `i2c0_scl`, `one_wire_data`, `battery_adc`, and `sensor_enable` as `Option<u8>`-style values |
 
-**Initialization:** At HAL init time, the firmware reads `i2c0_sda` and `i2c0_scl` from NVS. If either key is absent, the compiled-in default is used (GPIO 0 / GPIO 1, matching DevKitM-1 Qwiic mapping).
+**Boot-time expansion:** On boot, the firmware:
 
-**Provisioning path:** Pin config is included as optional trailing bytes in the NODE_PROVISION BLE message body (see §BLE pairing). When the node receives a NODE_PROVISION with pin config, it writes the values to NVS before rebooting into PEER_REQUEST mode. An older pairing tool that omits pin config produces no NVS writes — the defaults apply.
+1. Reads `board_layout` from flash.
+2. If the key is present and valid, decodes it into an internal `BoardLayout` struct.
+3. If the key is absent, synthesizes a legacy compatibility layout equivalent to the pre-layout implementation (`i2c0_sda=Some(0)`, `i2c0_scl=Some(1)`, all other functions `None`).
+4. Copies the effective `BoardLayout` into RTC-backed runtime state so the HAL, wake-cycle engine, and sleep manager use the same resolved layout during the wake.
 
-**Factory reset:** Pin config keys are NOT erased during factory reset (ND-0917). The board's physical pin mapping does not change when the node is re-provisioned.
+```rust
+pub struct BoardLayout {
+    pub i2c0_sda: Option<u8>,
+    pub i2c0_scl: Option<u8>,
+    pub one_wire_data: Option<u8>,
+    pub battery_adc: Option<u8>,
+    pub sensor_enable: Option<u8>, // active-low when present
+}
+```
+
+**Provisioning path:** Board layout is included as optional trailing bytes in the `NODE_PROVISION` BLE message body (see §15.6). When the node receives a `NODE_PROVISION` with a valid board-layout map, it serializes and writes the decoded layout to the `board_layout` flash key before rebooting into PEER_REQUEST mode. When the layout bytes are malformed, provisioning fails with `NODE_ACK(0x02)` rather than guessing. When an older pairing tool omits layout bytes entirely, the node retains any existing `board_layout` record; if none exists yet, it synthesizes the legacy compatibility layout.
+
+**Factory reset:** The `board_layout` key is NOT erased during factory reset (ND-0917). The board's physical layout does not change when the node is re-provisioned.
 
 ---
 
@@ -538,15 +553,15 @@ The flag for `WAKE_EARLY` is stored in RTC SRAM and cleared after reading.
 
 Before entering deep sleep, `prepare_for_sleep()` is called to eliminate GPIO leakage current (ND-1013).
 
-1. Enumerate the I2C0 bus GPIOs (SDA and SCL for the currently supported I2C bus) and reset them to a disabled/high-impedance state with no pull resistors via `gpio_reset_pin()`. Additional I2C buses may be added in future revisions.
-2. Enumerate any GPIOs that were configured as outputs by BPF helper calls (`gpio_write`) during the current wake cycle and reset them to a disabled state.
+1. Enumerate all assigned GPIOs from the effective `BoardLayout` (`i2c0_sda`, `i2c0_scl`, `one_wire_data`, `battery_adc`, `sensor_enable`) and return them to input mode with output drive disabled and all pull resistors removed.
+2. Enumerate any GPIOs that were configured as outputs by BPF helper calls (`gpio_write`) during the current wake cycle and return them to the same high-impedance input state.
 3. Skip RTC-domain pins required for wake-up sources (e.g., pairing button GPIO) — these must retain their configured state.
 
 **Implementation notes:**
 
 - `prepare_for_sleep()` is called from the node main loop (deep sleep entry in `bin/node.rs`) immediately before step 3 in §11.1.
 - The HAL layer tracks which GPIOs were configured during the wake cycle via a small bitset.
-- `gpio_reset_pin()` restores the ESP-IDF default: input-disabled, output-disabled, no pull-up/pull-down.
+- The sleep preparation path uses explicit "input, no pulls, no output drive" configuration rather than relying on `gpio_reset_pin()`, because ND-1013 requires high-Z input state rather than input-disabled state.
 
 ---
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -126,15 +126,17 @@ Each wake cycle MUST follow this structure: wake → send one or more `WAKE` mes
 **Source:** protocol.md §5.1
 
 **Description:**  
-The `WAKE` message MUST include `firmware_abi_version`, `program_hash` (SHA-256 of the resident program, or zero-length if none installed), `battery_mv`, and `firmware_version` (semantic version string derived from `CARGO_PKG_VERSION` at compile time, e.g., `"0.5.0"`). The `nonce` header field MUST contain a fresh 64-bit random value from the hardware RNG. The WAKE message MAY include an optional `blob` field (CBOR key 10) containing a single piggybacked uplink data blob from a prior `send_async()` call. The blob is included only when exactly one message is queued and it fits within the available payload budget (223 bytes minus the space consumed by the four required fields and their CBOR encoding overhead). When the blob would not fit or multiple messages are queued, the `blob` field is omitted and data is sent via APP_DATA after receiving COMMAND.
+The `WAKE` message MUST include `firmware_abi_version`, `program_hash` (SHA-256 of the resident program, or zero-length if none installed), `battery_mv`, and `firmware_version` (semantic version string derived from `CARGO_PKG_VERSION` at compile time, e.g., `"0.5.0"`). The `battery_mv` field reports the battery reading stored from the previous wake cycle in RTC-retained state. On the first wake after provisioning or cold boot, before any battery value has been stored, `battery_mv` MUST be `0`. If the provisioned board layout does not assign a battery ADC pin, the firmware stores a known fallback value (`3300` mV) for use on subsequent wakes. The `nonce` header field MUST contain a fresh 64-bit random value from the hardware RNG. The WAKE message MAY include an optional `blob` field (CBOR key 10) containing a single piggybacked uplink data blob from a prior `send_async()` call. The blob is included only when exactly one message is queued and it fits within the available payload budget (223 bytes minus the space consumed by the four required fields and their CBOR encoding overhead). When the blob would not fit or multiple messages are queued, the `blob` field is omitted and data is sent via APP_DATA after receiving COMMAND.
 
 **Acceptance criteria:**
 
 1. `firmware_abi_version` reflects the actual firmware ABI.
 2. `program_hash` matches the SHA-256 of the currently installed resident program.
-3. `battery_mv` is a current ADC reading of the battery voltage.
-4. `firmware_version` is a valid semantic version string matching the compiled firmware version.
-5. The nonce is generated from the hardware RNG (not a constant or predictable value).
+3. On the first wake after provisioning or cold boot, `battery_mv` is `0`.
+4. On subsequent wakes, `battery_mv` equals the battery value stored from the previous wake cycle.
+5. If the provisioned board layout does not assign a battery ADC pin, the firmware stores and later reports the known fallback value (`3300` mV).
+6. `firmware_version` is a valid semantic version string matching the compiled firmware version.
+7. The nonce is generated from the hardware RNG (not a constant or predictable value).
 
 ---
 
@@ -441,7 +443,7 @@ The firmware MUST populate a read-only `sonde_context` structure before each BPF
 **Acceptance criteria:**
 
 1. `timestamp` is derived from the gateway's `timestamp_ms` plus local elapsed time since COMMAND was received.
-2. `battery_mv` is a current ADC reading.
+2. `battery_mv` is the current-cycle battery value captured after `COMMAND` processing using the provisioned board layout (fresh ADC reading when a battery ADC pin is assigned, otherwise the known fallback value).
 3. `firmware_abi_version` matches the firmware's actual ABI.
 4. `wake_reason` is set correctly: `WAKE_SCHEDULED` (0x00) for normal wake, `WAKE_EARLY` (0x01) when woken early due to `set_next_wake()`, `WAKE_PROGRAM_UPDATE` (0x02) on first execution after a program update.
 5. The context is read-only — the BPF program cannot modify it.
@@ -544,7 +546,7 @@ The firmware MUST provide `get_time()`, `get_battery_mv()`, `delay_us()`, `set_n
 **Acceptance criteria:**
 
 1. `get_time()` returns the current time in milliseconds since epoch.
-2. `get_battery_mv()` returns the current battery voltage.
+2. `get_battery_mv()` returns the current-cycle battery value captured after `COMMAND` processing using the provisioned board layout (fresh ADC reading when a battery ADC pin is assigned, otherwise the known fallback value).
 3. `delay_us()` busy-waits for the specified microseconds; the firmware enforces a maximum delay value.
 4. `set_next_wake()` sets the interval for the next wake cycle only; the firmware applies `min(requested, base interval)`.
 5. Ephemeral programs calling `set_next_wake()` receive an error.
@@ -604,22 +606,42 @@ The program image format MUST support optional initial data for each map definit
 
 ---
 
-### ND-0608  Configurable I2C pin assignments
+### ND-0608  Provisioned board layout
 
-**Priority:** Should  
+**Priority:** Must  
 **Source:** issue #490
 
 **Description:**  
-The firmware MUST support configurable I2C bus GPIO pin assignments so that a single firmware binary works across ESP32-C3 boards with different Qwiic/I2C pin mappings. Pin assignments are provided during BLE provisioning as optional fields in the NODE_PROVISION message body and persisted to NVS. If no pin config is provided, the firmware uses compiled-in defaults (GPIO 0 = SDA, GPIO 1 = SCL).
+The firmware MUST support a provisioned board layout so that a single firmware binary works across different hardware revisions without assuming any specific board layout. The provisioned layout is stored in flash during BLE provisioning, loaded on boot, and copied into RTC-backed runtime state for the current wake cycle. The layout defines the GPIO assignment (or explicit unassigned state) for `i2c0_sda`, `i2c0_scl`, `one_wire_data`, `battery_adc`, and `sensor_enable`.
 
 **Acceptance criteria:**
 
-1. I2C0 SDA and SCL GPIO pin numbers are read from NVS at HAL initialization time.
-2. If the NVS keys are absent, the firmware falls back to compiled-in defaults (SDA=0, SCL=1).
-3. Pin assignments persist across deep-sleep cycles and power-on resets.
-4. Factory reset (ND-0917) does NOT erase pin config — the board hardware does not change.
-5. The NODE_PROVISION BLE message body may include optional pin config bytes after the encrypted payload; the node parses and persists them to NVS.
-6. Backward compatibility: a NODE_PROVISION body without pin config bytes (from an older pairing tool) is accepted without error.
+1. The provisioned board-layout record is read from flash at boot and made available to the HAL and wake-cycle code before peripheral initialization.
+2. The effective board layout for the current wake cycle is copied into RTC-backed runtime state on boot.
+3. Board-layout assignments persist across deep-sleep cycles and power-on resets.
+4. Factory reset (ND-0917) does NOT erase the provisioned board layout — the board hardware does not change when the node is re-provisioned.
+5. The `NODE_PROVISION` BLE message body may include optional board-layout bytes after the encrypted payload; when present, the node parses and persists them to flash.
+6. A `NODE_PROVISION` body without board-layout bytes (from an older pairing tool) is accepted without error. If a board layout is already provisioned, it is retained unchanged; otherwise the node synthesizes a legacy compatibility layout equivalent to the pre-layout implementation (`i2c0_sda=0`, `i2c0_scl=1`, all other functions explicitly unassigned).
+7. The persisted board layout preserves explicit "function unassigned" state for each supported function.
+8. Malformed board-layout data is rejected; the firmware MUST NOT guess or silently substitute a different layout.
+
+---
+
+### ND-0608a  Provisioned sensor rail and battery sampling
+
+**Priority:** Must  
+**Source:** issue #134, hw/carrier-board netlists
+
+**Description:**  
+The firmware MUST use the provisioned board layout to control sensor power and capture the current-cycle battery value after the `WAKE` / `COMMAND` exchange. If the provisioned board layout assigns `sensor_enable`, the firmware asserts that GPIO active after a valid `COMMAND` is received, waits for the provisioned buses and battery divider to settle, then captures the battery value for the current cycle. If `battery_adc` is assigned, the firmware samples the configured ADC pin; otherwise it uses the known fallback value (`3300` mV). The captured current-cycle value is stored in RTC-retained state for the next wake and exposed to the current-cycle BPF execution context and helpers.
+
+**Acceptance criteria:**
+
+1. When `sensor_enable` is assigned, the firmware asserts the configured GPIO only after a valid `COMMAND` is received and before executing BPF or other post-WAKE command work.
+2. When `sensor_enable` is assigned, the firmware waits for the sensor rail and attached buses to settle before taking a battery measurement or using the provisioned bus helpers.
+3. When `battery_adc` is assigned, the firmware samples the configured ADC pin and stores the resulting battery value in RTC-retained state for the next wake.
+4. When `battery_adc` is unassigned, the firmware stores the known fallback value (`3300` mV) in RTC-retained state for the next wake.
+5. The same-cycle `sonde_context.battery_mv` value and `get_battery_mv()` helper return the current-cycle value captured after `COMMAND` processing, not the previous wake's stored `WAKE.battery_mv`.
 
 ---
 
@@ -1363,13 +1385,13 @@ The node MUST apply build-type–aware log-level policies to eliminate logging o
 **Source:** issue #517
 
 **Description:**  
-Before entering deep sleep, the firmware MUST reset all bus peripheral GPIOs (I2C SDA/SCL, any BPF-configured output GPIOs) to a disabled state with no pull resistors to minimize sleep leakage current.
+Before entering deep sleep, the firmware MUST place all provisioned bus and control GPIOs into a high-impedance input state with no pull resistors to minimize sleep leakage current and prevent floating bus lines. This includes provisioned I2C pins, 1-Wire data, battery ADC, provisioned sensor-enable GPIO, and any GPIOs configured as outputs by BPF helper calls, except for RTC-domain pins explicitly required as wake-up sources.
 
 **Acceptance criteria:**
 
 1. On the normal wake-cycle deep-sleep path, a `prepare_for_sleep()` function is called before `esp_deep_sleep_start()`.
-2. All I2C bus GPIOs (SDA, SCL) are reset to a disabled/high-impedance state with pull resistors removed.
-3. Any GPIOs configured as outputs by BPF helper calls during the wake cycle are reset to a disabled state.
+2. All provisioned bus and control GPIOs (`i2c0_sda`, `i2c0_scl`, `one_wire_data`, `battery_adc`, `sensor_enable`) are placed into a high-impedance input state with pull resistors removed, unless a particular pin is explicitly unassigned in the board layout.
+3. Any GPIOs configured as outputs by BPF helper calls during the wake cycle are returned to high-impedance input state.
 4. After `prepare_for_sleep()` completes on the wake-cycle path, no GPIO pin sources leakage current through an active pull resistor or driven output.
 5. The GPIO reset does not affect RTC-domain pins required for wake-up (e.g., the pairing button GPIO).
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -633,14 +633,14 @@ The firmware MUST support a provisioned board layout so that a single firmware b
 **Source:** issue #134, hw/carrier-board netlists
 
 **Description:**  
-The firmware MUST use the provisioned board layout to control sensor power and capture the current-cycle battery value after the `WAKE` / `COMMAND` exchange. If the provisioned board layout assigns `sensor_enable`, the firmware asserts that GPIO active after a valid `COMMAND` is received, waits for the provisioned buses and battery divider to settle, then captures the battery value for the current cycle. If `battery_adc` is assigned, the firmware samples the configured ADC pin; otherwise it uses the known fallback value (`3300` mV). The captured current-cycle value is stored in RTC-retained state for the next wake and exposed to the current-cycle BPF execution context and helpers.
+The firmware MUST use the provisioned board layout to control sensor power and capture the current-cycle battery value after the `WAKE` / `COMMAND` exchange. If the provisioned board layout assigns `sensor_enable`, the firmware asserts that GPIO active after a valid `COMMAND` is received, waits for the provisioned buses and battery divider to settle, then captures the battery value for the current cycle. If `battery_adc` is assigned to a GPIO that the current ESP32-C3 target can sample, the firmware samples that configured ADC pin; otherwise it uses the known fallback value (`3300` mV). The captured current-cycle value is stored in RTC-retained state for the next wake and exposed to the current-cycle BPF execution context and helpers.
 
 **Acceptance criteria:**
 
 1. When `sensor_enable` is assigned, the firmware asserts the configured GPIO only after a valid `COMMAND` is received and before executing BPF or other post-WAKE command work.
 2. When `sensor_enable` is assigned, the firmware waits for the sensor rail and attached buses to settle before taking a battery measurement or using the provisioned bus helpers.
-3. When `battery_adc` is assigned, the firmware samples the configured ADC pin and stores the resulting battery value in RTC-retained state for the next wake.
-4. When `battery_adc` is unassigned, the firmware stores the known fallback value (`3300` mV) in RTC-retained state for the next wake.
+3. When `battery_adc` is assigned to an ADC-capable GPIO supported on the current ESP32-C3 target, the firmware samples the configured ADC pin and stores the resulting battery value in RTC-retained state for the next wake.
+4. When `battery_adc` is unassigned, or assigned to a GPIO that is not ADC-capable on the current target, the firmware stores the known fallback value (`3300` mV) in RTC-retained state for the next wake.
 5. The same-cycle `sonde_context.battery_mv` value and `get_battery_mv()` helper return the current-cycle value captured after `COMMAND` processing, not the previous wake's stored `WAKE.battery_mv`.
 
 ---

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -153,7 +153,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Validates:** ND-0201
 
 **Procedure:**
-1. Install a known program (hash X). Set battery to 3300 mV via mock ADC.
+1. Install a known program (hash X). Preload RTC-retained battery state with 3300 mV.
 2. Boot node.
 3. Capture WAKE frame, parse the fixed 11-byte frame header, and decode the CBOR payload.
 4. Assert: `firmware_abi_version` matches firmware ABI.
@@ -161,6 +161,30 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 6. Assert: `battery_mv` = 3300.
 7. Assert: `firmware_version` is a valid semantic version string matching the compiled firmware version.
 8. Assert: the WAKE frame header `nonce` field (in the fixed 11-byte header, not the CBOR payload) is present and sourced from the hardware RNG.
+
+---
+
+### T-N202a  First WAKE sends zero battery reading
+
+**Validates:** ND-0201
+
+**Procedure:**
+1. Boot node with no RTC-retained battery value present (cold boot or immediately after provisioning).
+2. Capture the WAKE frame and decode the CBOR payload.
+3. Assert: `battery_mv` = 0.
+
+---
+
+### T-N202b  Board without battery ADC uses fallback on subsequent wakes
+
+**Validates:** ND-0201, ND-0608a
+
+**Procedure:**
+1. Provision a board layout with `battery_adc = null`.
+2. Run one full wake cycle through `COMMAND` processing so the node computes a current-cycle battery value.
+3. Assert: the node stores `3300` mV in RTC-retained battery state.
+4. Trigger the next wake cycle and capture WAKE.
+5. Assert: `battery_mv` = 3300.
 
 ---
 
@@ -487,7 +511,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 1. Mock gateway sends `timestamp_ms = 1710000000000`.
 2. Install a program that reads `ctx->timestamp`, `ctx->battery_mv`, `ctx->firmware_abi_version`, `ctx->wake_reason` and sends them via `send()`.
 3. Assert: `timestamp` ≈ 1710000000000 + elapsed time since COMMAND was processed (within a few ms tolerance).
-4. Assert: `battery_mv` matches ADC reading.
+4. Assert: `battery_mv` matches the current-cycle battery value captured after `COMMAND` processing.
 5. Assert: `firmware_abi_version` matches firmware.
 6. Assert: `wake_reason` = `WAKE_SCHEDULED` (0x00).
 
@@ -676,7 +700,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 1. Mock gateway sends `timestamp_ms = 1710000000000`.
 2. Install program that calls `get_time()` and `get_battery_mv()`.
 3. Assert: `get_time()` ≈ 1710000000000 + elapsed time since COMMAND was processed (within a few ms tolerance).
-4. Assert: `get_battery_mv()` matches mock ADC.
+4. Assert: `get_battery_mv()` matches the current-cycle battery value captured after `COMMAND` processing.
 
 ---
 
@@ -1380,12 +1404,12 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Validates:** ND-1013
 
 **Procedure:**
-1. Provision a node with non-default I2C pins (e.g., SDA=5, SCL=6).
+1. Provision a node with a full board layout (for example `i2c0_sda=6`, `i2c0_scl=7`, `one_wire_data=3`, `battery_adc=2`, `sensor_enable=4`).
 2. Install a BPF program that calls `gpio_write` on an additional output GPIO (e.g., GPIO 7).
 3. Run a complete wake cycle so that I2C and GPIO peripherals are active.
 4. Assert: `prepare_for_sleep()` is called before deep sleep entry.
-5. Assert: I2C SDA and SCL GPIOs are reset to disabled/high-impedance with no pull resistors.
-6. Assert: the BPF-configured output GPIO is reset to a disabled state.
+5. Assert: provisioned I2C, 1-Wire, battery ADC, and sensor-enable GPIOs are returned to high-impedance input state with no pull resistors.
+6. Assert: the BPF-configured output GPIO is returned to high-impedance input state.
 7. Assert: the RTC wake-up GPIO (pairing button) retains its configured state.
 
 ---
@@ -1841,76 +1865,129 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
-### T-N0607a  I2C pins read from NVS at HAL init
+### T-N0607a  Board layout read from flash and expanded at boot
 
-**Validates:** ND-0608 (AC 1, 3)
+**Validates:** ND-0608 (AC 1, 2, 3)
 
 **Procedure:**
-1. Write SDA=4, SCL=5 to NVS keys `i2c0_sda` and `i2c0_scl`.
-2. Trigger HAL initialization (power-on reset or deep-sleep wake).
-3. Assert: the I2C0 peripheral is configured with SDA=4, SCL=5.
-4. Assert: pin assignments survive a deep-sleep cycle — repeat step 2 and verify the same pins are used.
+1. Write a board-layout record to flash with `i2c0_sda=6`, `i2c0_scl=7`, `one_wire_data=3`, `battery_adc=2`, and `sensor_enable=4`.
+2. Trigger boot initialization (power-on reset or deep-sleep wake).
+3. Assert: the effective runtime board layout is loaded before HAL initialization.
+4. Assert: the I2C0 peripheral is configured with SDA=6, SCL=7.
+5. Assert: the same layout survives a deep-sleep cycle and a power-on reset.
 
 ---
 
-### T-N0607b  Missing NVS keys fall back to defaults
+### T-N0607b  Missing board layout falls back to legacy compatibility layout
 
 **Validates:** ND-0608 (AC 2)
 
 **Procedure:**
-1. Erase NVS keys `i2c0_sda` and `i2c0_scl` (or start with a fresh NVS partition).
+1. Erase the `board_layout` flash key (or start with a fresh NVS partition).
 2. Trigger HAL initialization.
-3. Assert: the I2C0 peripheral is configured with the compiled-in defaults SDA=0, SCL=1.
+3. Assert: the effective layout is `i2c0_sda=0`, `i2c0_scl=1`, `one_wire_data=null`, `battery_adc=null`, `sensor_enable=null`.
+4. Assert: the I2C0 peripheral is configured with SDA=0, SCL=1.
 
 ---
 
-### T-N0607c  Pin config persisted from NODE_PROVISION with CBOR pin data
+### T-N0607c  Board layout persisted from NODE_PROVISION with CBOR layout data
 
 **Validates:** ND-0608 (AC 5)
 
 **Procedure:**
-1. Construct a NODE_PROVISION BLE message body with a valid encrypted payload followed by a deterministic CBOR map `{1: 6, 2: 7}` (SDA=6, SCL=7).
+1. Construct a NODE_PROVISION BLE message body with a valid encrypted payload followed by a deterministic CBOR map `{1: 6, 2: 7, 3: 3, 4: 2, 5: 4}`.
 2. Deliver the message to the node's provisioning handler.
-3. Assert: NVS keys `i2c0_sda` and `i2c0_scl` are written with values 6 and 7 respectively.
+3. Assert: the `board_layout` flash key is written with the decoded layout.
 4. Trigger a HAL re-initialization (or reboot).
-5. Assert: the I2C0 peripheral is configured with SDA=6, SCL=7.
+5. Assert: the I2C0 peripheral is configured with SDA=6, SCL=7 and the other functions are available in runtime layout state.
 
 ---
 
-### T-N0607d  NODE_PROVISION without pin config — backward compatible
+### T-N0607d  NODE_PROVISION without board layout — backward compatible
 
 **Validates:** ND-0608 (AC 6)
 
 **Procedure:**
-1. Construct a NODE_PROVISION BLE message body with a valid encrypted payload and no trailing pin config bytes.
+1. Construct a NODE_PROVISION BLE message body with a valid encrypted payload and no trailing board-layout bytes.
 2. Deliver the message to the node's provisioning handler.
 3. Assert: provisioning succeeds without error.
-4. Assert: NVS keys `i2c0_sda` and `i2c0_scl` are not written (or remain at their prior values).
+4. Assert: if a `board_layout` flash key already exists, it is not overwritten.
+5. Assert: if no `board_layout` flash key exists, the node uses the legacy compatibility layout on next boot (`i2c0_sda=0`, `i2c0_scl=1`, `one_wire_data=null`, `battery_adc=null`, `sensor_enable=null`).
 
 ---
 
-### T-N0607e  Factory reset does NOT erase pin config
+### T-N0607e  Factory reset does NOT erase board layout
 
 **Validates:** ND-0608 (AC 4), ND-0917
 
 **Procedure:**
-1. Write SDA=4, SCL=5 to NVS keys `i2c0_sda` and `i2c0_scl`.
+1. Write a board-layout record to flash.
 2. Trigger a factory reset (ND-0917).
-3. Assert: NVS keys `i2c0_sda` and `i2c0_scl` still contain 4 and 5.
+3. Assert: the `board_layout` flash key is unchanged.
 4. Trigger HAL initialization.
-5. Assert: the I2C0 peripheral is configured with SDA=4, SCL=5.
+5. Assert: the effective runtime layout still matches the pre-reset board layout.
 
 ---
 
-### T-N0607f  Invalid CBOR trailing data treated as no pin config
+### T-N0607f  Invalid board-layout CBOR is rejected
 
-**Validates:** ND-0608 (AC 6)
+**Validates:** ND-0608 (AC 8)
 
 **Procedure:**
 1. Construct a NODE_PROVISION BLE message body with a valid encrypted payload followed by invalid trailing bytes (e.g., truncated CBOR or random data).
 2. Deliver the message to the node's provisioning handler.
-3. Assert: provisioning succeeds (the encrypted payload is processed normally).
-4. Assert: NVS keys `i2c0_sda` and `i2c0_scl` are not written.
+3. Assert: provisioning fails with a storage / validation error response rather than treating the bytes as "no layout".
+4. Assert: the existing `board_layout` flash key is not modified.
+
+---
+
+### T-N0607g  Explicitly unassigned functions preserved in board layout
+
+**Validates:** ND-0608 (AC 7)
+
+**Procedure:**
+1. Construct a NODE_PROVISION BLE message body with board-layout CBOR `{1: 0, 2: 1, 3: null, 4: null, 5: null}`.
+2. Deliver the message to the provisioning handler and reboot.
+3. Assert: the effective runtime layout preserves `one_wire_data=null`, `battery_adc=null`, and `sensor_enable=null`.
+4. Assert: those functions are distinguishable from concrete GPIO assignments.
+
+---
+
+### T-N0608a  Sensor rail enable occurs after COMMAND
+
+**Validates:** ND-0608a (AC 1)
+
+**Procedure:**
+1. Provision a board layout with `sensor_enable=4` and `battery_adc=2`.
+2. Run a wake cycle with instrumentation on GPIO4 transitions.
+3. Assert: GPIO4 is not asserted before `COMMAND` is successfully received.
+4. Assert: GPIO4 is driven active before post-WAKE command work / BPF execution begins.
+
+---
+
+### T-N0608b  Battery ADC sample stored for next wake
+
+**Validates:** ND-0608a (AC 2, AC 3, AC 5)
+
+**Procedure:**
+1. Provision a board layout with `sensor_enable=4` and `battery_adc=2`.
+2. Configure mock ADC reading to 3125 mV equivalent.
+3. Run a wake cycle through `COMMAND` processing and BPF execution.
+4. Assert: the firmware waits for the configured settle interval before sampling.
+5. Assert: the current-cycle `sonde_context.battery_mv` and `get_battery_mv()` value are 3125.
+6. Assert: 3125 mV is stored in RTC-retained state for the next wake.
+
+---
+
+### T-N0608c  Fallback battery value stored when no ADC assigned
+
+**Validates:** ND-0608a (AC 4, AC 5)
+
+**Procedure:**
+1. Provision a board layout with `battery_adc=null`.
+2. Run a wake cycle through `COMMAND` processing.
+3. Assert: the current-cycle `sonde_context.battery_mv` and `get_battery_mv()` value are 3300.
+4. Assert: 3300 mV is stored in RTC-retained state for the next wake.
 
 ---
 
@@ -2064,7 +2141,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0102 | T-N102 |
 | ND-0103 | T-N103, T-N104, T-N920 |
 | ND-0200 | T-N200, T-N201, T-N921 |
-| ND-0201 | T-N202, T-N203 |
+| ND-0201 | T-N202, T-N202a, T-N202b, T-N203 |
 | ND-0202 | T-N204, T-N205, T-N206, T-N207, T-N922 |
 | ND-0203 | T-N205, T-N208, T-N209, T-N923 |
 | ND-0300 | T-N606a, T-N606b (AEAD path) |
@@ -2088,7 +2165,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0601 | T-N600, T-N601, T-N602, T-N603, T-N931 |
 | ND-0602 | T-N604, T-N605, T-N606, T-N621, T-N627a |
 | ND-0603 | T-N607, T-N608, T-N609, T-N932 |
-| ND-0604 | T-N610, T-N611, T-N612, T-N613, T-N933 |
+| ND-0604 | T-N610, T-N611, T-N612, T-N613, T-N933, T-N0608b, T-N0608c |
 | ND-0605 | T-N614, T-N615, T-N934 |
 | ND-0606 | T-N616, T-N619, T-N620, T-N935 |
 | ND-0700 | T-N201, T-N700 |
@@ -2116,7 +2193,8 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0916 | T-N918 |
 | ND-0917 | T-N906 |
 | ND-0918 | *(verified by sdkconfig.defaults setting)* |
-| ND-0608 | T-N0607a, T-N0607b, T-N0607c, T-N0607d, T-N0607e, T-N0607f |
+| ND-0608 | T-N0607a, T-N0607b, T-N0607c, T-N0607d, T-N0607e, T-N0607f, T-N0607g |
+| ND-0608a | T-N202b, T-N0608a, T-N0608b, T-N0608c |
 | ND-0609 | T-N621, T-N626, T-N627, T-N632 |
 | ND-0610 | T-N622, T-N623, T-N624 |
 | ND-0611 | T-N623 |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1973,7 +1973,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 1. Provision a board layout with `sensor_enable=4` and `battery_adc=2`.
 2. Configure mock ADC reading to 3125 mV equivalent.
 3. Run a wake cycle through `COMMAND` processing and BPF execution.
-4. Assert: the firmware waits for the configured settle interval before sampling.
+4. Assert: the firmware waits for the fixed `SENSOR_SETTLE_MS` delay (10 ms) before sampling.
 5. Assert: the current-cycle `sonde_context.battery_mv` and `get_battery_mv()` value are 3125.
 6. Assert: 3125 mV is stored in RTC-retained state for the next wake.
 


### PR DESCRIPTION
## Summary
- add shared BoardLayout encoding/decoding and use it for pairing provisioning instead of I2C-only pin config
- add Sonde Sensor Node rev_a as the default pairing preset while keeping Espressif and SparkFun layouts available
- persist board layout on the node, stage it into RTC-backed runtime state, report stored battery on WAKE, and restore provisioned GPIOs to high-Z before deep sleep

## Testing
- cargo fmt --all
- cargo build --workspace
- cargo clippy --workspace -- -D warnings
- cargo test --workspace

Closes #134