### PR TITLE
Add gateway companion gRPC API

### DIFF
--- a/crates/sonde-gateway/build.rs
+++ b/crates/sonde-gateway/build.rs
@@ -4,7 +4,9 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=proto");
     println!("cargo:rerun-if-changed=proto/admin.proto");
-    tonic_prost_build::compile_protos("proto/admin.proto")?;
+    println!("cargo:rerun-if-changed=proto/companion.proto");
+    tonic_prost_build::configure()
+        .compile_protos(&["proto/admin.proto", "proto/companion.proto"], &["proto"])?;
 
     // Inject the git commit SHA so the binary can display it at runtime (GW-1303).
     // Prefer an explicit SONDE_GIT_COMMIT env var (set by CI) over running git.

--- a/crates/sonde-gateway/proto/companion.proto
+++ b/crates/sonde-gateway/proto/companion.proto
@@ -1,0 +1,75 @@
+syntax = "proto3";
+package sonde.companion;
+
+service GatewayCompanion {
+    rpc StreamEvents(CompanionStreamEventsRequest) returns (stream CompanionEvent);
+    rpc ListNodes(CompanionListNodesRequest) returns (CompanionListNodesResponse);
+    rpc GetNode(CompanionGetNodeRequest) returns (CompanionNodeInfo);
+    rpc AssignProgram(CompanionAssignProgramRequest) returns (CompanionEmpty);
+    rpc SetSchedule(CompanionSetScheduleRequest) returns (CompanionEmpty);
+    rpc QueueReboot(CompanionQueueRebootRequest) returns (CompanionEmpty);
+    rpc QueueEphemeral(CompanionQueueEphemeralRequest) returns (CompanionEmpty);
+    rpc GetNodeStatus(CompanionGetNodeStatusRequest) returns (CompanionNodeStatus);
+}
+
+message CompanionEmpty {}
+message CompanionStreamEventsRequest {}
+message CompanionListNodesRequest {}
+message CompanionListNodesResponse { repeated CompanionNodeInfo nodes = 1; }
+message CompanionGetNodeRequest { string node_id = 1; }
+message CompanionAssignProgramRequest { string node_id = 1; bytes program_hash = 2; }
+message CompanionSetScheduleRequest { string node_id = 1; uint32 interval_s = 2; }
+message CompanionQueueRebootRequest { string node_id = 1; }
+message CompanionQueueEphemeralRequest { string node_id = 1; bytes program_hash = 2; }
+message CompanionGetNodeStatusRequest { string node_id = 1; }
+
+message CompanionEvent {
+    oneof event {
+        CompanionNodeCheckIn node_checkin = 1;
+        CompanionNodePayload node_payload = 2;
+    }
+}
+
+message CompanionNodeCheckIn {
+    string node_id = 1;
+    bytes current_program_hash = 2;
+    optional bytes assigned_program_hash = 3;
+    uint32 battery_mv = 4;
+    uint32 firmware_abi_version = 5;
+    string firmware_version = 6;
+    uint64 timestamp_ms = 7;
+}
+
+enum CompanionPayloadOrigin {
+    COMPANION_PAYLOAD_ORIGIN_UNSPECIFIED = 0;
+    COMPANION_PAYLOAD_ORIGIN_APP_DATA = 1;
+    COMPANION_PAYLOAD_ORIGIN_WAKE_BLOB = 2;
+}
+
+message CompanionNodePayload {
+    string node_id = 1;
+    bytes program_hash = 2;
+    bytes payload = 3;
+    uint64 timestamp_ms = 4;
+    CompanionPayloadOrigin payload_origin = 5;
+}
+
+message CompanionNodeInfo {
+    string node_id = 1;
+    uint32 key_hint = 2;
+    optional bytes assigned_program_hash = 3;
+    optional bytes current_program_hash = 4;
+    optional uint32 last_battery_mv = 5;
+    optional uint32 last_firmware_abi_version = 6;
+    optional uint64 last_seen_ms = 7;
+    optional uint32 schedule_interval_s = 8;
+}
+
+message CompanionNodeStatus {
+    string node_id = 1;
+    bytes current_program_hash = 2;
+    optional uint32 battery_mv = 3;
+    optional uint32 firmware_abi_version = 4;
+    optional uint64 last_seen_ms = 5;
+    bool has_active_session = 6;
+}

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -218,7 +218,7 @@ pub fn handler_record_to_config(r: HandlerRecord) -> Option<HandlerConfig> {
     })
 }
 
-fn system_time_to_millis(t: std::time::SystemTime) -> Option<u64> {
+pub(crate) fn system_time_to_millis(t: std::time::SystemTime) -> Option<u64> {
     t.duration_since(UNIX_EPOCH)
         .ok()
         .map(|d| d.as_millis() as u64)

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -236,6 +236,16 @@ fn node_to_info(n: &NodeRecord) -> NodeInfo {
     }
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct NodeStatusSnapshot {
+    pub(crate) node_id: String,
+    pub(crate) current_program_hash: Vec<u8>,
+    pub(crate) battery_mv: Option<u32>,
+    pub(crate) firmware_abi_version: Option<u32>,
+    pub(crate) last_seen_ms: Option<u64>,
+    pub(crate) has_active_session: bool,
+}
+
 #[allow(clippy::result_large_err)]
 fn parse_profile(value: i32) -> Result<VerificationProfile, Status> {
     match value {
@@ -279,6 +289,181 @@ fn validate_program_hash_bytes(operation: &str, hash: &[u8]) -> Result<String, S
         )));
     }
     Ok(fmt_hex(hash))
+}
+
+pub(crate) async fn list_nodes_impl(storage: &Arc<dyn Storage>) -> Result<Vec<NodeRecord>, Status> {
+    storage.list_nodes().await.map_err(storage_err)
+}
+
+pub(crate) async fn get_node_impl(
+    storage: &Arc<dyn Storage>,
+    node_id: &str,
+) -> Result<NodeRecord, Status> {
+    storage
+        .get_node(node_id)
+        .await
+        .map_err(storage_err)?
+        .ok_or_else(|| Status::not_found(format!("node `{node_id}` not found")))
+}
+
+pub(crate) async fn assign_program_impl(
+    storage: &Arc<dyn Storage>,
+    node_id: &str,
+    program_hash: &[u8],
+) -> Result<(), Status> {
+    let program_hash_hex = validate_program_hash_bytes("assign program", program_hash)?;
+    let mut node = storage
+        .get_node(node_id)
+        .await
+        .map_err(|e| {
+            storage_err_with_context(&format!("assign program: look up node `{node_id}`"), e)
+        })?
+        .ok_or_else(|| {
+            Status::not_found(format!(
+                "assign program failed: node `{node_id}` not found; use ListNodes to verify the node_id",
+            ))
+        })?;
+    storage
+        .get_program(program_hash)
+        .await
+        .map_err(|e| {
+            storage_err_with_context(
+                &format!("assign program: look up program `{program_hash_hex}`"),
+                e,
+            )
+        })?
+        .ok_or_else(|| {
+            Status::not_found(format!(
+                "assign program failed: program `{program_hash_hex}` not found; \
+                 use IngestProgram to upload it first, then ListPrograms to verify",
+            ))
+        })?;
+    node.assigned_program_hash = Some(program_hash.to_vec());
+    storage.upsert_node(&node).await.map_err(|e| {
+        storage_err_with_context(
+            &format!("assign program: update node `{node_id}` with program `{program_hash_hex}`"),
+            e,
+        )
+    })?;
+    Ok(())
+}
+
+pub(crate) async fn set_schedule_impl(
+    storage: &Arc<dyn Storage>,
+    pending_commands: &Arc<RwLock<HashMap<String, Vec<PendingCommand>>>>,
+    node_id: &str,
+    interval_s: u32,
+) -> Result<(), Status> {
+    let mut node = storage
+        .get_node(node_id)
+        .await
+        .map_err(storage_err)?
+        .ok_or_else(|| Status::not_found(format!("node `{node_id}` not found")))?;
+
+    node.schedule_interval_s = interval_s;
+    storage.upsert_node(&node).await.map_err(storage_err)?;
+
+    let mut guard = pending_commands.write().await;
+    let commands = guard.entry(node_id.to_string()).or_default();
+    commands.retain(|cmd| !matches!(cmd, PendingCommand::UpdateSchedule { .. }));
+    commands.push(PendingCommand::UpdateSchedule { interval_s });
+    Ok(())
+}
+
+pub(crate) async fn queue_reboot_impl(
+    storage: &Arc<dyn Storage>,
+    pending_commands: &Arc<RwLock<HashMap<String, Vec<PendingCommand>>>>,
+    node_id: &str,
+) -> Result<(), Status> {
+    storage
+        .get_node(node_id)
+        .await
+        .map_err(storage_err)?
+        .ok_or_else(|| Status::not_found(format!("node `{node_id}` not found")))?;
+    pending_commands
+        .write()
+        .await
+        .entry(node_id.to_string())
+        .or_default()
+        .push(PendingCommand::Reboot);
+    Ok(())
+}
+
+pub(crate) async fn queue_ephemeral_impl(
+    storage: &Arc<dyn Storage>,
+    pending_commands: &Arc<RwLock<HashMap<String, Vec<PendingCommand>>>>,
+    node_id: &str,
+    program_hash: &[u8],
+) -> Result<(), Status> {
+    let program_hash_hex = validate_program_hash_bytes("queue ephemeral", program_hash)?;
+    storage
+        .get_node(node_id)
+        .await
+        .map_err(|e| {
+            storage_err_with_context(&format!("queue ephemeral: look up node `{node_id}`"), e)
+        })?
+        .ok_or_else(|| {
+            Status::not_found(format!(
+                "queue ephemeral failed: node `{node_id}` not found; use ListNodes to verify",
+            ))
+        })?;
+    let program = storage
+        .get_program(program_hash)
+        .await
+        .map_err(|e| {
+            storage_err_with_context(
+                &format!("queue ephemeral: look up program `{program_hash_hex}`"),
+                e,
+            )
+        })?
+        .ok_or_else(|| {
+            Status::not_found(format!(
+                "queue ephemeral failed: program `{program_hash_hex}` not found; \
+                 use IngestProgram to upload it first",
+            ))
+        })?;
+    if program.verification_profile != VerificationProfile::Ephemeral {
+        return Err(Status::failed_precondition(format!(
+            "queue ephemeral failed: program `{program_hash_hex}` has {:?} \
+             verification profile, expected Ephemeral",
+            program.verification_profile,
+        )));
+    }
+    pending_commands
+        .write()
+        .await
+        .entry(node_id.to_string())
+        .or_default()
+        .push(PendingCommand::RunEphemeral {
+            program_hash: program_hash.to_vec(),
+        });
+    Ok(())
+}
+
+pub(crate) async fn get_node_status_impl(
+    storage: &Arc<dyn Storage>,
+    session_manager: &Arc<SessionManager>,
+    node_id: &str,
+) -> Result<NodeStatusSnapshot, Status> {
+    let node = storage
+        .get_node(node_id)
+        .await
+        .map_err(storage_err)?
+        .ok_or_else(|| Status::not_found(format!("node `{node_id}` not found")))?;
+    let has_active_session = session_manager.get_session(node_id).await.is_some();
+    let last_seen_ms = node.last_seen.and_then(|t| {
+        t.duration_since(UNIX_EPOCH)
+            .ok()
+            .map(|d| d.as_millis() as u64)
+    });
+    Ok(NodeStatusSnapshot {
+        node_id: node.node_id,
+        current_program_hash: node.current_program_hash.unwrap_or_default(),
+        battery_mv: node.last_battery_mv,
+        firmware_abi_version: node.firmware_abi_version,
+        last_seen_ms,
+        has_active_session,
+    })
 }
 
 fn storage_err_with_context(operation: &str, e: crate::storage::StorageError) -> Status {
@@ -361,7 +546,7 @@ impl GatewayAdmin for AdminService {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<ListNodesResponse>, Status> {
-        let nodes = self.storage.list_nodes().await.map_err(storage_err)?;
+        let nodes = list_nodes_impl(&self.storage).await?;
         let mut nodes: Vec<_> = nodes.iter().map(node_to_info).collect();
         nodes.sort_by(|a, b| a.node_id.cmp(&b.node_id));
         Ok(Response::new(ListNodesResponse { nodes }))
@@ -371,13 +556,7 @@ impl GatewayAdmin for AdminService {
         &self,
         request: Request<GetNodeRequest>,
     ) -> Result<Response<NodeInfo>, Status> {
-        let node_id = &request.get_ref().node_id;
-        let node = self
-            .storage
-            .get_node(node_id)
-            .await
-            .map_err(storage_err)?
-            .ok_or_else(|| Status::not_found(format!("node `{node_id}` not found")))?;
+        let node = get_node_impl(&self.storage, &request.get_ref().node_id).await?;
         Ok(Response::new(node_to_info(&node)))
     }
 
@@ -602,49 +781,8 @@ impl GatewayAdmin for AdminService {
         &self,
         request: Request<AssignProgramRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let req = request.get_ref();
-        let program_hash_hex = validate_program_hash_bytes("assign program", &req.program_hash)?;
-        let mut node = self
-            .storage
-            .get_node(&req.node_id)
-            .await
-            .map_err(|e| {
-                storage_err_with_context(
-                    &format!("assign program: look up node `{}`", req.node_id),
-                    e,
-                )
-            })?
-            .ok_or_else(|| {
-                Status::not_found(format!(
-                    "assign program failed: node `{}` not found; use ListNodes to verify the node_id",
-                    req.node_id
-                ))
-            })?;
-        self.storage
-            .get_program(&req.program_hash)
-            .await
-            .map_err(|e| {
-                storage_err_with_context(
-                    &format!("assign program: look up program `{program_hash_hex}`"),
-                    e,
-                )
-            })?
-            .ok_or_else(|| {
-                Status::not_found(format!(
-                    "assign program failed: program `{program_hash_hex}` not found; \
-                     use IngestProgram to upload it first, then ListPrograms to verify",
-                ))
-            })?;
-        node.assigned_program_hash = Some(req.program_hash.clone());
-        self.storage.upsert_node(&node).await.map_err(|e| {
-            storage_err_with_context(
-                &format!(
-                    "assign program: update node `{}` with program `{program_hash_hex}`",
-                    req.node_id
-                ),
-                e,
-            )
-        })?;
+        let req = request.into_inner();
+        assign_program_impl(&self.storage, &req.node_id, &req.program_hash).await?;
         Ok(Response::new(Empty {}))
     }
 
@@ -705,26 +843,14 @@ impl GatewayAdmin for AdminService {
         &self,
         request: Request<SetScheduleRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let req = request.get_ref();
-        let mut node = self
-            .storage
-            .get_node(&req.node_id)
-            .await
-            .map_err(storage_err)?
-            .ok_or_else(|| Status::not_found(format!("node `{}` not found", req.node_id)))?;
-
-        // Persist the new schedule in the node record
-        node.schedule_interval_s = req.interval_s;
-        self.storage.upsert_node(&node).await.map_err(storage_err)?;
-
-        // Queue the command for delivery on next WAKE, replacing any
-        // previously-queued schedule update so the node always gets the latest.
-        let mut guard = self.pending_commands.write().await;
-        let commands = guard.entry(req.node_id.clone()).or_default();
-        commands.retain(|cmd| !matches!(cmd, PendingCommand::UpdateSchedule { .. }));
-        commands.push(PendingCommand::UpdateSchedule {
-            interval_s: req.interval_s,
-        });
+        let req = request.into_inner();
+        set_schedule_impl(
+            &self.storage,
+            &self.pending_commands,
+            &req.node_id,
+            req.interval_s,
+        )
+        .await?;
         Ok(Response::new(Empty {}))
     }
 
@@ -732,18 +858,8 @@ impl GatewayAdmin for AdminService {
         &self,
         request: Request<QueueRebootRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let node_id = &request.get_ref().node_id;
-        self.storage
-            .get_node(node_id)
-            .await
-            .map_err(storage_err)?
-            .ok_or_else(|| Status::not_found(format!("node `{node_id}` not found")))?;
-        self.pending_commands
-            .write()
-            .await
-            .entry(node_id.clone())
-            .or_default()
-            .push(PendingCommand::Reboot);
+        let req = request.into_inner();
+        queue_reboot_impl(&self.storage, &self.pending_commands, &req.node_id).await?;
         Ok(Response::new(Empty {}))
     }
 
@@ -751,54 +867,14 @@ impl GatewayAdmin for AdminService {
         &self,
         request: Request<QueueEphemeralRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let req = request.get_ref();
-        let program_hash_hex = validate_program_hash_bytes("queue ephemeral", &req.program_hash)?;
-        self.storage
-            .get_node(&req.node_id)
-            .await
-            .map_err(|e| {
-                storage_err_with_context(
-                    &format!("queue ephemeral: look up node `{}`", req.node_id),
-                    e,
-                )
-            })?
-            .ok_or_else(|| {
-                Status::not_found(format!(
-                    "queue ephemeral failed: node `{}` not found; use ListNodes to verify",
-                    req.node_id,
-                ))
-            })?;
-        let program = self
-            .storage
-            .get_program(&req.program_hash)
-            .await
-            .map_err(|e| {
-                storage_err_with_context(
-                    &format!("queue ephemeral: look up program `{program_hash_hex}`"),
-                    e,
-                )
-            })?
-            .ok_or_else(|| {
-                Status::not_found(format!(
-                    "queue ephemeral failed: program `{program_hash_hex}` not found; \
-                     use IngestProgram to upload it first",
-                ))
-            })?;
-        if program.verification_profile != VerificationProfile::Ephemeral {
-            return Err(Status::failed_precondition(format!(
-                "queue ephemeral failed: program `{program_hash_hex}` has {:?} \
-                 verification profile, expected Ephemeral",
-                program.verification_profile,
-            )));
-        }
-        self.pending_commands
-            .write()
-            .await
-            .entry(req.node_id.clone())
-            .or_default()
-            .push(PendingCommand::RunEphemeral {
-                program_hash: req.program_hash.clone(),
-            });
+        let req = request.into_inner();
+        queue_ephemeral_impl(
+            &self.storage,
+            &self.pending_commands,
+            &req.node_id,
+            &req.program_hash,
+        )
+        .await?;
         Ok(Response::new(Empty {}))
     }
 
@@ -806,26 +882,19 @@ impl GatewayAdmin for AdminService {
         &self,
         request: Request<GetNodeStatusRequest>,
     ) -> Result<Response<NodeStatus>, Status> {
-        let node_id = &request.get_ref().node_id;
-        let node = self
-            .storage
-            .get_node(node_id)
-            .await
-            .map_err(storage_err)?
-            .ok_or_else(|| Status::not_found(format!("node `{node_id}` not found")))?;
-        let has_active_session = self.session_manager.get_session(node_id).await.is_some();
-        let last_seen_ms = node.last_seen.and_then(|t| {
-            t.duration_since(UNIX_EPOCH)
-                .ok()
-                .map(|d| d.as_millis() as u64)
-        });
+        let status = get_node_status_impl(
+            &self.storage,
+            &self.session_manager,
+            &request.get_ref().node_id,
+        )
+        .await?;
         Ok(Response::new(NodeStatus {
-            node_id: node.node_id,
-            current_program_hash: node.current_program_hash.unwrap_or_default(),
-            battery_mv: node.last_battery_mv,
-            firmware_abi_version: node.firmware_abi_version,
-            last_seen_ms,
-            has_active_session,
+            node_id: status.node_id,
+            current_program_hash: status.current_program_hash,
+            battery_mv: status.battery_mv,
+            firmware_abi_version: status.firmware_abi_version,
+            last_seen_ms: status.last_seen_ms,
+            has_active_session: status.has_active_session,
         }))
     }
 

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -34,13 +34,17 @@ use sonde_gateway::session::SessionManager;
 use sonde_gateway::sqlite_storage::SqliteStorage;
 use sonde_gateway::storage::Storage;
 use sonde_gateway::transport::Transport;
-use sonde_gateway::AdminService;
+use sonde_gateway::{AdminService, CompanionService};
 use zeroize::Zeroizing;
 
 #[cfg(unix)]
 const DEFAULT_ADMIN_SOCKET: &str = "/var/run/sonde/admin.sock";
 #[cfg(windows)]
 const DEFAULT_ADMIN_SOCKET: &str = r"\\.\pipe\sonde-admin";
+#[cfg(unix)]
+const DEFAULT_COMPANION_SOCKET: &str = "/var/run/sonde/companion.sock";
+#[cfg(windows)]
+const DEFAULT_COMPANION_SOCKET: &str = r"\\.\pipe\sonde-companion";
 
 /// Maximum time to wait for graceful shutdown before force-exiting (GW-1400).
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -647,6 +651,10 @@ struct Cli {
     #[arg(long, default_value = DEFAULT_ADMIN_SOCKET)]
     admin_socket: String,
 
+    /// gRPC companion API socket path (UDS on Linux/macOS, named pipe on Windows).
+    #[arg(long, default_value = DEFAULT_COMPANION_SOCKET)]
+    companion_socket: String,
+
     /// Session timeout in seconds.
     #[arg(long, default_value_t = 30)]
     session_timeout: u64,
@@ -926,6 +934,20 @@ async fn run_gateway(
         );
         gw.set_rssi_thresholds(cli.rssi_good_threshold, cli.rssi_bad_threshold);
         gw
+    });
+    let companion_service = CompanionService::new(
+        storage.clone(),
+        pending_commands.clone(),
+        session_manager.clone(),
+        gateway.companion_event_hub(),
+    );
+    let companion_socket = cli.companion_socket.clone();
+    let mut companion_handle = tokio::spawn(async move {
+        if let Err(e) =
+            sonde_gateway::companion::serve_companion(companion_service, &companion_socket).await
+        {
+            error!("companion gRPC server error: {}", e);
+        }
     });
 
     // 6–9. Modem transport + processing loops with reconnection (GW-1103).
@@ -1365,6 +1387,7 @@ async fn run_gateway(
                 frame_loop.abort();
                 ble_loop.abort();
                 grpc_handle.abort();
+                companion_handle.abort();
                 if !frame_loop.is_finished() {
                     let _ = frame_loop.await;
                 }
@@ -1373,6 +1396,9 @@ async fn run_gateway(
                 }
                 if !grpc_handle.is_finished() {
                     let _ = grpc_handle.await;
+                }
+                if !companion_handle.is_finished() {
+                    let _ = companion_handle.await;
                 }
                 if !health_handle.is_finished() {
                     let _ = health_handle.await;
@@ -1394,17 +1420,43 @@ async fn run_gateway(
                 health_cancel.cancel();
                 frame_loop.abort();
                 ble_loop.abort();
+                companion_handle.abort();
                 if !frame_loop.is_finished() {
                     let _ = frame_loop.await;
                 }
                 if !ble_loop.is_finished() {
                     let _ = ble_loop.await;
                 }
+                if !companion_handle.is_finished() {
+                    let _ = companion_handle.await;
+                }
                 if !health_handle.is_finished() {
                     let _ = health_handle.await;
                 }
                 transport.abort_reader_and_wait().await;
                 break; // gRPC failure is not recoverable
+            }
+            _ = &mut companion_handle => {
+                error!("companion gRPC server exited unexpectedly");
+                ble_controller.cancel_and_wait().await;
+                health_cancel.cancel();
+                frame_loop.abort();
+                ble_loop.abort();
+                grpc_handle.abort();
+                if !frame_loop.is_finished() {
+                    let _ = frame_loop.await;
+                }
+                if !ble_loop.is_finished() {
+                    let _ = ble_loop.await;
+                }
+                if !grpc_handle.is_finished() {
+                    let _ = grpc_handle.await;
+                }
+                if !health_handle.is_finished() {
+                    let _ = health_handle.await;
+                }
+                transport.abort_reader_and_wait().await;
+                break;
             }
             result = &mut health_handle => {
                 let reconnect = result.unwrap_or(false);

--- a/crates/sonde-gateway/src/companion.rs
+++ b/crates/sonde-gateway/src/companion.rs
@@ -12,7 +12,8 @@ use tonic::{Request, Response, Status};
 
 use crate::admin::{
     assign_program_impl, get_node_impl, get_node_status_impl, list_nodes_impl,
-    queue_ephemeral_impl, queue_reboot_impl, set_schedule_impl, NodeStatusSnapshot,
+    queue_ephemeral_impl, queue_reboot_impl, set_schedule_impl, system_time_to_millis,
+    NodeStatusSnapshot,
 };
 use crate::engine::PendingCommand;
 use crate::registry::NodeRecord;
@@ -42,6 +43,7 @@ impl Default for CompanionEventHub {
 
 impl CompanionEventHub {
     pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
         let (tx, _) = broadcast::channel(capacity);
         Self { tx }
     }
@@ -115,12 +117,6 @@ impl CompanionService {
             event_hub,
         }
     }
-}
-
-fn system_time_to_millis(t: SystemTime) -> Option<u64> {
-    t.duration_since(std::time::UNIX_EPOCH)
-        .ok()
-        .map(|d: std::time::Duration| d.as_millis() as u64)
 }
 
 fn node_to_info(node: &NodeRecord, last_seen: Option<SystemTime>) -> CompanionNodeInfo {

--- a/crates/sonde-gateway/src/companion.rs
+++ b/crates/sonde-gateway/src/companion.rs
@@ -2,10 +2,12 @@
 // Copyright (c) 2026 sonde contributors
 
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use tokio::sync::{broadcast, mpsc, RwLock};
+use futures::Stream;
+use tokio::sync::{broadcast, RwLock};
 use tonic::{Request, Response, Status};
 
 use crate::admin::{
@@ -26,7 +28,6 @@ use pb::gateway_companion_server::GatewayCompanion;
 use pb::*;
 
 pub const DEFAULT_COMPANION_EVENT_BUFFER: usize = 64;
-const STREAM_QUEUE_CAPACITY: usize = 16;
 
 #[derive(Clone)]
 pub struct CompanionEventHub {
@@ -148,47 +149,37 @@ fn node_status_to_proto(status: NodeStatusSnapshot) -> CompanionNodeStatus {
 #[tonic::async_trait]
 impl GatewayCompanion for CompanionService {
     type StreamEventsStream =
-        tokio_stream::wrappers::ReceiverStream<Result<CompanionEvent, Status>>;
+        Pin<Box<dyn Stream<Item = Result<CompanionEvent, Status>> + Send + 'static>>;
 
     async fn stream_events(
         &self,
         _request: Request<CompanionStreamEventsRequest>,
     ) -> Result<Response<Self::StreamEventsStream>, Status> {
-        let mut event_rx = self.event_hub.subscribe();
-        let (tx, rx) = mpsc::channel(STREAM_QUEUE_CAPACITY);
+        enum StreamState {
+            Active(broadcast::Receiver<CompanionEvent>),
+            Done,
+        }
 
-        tokio::spawn(async move {
-            loop {
-                if tx.is_closed() {
-                    break;
-                }
-
-                match event_rx.recv().await {
-                    Ok(event) => {
-                        if tx.capacity() <= 1 {
-                            let _ = tx.try_send(Err(Status::resource_exhausted(
+        let stream = futures::stream::unfold(
+            StreamState::Active(self.event_hub.subscribe()),
+            |state| async move {
+                match state {
+                    StreamState::Active(mut event_rx) => match event_rx.recv().await {
+                        Ok(event) => Some((Ok(event), StreamState::Active(event_rx))),
+                        Err(broadcast::error::RecvError::Lagged(_)) => Some((
+                            Err(Status::resource_exhausted(
                                 "companion subscriber fell behind the live event stream",
-                            )));
-                            break;
-                        }
-                        if tx.try_send(Ok(event)).is_err() {
-                            break;
-                        }
-                    }
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
-                        let _ = tx.try_send(Err(Status::resource_exhausted(
-                            "companion subscriber fell behind the live event stream",
-                        )));
-                        break;
-                    }
-                    Err(broadcast::error::RecvError::Closed) => break,
+                            )),
+                            StreamState::Done,
+                        )),
+                        Err(broadcast::error::RecvError::Closed) => None,
+                    },
+                    StreamState::Done => None,
                 }
-            }
-        });
+            },
+        );
 
-        Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
-            rx,
-        )))
+        Ok(Response::new(Box::pin(stream)))
     }
 
     async fn list_nodes(

--- a/crates/sonde-gateway/src/companion.rs
+++ b/crates/sonde-gateway/src/companion.rs
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::sync::{broadcast, mpsc, RwLock};
+use tonic::{Request, Response, Status};
+
+use crate::admin::{
+    assign_program_impl, get_node_impl, get_node_status_impl, list_nodes_impl,
+    queue_ephemeral_impl, queue_reboot_impl, set_schedule_impl, NodeStatusSnapshot,
+};
+use crate::engine::PendingCommand;
+use crate::registry::NodeRecord;
+use crate::session::SessionManager;
+use crate::storage::Storage;
+
+pub mod pb {
+    tonic::include_proto!("sonde.companion");
+}
+
+use pb::companion_event::Event;
+use pb::gateway_companion_server::GatewayCompanion;
+use pb::*;
+
+pub const DEFAULT_COMPANION_EVENT_BUFFER: usize = 64;
+const STREAM_QUEUE_CAPACITY: usize = 16;
+
+#[derive(Clone)]
+pub struct CompanionEventHub {
+    tx: broadcast::Sender<CompanionEvent>,
+}
+
+impl Default for CompanionEventHub {
+    fn default() -> Self {
+        Self::new(DEFAULT_COMPANION_EVENT_BUFFER)
+    }
+}
+
+impl CompanionEventHub {
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<CompanionEvent> {
+        self.tx.subscribe()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn emit_node_checkin(
+        &self,
+        node_id: String,
+        current_program_hash: Vec<u8>,
+        assigned_program_hash: Option<Vec<u8>>,
+        battery_mv: u32,
+        firmware_abi_version: u32,
+        firmware_version: String,
+        timestamp_ms: u64,
+    ) {
+        let _ = self.tx.send(CompanionEvent {
+            event: Some(Event::NodeCheckin(CompanionNodeCheckIn {
+                node_id,
+                current_program_hash,
+                assigned_program_hash,
+                battery_mv,
+                firmware_abi_version,
+                firmware_version,
+                timestamp_ms,
+            })),
+        });
+    }
+
+    pub fn emit_node_payload(
+        &self,
+        node_id: String,
+        program_hash: Vec<u8>,
+        payload: Vec<u8>,
+        timestamp_ms: u64,
+        payload_origin: CompanionPayloadOrigin,
+    ) {
+        let _ = self.tx.send(CompanionEvent {
+            event: Some(Event::NodePayload(CompanionNodePayload {
+                node_id,
+                program_hash,
+                payload,
+                timestamp_ms,
+                payload_origin: payload_origin as i32,
+            })),
+        });
+    }
+}
+
+pub struct CompanionService {
+    storage: Arc<dyn Storage>,
+    pending_commands: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>>,
+    session_manager: Arc<SessionManager>,
+    event_hub: Arc<CompanionEventHub>,
+}
+
+impl CompanionService {
+    pub fn new(
+        storage: Arc<dyn Storage>,
+        pending_commands: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>>,
+        session_manager: Arc<SessionManager>,
+        event_hub: Arc<CompanionEventHub>,
+    ) -> Self {
+        Self {
+            storage,
+            pending_commands,
+            session_manager,
+            event_hub,
+        }
+    }
+}
+
+fn node_to_info(node: &NodeRecord) -> CompanionNodeInfo {
+    let last_seen_ms = node.last_seen.and_then(|t: SystemTime| {
+        t.duration_since(UNIX_EPOCH)
+            .ok()
+            .map(|d: std::time::Duration| d.as_millis() as u64)
+    });
+    CompanionNodeInfo {
+        node_id: node.node_id.clone(),
+        key_hint: node.key_hint as u32,
+        assigned_program_hash: node.assigned_program_hash.clone(),
+        current_program_hash: node.current_program_hash.clone(),
+        last_battery_mv: node.last_battery_mv,
+        last_firmware_abi_version: node.firmware_abi_version,
+        last_seen_ms,
+        schedule_interval_s: Some(node.schedule_interval_s),
+    }
+}
+
+fn node_status_to_proto(status: NodeStatusSnapshot) -> CompanionNodeStatus {
+    CompanionNodeStatus {
+        node_id: status.node_id,
+        current_program_hash: status.current_program_hash,
+        battery_mv: status.battery_mv,
+        firmware_abi_version: status.firmware_abi_version,
+        last_seen_ms: status.last_seen_ms,
+        has_active_session: status.has_active_session,
+    }
+}
+
+#[tonic::async_trait]
+impl GatewayCompanion for CompanionService {
+    type StreamEventsStream =
+        tokio_stream::wrappers::ReceiverStream<Result<CompanionEvent, Status>>;
+
+    async fn stream_events(
+        &self,
+        _request: Request<CompanionStreamEventsRequest>,
+    ) -> Result<Response<Self::StreamEventsStream>, Status> {
+        let mut event_rx = self.event_hub.subscribe();
+        let (tx, rx) = mpsc::channel(STREAM_QUEUE_CAPACITY);
+
+        tokio::spawn(async move {
+            loop {
+                if tx.is_closed() {
+                    break;
+                }
+
+                match event_rx.recv().await {
+                    Ok(event) => {
+                        if tx.capacity() <= 1 {
+                            let _ = tx.try_send(Err(Status::resource_exhausted(
+                                "companion subscriber fell behind the live event stream",
+                            )));
+                            break;
+                        }
+                        if tx.try_send(Ok(event)).is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                        let _ = tx.try_send(Err(Status::resource_exhausted(
+                            "companion subscriber fell behind the live event stream",
+                        )));
+                        break;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+
+        Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+            rx,
+        )))
+    }
+
+    async fn list_nodes(
+        &self,
+        _request: Request<CompanionListNodesRequest>,
+    ) -> Result<Response<CompanionListNodesResponse>, Status> {
+        let nodes_records = list_nodes_impl(&self.storage).await?;
+        let mut nodes: Vec<_> = nodes_records.iter().map(node_to_info).collect();
+        nodes.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        Ok(Response::new(CompanionListNodesResponse { nodes }))
+    }
+
+    async fn get_node(
+        &self,
+        request: Request<CompanionGetNodeRequest>,
+    ) -> Result<Response<CompanionNodeInfo>, Status> {
+        let node = get_node_impl(&self.storage, &request.get_ref().node_id).await?;
+        Ok(Response::new(node_to_info(&node)))
+    }
+
+    async fn assign_program(
+        &self,
+        request: Request<CompanionAssignProgramRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        let req = request.into_inner();
+        assign_program_impl(&self.storage, &req.node_id, &req.program_hash).await?;
+        Ok(Response::new(CompanionEmpty {}))
+    }
+
+    async fn set_schedule(
+        &self,
+        request: Request<CompanionSetScheduleRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        let req = request.into_inner();
+        set_schedule_impl(
+            &self.storage,
+            &self.pending_commands,
+            &req.node_id,
+            req.interval_s,
+        )
+        .await?;
+        Ok(Response::new(CompanionEmpty {}))
+    }
+
+    async fn queue_reboot(
+        &self,
+        request: Request<CompanionQueueRebootRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        let req = request.into_inner();
+        queue_reboot_impl(&self.storage, &self.pending_commands, &req.node_id).await?;
+        Ok(Response::new(CompanionEmpty {}))
+    }
+
+    async fn queue_ephemeral(
+        &self,
+        request: Request<CompanionQueueEphemeralRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        let req = request.into_inner();
+        queue_ephemeral_impl(
+            &self.storage,
+            &self.pending_commands,
+            &req.node_id,
+            &req.program_hash,
+        )
+        .await?;
+        Ok(Response::new(CompanionEmpty {}))
+    }
+
+    async fn get_node_status(
+        &self,
+        request: Request<CompanionGetNodeStatusRequest>,
+    ) -> Result<Response<CompanionNodeStatus>, Status> {
+        let status = get_node_status_impl(
+            &self.storage,
+            &self.session_manager,
+            &request.get_ref().node_id,
+        )
+        .await?;
+        Ok(Response::new(node_status_to_proto(status)))
+    }
+}
+
+#[cfg(unix)]
+pub async fn serve_companion(
+    service: CompanionService,
+    socket_path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use tokio::net::UnixListener;
+    use tokio_stream::wrappers::UnixListenerStream;
+    use tracing::info;
+
+    if let Some(parent) = std::path::Path::new(socket_path).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let _ = std::fs::remove_file(socket_path);
+
+    let listener = UnixListener::bind(socket_path)?;
+    info!(socket = %socket_path, "gRPC companion server listening on Unix socket");
+
+    tonic::transport::Server::builder()
+        .add_service(pb::gateway_companion_server::GatewayCompanionServer::new(
+            service,
+        ))
+        .serve_with_incoming(UnixListenerStream::new(listener))
+        .await?;
+    Ok(())
+}
+
+#[cfg(windows)]
+pub async fn serve_companion(
+    service: CompanionService,
+    pipe_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+    use tokio::net::windows::named_pipe::ServerOptions;
+    use tonic::transport::server::Connected;
+    use tracing::info;
+
+    struct NamedPipeConn(tokio::net::windows::named_pipe::NamedPipeServer);
+
+    impl Connected for NamedPipeConn {
+        type ConnectInfo = ();
+        fn connect_info(&self) -> Self::ConnectInfo {}
+    }
+
+    impl AsyncRead for NamedPipeConn {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.0).poll_read(cx, buf)
+        }
+    }
+
+    impl AsyncWrite for NamedPipeConn {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Pin::new(&mut self.0).poll_write(cx, buf)
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.0).poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.0).poll_shutdown(cx)
+        }
+    }
+
+    let pipe_name = pipe_name.to_owned();
+    info!(pipe = %pipe_name, "gRPC companion server listening on named pipe");
+
+    let incoming = futures::stream::unfold((true, pipe_name), |(first, name)| async move {
+        let server = match ServerOptions::new()
+            .first_pipe_instance(first)
+            .create(&name)
+        {
+            Ok(s) => s,
+            Err(e) => return Some((Err::<NamedPipeConn, _>(e), (false, name))),
+        };
+        match server.connect().await {
+            Ok(()) => Some((Ok(NamedPipeConn(server)), (false, name))),
+            Err(e) => Some((Err(e), (false, name))),
+        }
+    });
+
+    tonic::transport::Server::builder()
+        .add_service(pb::gateway_companion_server::GatewayCompanionServer::new(
+            service,
+        ))
+        .serve_with_incoming(incoming)
+        .await?;
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+pub async fn serve_companion(
+    _service: CompanionService,
+    _socket: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    Err("sonde-gateway companion gRPC requires Unix (UDS) or Windows (named pipe)".into())
+}

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1262,14 +1262,11 @@ impl Gateway {
             }
         };
 
-        let timestamp = SystemTime::now()
+        let now_duration = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let timestamp_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as u64;
+            .unwrap_or_default();
+        let timestamp = now_duration.as_secs();
+        let timestamp_ms = now_duration.as_millis() as u64;
 
         self.companion_event_hub.emit_node_payload(
             node.node_id.clone(),

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -17,6 +17,7 @@ use sonde_protocol::{
 
 use std::collections::BTreeMap;
 
+use crate::companion::{pb::CompanionPayloadOrigin, CompanionEventHub};
 use crate::crypto::RustCryptoSha256;
 use crate::gateway_identity::GatewayIdentity;
 use crate::handler::HandlerRouter;
@@ -231,6 +232,8 @@ pub struct Gateway {
     rssi_bad_threshold: i8,
     /// Deferred handler replies awaiting delivery on the next WAKE cycle.
     deferred_replies: Arc<RwLock<HashMap<String, Vec<u8>>>>,
+    /// Live event publication for companion processes.
+    companion_event_hub: Arc<CompanionEventHub>,
 }
 
 impl Gateway {
@@ -248,6 +251,7 @@ impl Gateway {
             rssi_good_threshold: -60,
             rssi_bad_threshold: -75,
             deferred_replies: Arc::new(RwLock::new(HashMap::new())),
+            companion_event_hub: Arc::new(CompanionEventHub::default()),
         }
     }
 
@@ -276,6 +280,7 @@ impl Gateway {
             rssi_good_threshold: -60,
             rssi_bad_threshold: -75,
             deferred_replies: Arc::new(RwLock::new(HashMap::new())),
+            companion_event_hub: Arc::new(CompanionEventHub::default()),
         }
     }
 
@@ -297,6 +302,7 @@ impl Gateway {
             rssi_good_threshold: -60,
             rssi_bad_threshold: -75,
             deferred_replies: Arc::new(RwLock::new(HashMap::new())),
+            companion_event_hub: Arc::new(CompanionEventHub::default()),
         }
     }
 
@@ -332,6 +338,11 @@ impl Gateway {
     /// Return a clone of the shared handler router reference (GW-1407).
     pub fn handler_router(&self) -> Arc<tokio::sync::RwLock<HandlerRouter>> {
         Arc::clone(&self.handler_router)
+    }
+
+    /// Return a clone of the companion event hub.
+    pub fn companion_event_hub(&self) -> Arc<CompanionEventHub> {
+        Arc::clone(&self.companion_event_hub)
     }
 
     /// Process a raw frame using AES-256-GCM authenticated encryption.
@@ -869,6 +880,16 @@ impl Gateway {
         updated_node.update_telemetry(battery_mv, firmware_abi_version, firmware_version);
         let _ = self.storage.upsert_node(&updated_node).await;
 
+        self.companion_event_hub.emit_node_checkin(
+            node.node_id.clone(),
+            program_hash.clone(),
+            updated_node.assigned_program_hash.clone(),
+            battery_mv,
+            firmware_abi_version,
+            updated_node.firmware_version.clone().unwrap_or_default(),
+            timestamp_ms,
+        );
+
         // 4a. Emit node_online EVENT to handlers (GW-0507)
         {
             let process_refs = self.handler_router.read().await.clone_all_process_refs();
@@ -947,6 +968,13 @@ impl Gateway {
         // Spawned as a background task so it does not block COMMAND delivery.
         if let Some(wake_data) = wake_blob {
             if !wake_data.is_empty() && !program_hash.is_empty() {
+                self.companion_event_hub.emit_node_payload(
+                    node.node_id.clone(),
+                    program_hash.clone(),
+                    wake_data.clone(),
+                    timestamp_ms,
+                    CompanionPayloadOrigin::WakeBlob,
+                );
                 let handler_router = Arc::clone(&self.handler_router);
                 let deferred_replies = Arc::clone(&self.deferred_replies);
                 let node_id = node.node_id.clone();
@@ -1234,6 +1262,23 @@ impl Gateway {
             }
         };
 
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let timestamp_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        self.companion_event_hub.emit_node_payload(
+            node.node_id.clone(),
+            program_hash.clone(),
+            blob.clone(),
+            timestamp_ms,
+            CompanionPayloadOrigin::AppData,
+        );
+
         // Find the matching handler under the read lock, then release before I/O.
         let (config, process_arc) = {
             let router = self.handler_router.read().await;
@@ -1272,11 +1317,6 @@ impl Gateway {
                 "handler matched"
             );
         }
-
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
 
         // GW-1308 AC3: handler invoked with command.
         info!(command = %config.command, "handler invoked");

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -971,64 +971,74 @@ impl Gateway {
         // Spawned as a background task so it does not block COMMAND delivery.
         if let Some(wake_data) = wake_blob {
             if !wake_data.is_empty() && !program_hash.is_empty() {
-                self.companion_event_hub.emit_node_payload(
-                    node.node_id.clone(),
-                    program_hash.clone(),
-                    wake_data.clone(),
-                    timestamp_ms,
-                    CompanionPayloadOrigin::WakeBlob,
-                );
-                let handler_router = Arc::clone(&self.handler_router);
-                let deferred_replies = Arc::clone(&self.deferred_replies);
+                let handler_result = {
+                    let router = self.handler_router.read().await;
+                    (
+                        router.find_handler_cloned(&program_hash),
+                        router.handler_count(),
+                    )
+                };
                 let node_id = node.node_id.clone();
                 let program_hash = program_hash.clone();
-                let nonce = header.nonce;
-                tokio::spawn(async move {
-                    let (handler_result, handler_count) = {
-                        let router = handler_router.read().await;
-                        (
-                            router.find_handler_cloned(&program_hash),
-                            router.handler_count(),
-                        )
-                    };
-                    if let Some((config, process_arc)) = handler_result {
-                        let timestamp = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs();
-                        let msg = crate::handler::HandlerMessage::Data {
-                            request_id: nonce,
-                            node_id: node_id.clone(),
-                            program_hash: program_hash.clone(),
-                            data: wake_data,
-                            timestamp,
-                        };
-                        info!(
-                            node_id = %node_id,
-                            command = %config.command,
-                            "WAKE blob routed to handler"
+                match handler_result {
+                    (Some((config, process_arc)), _) => {
+                        self.companion_event_hub.emit_node_payload(
+                            node_id.clone(),
+                            program_hash.clone(),
+                            wake_data.clone(),
+                            timestamp_ms,
+                            CompanionPayloadOrigin::WakeBlob,
                         );
-                        let mut process = process_arc.lock().await;
-                        if let Some(crate::handler::HandlerMessage::DataReply { data, .. }) =
-                            process.send_data(&msg).await
-                        {
-                            if !data.is_empty()
-                                && data.len() <= sonde_protocol::MAX_COMMAND_BLOB_SIZE
+                        let deferred_replies = Arc::clone(&self.deferred_replies);
+                        let nonce = header.nonce;
+                        tokio::spawn(async move {
+                            let timestamp = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs();
+                            let msg = crate::handler::HandlerMessage::Data {
+                                request_id: nonce,
+                                node_id: node_id.clone(),
+                                program_hash: program_hash.clone(),
+                                data: wake_data,
+                                timestamp,
+                            };
+                            info!(
+                                node_id = %node_id,
+                                command = %config.command,
+                                "WAKE blob routed to handler"
+                            );
+                            let mut process = process_arc.lock().await;
+                            if let Some(crate::handler::HandlerMessage::DataReply {
+                                data, ..
+                            }) = process.send_data(&msg).await
                             {
-                                deferred_replies.write().await.insert(node_id.clone(), data);
-                                info!(
-                                    node_id = %node_id,
-                                    "deferred reply stored from WAKE blob handler response"
-                                );
-                            } else if data.len() > sonde_protocol::MAX_COMMAND_BLOB_SIZE {
-                                warn!(
-                                    node_id = %node_id,
-                                    len = data.len(),
-                                    "WAKE blob handler reply too large for deferred delivery — dropping"
-                                );
+                                if !data.is_empty()
+                                    && data.len() <= sonde_protocol::MAX_COMMAND_BLOB_SIZE
+                                {
+                                    deferred_replies.write().await.insert(node_id.clone(), data);
+                                    info!(
+                                        node_id = %node_id,
+                                        "deferred reply stored from WAKE blob handler response"
+                                    );
+                                } else if data.len() > sonde_protocol::MAX_COMMAND_BLOB_SIZE {
+                                    warn!(
+                                        node_id = %node_id,
+                                        len = data.len(),
+                                        "WAKE blob handler reply too large for deferred delivery — dropping"
+                                    );
+                                }
                             }
-                        }
-                    } else {
+                        });
+                    }
+                    (None, handler_count) => {
+                        self.companion_event_hub.emit_node_payload(
+                            node_id.clone(),
+                            program_hash.clone(),
+                            wake_data,
+                            timestamp_ms,
+                            CompanionPayloadOrigin::WakeBlob,
+                        );
                         let ph_hex: String =
                             program_hash.iter().map(|b| format!("{b:02x}")).collect();
                         warn!(
@@ -1038,7 +1048,7 @@ impl Gateway {
                             "WAKE blob dropped: no handler matched `program_hash`"
                         );
                     }
-                });
+                }
             }
         }
 
@@ -1271,31 +1281,43 @@ impl Gateway {
         let timestamp = now_duration.as_secs();
         let timestamp_ms = now_duration.as_millis() as u64;
 
-        self.companion_event_hub.emit_node_payload(
-            node.node_id.clone(),
-            program_hash.clone(),
-            blob.clone(),
-            timestamp_ms,
-            CompanionPayloadOrigin::AppData,
-        );
-
         // Find the matching handler under the read lock, then release before I/O.
-        let (config, process_arc) = {
+        let handler_result = {
             let router = self.handler_router.read().await;
             match router.find_handler_cloned(&program_hash) {
-                Some(result) => result,
-                None => {
-                    let ph_hex: String = program_hash.iter().map(|b| format!("{b:02x}")).collect();
-                    warn!(
-                        node_id = %node.node_id,
-                        program_hash = %ph_hex,
-                        handler_count = router.handler_count(),
-                        "APP_DATA dropped: no handler matched `program_hash`"
-                    );
-                    return None;
-                }
+                Some(result) => Ok(result),
+                None => Err(router.handler_count()),
             }
         }; // read lock released here
+        let (config, process_arc) = match handler_result {
+            Ok(result) => {
+                self.companion_event_hub.emit_node_payload(
+                    node.node_id.clone(),
+                    program_hash.clone(),
+                    blob.clone(),
+                    timestamp_ms,
+                    CompanionPayloadOrigin::AppData,
+                );
+                result
+            }
+            Err(handler_count) => {
+                self.companion_event_hub.emit_node_payload(
+                    node.node_id.clone(),
+                    program_hash.clone(),
+                    blob,
+                    timestamp_ms,
+                    CompanionPayloadOrigin::AppData,
+                );
+                let ph_hex: String = program_hash.iter().map(|b| format!("{b:02x}")).collect();
+                warn!(
+                    node_id = %node.node_id,
+                    program_hash = %ph_hex,
+                    handler_count,
+                    "APP_DATA dropped: no handler matched `program_hash`"
+                );
+                return None;
+            }
+        };
 
         // GW-1308 AC1: log APP_DATA received with node_id, program_hash, len.
         if tracing::enabled!(tracing::Level::INFO) {

--- a/crates/sonde-gateway/src/lib.rs
+++ b/crates/sonde-gateway/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod admin;
 pub mod aead;
 pub mod ble_pairing;
+pub mod companion;
 pub mod crypto;
 pub mod display_banner;
 pub mod display_control;
@@ -24,6 +25,7 @@ pub mod transport;
 
 pub use admin::AdminService;
 pub use aead::GatewayAead;
+pub use companion::{CompanionEventHub, CompanionService};
 pub use crypto::RustCryptoSha256;
 pub use engine::{resolve_espnow_channel, Gateway, PendingCommand};
 pub use gateway_identity::{GatewayIdentity, IdentityError};

--- a/crates/sonde-gateway/tests/companion_api.rs
+++ b/crates/sonde-gateway/tests/companion_api.rs
@@ -129,6 +129,32 @@ impl CompanionHarness {
     }
 }
 
+#[tokio::test]
+async fn companion_event_hub_zero_capacity_clamps_to_one() {
+    let hub = CompanionEventHub::new(0);
+    let mut events = hub.subscribe();
+
+    hub.emit_node_checkin(
+        "node-0".into(),
+        vec![0x42; 32],
+        None,
+        3200,
+        1,
+        "0.5.0".into(),
+        1234,
+    );
+
+    let event = events.recv().await.expect("event should be delivered");
+    match event.event {
+        Some(Event::NodeCheckin(checkin)) => {
+            assert_eq!(checkin.node_id, "node-0");
+            assert_eq!(checkin.current_program_hash, vec![0x42; 32]);
+            assert_eq!(checkin.timestamp_ms, 1234);
+        }
+        other => panic!("expected node_checkin, got {other:?}"),
+    }
+}
+
 fn make_cbor_image(bytecode: &[u8]) -> Vec<u8> {
     let image = ProgramImage {
         bytecode: bytecode.to_vec(),

--- a/crates/sonde-gateway/tests/companion_api.rs
+++ b/crates/sonde-gateway/tests/companion_api.rs
@@ -1,0 +1,643 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::RwLock;
+use tokio_stream::StreamExt;
+use tonic::Request;
+
+#[cfg(unix)]
+use sonde_gateway::admin::pb::gateway_admin_client::GatewayAdminClient;
+#[cfg(unix)]
+use sonde_gateway::admin::pb::Empty as AdminEmpty;
+use sonde_gateway::companion::pb::companion_event::Event;
+#[cfg(unix)]
+use sonde_gateway::companion::pb::gateway_companion_client::GatewayCompanionClient;
+use sonde_gateway::companion::pb::gateway_companion_server::GatewayCompanion;
+use sonde_gateway::companion::pb::*;
+use sonde_gateway::companion::{CompanionEventHub, CompanionService};
+use sonde_gateway::crypto::RustCryptoSha256;
+use sonde_gateway::engine::{Gateway, PendingCommand};
+use sonde_gateway::handler::HandlerRouter;
+use sonde_gateway::program::{ProgramRecord, VerificationProfile};
+use sonde_gateway::registry::NodeRecord;
+use sonde_gateway::session::SessionManager;
+use sonde_gateway::storage::{InMemoryStorage, Storage};
+use sonde_gateway::transport::PeerAddress;
+use sonde_gateway::GatewayAead;
+
+use sonde_protocol::{
+    decode_frame, encode_frame, open_frame, CommandPayload, FrameHeader, GatewayMessage,
+    NodeMessage, ProgramImage, MSG_APP_DATA, MSG_WAKE,
+};
+
+struct TestNode {
+    node_id: String,
+    key_hint: u16,
+    psk: [u8; 32],
+}
+
+impl TestNode {
+    fn new(node_id: &str, key_hint: u16, psk: [u8; 32]) -> Self {
+        Self {
+            node_id: node_id.to_string(),
+            key_hint,
+            psk,
+        }
+    }
+
+    fn peer_address(&self) -> PeerAddress {
+        self.node_id.as_bytes().to_vec()
+    }
+
+    fn build_wake(
+        &self,
+        nonce: u64,
+        firmware_abi_version: u32,
+        program_hash: &[u8],
+        battery_mv: u32,
+        blob: Option<Vec<u8>>,
+    ) -> Vec<u8> {
+        let header = FrameHeader {
+            key_hint: self.key_hint,
+            msg_type: MSG_WAKE,
+            nonce,
+        };
+        let msg = NodeMessage::Wake {
+            firmware_abi_version,
+            program_hash: program_hash.to_vec(),
+            battery_mv,
+            firmware_version: "0.5.0".into(),
+            blob,
+        };
+        let cbor = msg.encode().unwrap();
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+    }
+
+    fn build_app_data(&self, seq: u64, blob: &[u8]) -> Vec<u8> {
+        let header = FrameHeader {
+            key_hint: self.key_hint,
+            msg_type: MSG_APP_DATA,
+            nonce: seq,
+        };
+        let msg = NodeMessage::AppData {
+            blob: blob.to_vec(),
+        };
+        let cbor = msg.encode().unwrap();
+        encode_frame(&header, &cbor, &self.psk, &GatewayAead, &RustCryptoSha256).unwrap()
+    }
+}
+
+struct CompanionHarness {
+    storage: Arc<InMemoryStorage>,
+    gateway: Gateway,
+    event_hub: Arc<CompanionEventHub>,
+    companion: CompanionService,
+}
+
+impl CompanionHarness {
+    fn new() -> Self {
+        let storage = Arc::new(InMemoryStorage::new());
+        let pending_commands: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+        let gateway = Gateway::new_with_pending(
+            storage.clone(),
+            pending_commands.clone(),
+            session_manager.clone(),
+            Arc::new(RwLock::new(HandlerRouter::new(Vec::new()))),
+        );
+        let event_hub = gateway.companion_event_hub();
+        let companion = CompanionService::new(
+            storage.clone(),
+            pending_commands.clone(),
+            session_manager.clone(),
+            event_hub.clone(),
+        );
+        Self {
+            storage,
+            gateway,
+            event_hub,
+            companion,
+        }
+    }
+}
+
+fn make_cbor_image(bytecode: &[u8]) -> Vec<u8> {
+    let image = ProgramImage {
+        bytecode: bytecode.to_vec(),
+        maps: vec![],
+        map_initial_data: vec![],
+    };
+    image.encode_deterministic().unwrap()
+}
+
+const MINIMAL_BPF: &[u8] = &[
+    0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+fn decode_response(raw: &[u8], psk: &[u8; 32]) -> (FrameHeader, GatewayMessage) {
+    let decoded = decode_frame(raw).unwrap();
+    let plaintext = open_frame(&decoded, psk, &GatewayAead, &RustCryptoSha256).unwrap();
+    let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext).unwrap();
+    (decoded.header, msg)
+}
+
+async fn do_wake(
+    gw: &Gateway,
+    node: &TestNode,
+    nonce: u64,
+    program_hash: &[u8],
+    blob: Option<Vec<u8>>,
+) -> (u64, u64, CommandPayload) {
+    let frame = node.build_wake(nonce, 1, program_hash, 3300, blob);
+    let resp = gw
+        .process_frame(&frame, node.peer_address())
+        .await
+        .expect("expected COMMAND response");
+    let (_hdr, msg) = decode_response(&resp, &node.psk);
+    match msg {
+        GatewayMessage::Command {
+            starting_seq,
+            timestamp_ms,
+            payload,
+            blob: _,
+        } => (starting_seq, timestamp_ms, payload),
+        other => panic!("expected Command, got {other:?}"),
+    }
+}
+
+async fn next_stream_item(
+    stream: &mut tokio_stream::wrappers::ReceiverStream<Result<CompanionEvent, tonic::Status>>,
+) -> Result<CompanionEvent, tonic::Status> {
+    tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for companion event")
+        .expect("companion stream ended unexpectedly")
+}
+
+async fn assert_no_stream_item(
+    stream: &mut tokio_stream::wrappers::ReceiverStream<Result<CompanionEvent, tonic::Status>>,
+) {
+    let result = tokio::time::timeout(Duration::from_millis(150), stream.next()).await;
+    assert!(result.is_err(), "expected no replayed companion event");
+}
+
+async fn register_node(storage: &Arc<InMemoryStorage>, node: &TestNode) {
+    storage
+        .upsert_node(&NodeRecord::new(
+            node.node_id.clone(),
+            node.key_hint,
+            node.psk,
+        ))
+        .await
+        .unwrap();
+}
+
+async fn store_program(
+    storage: &Arc<InMemoryStorage>,
+    hash_byte: u8,
+    profile: VerificationProfile,
+) -> Vec<u8> {
+    let hash = vec![hash_byte; 32];
+    storage
+        .store_program(&ProgramRecord {
+            hash: hash.clone(),
+            image: make_cbor_image(MINIMAL_BPF),
+            size: MINIMAL_BPF.len() as u32,
+            verification_profile: profile,
+            abi_version: None,
+            source_filename: None,
+        })
+        .await
+        .unwrap();
+    hash
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn t0818_companion_grpc_uds_transport_and_distinct_contract() {
+    use hyper_util::rt::TokioIo;
+    use tonic::transport::{Endpoint, Uri};
+    use tower::service_fn;
+
+    let tmp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let socket_path = tmp_dir.path().join("companion.sock");
+    let socket_path_str = socket_path.to_str().unwrap().to_owned();
+    let h = CompanionHarness::new();
+
+    let socket_path_server = socket_path_str.clone();
+    let server_handle = tokio::spawn(async move {
+        if let Err(e) =
+            sonde_gateway::companion::serve_companion(h.companion, &socket_path_server).await
+        {
+            eprintln!("companion server task ended: {e}");
+        }
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+    let channel = loop {
+        let path = socket_path_str.clone();
+        match Endpoint::from_static("http://[::]:50051")
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let p = path.clone();
+                async move {
+                    let stream = tokio::net::UnixStream::connect(p).await?;
+                    Ok::<_, std::io::Error>(TokioIo::new(stream))
+                }
+            }))
+            .await
+        {
+            Ok(ch) => break ch,
+            Err(_) if tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            Err(e) => panic!("failed to connect to UDS companion socket: {e}"),
+        }
+    };
+
+    let mut companion_client = GatewayCompanionClient::new(channel.clone());
+    let mut admin_client = GatewayAdminClient::new(channel);
+
+    let list = companion_client
+        .list_nodes(Request::new(CompanionListNodesRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(list.nodes.is_empty());
+
+    let err = admin_client
+        .list_nodes(Request::new(AdminEmpty {}))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::Unimplemented);
+
+    server_handle.abort();
+}
+
+#[tokio::test]
+async fn t0819_node_checkin_event_on_wake() {
+    let h = CompanionHarness::new();
+    let node = TestNode::new("alpha", 0x1010, [0x11; 32]);
+    let program_hash = vec![0x44; 32];
+
+    register_node(&h.storage, &node).await;
+
+    let mut stream = h
+        .companion
+        .stream_events(Request::new(CompanionStreamEventsRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let _ = do_wake(&h.gateway, &node, 100, &program_hash, None).await;
+
+    let event = next_stream_item(&mut stream).await.unwrap();
+    match event.event.unwrap() {
+        Event::NodeCheckin(checkin) => {
+            assert_eq!(checkin.node_id, node.node_id);
+            assert_eq!(checkin.current_program_hash, program_hash);
+            assert_eq!(checkin.battery_mv, 3300);
+            assert_eq!(checkin.firmware_abi_version, 1);
+            assert_eq!(checkin.firmware_version, "0.5.0");
+            assert!(checkin.timestamp_ms > 0);
+        }
+        other => panic!("expected node_checkin, got {other:?}"),
+    }
+
+    let mut fresh_stream = h
+        .companion
+        .stream_events(Request::new(CompanionStreamEventsRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_no_stream_item(&mut fresh_stream).await;
+}
+
+#[tokio::test]
+async fn t0820_node_payload_event_on_app_data() {
+    let h = CompanionHarness::new();
+    let node = TestNode::new("beta", 0x2020, [0x22; 32]);
+    let program_hash = vec![0x55; 32];
+
+    register_node(&h.storage, &node).await;
+    let mut stored = h.storage.get_node(&node.node_id).await.unwrap().unwrap();
+    stored.current_program_hash = Some(program_hash.clone());
+    h.storage.upsert_node(&stored).await.unwrap();
+
+    let (starting_seq, _, _) = do_wake(&h.gateway, &node, 200, &program_hash, None).await;
+    let mut stream = h
+        .companion
+        .stream_events(Request::new(CompanionStreamEventsRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let app_payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
+    let frame = node.build_app_data(starting_seq, &app_payload);
+    let response = h.gateway.process_frame(&frame, node.peer_address()).await;
+    assert!(
+        response.is_none(),
+        "no handler configured, so no app-data reply is expected"
+    );
+
+    let event = next_stream_item(&mut stream).await.unwrap();
+    match event.event.unwrap() {
+        Event::NodePayload(payload) => {
+            assert_eq!(payload.node_id, node.node_id);
+            assert_eq!(payload.program_hash, program_hash);
+            assert_eq!(payload.payload, app_payload);
+            assert_eq!(payload.payload_origin(), CompanionPayloadOrigin::AppData);
+            assert!(payload.timestamp_ms > 0);
+        }
+        other => panic!("expected node_payload, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn t0821_wake_blob_orders_checkin_before_payload() {
+    let h = CompanionHarness::new();
+    let node = TestNode::new("gamma", 0x3030, [0x33; 32]);
+    let program_hash = vec![0x66; 32];
+    let wake_blob = vec![0x01, 0x02, 0x03];
+
+    register_node(&h.storage, &node).await;
+
+    let mut stream = h
+        .companion
+        .stream_events(Request::new(CompanionStreamEventsRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let _ = do_wake(
+        &h.gateway,
+        &node,
+        300,
+        &program_hash,
+        Some(wake_blob.clone()),
+    )
+    .await;
+
+    let first = next_stream_item(&mut stream).await.unwrap();
+    let second = next_stream_item(&mut stream).await.unwrap();
+
+    match first.event.unwrap() {
+        Event::NodeCheckin(checkin) => assert_eq!(checkin.node_id, node.node_id),
+        other => panic!("expected first event to be node_checkin, got {other:?}"),
+    }
+    match second.event.unwrap() {
+        Event::NodePayload(payload) => {
+            assert_eq!(payload.node_id, node.node_id);
+            assert_eq!(payload.program_hash, program_hash);
+            assert_eq!(payload.payload, wake_blob);
+            assert_eq!(payload.payload_origin(), CompanionPayloadOrigin::WakeBlob);
+        }
+        other => panic!("expected second event to be node_payload, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn t0822_lagging_subscriber_is_terminated_without_blocking_active_one() {
+    let h = CompanionHarness::new();
+
+    let mut stalled = h
+        .companion
+        .stream_events(Request::new(CompanionStreamEventsRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+    let mut active = h
+        .companion
+        .stream_events(Request::new(CompanionStreamEventsRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let active_reader = tokio::spawn(async move {
+        let mut seen = Vec::new();
+        for _ in 0..8 {
+            let item = tokio::time::timeout(Duration::from_secs(2), active.next())
+                .await
+                .expect("timed out waiting for active subscriber event")
+                .expect("active stream ended unexpectedly")
+                .expect("active subscriber should keep receiving events");
+            seen.push(item);
+        }
+        seen
+    });
+
+    for i in 0..24u8 {
+        h.event_hub.emit_node_checkin(
+            format!("node-{i}"),
+            vec![i; 32],
+            None,
+            3200 + i as u32,
+            1,
+            "0.5.0".into(),
+            i as u64,
+        );
+    }
+
+    let mut stalled_err = None;
+    for _ in 0..24 {
+        match next_stream_item(&mut stalled).await {
+            Ok(_) => continue,
+            Err(status) => {
+                stalled_err = Some(status);
+                break;
+            }
+        }
+    }
+    let stalled_err = stalled_err.expect("stalled subscriber should receive a terminal error");
+    assert_eq!(stalled_err.code(), tonic::Code::ResourceExhausted);
+
+    let active_events = active_reader.await.unwrap();
+    assert_eq!(active_events.len(), 8);
+
+    let mut fresh = h
+        .companion
+        .stream_events(Request::new(CompanionStreamEventsRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_no_stream_item(&mut fresh).await;
+
+    h.event_hub.emit_node_checkin(
+        "fresh-node".into(),
+        vec![0xAA; 32],
+        None,
+        3300,
+        1,
+        "0.5.0".into(),
+        999,
+    );
+    let fresh_event = next_stream_item(&mut fresh).await.unwrap();
+    match fresh_event.event.unwrap() {
+        Event::NodeCheckin(checkin) => assert_eq!(checkin.node_id, "fresh-node"),
+        other => panic!("expected fresh node_checkin, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn t0823_companion_commands_share_gateway_state() {
+    let h = CompanionHarness::new();
+    let resident_hash = store_program(&h.storage, 0x77, VerificationProfile::Resident).await;
+    let ephemeral_hash = store_program(&h.storage, 0x88, VerificationProfile::Ephemeral).await;
+    let assign_node = TestNode::new("delta-assign", 0x4040, [0x44; 32]);
+    let schedule_node = TestNode::new("delta-schedule", 0x4041, [0x45; 32]);
+    let reboot_node = TestNode::new("delta-reboot", 0x4042, [0x46; 32]);
+    let ephemeral_node = TestNode::new("delta-ephemeral", 0x4043, [0x47; 32]);
+
+    register_node(&h.storage, &assign_node).await;
+    register_node(&h.storage, &schedule_node).await;
+    register_node(&h.storage, &reboot_node).await;
+    register_node(&h.storage, &ephemeral_node).await;
+
+    h.companion
+        .assign_program(Request::new(CompanionAssignProgramRequest {
+            node_id: assign_node.node_id.clone(),
+            program_hash: resident_hash.clone(),
+        }))
+        .await
+        .unwrap();
+    let stored = h
+        .storage
+        .get_node(&assign_node.node_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.assigned_program_hash, Some(resident_hash.clone()));
+    let (_, _, assign_payload) = do_wake(&h.gateway, &assign_node, 600, &[0u8; 32], None).await;
+    assert!(matches!(
+        assign_payload,
+        CommandPayload::UpdateProgram { program_hash, .. } if program_hash == resident_hash
+    ));
+
+    h.companion
+        .set_schedule(Request::new(CompanionSetScheduleRequest {
+            node_id: schedule_node.node_id.clone(),
+            interval_s: 900,
+        }))
+        .await
+        .unwrap();
+    let (_, _, schedule_payload) = do_wake(&h.gateway, &schedule_node, 601, &[0u8; 32], None).await;
+    assert!(matches!(
+        schedule_payload,
+        CommandPayload::UpdateSchedule { interval_s: 900 }
+    ));
+
+    h.companion
+        .queue_reboot(Request::new(CompanionQueueRebootRequest {
+            node_id: reboot_node.node_id.clone(),
+        }))
+        .await
+        .unwrap();
+    let (_, _, reboot_payload) = do_wake(&h.gateway, &reboot_node, 602, &[0u8; 32], None).await;
+    assert!(matches!(reboot_payload, CommandPayload::Reboot));
+
+    h.companion
+        .queue_ephemeral(Request::new(CompanionQueueEphemeralRequest {
+            node_id: ephemeral_node.node_id.clone(),
+            program_hash: ephemeral_hash.clone(),
+        }))
+        .await
+        .unwrap();
+    let (_, _, ephemeral_payload) =
+        do_wake(&h.gateway, &ephemeral_node, 603, &[0u8; 32], None).await;
+    assert!(matches!(
+        ephemeral_payload,
+        CommandPayload::RunEphemeral { program_hash, .. } if program_hash == ephemeral_hash
+    ));
+}
+
+#[tokio::test]
+async fn t0824_companion_queries_report_node_state() {
+    let h = CompanionHarness::new();
+    let node = TestNode::new("epsilon", 0x5050, [0x55; 32]);
+    let program_hash = vec![0x99; 32];
+
+    register_node(&h.storage, &node).await;
+    let _ = do_wake(&h.gateway, &node, 500, &program_hash, None).await;
+
+    let list = h
+        .companion
+        .list_nodes(Request::new(CompanionListNodesRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(list.nodes.len(), 1);
+    assert_eq!(list.nodes[0].node_id, node.node_id);
+
+    let info = h
+        .companion
+        .get_node(Request::new(CompanionGetNodeRequest {
+            node_id: node.node_id.clone(),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(info.node_id, node.node_id);
+    assert_eq!(info.current_program_hash, None);
+    assert_eq!(info.last_battery_mv, Some(3300));
+    assert_eq!(info.last_firmware_abi_version, Some(1));
+    assert_eq!(info.schedule_interval_s, Some(60));
+
+    let status = h
+        .companion
+        .get_node_status(Request::new(CompanionGetNodeStatusRequest {
+            node_id: node.node_id.clone(),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(status.node_id, node.node_id);
+    assert!(status.current_program_hash.is_empty());
+    assert_eq!(status.battery_mv, Some(3300));
+    assert_eq!(status.firmware_abi_version, Some(1));
+    assert!(status.last_seen_ms.is_some());
+    assert!(status.has_active_session);
+}
+
+#[test]
+fn t0825_companion_contract_excludes_operator_only_workflows() {
+    let proto = include_str!("../proto/companion.proto");
+
+    for rpc in [
+        "rpc StreamEvents",
+        "rpc ListNodes",
+        "rpc GetNode",
+        "rpc AssignProgram",
+        "rpc SetSchedule",
+        "rpc QueueReboot",
+        "rpc QueueEphemeral",
+        "rpc GetNodeStatus",
+    ] {
+        assert!(
+            proto.contains(rpc),
+            "expected companion contract to include `{rpc}`"
+        );
+    }
+
+    for rpc in [
+        "RegisterNode",
+        "RemoveNode",
+        "IngestProgram",
+        "RemoveProgram",
+        "ExportState",
+        "ImportState",
+        "SetModemChannel",
+        "BeginBlePairing",
+        "EndBlePairing",
+        "AddHandler",
+        "RemoveHandler",
+    ] {
+        assert!(
+            !proto.contains(rpc),
+            "operator-only workflow `{rpc}` must not appear in companion contract"
+        );
+    }
+}

--- a/crates/sonde-gateway/tests/companion_api.rs
+++ b/crates/sonde-gateway/tests/companion_api.rs
@@ -446,21 +446,48 @@ async fn t0822_lagging_subscriber_is_terminated_without_blocking_active_one() {
         .unwrap()
         .into_inner();
 
+    let lag_count = DEFAULT_COMPANION_EVENT_BUFFER + 24;
+    let (active_started_tx, active_started_rx) = tokio::sync::oneshot::channel();
     let active_reader = tokio::spawn(async move {
         let mut seen = Vec::new();
-        for _ in 0..8 {
+
+        let first_item = tokio::time::timeout(Duration::from_secs(2), active.next())
+            .await
+            .expect("timed out waiting for active subscriber event")
+            .expect("active stream ended unexpectedly")
+            .expect("active subscriber should keep receiving events");
+        seen.push(first_item);
+        active_started_tx
+            .send(())
+            .expect("active reader should signal startup exactly once");
+
+        for _ in 1..lag_count {
             let item = tokio::time::timeout(Duration::from_secs(2), active.next())
                 .await
                 .expect("timed out waiting for active subscriber event")
                 .expect("active stream ended unexpectedly")
                 .expect("active subscriber should keep receiving events");
-            seen.push(item);
+            if seen.len() < 8 {
+                seen.push(item);
+            }
         }
         seen
     });
 
-    let lag_count = DEFAULT_COMPANION_EVENT_BUFFER + 24;
-    for i in 0..lag_count {
+    h.event_hub.emit_node_checkin(
+        "node-0".into(),
+        vec![0; 32],
+        None,
+        3200,
+        1,
+        "0.5.0".into(),
+        0,
+    );
+    active_started_rx
+        .await
+        .expect("active reader should observe the first event before the burst");
+
+    for i in 1..lag_count {
         let payload_byte = u8::try_from(i).expect("test event index should fit in u8");
         let battery_mv_offset = u32::try_from(i).expect("test event index should fit in u32");
         let timestamp = u64::try_from(i).expect("test event index should fit in u64");

--- a/crates/sonde-gateway/tests/companion_api.rs
+++ b/crates/sonde-gateway/tests/companion_api.rs
@@ -433,16 +433,19 @@ async fn t0822_lagging_subscriber_is_terminated_without_blocking_active_one() {
         seen
     });
 
-    let lag_count = DEFAULT_COMPANION_EVENT_BUFFER as u8 + 24;
+    let lag_count = DEFAULT_COMPANION_EVENT_BUFFER + 24;
     for i in 0..lag_count {
+        let payload_byte = u8::try_from(i).expect("test event index should fit in u8");
+        let battery_mv_offset = u32::try_from(i).expect("test event index should fit in u32");
+        let timestamp = u64::try_from(i).expect("test event index should fit in u64");
         h.event_hub.emit_node_checkin(
             format!("node-{i}"),
-            vec![i; 32],
+            vec![payload_byte; 32],
             None,
-            3200 + i as u32,
+            3200 + battery_mv_offset,
             1,
             "0.5.0".into(),
-            i as u64,
+            timestamp,
         );
         tokio::task::yield_now().await;
     }

--- a/crates/sonde-gateway/tests/companion_api.rs
+++ b/crates/sonde-gateway/tests/companion_api.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::Stream;
 use tokio::sync::RwLock;
 use tokio_stream::StreamExt;
 use tonic::Request;
@@ -18,7 +19,9 @@ use sonde_gateway::companion::pb::companion_event::Event;
 use sonde_gateway::companion::pb::gateway_companion_client::GatewayCompanionClient;
 use sonde_gateway::companion::pb::gateway_companion_server::GatewayCompanion;
 use sonde_gateway::companion::pb::*;
-use sonde_gateway::companion::{CompanionEventHub, CompanionService};
+use sonde_gateway::companion::{
+    CompanionEventHub, CompanionService, DEFAULT_COMPANION_EVENT_BUFFER,
+};
 use sonde_gateway::crypto::RustCryptoSha256;
 use sonde_gateway::engine::{Gateway, PendingCommand};
 use sonde_gateway::handler::HandlerRouter;
@@ -171,7 +174,7 @@ async fn do_wake(
 }
 
 async fn next_stream_item(
-    stream: &mut tokio_stream::wrappers::ReceiverStream<Result<CompanionEvent, tonic::Status>>,
+    stream: &mut (impl Stream<Item = Result<CompanionEvent, tonic::Status>> + Unpin),
 ) -> Result<CompanionEvent, tonic::Status> {
     tokio::time::timeout(Duration::from_secs(2), stream.next())
         .await
@@ -180,7 +183,7 @@ async fn next_stream_item(
 }
 
 async fn assert_no_stream_item(
-    stream: &mut tokio_stream::wrappers::ReceiverStream<Result<CompanionEvent, tonic::Status>>,
+    stream: &mut (impl Stream<Item = Result<CompanionEvent, tonic::Status>> + Unpin),
 ) {
     let result = tokio::time::timeout(Duration::from_millis(150), stream.next()).await;
     assert!(result.is_err(), "expected no replayed companion event");
@@ -430,7 +433,8 @@ async fn t0822_lagging_subscriber_is_terminated_without_blocking_active_one() {
         seen
     });
 
-    for i in 0..24u8 {
+    let lag_count = DEFAULT_COMPANION_EVENT_BUFFER as u8 + 24;
+    for i in 0..lag_count {
         h.event_hub.emit_node_checkin(
             format!("node-{i}"),
             vec![i; 32],
@@ -440,10 +444,11 @@ async fn t0822_lagging_subscriber_is_terminated_without_blocking_active_one() {
             "0.5.0".into(),
             i as u64,
         );
+        tokio::task::yield_now().await;
     }
 
     let mut stalled_err = None;
-    for _ in 0..24 {
+    for _ in 0..lag_count {
         match next_stream_item(&mut stalled).await {
             Ok(_) => continue,
             Err(status) => {

--- a/docs/gateway-api.md
+++ b/docs/gateway-api.md
@@ -5,7 +5,7 @@
 > **Document status:** Draft  
 > **Scope:** The data-plane API between a Sonde gateway and developer applications.  
 > **Audience:** Developers building applications on the Sonde platform.  
-> **Related:** [gateway-requirements.md](gateway-requirements.md), [protocol.md](protocol.md)
+> **Related:** [gateway-requirements.md](gateway-requirements.md), [gateway-companion-api.md](gateway-companion-api.md), [protocol.md](protocol.md)
 
 ---
 

--- a/docs/gateway-companion-api.md
+++ b/docs/gateway-companion-api.md
@@ -121,8 +121,8 @@ message CompanionNodePayload {
 
 The gateway emits `node_payload` for:
 
-- `APP_DATA { blob }`, with `payload_origin = APP_DATA`
-- `WAKE { blob }`, with `payload_origin = WAKE_BLOB`
+- `APP_DATA { blob }`, with `payload_origin = COMPANION_PAYLOAD_ORIGIN_APP_DATA`
+- `WAKE { blob }`, with `payload_origin = COMPANION_PAYLOAD_ORIGIN_WAKE_BLOB`
 
 For a `WAKE` carrying a blob, the gateway emits `node_checkin` before the corresponding `node_payload`.
 

--- a/docs/gateway-companion-api.md
+++ b/docs/gateway-companion-api.md
@@ -1,0 +1,179 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Gateway Companion API
+
+> **Document status:** Draft  
+> **Scope:** The local gRPC integration API between `sonde-gateway` and companion processes that subscribe to gateway events and issue node-targeted commands.  
+> **Audience:** Developers building sidecar or bridge processes alongside the gateway.  
+> **Related:** [gateway-requirements.md](gateway-requirements.md), [gateway-design.md](gateway-design.md), [gateway-api.md](gateway-api.md)
+
+---
+
+## 1  Overview
+
+The companion API is a **separate integration surface** from both:
+
+1. **`GatewayAdmin`** — the operator-facing local admin API.
+2. **`gateway-api.md`** — the handler stdin/stdout CBOR data-plane API.
+
+A companion process uses this API when it needs to:
+
+- subscribe to live gateway events such as node check-ins and payload arrivals, and
+- issue node-targeted commands through the gateway's existing control path.
+
+Example use case: a bridge process authenticates to Azure, forwards `node_checkin` and `node_payload` events to a Service Bus queue, reads cloud-issued commands, and relays them to the gateway.
+
+The companion API is **informational and control-only**. It does not replace the handler data-plane API and does not provide a reply channel for node payloads.
+
+---
+
+## 2  Transport and lifecycle
+
+### 2.1  Transport
+
+The gateway exposes the companion API over **local-only gRPC** on a dedicated endpoint:
+
+- **Unix/macOS:** Unix domain socket, default `/var/run/sonde/companion.sock`
+- **Windows:** named pipe, default `\\.\pipe\sonde-companion`
+
+No TCP listener is exposed in v1.
+
+The companion API uses a dedicated protobuf service and companion-specific message types so it can evolve independently from `GatewayAdmin`.
+
+### 2.2  Event stream lifecycle
+
+Companion clients subscribe with a server-streaming RPC:
+
+1. Client connects to the companion socket.
+2. Client calls `StreamEvents`.
+3. Gateway emits future `node_checkin` and `node_payload` events on the stream.
+4. If the client disconnects, the stream ends immediately.
+5. If the client falls behind the gateway's bounded event buffer, the gateway terminates the stream with `RESOURCE_EXHAUSTED`.
+
+The stream is **live best-effort only**:
+
+- events produced before subscription are not replayed;
+- reconnecting clients receive only newly produced events; and
+- durability, replay, and downstream queuing are the companion process's responsibility.
+
+---
+
+## 3  Protobuf contract
+
+### 3.1  Service definition
+
+```protobuf
+service GatewayCompanion {
+    rpc StreamEvents(CompanionStreamEventsRequest) returns (stream CompanionEvent);
+
+    rpc ListNodes(CompanionListNodesRequest) returns (CompanionListNodesResponse);
+    rpc GetNode(CompanionGetNodeRequest) returns (CompanionNodeInfo);
+    rpc AssignProgram(CompanionAssignProgramRequest) returns (CompanionEmpty);
+    rpc SetSchedule(CompanionSetScheduleRequest) returns (CompanionEmpty);
+    rpc QueueReboot(CompanionQueueRebootRequest) returns (CompanionEmpty);
+    rpc QueueEphemeral(CompanionQueueEphemeralRequest) returns (CompanionEmpty);
+    rpc GetNodeStatus(CompanionGetNodeStatusRequest) returns (CompanionNodeStatus);
+}
+```
+
+The companion service intentionally omits operator-only workflows such as node registration/removal, program ingestion/removal, state export/import, modem control, BLE pairing, and handler configuration.
+
+### 3.2  `node_checkin`
+
+```protobuf
+message CompanionEvent {
+    oneof event {
+        CompanionNodeCheckIn node_checkin = 1;
+        CompanionNodePayload node_payload = 2;
+    }
+}
+
+message CompanionNodeCheckIn {
+    string node_id = 1;
+    bytes current_program_hash = 2;
+    optional bytes assigned_program_hash = 3;
+    uint32 battery_mv = 4;
+    uint32 firmware_abi_version = 5;
+    string firmware_version = 6;
+    uint64 timestamp_ms = 7;
+}
+```
+
+The gateway emits `node_checkin` after it accepts an authenticated `WAKE` and updates the node's latest-known state.
+
+### 3.3  `node_payload`
+
+```protobuf
+enum CompanionPayloadOrigin {
+    COMPANION_PAYLOAD_ORIGIN_UNSPECIFIED = 0;
+    COMPANION_PAYLOAD_ORIGIN_APP_DATA = 1;
+    COMPANION_PAYLOAD_ORIGIN_WAKE_BLOB = 2;
+}
+
+message CompanionNodePayload {
+    string node_id = 1;
+    bytes program_hash = 2;
+    bytes payload = 3;
+    uint64 timestamp_ms = 4;
+    CompanionPayloadOrigin payload_origin = 5;
+}
+```
+
+The gateway emits `node_payload` for:
+
+- `APP_DATA { blob }`, with `payload_origin = APP_DATA`
+- `WAKE { blob }`, with `payload_origin = WAKE_BLOB`
+
+For a `WAKE` carrying a blob, the gateway emits `node_checkin` before the corresponding `node_payload`.
+
+### 3.4  Command and query RPCs
+
+```protobuf
+message CompanionEmpty {}
+message CompanionStreamEventsRequest {}
+message CompanionListNodesRequest {}
+message CompanionListNodesResponse { repeated CompanionNodeInfo nodes = 1; }
+message CompanionGetNodeRequest { string node_id = 1; }
+message CompanionAssignProgramRequest { string node_id = 1; bytes program_hash = 2; }
+message CompanionSetScheduleRequest { string node_id = 1; uint32 interval_s = 2; }
+message CompanionQueueRebootRequest { string node_id = 1; }
+message CompanionQueueEphemeralRequest { string node_id = 1; bytes program_hash = 2; }
+message CompanionGetNodeStatusRequest { string node_id = 1; }
+
+message CompanionNodeInfo {
+    string node_id = 1;
+    uint32 key_hint = 2;
+    optional bytes assigned_program_hash = 3;
+    optional bytes current_program_hash = 4;
+    optional uint32 last_battery_mv = 5;
+    optional uint32 last_firmware_abi_version = 6;
+    optional uint64 last_seen_ms = 7;
+    optional uint32 schedule_interval_s = 8;
+}
+
+message CompanionNodeStatus {
+    string node_id = 1;
+    bytes current_program_hash = 2;
+    optional uint32 battery_mv = 3;
+    optional uint32 firmware_abi_version = 4;
+    optional uint64 last_seen_ms = 5;
+    bool has_active_session = 6;
+}
+```
+
+The companion API's command RPCs reuse the gateway's existing command semantics:
+
+- `AssignProgram` changes the assigned resident program.
+- `SetSchedule` queues `UPDATE_SCHEDULE` for the next `WAKE`.
+- `QueueReboot` queues `REBOOT` for the next `WAKE`.
+- `QueueEphemeral` queues `RUN_EPHEMERAL` for the next `WAKE`.
+
+These operations act on the same gateway state as the corresponding admin operations; the companion API does not define a separate command pipeline.
+
+---
+
+## 4  Behavioral notes
+
+1. `node_payload` is informational only. Companion clients do not reply to payload events; node replies continue to use the handler flow defined in [gateway-api.md](gateway-api.md).
+2. Message ordering is guaranteed only within a single live stream as produced by the gateway runtime. There is no replay cursor, durable offset, or exactly-once delivery guarantee.
+3. Companion clients are expected to provide their own persistence and retry behavior when forwarding events to external systems.

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -5,7 +5,7 @@
 > **Document status:** Draft  
 > **Scope:** Architecture and internal design of the Sonde gateway service.  
 > **Audience:** Implementers (human or LLM agent) building the gateway.  
-> **Related:** [gateway-requirements.md](gateway-requirements.md), [protocol.md](protocol.md), [protocol-crate-design.md](protocol-crate-design.md), [security.md](security.md), [gateway-api.md](gateway-api.md)
+> **Related:** [gateway-requirements.md](gateway-requirements.md), [protocol.md](protocol.md), [protocol-crate-design.md](protocol-crate-design.md), [security.md](security.md), [gateway-api.md](gateway-api.md), [gateway-companion-api.md](gateway-companion-api.md)
 
 ---
 
@@ -40,7 +40,7 @@ The gateway is **stateless with respect to replay protection** — active sessio
 
 ## 3  Module architecture
 
-The gateway is composed of ten functional modules grouped in two tiers. The upper (data-path) tier contains: Transport (radio adapter, e.g., ESP-NOW over USB-CDC), Protocol Codec (frame serialization/deserialization), Session Manager (per-node lifecycle and sequence tracking), and Handler Router (forwarding application data to external handler processes). Each module in this tier connects to the next in series. The lower (infrastructure) tier contains: an ESP-NOW Adapter (concrete transport implementation), Node Registry (PSK and node metadata), Program Library (BPF program images and hash identity), Handler Process (handler stdin/stdout management), Admin API (gRPC interface and CLI tool), and BLE Pairing Handler (pairing protocol logic via modem relay). Node Registry and Program Library share a common Storage trait abstraction at the bottom. The architecture diagram below shows the eight core data-path and infrastructure modules; the Admin API and BLE Pairing Handler are described in §13 and §17 respectively.
+The gateway is composed of eleven functional modules grouped in two tiers. The upper (data-path) tier contains: Transport (radio adapter, e.g., ESP-NOW over USB-CDC), Protocol Codec (frame serialization/deserialization), Session Manager (per-node lifecycle and sequence tracking), and Handler Router (forwarding application data to external handler processes). Each module in this tier connects to the next in series. The lower (infrastructure) tier contains: an ESP-NOW Adapter (concrete transport implementation), Node Registry (PSK and node metadata), Program Library (BPF program images and hash identity), Handler Process (handler stdin/stdout management), Admin API (gRPC interface and CLI tool), Companion API (gRPC interface for companion processes), and BLE Pairing Handler (pairing protocol logic via modem relay). Node Registry and Program Library share a common Storage trait abstraction at the bottom. The architecture diagram below shows the eight core data-path and infrastructure modules; the Admin API, Companion API, and BLE Pairing Handler are described in §13, §13A, and §17 respectively.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -76,6 +76,7 @@ The gateway is composed of ten functional modules grouped in two tiers. The uppe
 | **Handler Process** | Manage handler stdin/stdout lifecycle | GW-0502, GW-0503, GW-0506 |
 | **Storage** | Persist node registry, program library, configuration | GW-0700, GW-1000, GW-1001 |
 | **Admin API** | gRPC admin interface, CLI tool | GW-0800, GW-0801, GW-0802, GW-0803, GW-0804, GW-0805, GW-0806 |
+| **Companion API** | gRPC integration interface for companion processes | GW-0810, GW-0811, GW-0812, GW-0813, GW-0814 |
 | **BLE Pairing Handler** | BLE pairing protocol logic via modem relay | GW-1200–GW-1222a |
 
 ---
@@ -996,6 +997,70 @@ All commands support `--format json` for machine-readable output.
 
 ---
 
+## 13A  Companion API
+
+> **Requirements:** GW-0810 (companion API), GW-0811 (live event subscription), GW-0812 (`node_checkin`), GW-0813 (`node_payload`), GW-0814 (command/query operations).
+
+The gateway exposes a second local gRPC API for companion processes that need a stable integration boundary distinct from the operator-focused `GatewayAdmin` surface. The companion API is specified in [gateway-companion-api.md](gateway-companion-api.md). It uses a separate socket, a separate protobuf service, and companion-specific message types so it can evolve independently without forcing `GatewayAdmin` changes.
+
+### 13A.1  Service definition and transport
+
+The companion server is implemented with `tonic` on the same platform-specific local transports used by the admin API:
+
+- **Unix/macOS:** Unix domain socket (default `/var/run/sonde/companion.sock`)
+- **Windows:** Named pipe (default `\\.\pipe\sonde-companion`)
+
+No TCP listener is opened. The companion API is a separate `GatewayCompanion` service, not an extension of `GatewayAdmin`.
+
+The protobuf contract includes:
+
+```protobuf
+service GatewayCompanion {
+    rpc StreamEvents(CompanionStreamEventsRequest) returns (stream CompanionEvent);
+    rpc ListNodes(CompanionListNodesRequest) returns (CompanionListNodesResponse);
+    rpc GetNode(CompanionGetNodeRequest) returns (CompanionNodeInfo);
+    rpc AssignProgram(CompanionAssignProgramRequest) returns (CompanionEmpty);
+    rpc SetSchedule(CompanionSetScheduleRequest) returns (CompanionEmpty);
+    rpc QueueReboot(CompanionQueueRebootRequest) returns (CompanionEmpty);
+    rpc QueueEphemeral(CompanionQueueEphemeralRequest) returns (CompanionEmpty);
+    rpc GetNodeStatus(CompanionGetNodeStatusRequest) returns (CompanionNodeStatus);
+}
+```
+
+The companion service intentionally omits operator-only workflows such as program ingestion, node registration/removal, state export/import, modem control, BLE pairing, and handler management.
+
+### 13A.2  Event publication path
+
+The session manager publishes companion events into a bounded in-memory event hub:
+
+```rust
+pub struct CompanionEventHub {
+    tx: tokio::sync::broadcast::Sender<CompanionEvent>,
+}
+```
+
+- `node_checkin` is published after an authenticated `WAKE` updates the node's latest-known registry state.
+- `node_payload` is published when the gateway accepts node-originated payload data (`APP_DATA` or `WAKE` `blob`).
+- For a `WAKE` carrying a `blob`, the session manager publishes `node_checkin` first, then `node_payload`.
+
+Each `StreamEvents` RPC subscribes to the broadcast hub. The stream is live-only: no replay cursor or durable offset is maintained in the gateway. If a subscriber lags and overruns the bounded broadcast buffer, the server terminates that stream with `RESOURCE_EXHAUSTED`; the client must reconnect and resume from newly produced events only.
+
+### 13A.3  Shared command and query path
+
+The companion service shares the same storage, `pending_commands`, and `SessionManager` used by the admin API and engine. Companion command RPCs call the same internal helpers used by `GatewayAdmin`; they do not maintain a parallel queue or alternate state store.
+
+This sharing is mandatory for:
+
+1. `AssignProgram` — updates the node's assigned resident program.
+2. `SetSchedule` — queues `UPDATE_SCHEDULE` for the next `WAKE`.
+3. `QueueReboot` — queues `REBOOT` for the next `WAKE`.
+4. `QueueEphemeral` — queues `RUN_EPHEMERAL` for the next `WAKE`.
+5. `ListNodes`, `GetNode`, and `GetNodeStatus` — surface the same node metadata/state as the gateway already maintains.
+
+The companion protobuf messages remain distinct from the admin protobuf messages even when fields overlap. This avoids coupling future companion-contract changes to the operator-facing admin contract.
+
+---
+
 ## 14  Configuration
 
 The gateway is configured via a configuration file (format TBD — TOML recommended for Rust ecosystem). Configuration includes:
@@ -1005,6 +1070,7 @@ The gateway is configured via a configuration file (format TBD — TOML recommen
 | `transport` | Transport backend and connection parameters | Required |
 | `storage` | Storage backend and connection parameters | Required |
 | `admin_socket` | gRPC admin API socket path | `/var/run/sonde/admin.sock` (Linux), `\\.\pipe\sonde-admin` (Windows) |
+| `companion_socket` | gRPC companion API socket path | `/var/run/sonde/companion.sock` (Linux), `\\.\pipe\sonde-companion` (Windows) |
 | `handlers` | Handler routing table (program_hash → command) | `[]` |
 | `session_timeout_s` | Session inactivity timeout | `30` |
 | `node_timeout_multiplier` | Multiple of node's schedule interval before `node_timeout` event | `3` |
@@ -1056,10 +1122,11 @@ The gateway emits the version string in its first `info!()` log line so that ope
 6. If `--handler-config` is provided, bootstrap handlers from YAML into the database (GW-1405, §19.6).
 7. Load handler configuration from database and build `HandlerRouter` (GW-1401, GW-1407). The router is always built, even if no handlers exist. Wrap in `Arc<tokio::sync::RwLock<HandlerRouter>>` for shared access.
 8. Start gRPC admin API server, passing the shared `HandlerRouter` reference to the `AdminService` for live reload (GW-1404).
-9. Start handler processes for configured handlers.
-10. Start session reaper background task.
-11. Start node timeout detector background task.
-12. Enter main recv loop.
+9. Start gRPC companion API server, passing shared storage, node state, pending-command state, and companion event hub.
+10. Start handler processes for configured handlers.
+11. Start session reaper background task.
+12. Start node timeout detector background task.
+13. Enter main recv loop.
 
 ---
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -5,7 +5,7 @@
 > **Document status:** Draft  
 > **Source:** Derived from [README.md](../README.md) (design-phase specification).  
 > **Scope:** This document covers the Sonde **gateway** component only. Node firmware requirements are out of scope.  
-> **Related:** [protocol.md](protocol.md), [gateway-api.md](gateway-api.md), [security.md](security.md), [node-requirements.md](node-requirements.md)
+> **Related:** [protocol.md](protocol.md), [gateway-api.md](gateway-api.md), [gateway-companion-api.md](gateway-companion-api.md), [security.md](security.md), [node-requirements.md](node-requirements.md)
 
 ---
 
@@ -984,6 +984,93 @@ transport is configured, it MUST fail with `UNAVAILABLE`.
 4. A second successful `ShowModemDisplayMessage` received before the first timeout expires replaces the earlier text and restarts the 60-second timeout window.
 5. While a BLE pairing session owns the display, `ShowModemDisplayMessage` returns `FAILED_PRECONDITION`.
 6. Without a configured modem transport, `ShowModemDisplayMessage` returns `UNAVAILABLE`.
+
+---
+
+## 9B  Companion API
+
+### GW-0810  Companion gRPC API
+
+**Priority:** Must  
+**Source:** `gateway-companion-api.md` §2
+
+**Description:**  
+The gateway MUST expose a separate local gRPC API for companion processes that integrate with the gateway at runtime. This companion API MUST be distinct from `GatewayAdmin`: it uses a separate service definition, companion-specific protobuf message types, and a separate configurable local socket (`/var/run/sonde/companion.sock` on Unix-like hosts; `\\.\pipe\sonde-companion` on Windows by default). The companion API MUST NOT expose a TCP listener in v1.
+
+**Acceptance criteria:**
+
+1. The companion API is available when the gateway is running.
+2. The companion API listens on a local-only transport (Unix domain socket or Windows named pipe) separate from the admin API endpoint.
+3. No TCP listener is opened for the companion API.
+4. The companion API does not require clients to use the `GatewayAdmin` service definition or `GatewayAdmin` protobuf messages.
+
+---
+
+### GW-0811  Companion API — live event subscription
+
+**Priority:** Must  
+**Source:** `gateway-companion-api.md` §2.2, §4
+
+**Description:**  
+The companion API MUST provide a server-streaming event subscription for live gateway events. The stream is best-effort and non-durable: it delivers only events produced after the subscription is established and MUST NOT replay historical events to reconnecting clients. The gateway MUST bound in-memory buffering for this stream; if a subscriber falls behind, the gateway MUST terminate that subscriber's stream with `RESOURCE_EXHAUSTED` and require the client to reconnect.
+
+**Acceptance criteria:**
+
+1. After a client subscribes, newly produced companion events are delivered on the stream.
+2. A client that disconnects and reconnects receives only events produced after the new subscription is established.
+3. If a subscriber falls behind the bounded in-memory event buffer, its stream terminates with `RESOURCE_EXHAUSTED`.
+4. Terminating one lagging subscriber does not interrupt gateway processing or other active companion subscribers.
+
+---
+
+### GW-0812  Companion event — `node_checkin`
+
+**Priority:** Must  
+**Source:** `gateway-companion-api.md` §3.2
+
+**Description:**  
+The gateway MUST emit a `node_checkin` companion event when it accepts and processes an authenticated `WAKE` from a registered node. The event MUST include the admin-assigned `node_id`, the node-reported `current_program_hash`, the assigned resident `program_hash` when one exists, `battery_mv`, `firmware_abi_version`, `firmware_version`, and a reception timestamp in Unix milliseconds.
+
+**Acceptance criteria:**
+
+1. Each valid `WAKE` from a registered node produces exactly one `node_checkin` event.
+2. The event fields reflect the values extracted from that `WAKE` and the gateway's current assignment state for the node.
+3. The event is emitted only after the gateway has accepted the `WAKE` and updated the node's latest-known status.
+
+---
+
+### GW-0813  Companion event — `node_payload`
+
+**Priority:** Must  
+**Source:** `gateway-companion-api.md` §3.3
+
+**Description:**  
+The gateway MUST emit a `node_payload` companion event whenever it accepts node-originated application payload data. This includes both `APP_DATA { blob }` frames and `WAKE` messages carrying a piggybacked `blob`. The event MUST include `node_id`, `program_hash`, the opaque payload bytes, a reception timestamp in Unix milliseconds, and a `payload_origin` value of `app_data` or `wake_blob`. The companion API is informational only: it MUST NOT provide a reply channel for payload events.
+
+**Acceptance criteria:**
+
+1. Accepted `APP_DATA` messages produce a `node_payload` event with `payload_origin = app_data`.
+2. Accepted `WAKE` blobs produce a `node_payload` event with `payload_origin = wake_blob`.
+3. The payload bytes are delivered to the companion stream without modification.
+4. For a `WAKE` carrying a blob, the gateway emits `node_checkin` before the corresponding `node_payload`.
+5. Companion clients do not reply to `node_payload`; node replies continue to use the existing handler flow defined by GW-0501 and GW-0506.
+
+---
+
+### GW-0814  Companion API — command and query operations
+
+**Priority:** Must  
+**Source:** `gateway-companion-api.md` §3.1, §4
+
+**Description:**  
+The companion API MUST expose companion-specific RPCs for the node-targeted control and query operations needed by external automation: listing nodes, getting node metadata, assigning a resident program by `program_hash`, setting schedule, queuing reboot, queuing an ephemeral program by `program_hash`, and fetching node status. These operations MUST affect the same underlying gateway state and pending-command pipeline as the corresponding admin operations; the companion API MUST NOT maintain a separate command queue. Operator-focused workflows such as node registration/removal, program ingestion/removal, state export/import, modem management, BLE pairing, and handler management remain outside the v1 companion API surface.
+
+**Acceptance criteria:**
+
+1. A companion client can list nodes and fetch per-node metadata needed to target a command.
+2. `AssignProgram`, `SetSchedule`, `QueueReboot`, and `QueueEphemeral` via the companion API update the same pending state that the gateway uses for the corresponding admin operations.
+3. `GetNodeStatus` via the companion API returns the latest known gateway state for the target node.
+4. The published companion protobuf contract lists only the companion RPCs described above; operator-only workflows remain available only through `GatewayAdmin`.
 
 ---
 
@@ -2317,6 +2404,12 @@ The `secret-service` (D-Bus keyring) dependency MUST be behind a cargo feature f
 | GW-0806 | Admin CLI tool | Must |
 | GW-0807 | Admin API — modem management | Must |
 | GW-0808 | ESP-NOW channel persistence | Must |
+| GW-0809 | Admin API — transient modem display message | Must |
+| GW-0810 | Companion gRPC API | Must |
+| GW-0811 | Companion API — live event subscription | Must |
+| GW-0812 | Companion event — `node_checkin` | Must |
+| GW-0813 | Companion event — `node_payload` | Must |
+| GW-0814 | Companion API — command and query operations | Must |
 | GW-1000 | Gateway failover / replaceability | Must |
 | GW-1004 | Program hash consistency across failover group | Must |
 | GW-1001 | Exportable / importable state | Should |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -5,7 +5,7 @@
 > **Document status:** Draft  
 > **Scope:** Integration and system-level test plan for the Sonde gateway.  
 > **Audience:** Implementers (human or LLM agent) writing gateway tests.  
-> **Related:** [gateway-requirements.md](gateway-requirements.md), [gateway-design.md](gateway-design.md), [protocol.md](protocol.md)
+> **Related:** [gateway-requirements.md](gateway-requirements.md), [gateway-design.md](gateway-design.md), [gateway-companion-api.md](gateway-companion-api.md), [protocol.md](protocol.md)
 
 ---
 
@@ -13,7 +13,7 @@
 
 This document defines integration test cases that validate the gateway against the requirements in [gateway-requirements.md](gateway-requirements.md). Each test case is traceable to one or more requirements.
 
-**Scope:** These are integration tests that exercise the gateway through its external interfaces (transport and handler I/O). Unit tests for internal modules are expected but are not specified here.
+**Scope:** These are integration tests that exercise the gateway through its external interfaces (transport, handler I/O, and local gRPC APIs). Unit tests for internal modules are expected but are not specified here.
 
 **Test harness:** All tests use a **mock transport** (in-process implementation of the `Transport` trait) and a **mock storage** backend. The mock transport simulates node frames — no real radio hardware is needed. A mock or stub handler process is used for handler API tests.
 
@@ -1574,6 +1574,114 @@ A configurable stub handler process (or in-process mock) that:
 2. Assert: non-zero exit code and meaningful error message.
 3. Run `sonde-admin program assign <node-id> 0000000000000000000000000000000000000000000000000000000000000000`.
 4. Assert: non-zero exit code indicating program not found.
+
+---
+
+## 9B  Companion API tests
+
+### T-0818  Companion API availability and local-only binding
+
+**Validates:** GW-0810
+
+**Procedure:**
+1. Start the gateway.
+2. Connect to the companion gRPC API on the configured companion socket.
+3. Assert: the connection succeeds and a defined companion RPC (for example, `ListNodes`) can be called successfully.
+4. Using a `GatewayAdmin` client against the companion socket, attempt to call an admin RPC and assert the call fails with `UNIMPLEMENTED`, proving the companion endpoint does not expose the `GatewayAdmin` service definition.
+5. Assert: the companion API is bound to a local-only transport (Unix domain socket or Windows named pipe) distinct from the admin API endpoint.
+6. Assert: no TCP listener is opened for the companion API.
+
+---
+
+### T-0819  `node_checkin` event stream
+
+**Validates:** GW-0811, GW-0812
+
+**Procedure:**
+1. Start the gateway and register a node with an assigned resident program.
+2. Open a companion `StreamEvents` subscription.
+3. Send a valid `WAKE` from the registered node with known `program_hash`, `battery_mv`, `firmware_abi_version`, and `firmware_version`.
+4. Assert: the stream yields exactly one `node_checkin` event for that `WAKE`.
+5. Assert: the event contains the expected `node_id`, current and assigned program hashes, `battery_mv`, `firmware_abi_version`, `firmware_version`, and a recent `timestamp_ms`.
+6. Disconnect and open a new `StreamEvents` subscription without sending another `WAKE`.
+7. Assert: the new subscription does not replay the earlier `node_checkin`.
+
+---
+
+### T-0820  `node_payload` event stream for `APP_DATA`
+
+**Validates:** GW-0811, GW-0813
+
+**Procedure:**
+1. Start the gateway, register a node, and open a companion `StreamEvents` subscription.
+2. Send `APP_DATA { blob = [0xAA, 0xBB] }` from the node.
+3. Assert: the stream yields one `node_payload` event with `payload_origin = app_data`.
+4. Assert: the event contains the expected `node_id`, `program_hash`, payload bytes `[0xAA, 0xBB]`, and a recent `timestamp_ms`.
+5. Assert: the companion stream requires no reply from the subscriber and the gateway continues to use the handler path for any node reply.
+
+---
+
+### T-0821  `node_payload` event stream for WAKE piggybacked blobs
+
+**Validates:** GW-0813
+
+**Procedure:**
+1. Start the gateway, register a node, and open a companion `StreamEvents` subscription.
+2. Send a `WAKE` carrying `blob = [0xCC]`.
+3. Assert: the stream first yields `node_checkin`, then yields `node_payload`.
+4. Assert: the `node_payload` event contains payload `[0xCC]` with `payload_origin = wake_blob`.
+
+---
+
+### T-0822  Slow companion subscriber is disconnected
+
+**Validates:** GW-0811
+
+**Procedure:**
+1. Start the gateway and open two companion `StreamEvents` subscriptions: one backed by a test client that stops reading after the stream is established, and one backed by an active reader.
+2. Generate enough `node_checkin` and/or `node_payload` events to exceed the bounded in-memory stream buffer for the stalled subscriber.
+3. Assert: the stalled stream terminates with gRPC status `RESOURCE_EXHAUSTED`.
+4. Assert: the active subscriber continues receiving events during and after the stalled subscriber's termination.
+5. Open a fresh `StreamEvents` subscription.
+6. Assert: the fresh subscription receives only events produced after it reconnects.
+
+---
+
+### T-0823  Companion command RPCs share gateway pending-command state
+
+**Validates:** GW-0814
+
+**Procedure:**
+1. Start the gateway and register a node.
+2. Call companion `AssignProgram` with a previously ingested resident `program_hash`.
+3. Call companion `SetSchedule`, `QueueReboot`, and `QueueEphemeral` for the same node in separate sub-cases.
+4. For each sub-case, send the node's next `WAKE`.
+5. Assert: the resulting `COMMAND` matches the behavior defined for the corresponding admin operation, proving the companion RPC updated the gateway's normal pending-command path rather than a separate queue.
+
+---
+
+### T-0824  Companion node query RPCs
+
+**Validates:** GW-0814
+
+**Procedure:**
+1. Start the gateway, register a node, and send a `WAKE` with known battery and ABI values.
+2. Call companion `ListNodes`.
+3. Assert: the registered node appears with the expected metadata required for command targeting.
+4. Call companion `GetNode` and `GetNodeStatus`.
+5. Assert: both responses reflect the gateway's latest known state for the node.
+
+---
+
+### T-0825  Companion API surface excludes operator-only workflows
+
+**Validates:** GW-0814
+
+**Procedure:**
+1. Generate or compile a companion client from the published companion protobuf contract.
+2. Assert: the client exposes only the documented companion RPCs (`StreamEvents`, `ListNodes`, `GetNode`, `AssignProgram`, `SetSchedule`, `QueueReboot`, `QueueEphemeral`, `GetNodeStatus`).
+3. Assert: operator-only workflows such as node registration/removal, program ingestion/removal, state export/import, modem management, BLE pairing, and handler management are absent from the companion client surface.
+4. Assert: those operator-only workflows remain available through `GatewayAdmin`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a separate local gRPC companion contract, service, and socket wiring alongside GatewayAdmin
- emit companion node_checkin and node_payload events from gateway wake/app-data processing
- reuse shared gateway state for companion command/query RPCs and add companion API coverage

## Testing
- cargo test -p sonde-gateway
- cargo clippy -p sonde-gateway --all-targets -- -D warnings