### PR TITLE
Bundle modem firmware into gateway container

### DIFF
--- a/.github/docker/Dockerfile.gateway
+++ b/.github/docker/Dockerfile.gateway
@@ -28,7 +28,7 @@
 FROM rust:alpine@sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334 AS builder
 
 RUN apk add --no-cache build-base eudev-dev musl-dev pkgconf protobuf \
-    && cargo install --locked espflash --root /opt/espflash
+    && cargo install --locked espflash@4.4.0 --root /opt/espflash
 
 WORKDIR /src
 COPY . .

--- a/.github/docker/Dockerfile.gateway
+++ b/.github/docker/Dockerfile.gateway
@@ -3,13 +3,17 @@
 #
 # Multi-stage Dockerfile for the sonde-gateway container image.
 # Produces a minimal Alpine-based image containing sonde-gateway,
-# sonde-admin, and the sensor handler binaries.
+# sonde-admin, the sensor handler binaries, espflash, and the
+# bundled modem firmware images prepared by gateway-container.yml.
 #
 # Published to ghcr.io/alan-jowett/sonde-gateway by the
 # gateway-container.yml CI workflow (GW-1800).
 #
 # Build:
 #   docker build -f .github/docker/Dockerfile.gateway -t sonde-gateway .
+#   # Requires modem artifacts at:
+#   #   .artifacts/modem-firmware/flash_image.bin
+#   #   .artifacts/modem-firmware-verbose/flash_image.bin
 #
 # Run:
 #   docker run -d \
@@ -23,7 +27,8 @@
 # rust:alpine — pinned by digest for reproducible builds.
 FROM rust:alpine@sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334 AS builder
 
-RUN apk add --no-cache musl-dev protobuf
+RUN apk add --no-cache build-base eudev-dev musl-dev pkgconf protobuf \
+    && cargo install --locked espflash --root /opt/espflash
 
 WORKDIR /src
 COPY . .
@@ -43,12 +48,17 @@ FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d650
 # Non-root user for the gateway process (GW-1802 AC3).
 RUN addgroup -S sonde && adduser -S sonde -G sonde \
     && mkdir -p /var/lib/sonde \
+       /usr/local/share/sonde/firmware/modem/default \
+       /usr/local/share/sonde/firmware/modem/verbose \
     && chown sonde:sonde /var/lib/sonde
 
+COPY --from=builder /opt/espflash/bin/espflash             /usr/local/bin/
 COPY --from=builder /src/target/release/sonde-gateway      /usr/local/bin/
 COPY --from=builder /src/target/release/sonde-admin         /usr/local/bin/
 COPY --from=builder /src/target/release/sonde-sht40-handler /usr/local/bin/
 COPY --from=builder /src/target/release/sonde-tmp102-handler /usr/local/bin/
+COPY .artifacts/modem-firmware/flash_image.bin /usr/local/share/sonde/firmware/modem/default/flash_image.bin
+COPY .artifacts/modem-firmware-verbose/flash_image.bin /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin
 
 # Persist the database across container restarts (GW-1802 AC2).
 VOLUME /var/lib/sonde

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -23,8 +23,18 @@ env:
   IMAGE_NAME: alan-jowett/sonde-gateway
 
 jobs:
+  # Standalone dispatches do not have a caller workflow to provide same-run
+  # modem artifacts, so build them here first. workflow_call executions expect
+  # the caller to produce modem-firmware and modem-firmware-verbose in the same run.
+  modem-firmware:
+    if: github.event_name == 'workflow_dispatch'
+    name: Build modem firmware (same run)
+    uses: ./.github/workflows/esp32-modem.yml
+
   # ── Per-architecture native builds ────────────────────────────────
   build:
+    needs: [modem-firmware]
+    if: ${{ always() && (needs.modem-firmware.result == 'success' || needs.modem-firmware.result == 'skipped') }}
     strategy:
       matrix:
         include:
@@ -40,6 +50,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download default modem firmware artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: modem-firmware
+          path: .artifacts/modem-firmware
+
+      - name: Download verbose modem firmware artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: modem-firmware-verbose
+          path: .artifacts/modem-firmware-verbose
 
       - name: Log in to GitHub Container Registry
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
@@ -71,11 +93,13 @@ jobs:
           docker run --rm --entrypoint sonde-admin ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
           docker run --rm --entrypoint sonde-sht40-handler ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
           docker run --rm --entrypoint sonde-tmp102-handler ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
+          docker run --rm --entrypoint espflash ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --help
 
       - name: Smoke test — runtime defaults
         run: |
           test "$(docker inspect -f '{{json .Config.Entrypoint}}' ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }})" = '["sonde-gateway"]'
           test "$(docker inspect -f '{{json .Config.Cmd}}' ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }})" = '["--db","/var/lib/sonde/sonde.db","--port","/dev/ttyACM0","--key-provider","env"]'
+          docker run --rm ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --help | grep -q -- '--key-provider'
 
       - name: Smoke test — static musl linkage
         run: |
@@ -97,6 +121,33 @@ jobs:
         run: |
           docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
             'whoami | grep -q sonde && touch /var/lib/sonde/test && rm /var/lib/sonde/test'
+
+      - name: Smoke test — bundled modem images
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'test -r /usr/local/share/sonde/firmware/modem/default/flash_image.bin \
+             && test -r /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin'
+
+      - name: Smoke test — runtime image excludes Rust toolchain and source tree
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            '! command -v cargo >/dev/null 2>&1 \
+             && ! command -v rustc >/dev/null 2>&1 \
+             && ! test -d /root/.cargo \
+             && ! test -d /usr/local/cargo \
+             && ! test -d /src'
+
+      - name: Smoke test — modem artifact hashes match same-run downloads
+        run: |
+          set -euo pipefail
+          default_expected="$(sha256sum .artifacts/modem-firmware/flash_image.bin | awk '{print $1}')"
+          verbose_expected="$(sha256sum .artifacts/modem-firmware-verbose/flash_image.bin | awk '{print $1}')"
+          read -r default_actual verbose_actual < <(
+            docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+              'sha256sum /usr/local/share/sonde/firmware/modem/default/flash_image.bin /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin | awk "{print \$1}" | tr "\n" " "'
+          )
+          test "$default_actual" = "$default_expected"
+          test "$verbose_actual" = "$verbose_expected"
 
       # Push the per-arch image with a temporary tag (consumed by the
       # manifest job). Include the workflow run ID so overlapping runs

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -144,7 +144,7 @@ jobs:
           verbose_expected="$(sha256sum .artifacts/modem-firmware-verbose/flash_image.bin | awk '{print $1}')"
           read -r default_actual verbose_actual < <(
             docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
-              'sha256sum /usr/local/share/sonde/firmware/modem/default/flash_image.bin /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin | awk "{print \$1}" | tr "\n" " "'
+              'sha256sum /usr/local/share/sonde/firmware/modem/default/flash_image.bin /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin | awk "{print \$1}" | paste -sd" " -'
           )
           test "$default_actual" = "$default_expected"
           test "$verbose_actual" = "$verbose_expected"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -28,6 +28,7 @@ jobs:
 
   gateway-container:
     name: Gateway container
+    needs: [modem-firmware]
     uses: ./.github/workflows/gateway-container.yml
     permissions:
       contents: read

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1812,11 +1812,11 @@ All diagnostic events are logged at `INFO` level **(GW-1706)**:
 
 ## 22  Container image
 
-> **Requirements:** GW-1800 (multi-arch image), GW-1801 (tagging), GW-1802 (runtime configuration), GW-1803 (optional secret-service).
+> **Requirements:** GW-1800 (multi-arch image), GW-1801 (tagging), GW-1802 (runtime configuration), GW-1803 (optional secret-service), GW-1804 (bundled modem flashing assets).
 
 ### 22.1  Overview
 
-The gateway is distributed as a multi-architecture Docker container image alongside the traditional bare-metal binaries and `.deb` packages. The image targets Alpine Linux (musl libc) for minimal size and contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, and `sonde-tmp102-handler`.
+The gateway is distributed as a multi-architecture Docker container image alongside the traditional bare-metal binaries and `.deb` packages. The image targets Alpine Linux (musl libc) for minimal size and contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, `sonde-tmp102-handler`, `espflash`, and two bundled modem merged flash images (default and verbose).
 
 ### 22.2  Build strategy
 
@@ -1825,13 +1825,28 @@ Each architecture (`linux/amd64`, `linux/arm64`) is built natively on a per-arch
 **Multi-stage Dockerfile** (`.github/docker/Dockerfile.gateway`):
 
 1. **Builder stage** (`rust:alpine`): installs `musl-dev` and `protobuf`, builds all four binaries; the `sonde-gateway` build uses `--no-default-features` to exclude the `keyring` feature and its `secret-service`/`zbus` dependency tree.
-2. **Runtime stage** (`alpine:3.21`): copies only the compiled binaries, creates a non-root `sonde` user, and declares `VOLUME /var/lib/sonde`.
+2. **Flashing-assets stage**: produces or imports the `espflash` executable plus the two merged modem flash images (`modem-firmware` and `modem-firmware-verbose`) generated for the same workflow run and source revision as the gateway image build.
+3. **Runtime stage** (`alpine:3.21`): copies only the compiled runtime binaries, `espflash`, and the bundled modem flash images, creates a non-root `sonde` user, and declares `VOLUME /var/lib/sonde`.
 
-### 22.3  Feature flag: `keyring` (GW-1803)
+### 22.3  Bundled flashing assets (GW-1804)
+
+The runtime image exposes the bundled modem flashing assets at fixed paths:
+
+| Asset | Path |
+|-------|------|
+| `espflash` | `/usr/local/bin/espflash` |
+| Default modem image | `/usr/local/share/sonde/firmware/modem/default/flash_image.bin` |
+| Verbose modem image | `/usr/local/share/sonde/firmware/modem/verbose/flash_image.bin` |
+
+The container continues to start with `sonde-gateway` as its default entrypoint. Operators who need to reflash a modem run the container with an entrypoint override (for example `--entrypoint espflash` or `--entrypoint sh`) and invoke `espflash write-bin -p PORT 0x0 <image-path>` manually. The gateway process does not invoke `espflash` on startup or during routine operation.
+
+To keep "latest" unambiguous, the bundled modem images are defined as the modem artifacts produced from the same git revision and workflow run as the container image build. The container workflow therefore consumes the `modem-firmware` and `modem-firmware-verbose` artifacts from the same CI execution rather than downloading an arbitrary previously published release.
+
+### 22.4  Feature flag: `keyring` (GW-1803)
 
 The `secret-service` dependency (D-Bus keyring via `zbus`) is gated behind a `keyring` cargo feature, enabled by default. Container builds pass `--no-default-features` to exclude it, since containers use `--key-provider file` or `--key-provider env` instead. All `#[cfg(target_os = "linux")]` gates on secret-service code are extended to `#[cfg(all(target_os = "linux", feature = "keyring"))]`.
 
-### 22.4  Tagging strategy (GW-1801)
+### 22.5  Tagging strategy (GW-1801)
 
 | Trigger | Tags |
 |---------|------|
@@ -1840,7 +1855,7 @@ The `secret-service` dependency (D-Bus keyring via `zbus`) is gated behind a `ke
 
 Public tags are created only after both architectures pass smoke tests.
 
-### 22.5  Runtime configuration (GW-1802)
+### 22.6  Runtime configuration (GW-1802)
 
 | Property | Value |
 |----------|-------|
@@ -1849,8 +1864,10 @@ Public tags are created only after both architectures pass smoke tests.
 | `VOLUME` | `/var/lib/sonde` |
 | `USER` | `sonde` (non-root) |
 
-Serial device access requires the operator to pass `--device=/dev/ttyACM0` and `--group-add <host-dialout-gid>` at `docker run` time. The container defaults assume `/dev/ttyACM0`; operators using a different modem path must override `--port`.
+Serial device access requires the operator to pass `--device=/dev/ttyACM0` and `--group-add <host-dialout-gid>` at `docker run` time. The container defaults assume `/dev/ttyACM0`; operators using a different modem path must override `--port`. The bundled modem images remain readable by the non-root `sonde` user so operators can invoke manual flashing commands without switching users inside the container.
 
-### 22.6  CI integration
+### 22.7  CI integration
 
 The `gateway-container.yml` workflow is called by `nightly-release.yml` as a parallel job. The nightly release job waits for the container build to complete before publishing the GitHub release. Release-tag container builds are therefore driven indirectly via `nightly-release.yml`, while `gateway-container.yml` itself is also available via `workflow_dispatch`.
+
+To satisfy GW-1804's provenance rule, every execution path that publishes or smoke-tests the gateway container must make the modem artifacts available in the same workflow run before the image-build step. In the nightly/release path, those artifacts come from the sibling modem-firmware job in the caller workflow. In the standalone `workflow_dispatch` path, the workflow must first run the modem build (or an equivalent reusable workflow) so the image still consumes same-run `modem-firmware` and `modem-firmware-verbose` artifacts rather than downloading files from a previous run.

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1824,9 +1824,8 @@ Each architecture (`linux/amd64`, `linux/arm64`) is built natively on a per-arch
 
 **Multi-stage Dockerfile** (`.github/docker/Dockerfile.gateway`):
 
-1. **Builder stage** (`rust:alpine`): installs `musl-dev` and `protobuf`, builds all four binaries; the `sonde-gateway` build uses `--no-default-features` to exclude the `keyring` feature and its `secret-service`/`zbus` dependency tree.
-2. **Flashing-assets stage**: produces or imports the `espflash` executable plus the two merged modem flash images (`modem-firmware` and `modem-firmware-verbose`) generated for the same workflow run and source revision as the gateway image build.
-3. **Runtime stage** (`alpine:3.21`): copies only the compiled runtime binaries, `espflash`, and the bundled modem flash images, creates a non-root `sonde` user, and declares `VOLUME /var/lib/sonde`.
+1. **Builder stage** (`rust:alpine`): installs `musl-dev`, `protobuf`, and the additional native dependencies required to build `espflash`; installs the pinned `espflash` CLI; builds all four Sonde binaries; and uses `--no-default-features` for `sonde-gateway` to exclude the `keyring` feature and its `secret-service`/`zbus` dependency tree.
+2. **Runtime stage** (`alpine:3.21`): copies only the compiled runtime binaries, the `espflash` executable from the builder stage, and the two merged modem flash images (`modem-firmware` and `modem-firmware-verbose`) supplied in the Docker build context by the same workflow run. It then creates a non-root `sonde` user and declares `VOLUME /var/lib/sonde`.
 
 ### 22.3  Bundled flashing assets (GW-1804)
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2113,14 +2113,14 @@ The gateway MUST log `DIAG_REQUEST` reception and `DIAG_REPLY` transmission at `
 **Source:** Issue #780
 
 **Description:**  
-The CI MUST produce a multi-architecture Docker container image (`linux/amd64` + `linux/arm64`) published to `ghcr.io/alan-jowett/sonde-gateway`. The image MUST be based on Alpine Linux (musl libc) for minimal size. A multi-stage build ensures the final image contains no Rust toolchain, build artifacts, or source code. Each architecture MUST be built natively on a per-arch GitHub runner (no QEMU cross-compilation).
+The CI MUST produce a multi-architecture Docker container image (`linux/amd64` + `linux/arm64`) published to `ghcr.io/alan-jowett/sonde-gateway`. The image MUST be based on Alpine Linux (musl libc) for minimal size. A multi-stage build ensures the final image contains no Rust toolchain or source code, and no build artifacts other than the intentionally bundled runtime assets described by GW-1804. Each architecture MUST be built natively on a per-arch GitHub runner (no QEMU cross-compilation).
 
 **Acceptance criteria:**
 
 1. The image is based on Alpine Linux (musl libc).
-2. The image contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, and `sonde-tmp102-handler` binaries.
+2. The image contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, `sonde-tmp102-handler`, and `espflash`.
 3. `docker manifest inspect` shows both `linux/amd64` and `linux/arm64` platforms.
-4. The final image contains no Rust toolchain, build artifacts, or source code.
+4. The final image contains no Rust toolchain or source code, and no build artifacts other than the intentionally bundled modem flash images required by GW-1804.
 5. Each architecture is built on a native runner (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`).
 6. Per-arch images pass smoke tests (binary execution, linkage verification) before any public tag is created.
 
@@ -2150,7 +2150,7 @@ Container images MUST follow a consistent tagging strategy. Release builds (git 
 **Source:** Issue #780
 
 **Description:**  
-The container image MUST be configured for production use. The `ENTRYPOINT` is `sonde-gateway` with a default `CMD` that points the database to the declared volume, selects `/dev/ttyACM0` as the default modem path, and uses the `env` key provider that is suitable for container deployments. A `VOLUME` at `/var/lib/sonde` is declared for database persistence. The gateway runs as a non-root `sonde` user inside the container. The `--key-provider file` and `--key-provider env` backends work without D-Bus.
+The container image MUST be configured for production use. The `ENTRYPOINT` is `sonde-gateway` with a default `CMD` that points the database to the declared volume, selects `/dev/ttyACM0` as the default modem path, and uses the `env` key provider that is suitable for container deployments. A `VOLUME` at `/var/lib/sonde` is declared for database persistence. The gateway runs as a non-root `sonde` user inside the container. The `--key-provider file` and `--key-provider env` backends work without D-Bus. The image MUST also expose the bundled modem flash images at stable in-image paths so an operator can invoke `espflash` manually from the container when needed.
 
 **Acceptance criteria:**
 
@@ -2160,6 +2160,8 @@ The container image MUST be configured for production use. The `ENTRYPOINT` is `
 4. The gateway runs as a non-root `sonde` user inside the container.
 5. `--key-provider file` and `--key-provider env` work without D-Bus.
 6. Serial device access requires the operator to pass `--device` and `--group-add` at `docker run` time.
+7. The default modem flash image is available at `/usr/local/share/sonde/firmware/modem/default/flash_image.bin`.
+8. The verbose modem flash image is available at `/usr/local/share/sonde/firmware/modem/verbose/flash_image.bin`.
 
 ---
 
@@ -2178,6 +2180,24 @@ The `secret-service` (D-Bus keyring) dependency MUST be behind a cargo feature f
 3. The default feature set includes `keyring` (no behavior change for existing builds).
 4. Container builds use `--no-default-features` to exclude `keyring`.
 5. Building with `--no-default-features` produces a working binary that supports `file` and `env` key providers.
+
+---
+
+### GW-1804  Bundled modem flashing assets
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+The gateway container image MUST bundle the modem flashing assets needed for manual/operator flashing. This includes an `espflash` executable plus both merged modem flash images (`default` and `verbose`). The bundled modem flash images MUST be the artifacts produced for the same git revision and workflow run as the container image build. These assets are for operator-invoked flashing only; normal gateway startup continues to run `sonde-gateway` and does not automatically reflash the modem.
+
+**Acceptance criteria:**
+
+1. Running `espflash --help` or `espflash --version` inside the container succeeds.
+2. The image contains the default merged modem flash image.
+3. The image contains the verbose merged modem flash image.
+4. The default and verbose files bundled into the image are byte-identical to the `modem-firmware` and `modem-firmware-verbose` artifacts produced for the same workflow run as the container image build.
+5. The container's default startup path remains `sonde-gateway`; using the bundled flashing assets requires an operator to invoke `espflash` manually.
 
 ---
 
@@ -2301,3 +2321,4 @@ The `secret-service` (D-Bus keyring) dependency MUST be behind a cargo feature f
 | GW-1801 | Container image tagging | Must |
 | GW-1802 | Container runtime configuration | Must |
 | GW-1803 | Optional secret-service dependency | Must |
+| GW-1804 | Bundled modem flashing assets | Must |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -3394,11 +3394,10 @@ A configurable stub handler process (or in-process mock) that:
 4. Run `docker run --rm <image> --help` and verify `--key-provider env` appears in the output.
 
 **Expected:**
-1. `ENTRYPOINT` is `["sonde-gateway"]` and `CMD` is `["--db", "/var/lib/sonde/sonde.db", "--port", "/dev/ttyACM0", "--key-provider", "env"]`.
+1. `ENTRYPOINT` is `["sonde-gateway"]` and `CMD` is `["--db", "/var/lib/sonde/sonde.db", "--port", "/dev/ttyACM0", "--key-provider", "env"]`, so the default startup path remains the gateway binary rather than `espflash`.
 2. `whoami` outputs `sonde`.
 3. File creation in `/var/lib/sonde` succeeds (writable by `sonde` user).
 4. `--key-provider env` is accepted by the CLI help path.
-5. The default startup path is the gateway binary, not `espflash`.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -3332,9 +3332,9 @@ A configurable stub handler process (or in-process mock) that:
 
 ## 17  Container image tests
 
-### T-1800  Container image contains expected binaries
+### T-1800  Container image contains expected binaries and flashing tool
 
-**Traces to:** GW-1800 (AC-2, AC-4)
+**Traces to:** GW-1800 (AC-2, AC-4), GW-1804 (AC-1)
 
 **Preconditions:** Container image built from `Dockerfile.gateway` for the native architecture.
 
@@ -3343,10 +3343,11 @@ A configurable stub handler process (or in-process mock) that:
 2. Run `docker run --rm --entrypoint sonde-admin <image> --version`.
 3. Run `docker run --rm --entrypoint sonde-sht40-handler <image> --version`.
 4. Run `docker run --rm --entrypoint sonde-tmp102-handler <image> --version`.
+5. Run `docker run --rm --entrypoint espflash <image> --help`.
 
 **Expected:**
-1. All four commands exit 0 and print version strings.
-2. No Rust toolchain or source code is present in the image.
+1. All five commands exit 0; the four Sonde binaries print version strings and `espflash` prints help text.
+2. No Rust toolchain or source code is present in the image; the only non-binary build outputs present are the intentionally bundled modem flash images.
 
 ---
 
@@ -3382,7 +3383,7 @@ A configurable stub handler process (or in-process mock) that:
 
 ### T-1802  Container runtime defaults, non-root user, and writable volume
 
-**Traces to:** GW-1802 (AC-2, AC-3, AC-4)
+**Traces to:** GW-1802 (AC-2, AC-3, AC-4), GW-1804 (AC-5)
 
 **Preconditions:** Container image built.
 
@@ -3397,6 +3398,24 @@ A configurable stub handler process (or in-process mock) that:
 2. `whoami` outputs `sonde`.
 3. File creation in `/var/lib/sonde` succeeds (writable by `sonde` user).
 4. `--key-provider env` is accepted by the CLI help path.
+5. The default startup path is the gateway binary, not `espflash`.
+
+---
+
+### T-1802a  Container exposes bundled modem image paths
+
+**Traces to:** GW-1802 (AC-7, AC-8), GW-1804 (AC-2, AC-3)
+
+**Preconditions:** Container image built.
+
+**Steps:**
+1. Run `docker run --rm --entrypoint sh <image> -c 'test -f /usr/local/share/sonde/firmware/modem/default/flash_image.bin'`.
+2. Run `docker run --rm --entrypoint sh <image> -c 'test -f /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin'`.
+3. Run `docker run --rm --entrypoint sh <image> -c 'test -r /usr/local/share/sonde/firmware/modem/default/flash_image.bin && test -r /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin'`.
+
+**Expected:**
+1. Both files exist at the documented stable paths.
+2. Both files are readable by the container's default non-root user.
 
 ---
 
@@ -3447,6 +3466,24 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1806  Bundled modem images match same-run CI artifacts
+
+**Traces to:** GW-1804 (AC-4)
+
+**Preconditions:** A workflow run has produced `modem-firmware`, `modem-firmware-verbose`, and the container image for the same commit/tag. This applies both to nightly/release runs and to standalone `workflow_dispatch` runs, which must include a same-run modem-artifact production step before the image build.
+
+**Steps:**
+1. Download the `modem-firmware` and `modem-firmware-verbose` artifacts from the same workflow run that produced the container image.
+2. Extract `/usr/local/share/sonde/firmware/modem/default/flash_image.bin` and `/usr/local/share/sonde/firmware/modem/verbose/flash_image.bin` from the container image.
+3. Compute SHA-256 hashes for the two downloaded artifacts and the two extracted in-image files.
+
+**Expected:**
+1. The hash of the in-image default file matches the hash of the downloaded `modem-firmware` artifact.
+2. The hash of the in-image verbose file matches the hash of the downloaded `modem-firmware-verbose` artifact.
+3. The compared artifacts and image were all produced by the same workflow run.
+
+---
+
 | GW-1306 | T-1306a, T-1306b, T-1306c, T-1306d |
 | GW-1307 | T-1307a, T-1307b, T-1307c, T-1307d, T-1307e, T-1307f, T-1307g, T-1307h, T-1307i |
 | GW-1308 | T-1308 |
@@ -3475,5 +3512,6 @@ A configurable stub handler process (or in-process mock) that:
 | GW-1706 | T-1711 |
 | GW-1800 | T-1800, T-1804, T-1805 |
 | GW-1801 | T-1801, T-1801a, T-1804 |
-| GW-1802 | T-1802 |
+| GW-1802 | T-1802, T-1802a |
 | GW-1803 | T-1803 |
+| GW-1804 | T-1800, T-1802a, T-1806 |


### PR DESCRIPTION
## Summary
- update gateway container requirements, design, and validation to cover bundled `espflash`, fixed in-image modem flash paths, same-run artifact provenance, and manual-only flashing
- install `espflash` in `.github/docker/Dockerfile.gateway` and copy the default + verbose modem flash images into the runtime image
- extend `.github/workflows/gateway-container.yml` to guarantee same-run modem artifacts for both `workflow_call` and standalone `workflow_dispatch`, and add smoke tests for bundled assets and runtime image hygiene
- make `nightly-release.yml` wait for the sibling modem-firmware job before the gateway container job runs

## Traceability
- requirements: `GW-1800`, `GW-1802`, new `GW-1804`
- design: gateway container section 22 updated for bundled flashing assets and CI provenance
- validation: added coverage for `espflash`, stable bundled firmware paths, and same-run artifact hash parity

## Audit
- specification audit verdict: PASS
- implementation audit verdict: PASS

## Validation
- `cargo fmt --all`
- `cargo build --workspace`
- Python YAML parse for `.github/workflows/gateway-container.yml` and `.github/workflows/nightly-release.yml`
- `git diff --check`
- limitation: Docker is not installed in this local shell, so the container build/smoke path was validated statically and should run in CI