### PR TITLE
Apply maintenance audit drift fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,6 +5430,7 @@ dependencies = [
  "ed25519-dalek",
  "sha2 0.10.9",
  "sonde-gateway",
+ "sonde-modem",
  "sonde-node",
  "sonde-pair",
  "sonde-protocol",

--- a/crates/sonde-admin/tests/cli.rs
+++ b/crates/sonde-admin/tests/cli.rs
@@ -4,6 +4,51 @@
 use std::process::Command;
 
 #[test]
+fn help_lists_top_level_subcommands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .arg("--help")
+        .output()
+        .expect("failed to run sonde-admin");
+
+    assert!(output.status.success(), "--help should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for subcommand in [
+        "node",
+        "program",
+        "schedule",
+        "reboot",
+        "ephemeral",
+        "status",
+        "state",
+        "modem",
+        "pairing",
+        "handler",
+    ] {
+        assert!(
+            stdout.contains(subcommand),
+            "top-level help should list `{subcommand}`: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn node_help_lists_nested_subcommands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args(["node", "--help"])
+        .output()
+        .expect("failed to run sonde-admin");
+
+    assert!(output.status.success(), "node --help should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for subcommand in ["list", "get", "register", "remove", "factory-reset"] {
+        assert!(
+            stdout.contains(subcommand),
+            "node help should list `{subcommand}`: {stdout}"
+        );
+    }
+}
+
+#[test]
 fn modem_display_rejects_more_than_four_lines() {
     let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
         .args(["modem", "display", "one", "two", "three", "four", "five"])

--- a/crates/sonde-admin/tests/integration.rs
+++ b/crates/sonde-admin/tests/integration.rs
@@ -8,6 +8,7 @@
 //! and exercise the `AdminClient` wrapper.
 
 use std::collections::HashMap;
+use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -64,6 +65,50 @@ async fn start_server_and_connect(test_name: &str) -> AdminClient {
     }
 }
 
+/// Start an admin gRPC server and return its endpoint once it is accepting connections.
+async fn start_server(test_name: &str) -> String {
+    let storage = Arc::new(InMemoryStorage::new());
+    let pending: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
+        Arc::new(RwLock::new(HashMap::new()));
+    let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+    let admin = AdminService::new(storage, pending, session_manager);
+
+    let endpoint = unique_endpoint(test_name);
+    let server_endpoint = endpoint.clone();
+
+    tokio::spawn(async move {
+        if let Err(e) = sonde_gateway::admin::serve_admin(admin, &server_endpoint).await {
+            eprintln!("admin server ended: {e}");
+        }
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        match AdminClient::connect(&endpoint).await {
+            Ok(_) => return endpoint,
+            Err(_) if tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => panic!("failed to connect to admin server: {e}"),
+        }
+    }
+}
+
+fn minimal_program_cbor() -> Vec<u8> {
+    let bytecode: Vec<u8> = vec![
+        0xB7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mov r0, 0
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    ];
+    let mut cbor = Vec::new();
+    cbor.push(0xA2); // map(2)
+    cbor.push(0x01); // key: 1
+    cbor.push(0x50); // bytes(16)
+    cbor.extend_from_slice(&bytecode);
+    cbor.push(0x02); // key: 2
+    cbor.push(0x80); // array(0)
+    cbor
+}
+
 // ── gRPC client tests ───────────────────────────────────────────────────────
 
 /// Test: list nodes on empty gateway returns empty list.
@@ -109,6 +154,46 @@ async fn grpc_register_remove_node() {
     assert_eq!(client.list_nodes().await.unwrap().len(), 0);
 }
 
+/// Test: get_node on a fresh gateway returns not found.
+#[tokio::test]
+async fn grpc_get_node_missing_returns_error() {
+    let mut client = start_server_and_connect("get_node_missing").await;
+    let err = client
+        .get_node("missing-node")
+        .await
+        .expect_err("missing node lookup should fail");
+    assert_eq!(err.code(), tonic::Code::NotFound);
+}
+
+/// Test: remove_node on a fresh gateway returns not found.
+#[tokio::test]
+async fn grpc_remove_nonexistent_node_returns_error() {
+    let mut client = start_server_and_connect("remove_node_missing").await;
+    let err = client
+        .remove_node("missing-node")
+        .await
+        .expect_err("removing a missing node should fail");
+    assert_eq!(err.code(), tonic::Code::NotFound);
+}
+
+/// Test: factory_reset removes the node from the registry.
+#[tokio::test]
+async fn grpc_factory_reset_removes_node() {
+    let mut client = start_server_and_connect("factory_reset_node").await;
+    client
+        .register_node("factory-node", 0x2222, vec![0xAB; 32])
+        .await
+        .unwrap();
+
+    client.factory_reset("factory-node").await.unwrap();
+
+    let err = client
+        .get_node("factory-node")
+        .await
+        .expect_err("factory reset should remove the node");
+    assert_eq!(err.code(), tonic::Code::NotFound);
+}
+
 /// Test: ingest a program and list it.
 ///
 /// Skipped in release builds — the gateway rejects raw CBOR program images
@@ -146,6 +231,63 @@ async fn grpc_ingest_list_program() {
     assert_eq!(programs[0].hash, hash);
 }
 
+/// Test: list_programs on a fresh gateway returns empty.
+#[tokio::test]
+async fn grpc_list_programs_empty() {
+    let mut client = start_server_and_connect("list_programs_empty").await;
+    let programs = client.list_programs().await.unwrap();
+    assert!(programs.is_empty(), "fresh gateway should have no programs");
+}
+
+/// Test: assign a program to a node and observe it via get_node.
+#[cfg(debug_assertions)]
+#[tokio::test]
+async fn grpc_assign_program_to_node() {
+    let mut client = start_server_and_connect("assign_program_to_node").await;
+    client
+        .register_node("assign-node", 0x3333, vec![0xCD; 32])
+        .await
+        .unwrap();
+
+    let (hash, _) = client
+        .ingest_program(minimal_program_cbor(), 1, None, None)
+        .await
+        .unwrap();
+    client
+        .assign_program("assign-node", hash.clone())
+        .await
+        .unwrap();
+
+    let node = client.get_node("assign-node").await.unwrap();
+    assert_eq!(node.assigned_program_hash, hash);
+}
+
+/// Test: remove_program deletes the program from storage.
+#[cfg(debug_assertions)]
+#[tokio::test]
+async fn grpc_remove_program() {
+    let mut client = start_server_and_connect("remove_program").await;
+    let (hash, _) = client
+        .ingest_program(minimal_program_cbor(), 1, None, None)
+        .await
+        .unwrap();
+    assert_eq!(client.list_programs().await.unwrap().len(), 1);
+
+    client.remove_program(hash).await.unwrap();
+    assert!(client.list_programs().await.unwrap().is_empty());
+}
+
+/// Test: remove_program on a missing hash returns not found.
+#[tokio::test]
+async fn grpc_remove_nonexistent_program_returns_error() {
+    let mut client = start_server_and_connect("remove_program_missing").await;
+    let err = client
+        .remove_program(vec![0x11; 32])
+        .await
+        .expect_err("removing a missing program should fail");
+    assert_eq!(err.code(), tonic::Code::NotFound);
+}
+
 /// Test: set schedule on a node.
 #[tokio::test]
 async fn grpc_set_schedule() {
@@ -172,6 +314,41 @@ async fn grpc_queue_reboot() {
 
     // queue_reboot should succeed without error.
     client.queue_reboot("reboot-node").await.unwrap();
+}
+
+/// Test: queue an ephemeral program for a node.
+#[cfg(debug_assertions)]
+#[tokio::test]
+async fn grpc_queue_ephemeral() {
+    let mut client = start_server_and_connect("queue_ephemeral").await;
+    client
+        .register_node("ephemeral-node", 0x4444, vec![0xEF; 32])
+        .await
+        .unwrap();
+
+    let (hash, _) = client
+        .ingest_program(minimal_program_cbor(), 2, None, None)
+        .await
+        .unwrap();
+    client
+        .queue_ephemeral("ephemeral-node", hash)
+        .await
+        .unwrap();
+}
+
+/// Test: get_node_status reports no active session before any WAKE.
+#[tokio::test]
+async fn grpc_get_node_status_without_session() {
+    let mut client = start_server_and_connect("get_node_status_no_session").await;
+    client
+        .register_node("status-node", 0x5555, vec![0xBC; 32])
+        .await
+        .unwrap();
+
+    let status = client.get_node_status("status-node").await.unwrap();
+    assert_eq!(status.node_id, "status-node");
+    assert!(!status.has_active_session);
+    assert_eq!(status.battery_mv, None);
 }
 
 // ── BLE pairing tests ───────────────────────────────────────────────────────
@@ -212,6 +389,39 @@ async fn grpc_show_modem_display_message_no_modem() {
     assert_eq!(status.code(), tonic::Code::Unavailable);
 }
 
+/// Test: get_modem_status fails cleanly when no modem transport exists.
+#[tokio::test]
+async fn grpc_get_modem_status_no_modem() {
+    let mut client = start_server_and_connect("get_modem_status_no_modem").await;
+    let err = client
+        .get_modem_status()
+        .await
+        .expect_err("missing modem transport should fail");
+    assert_eq!(err.code(), tonic::Code::Unavailable);
+}
+
+/// Test: set_modem_channel fails cleanly when no modem transport exists.
+#[tokio::test]
+async fn grpc_set_modem_channel_no_modem() {
+    let mut client = start_server_and_connect("set_modem_channel_no_modem").await;
+    let err = client
+        .set_modem_channel(6)
+        .await
+        .expect_err("missing modem transport should fail");
+    assert_eq!(err.code(), tonic::Code::Unavailable);
+}
+
+/// Test: scan_modem_channels fails cleanly when no modem transport exists.
+#[tokio::test]
+async fn grpc_scan_modem_channels_no_modem() {
+    let mut client = start_server_and_connect("scan_modem_channels_no_modem").await;
+    let err = client
+        .scan_modem_channels()
+        .await
+        .expect_err("missing modem transport should fail");
+    assert_eq!(err.code(), tonic::Code::Unavailable);
+}
+
 // ── State export/import ─────────────────────────────────────────────────────
 
 /// Test: export empty state and import it back.
@@ -239,4 +449,113 @@ async fn grpc_export_import_state() {
         nodes.iter().any(|n| n.node_id == "export-node"),
         "imported state must contain the original node"
     );
+}
+
+/// Test: add_handler, list_handlers, then remove_handler.
+#[tokio::test]
+async fn grpc_add_list_remove_handler() {
+    let mut client = start_server_and_connect("add_list_remove_handler").await;
+
+    client
+        .add_handler("*", "echo", vec!["hello".into()], None, None)
+        .await
+        .unwrap();
+
+    let handlers = client.list_handlers().await.unwrap();
+    assert_eq!(handlers.len(), 1);
+    assert_eq!(handlers[0].program_hash, "*");
+    assert_eq!(handlers[0].command, "echo");
+    assert_eq!(handlers[0].args, vec!["hello"]);
+
+    client.remove_handler("*").await.unwrap();
+    assert!(client.list_handlers().await.unwrap().is_empty());
+}
+
+/// Test: `node list --format json` emits valid JSON.
+#[tokio::test(flavor = "multi_thread")]
+async fn cli_node_list_json_output() {
+    let endpoint = start_server("cli_node_list_json_output").await;
+    let mut client = AdminClient::connect(&endpoint).await.unwrap();
+    client
+        .register_node("json-node", 0x1234, vec![0xAA; 32])
+        .await
+        .unwrap();
+    drop(client);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args(["--socket", &endpoint, "--format", "json", "node", "list"])
+        .output()
+        .expect("failed to run sonde-admin");
+
+    assert!(output.status.success(), "CLI should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("stdout must be JSON");
+    let nodes = parsed
+        .as_array()
+        .expect("node list output must be an array");
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes[0]["node_id"], "json-node");
+    assert_eq!(nodes[0]["key_hint"], 0x1234);
+}
+
+/// Test: non-interactive `node remove` refuses to proceed without `--yes`.
+#[tokio::test(flavor = "multi_thread")]
+async fn cli_node_remove_noninteractive_requires_yes() {
+    let endpoint = start_server("cli_node_remove_noninteractive_requires_yes").await;
+    let mut client = AdminClient::connect(&endpoint).await.unwrap();
+    client
+        .register_node("remove-me", 0x4321, vec![0xBB; 32])
+        .await
+        .unwrap();
+    drop(client);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args(["--socket", &endpoint, "node", "remove", "remove-me"])
+        .output()
+        .expect("failed to run sonde-admin");
+
+    assert!(
+        !output.status.success(),
+        "CLI should refuse non-interactive removal"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("non-interactive") || stderr.contains("--yes"),
+        "stderr should explain the confirmation requirement: {stderr}"
+    );
+
+    let mut client = AdminClient::connect(&endpoint).await.unwrap();
+    let remaining = client.list_nodes().await.unwrap();
+    assert_eq!(remaining.len(), 1, "node must not be removed");
+}
+
+/// Test: `node remove --yes` succeeds in non-interactive mode.
+#[tokio::test(flavor = "multi_thread")]
+async fn cli_node_remove_with_yes_succeeds() {
+    let endpoint = start_server("cli_node_remove_with_yes_succeeds").await;
+    let mut client = AdminClient::connect(&endpoint).await.unwrap();
+    client
+        .register_node("remove-me", 0x6789, vec![0xCC; 32])
+        .await
+        .unwrap();
+    drop(client);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args([
+            "--socket",
+            &endpoint,
+            "--yes",
+            "node",
+            "remove",
+            "remove-me",
+        ])
+        .output()
+        .expect("failed to run sonde-admin");
+
+    assert!(
+        output.status.success(),
+        "CLI should remove the node with --yes"
+    );
+    let mut client = AdminClient::connect(&endpoint).await.unwrap();
+    assert!(client.list_nodes().await.unwrap().is_empty());
 }

--- a/crates/sonde-admin/tests/integration.rs
+++ b/crates/sonde-admin/tests/integration.rs
@@ -94,6 +94,7 @@ async fn start_server(test_name: &str) -> String {
     }
 }
 
+#[cfg(debug_assertions)]
 fn minimal_program_cbor() -> Vec<u8> {
     let bytecode: Vec<u8> = vec![
         0xB7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mov r0, 0

--- a/crates/sonde-e2e/Cargo.toml
+++ b/crates/sonde-e2e/Cargo.toml
@@ -21,6 +21,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 ciborium = "0.2"
+sonde-modem = { path = "../sonde-modem" }
 tempfile = "3"
 
 [lib]

--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -134,11 +134,30 @@ pub struct WakeCycleStats {
 }
 
 /// Node transport that exposes captured per-frame statistics for test assertions.
+///
+/// Implementations must return cumulative lifetime statistics for a single
+/// transport instance. Callers snapshot these values before and after a wake
+/// cycle and derive per-cycle deltas by subtracting counts and slicing from the
+/// previous lengths.
+///
+/// Therefore:
+///
+/// - [`response_count`](Self::response_count) must be monotonic and never decrease.
+/// - The slices returned by the other methods must be cumulative append-only
+///   views whose lengths never decrease while the transport is being observed.
+/// - Earlier entries must remain at the same indices; implementations must not
+///   clear, rotate, or reorder recorded data between snapshots.
 pub trait RecordedNodeTransport: NodeTransport {
+    /// Returns the cumulative number of non-`None` responses seen by this
+    /// transport instance.
     fn response_count(&self) -> usize;
+    /// Returns all WAKE nonces recorded so far.
     fn wake_nonces(&self) -> &[u64];
+    /// Returns all `(msg_type, nonce)` pairs recorded so far.
     fn sent_frames(&self) -> &[(u8, u64)];
+    /// Returns all captured outbound APP_DATA raw frames recorded so far.
     fn sent_raw_frames(&self) -> &[Vec<u8>];
+    /// Returns the message types of all valid non-`None` responses recorded so far.
     fn received_msg_types(&self) -> &[u8];
 }
 
@@ -298,13 +317,41 @@ impl NodeProxy {
             &mut self.async_queue,
         );
 
+        let response_count_after = transport.response_count();
+        let wake_nonces_after = transport.wake_nonces().len();
+        let sent_frames_after = transport.sent_frames().len();
+        let sent_raw_after = transport.sent_raw_frames().len();
+        let recv_type_after = transport.received_msg_types().len();
+
+        assert!(
+            wake_nonces_after >= wake_nonce_start,
+            "RecordedNodeTransport::wake_nonces must be cumulative and append-only"
+        );
+        assert!(
+            sent_frames_after >= sent_frame_start,
+            "RecordedNodeTransport::sent_frames must be cumulative and append-only"
+        );
+        assert!(
+            sent_raw_after >= sent_raw_start,
+            "RecordedNodeTransport::sent_raw_frames must be cumulative and append-only"
+        );
+        assert!(
+            recv_type_after >= recv_type_start,
+            "RecordedNodeTransport::received_msg_types must be cumulative and append-only"
+        );
+
         WakeCycleStats {
             outcome,
-            response_count: transport.response_count() - response_count_before,
-            wake_nonces: transport.wake_nonces()[wake_nonce_start..].to_vec(),
-            sent_frames: transport.sent_frames()[sent_frame_start..].to_vec(),
-            sent_raw_frames: transport.sent_raw_frames()[sent_raw_start..].to_vec(),
-            received_msg_types: transport.received_msg_types()[recv_type_start..].to_vec(),
+            response_count: response_count_after.checked_sub(response_count_before).expect(
+                "RecordedNodeTransport::response_count must be cumulative and never decrease",
+            ),
+            wake_nonces: transport.wake_nonces()
+                [wake_nonce_start..wake_nonces_after]
+                .to_vec(),
+            sent_frames: transport.sent_frames()[sent_frame_start..sent_frames_after].to_vec(),
+            sent_raw_frames: transport.sent_raw_frames()[sent_raw_start..sent_raw_after].to_vec(),
+            received_msg_types: transport.received_msg_types()[recv_type_start..recv_type_after]
+                .to_vec(),
         }
     }
 }

--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -342,12 +342,12 @@ impl NodeProxy {
 
         WakeCycleStats {
             outcome,
-            response_count: response_count_after.checked_sub(response_count_before).expect(
-                "RecordedNodeTransport::response_count must be cumulative and never decrease",
-            ),
-            wake_nonces: transport.wake_nonces()
-                [wake_nonce_start..wake_nonces_after]
-                .to_vec(),
+            response_count: response_count_after
+                .checked_sub(response_count_before)
+                .expect(
+                    "RecordedNodeTransport::response_count must be cumulative and never decrease",
+                ),
+            wake_nonces: transport.wake_nonces()[wake_nonce_start..wake_nonces_after].to_vec(),
             sent_frames: transport.sent_frames()[sent_frame_start..sent_frames_after].to_vec(),
             sent_raw_frames: transport.sent_raw_frames()[sent_raw_start..sent_raw_after].to_vec(),
             received_msg_types: transport.received_msg_types()[recv_type_start..recv_type_after]

--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -133,6 +133,15 @@ pub struct WakeCycleStats {
     pub received_msg_types: Vec<u8>,
 }
 
+/// Node transport that exposes captured per-frame statistics for test assertions.
+pub trait RecordedNodeTransport: NodeTransport {
+    fn response_count(&self) -> usize;
+    fn wake_nonces(&self) -> &[u64];
+    fn sent_frames(&self) -> &[(u8, u64)];
+    fn sent_raw_frames(&self) -> &[Vec<u8>];
+    fn received_msg_types(&self) -> &[u8];
+}
+
 /// Lightweight handle representing a remote node.
 ///
 /// Identity and schedule are stored exclusively in `self.storage`
@@ -198,6 +207,26 @@ impl NodeProxy {
         self.run_wake_cycle_inner(env, &mut interpreter, false)
     }
 
+    /// Run one wake cycle using a caller-supplied transport.
+    ///
+    /// Requires a multi-thread Tokio runtime (see [`run_wake_cycle`]).
+    pub fn run_wake_cycle_on<T: RecordedNodeTransport + 'static>(
+        &mut self,
+        transport: &mut T,
+    ) -> WakeCycleStats {
+        let mut interpreter = MockBpfInterpreter::new();
+        self.run_wake_cycle_on_with(transport, &mut interpreter)
+    }
+
+    /// Like [`run_wake_cycle_on`] but accepts a caller-supplied BPF interpreter.
+    pub fn run_wake_cycle_on_with<T: RecordedNodeTransport + 'static>(
+        &mut self,
+        transport: &mut T,
+        interpreter: &mut impl BpfInterpreter,
+    ) -> WakeCycleStats {
+        self.run_wake_cycle_with_transport(transport, interpreter)
+    }
+
     /// Like [`run_wake_cycle`] but accepts a caller-supplied BPF
     /// interpreter for tests that require real BPF program execution.
     ///
@@ -228,6 +257,19 @@ impl NodeProxy {
         interpreter: &mut impl BpfInterpreter,
         tamper: bool,
     ) -> WakeCycleStats {
+        let mut transport = if tamper {
+            BridgeTransport::new_tampered(env.gateway.clone(), self.mac.clone())
+        } else {
+            BridgeTransport::new(env.gateway.clone(), self.mac.clone())
+        };
+        self.run_wake_cycle_with_transport(&mut transport, interpreter)
+    }
+
+    fn run_wake_cycle_with_transport<T: RecordedNodeTransport + 'static>(
+        &mut self,
+        transport: &mut T,
+        interpreter: &mut impl BpfInterpreter,
+    ) -> WakeCycleStats {
         use sonde_node::node_aead::NodeAead;
         use sonde_node::wake_cycle::run_wake_cycle;
 
@@ -236,14 +278,14 @@ impl NodeProxy {
         let sha = TestSha256;
         let aead = NodeAead;
 
-        let mut transport = if tamper {
-            BridgeTransport::new_tampered(env.gateway.clone(), self.mac.clone())
-        } else {
-            BridgeTransport::new(env.gateway.clone(), self.mac.clone())
-        };
+        let response_count_before = transport.response_count();
+        let wake_nonce_start = transport.wake_nonces().len();
+        let sent_frame_start = transport.sent_frames().len();
+        let sent_raw_start = transport.sent_raw_frames().len();
+        let recv_type_start = transport.received_msg_types().len();
 
         let outcome = run_wake_cycle(
-            &mut transport,
+            transport,
             &mut self.storage,
             &mut hal,
             &mut self.rng,
@@ -255,13 +297,14 @@ impl NodeProxy {
             &aead,
             &mut self.async_queue,
         );
+
         WakeCycleStats {
             outcome,
-            response_count: transport.response_count(),
-            wake_nonces: transport.wake_nonces().to_vec(),
-            sent_frames: transport.sent_frames().to_vec(),
-            sent_raw_frames: transport.sent_raw_frames().to_vec(),
-            received_msg_types: transport.received_msg_types().to_vec(),
+            response_count: transport.response_count() - response_count_before,
+            wake_nonces: transport.wake_nonces()[wake_nonce_start..].to_vec(),
+            sent_frames: transport.sent_frames()[sent_frame_start..].to_vec(),
+            sent_raw_frames: transport.sent_raw_frames()[sent_raw_start..].to_vec(),
+            received_msg_types: transport.received_msg_types()[recv_type_start..].to_vec(),
         }
     }
 }
@@ -376,6 +419,28 @@ impl NodeTransport for BridgeTransport {
 
     fn recv(&mut self, _timeout_ms: u32) -> NodeResult<Option<Vec<u8>>> {
         Ok(self.pending_response.take())
+    }
+}
+
+impl RecordedNodeTransport for BridgeTransport {
+    fn response_count(&self) -> usize {
+        self.response_count()
+    }
+
+    fn wake_nonces(&self) -> &[u64] {
+        self.wake_nonces()
+    }
+
+    fn sent_frames(&self) -> &[(u8, u64)] {
+        self.sent_frames()
+    }
+
+    fn sent_raw_frames(&self) -> &[Vec<u8>] {
+        self.sent_raw_frames()
+    }
+
+    fn received_msg_types(&self) -> &[u8] {
+        self.received_msg_types()
     }
 }
 

--- a/crates/sonde-e2e/tests/modem_bridge_tests.rs
+++ b/crates/sonde-e2e/tests/modem_bridge_tests.rs
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Modem-bridge end-to-end integration tests.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, TryRecvError};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use sonde_e2e::harness::{E2eTestEnv, NodeProxy, RecordedNodeTransport, TestSha256};
+use sonde_gateway::modem::UsbEspNowTransport;
+use sonde_gateway::storage::Storage;
+use sonde_gateway::transport::Transport;
+use sonde_modem::bridge::{Bridge, Radio, SerialPort};
+use sonde_modem::status::ModemCounters;
+use sonde_node::error::{NodeError, NodeResult};
+use sonde_node::traits::Transport as NodeTransport;
+use sonde_node::wake_cycle::WakeCycleOutcome;
+use sonde_protocol::modem::{RecvFrame, MAC_SIZE};
+use sonde_protocol::{ProgramImage, Sha256Provider};
+use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+
+use sonde_gateway::{ProgramRecord, VerificationProfile};
+
+const TEST_CHANNEL: u8 = 6;
+const MODEM_MAC: [u8; 6] = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+const NODE_MAC: [u8; 6] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+
+struct BridgeHandle {
+    stop: Arc<AtomicBool>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl BridgeHandle {
+    fn spawn<S, R>(mut bridge: Bridge<S, R>) -> Self
+    where
+        S: SerialPort + Send + 'static,
+        R: Radio + Send + 'static,
+    {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = Arc::clone(&stop);
+        let join = thread::spawn(move || {
+            while !stop_thread.load(Ordering::Relaxed) {
+                bridge.poll();
+                thread::sleep(Duration::from_millis(1));
+            }
+        });
+        Self {
+            stop,
+            join: Some(join),
+        }
+    }
+}
+
+impl Drop for BridgeHandle {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+struct PipeSerial {
+    incoming_rx: Receiver<Vec<u8>>,
+    pending: VecDeque<u8>,
+    outgoing_tx: UnboundedSender<Vec<u8>>,
+    first_read: bool,
+    _read_task: tokio::task::JoinHandle<()>,
+    _write_task: tokio::task::JoinHandle<()>,
+}
+
+impl PipeSerial {
+    fn new(stream: DuplexStream) -> Self {
+        let (incoming_tx, incoming_rx) = mpsc::channel();
+        let (outgoing_tx, mut outgoing_rx) = unbounded_channel::<Vec<u8>>();
+        let (mut read_half, mut write_half) = tokio::io::split(stream);
+
+        let read_task = tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            loop {
+                match read_half.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        if incoming_tx.send(buf[..n].to_vec()).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let write_task = tokio::spawn(async move {
+            while let Some(data) = outgoing_rx.recv().await {
+                if write_half.write_all(&data).await.is_err() {
+                    break;
+                }
+                if write_half.flush().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            incoming_rx,
+            pending: VecDeque::new(),
+            outgoing_tx,
+            first_read: true,
+            _read_task: read_task,
+            _write_task: write_task,
+        }
+    }
+
+    fn drain_incoming(&mut self) {
+        while let Ok(chunk) = self.incoming_rx.try_recv() {
+            self.pending.extend(chunk);
+        }
+    }
+}
+
+impl SerialPort for PipeSerial {
+    fn read(&mut self, buf: &mut [u8]) -> (usize, bool) {
+        self.drain_incoming();
+
+        let reconnected = if self.first_read {
+            self.first_read = false;
+            self.pending.is_empty()
+        } else {
+            false
+        };
+
+        let n = buf.len().min(self.pending.len());
+        for slot in &mut buf[..n] {
+            *slot = self.pending.pop_front().expect("pending length checked");
+        }
+        (n, reconnected)
+    }
+
+    fn write(&mut self, data: &[u8]) -> bool {
+        self.outgoing_tx.send(data.to_vec()).is_ok()
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+}
+
+struct ChannelRadio {
+    tx: Sender<Vec<u8>>,
+    rx: std::sync::Mutex<Receiver<Vec<u8>>>,
+    channel: Arc<AtomicU8>,
+}
+
+impl ChannelRadio {
+    fn new(tx: Sender<Vec<u8>>, rx: Receiver<Vec<u8>>, channel: Arc<AtomicU8>) -> Self {
+        Self {
+            tx,
+            rx: std::sync::Mutex::new(rx),
+            channel,
+        }
+    }
+}
+
+impl Radio for ChannelRadio {
+    fn send(&mut self, _peer_mac: &[u8; MAC_SIZE], data: &[u8]) -> bool {
+        self.tx.send(data.to_vec()).is_ok()
+    }
+
+    fn drain_one(&self) -> Option<RecvFrame> {
+        match self.rx.lock().unwrap().try_recv() {
+            Ok(frame_data) => Some(RecvFrame {
+                peer_mac: NODE_MAC,
+                rssi: -40,
+                frame_data,
+            }),
+            Err(TryRecvError::Empty | TryRecvError::Disconnected) => None,
+        }
+    }
+
+    fn set_channel(&mut self, channel: u8) -> Result<(), &'static str> {
+        if !(1..=14).contains(&channel) {
+            return Err("invalid channel");
+        }
+        self.channel.store(channel, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn channel(&self) -> u8 {
+        self.channel.load(Ordering::Relaxed)
+    }
+
+    fn scan_channels(&mut self) -> Vec<(u8, u8, i8)> {
+        Vec::new()
+    }
+
+    fn mac_address(&self) -> [u8; MAC_SIZE] {
+        MODEM_MAC
+    }
+
+    fn reset_state(&mut self) {}
+}
+
+struct ChannelTransport {
+    tx: Sender<Vec<u8>>,
+    rx: Receiver<Vec<u8>>,
+    response_count: usize,
+    wake_nonces: Vec<u64>,
+    sent_frames: Vec<(u8, u64)>,
+    sent_raw_frames: Vec<Vec<u8>>,
+    received_msg_types: Vec<u8>,
+}
+
+impl ChannelTransport {
+    fn new(tx: Sender<Vec<u8>>, rx: Receiver<Vec<u8>>) -> Self {
+        Self {
+            tx,
+            rx,
+            response_count: 0,
+            wake_nonces: Vec::new(),
+            sent_frames: Vec::new(),
+            sent_raw_frames: Vec::new(),
+            received_msg_types: Vec::new(),
+        }
+    }
+}
+
+impl NodeTransport for ChannelTransport {
+    fn send(&mut self, frame: &[u8]) -> NodeResult<()> {
+        if frame.len() >= sonde_protocol::HEADER_SIZE {
+            let msg_type = frame[sonde_protocol::OFFSET_MSG_TYPE];
+            let nonce = u64::from_be_bytes(
+                frame[sonde_protocol::OFFSET_NONCE..sonde_protocol::OFFSET_NONCE + 8]
+                    .try_into()
+                    .expect("nonce slice must be 8 bytes"),
+            );
+            self.sent_frames.push((msg_type, nonce));
+            if msg_type == sonde_protocol::MSG_WAKE {
+                self.wake_nonces.push(nonce);
+            }
+            if msg_type == sonde_protocol::MSG_APP_DATA {
+                self.sent_raw_frames.push(frame.to_vec());
+            }
+        }
+        self.tx
+            .send(frame.to_vec())
+            .map_err(|_| NodeError::Transport("channel send failed"))?;
+        Ok(())
+    }
+
+    fn recv(&mut self, timeout_ms: u32) -> NodeResult<Option<Vec<u8>>> {
+        match self
+            .rx
+            .recv_timeout(Duration::from_millis(u64::from(timeout_ms)))
+        {
+            Ok(frame) => {
+                self.response_count += 1;
+                if frame.len() >= sonde_protocol::HEADER_SIZE {
+                    self.received_msg_types
+                        .push(frame[sonde_protocol::OFFSET_MSG_TYPE]);
+                }
+                Ok(Some(frame))
+            }
+            Err(RecvTimeoutError::Timeout) => Ok(None),
+            Err(RecvTimeoutError::Disconnected) => Err(NodeError::Transport("channel recv failed")),
+        }
+    }
+}
+
+impl RecordedNodeTransport for ChannelTransport {
+    fn response_count(&self) -> usize {
+        self.response_count
+    }
+
+    fn wake_nonces(&self) -> &[u64] {
+        &self.wake_nonces
+    }
+
+    fn sent_frames(&self) -> &[(u8, u64)] {
+        &self.sent_frames
+    }
+
+    fn sent_raw_frames(&self) -> &[Vec<u8>] {
+        &self.sent_raw_frames
+    }
+
+    fn received_msg_types(&self) -> &[u8] {
+        &self.received_msg_types
+    }
+}
+
+struct ModemBridgeEnv {
+    e2e: E2eTestEnv,
+    transport: Arc<UsbEspNowTransport>,
+    node_transport: ChannelTransport,
+    bridge: BridgeHandle,
+    gateway_task: Option<tokio::task::JoinHandle<()>>,
+    channel: Arc<AtomicU8>,
+}
+
+impl ModemBridgeEnv {
+    async fn new() -> Self {
+        let e2e = E2eTestEnv::new();
+        let (gateway_client, gateway_server) = duplex(4096);
+        let pipe_serial = PipeSerial::new(gateway_server);
+
+        let (to_node_tx, to_node_rx) = mpsc::channel();
+        let (to_bridge_tx, to_bridge_rx) = mpsc::channel();
+        let channel = Arc::new(AtomicU8::new(1));
+        let radio = ChannelRadio::new(to_node_tx, to_bridge_rx, Arc::clone(&channel));
+        let bridge = Bridge::new(pipe_serial, radio, ModemCounters::new());
+
+        let transport_task =
+            tokio::spawn(
+                async move { UsbEspNowTransport::new(gateway_client, TEST_CHANNEL).await },
+            );
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let bridge = BridgeHandle::spawn(bridge);
+
+        let transport = Arc::new(
+            transport_task
+                .await
+                .expect("transport task must not panic")
+                .expect("transport startup must succeed"),
+        );
+
+        Self {
+            e2e,
+            transport,
+            node_transport: ChannelTransport::new(to_bridge_tx, to_node_rx),
+            bridge,
+            gateway_task: None,
+            channel,
+        }
+    }
+
+    fn start_gateway_loop(&mut self) {
+        if self.gateway_task.is_some() {
+            return;
+        }
+
+        let gateway = Arc::clone(&self.e2e.gateway);
+        let transport = Arc::clone(&self.transport);
+        self.gateway_task = Some(tokio::spawn(async move {
+            loop {
+                let (frame, peer, rssi) = match transport.recv_with_rssi().await {
+                    Ok(msg) => msg,
+                    Err(_) => break,
+                };
+                if let Some(response) = gateway
+                    .process_frame_with_rssi(&frame, peer.clone(), Some(rssi))
+                    .await
+                {
+                    if transport.send(&response, &peer).await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }));
+    }
+}
+
+impl Drop for ModemBridgeEnv {
+    fn drop(&mut self) {
+        if let Some(task) = self.gateway_task.take() {
+            task.abort();
+        }
+        let _ = &self.bridge;
+    }
+}
+
+fn make_program_from_bytecode(bytecode: &[u8]) -> (ProgramRecord, Vec<u8>) {
+    let image = ProgramImage {
+        bytecode: bytecode.to_vec(),
+        maps: vec![],
+        map_initial_data: vec![],
+    };
+    let cbor = image
+        .encode_deterministic()
+        .expect("program image must encode");
+    let sha = TestSha256;
+    let hash = sha.hash(&cbor).to_vec();
+    let size = cbor.len() as u32;
+    let record = ProgramRecord {
+        hash: hash.clone(),
+        image: cbor,
+        size,
+        verification_profile: VerificationProfile::Resident,
+        abi_version: None,
+        source_filename: None,
+    };
+    (record, hash)
+}
+
+fn make_send_program() -> (ProgramRecord, Vec<u8>) {
+    let bytecode = [
+        0x6a, 0x0a, 0xf8, 0xff, 0xAA, 0xBB, 0x00, 0x00, 0xbf, 0xa1, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x07, 0x01, 0x00, 0x00, 0xf8, 0xff, 0xff, 0xff, 0xb7, 0x02, 0x00, 0x00, 0x02, 0x00,
+        0x00, 0x00, 0x85, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0xb7, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+    make_program_from_bytecode(&bytecode)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_050_modem_startup_handshake() {
+    let env = ModemBridgeEnv::new().await;
+
+    assert_eq!(env.channel.load(Ordering::Relaxed), TEST_CHANNEL);
+    assert_eq!(env.transport.modem_mac(), &MODEM_MAC);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_051_frame_round_trip_through_modem_bridge() {
+    let mut env = ModemBridgeEnv::new().await;
+
+    let outbound = vec![0x10, 0x20, 0x30, 0x40];
+    env.node_transport
+        .send(&outbound)
+        .expect("node send through modem bridge must succeed");
+
+    let (gateway_frame, peer) = env
+        .transport
+        .recv()
+        .await
+        .expect("gateway transport must receive node frame");
+    assert_eq!(gateway_frame, outbound);
+    assert_eq!(peer, NODE_MAC.to_vec());
+
+    let response = vec![0xAA, 0xBB, 0xCC];
+    env.transport
+        .send(&response, &peer)
+        .await
+        .expect("gateway response through modem bridge must succeed");
+
+    let node_frame = env
+        .node_transport
+        .recv(1_000)
+        .expect("node recv must not error")
+        .expect("node must receive gateway response");
+    assert_eq!(node_frame, response);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_052_consecutive_wake_cycles_through_modem_bridge() {
+    let mut env = ModemBridgeEnv::new().await;
+    env.start_gateway_loop();
+
+    let psk = [0x52; 32];
+    env.e2e.register_node("modem-cycles", 1, psk).await;
+
+    let mut node = NodeProxy::new(1, psk);
+
+    let stats1 = node.run_wake_cycle_on(&mut env.node_transport);
+    assert_eq!(stats1.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    let stats2 = node.run_wake_cycle_on(&mut env.node_transport);
+    assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+
+    assert!(!stats1.wake_nonces.is_empty(), "first cycle must send WAKE");
+    assert!(
+        !stats2.wake_nonces.is_empty(),
+        "second cycle must send WAKE"
+    );
+    assert_ne!(stats1.wake_nonces[0], stats2.wake_nonces[0]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_053_wrong_psk_through_modem_bridge() {
+    let mut env = ModemBridgeEnv::new().await;
+    env.start_gateway_loop();
+
+    env.e2e
+        .register_node("modem-wrong-psk", 1, [0xAA; 32])
+        .await;
+
+    let mut node = NodeProxy::new(1, [0xBB; 32]);
+    let stats = node.run_wake_cycle_on(&mut env.node_transport);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+    assert_eq!(stats.response_count, 0);
+    assert!(env
+        .e2e
+        .gateway
+        .session_manager()
+        .get_last_seen("modem-wrong-psk")
+        .await
+        .is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn t_e2e_054_program_update_through_modem_bridge() {
+    use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
+
+    let mut env = ModemBridgeEnv::new().await;
+    env.start_gateway_loop();
+
+    let psk = [0x54; 32];
+    env.e2e.register_node("modem-program-update", 1, psk).await;
+
+    let (program, hash) = make_send_program();
+    env.e2e.storage.store_program(&program).await.unwrap();
+
+    let mut node_record = env
+        .e2e
+        .storage
+        .get_node("modem-program-update")
+        .await
+        .unwrap()
+        .unwrap();
+    node_record.assigned_program_hash = Some(hash.clone());
+    env.e2e.storage.upsert_node(&node_record).await.unwrap();
+
+    let mut node = NodeProxy::new(1, psk);
+    let mut interpreter = SondeBpfInterpreter::new();
+    let stats = node.run_wake_cycle_on_with(&mut env.node_transport, &mut interpreter);
+
+    assert_eq!(stats.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
+    assert!(
+        stats
+            .sent_frames
+            .iter()
+            .any(|(msg_type, _)| *msg_type == sonde_protocol::MSG_GET_CHUNK),
+        "node must request at least one chunk through the modem bridge"
+    );
+    assert_eq!(
+        stats
+            .sent_frames
+            .iter()
+            .filter(|(msg_type, _)| *msg_type == sonde_protocol::MSG_PROGRAM_ACK)
+            .count(),
+        1,
+        "node must send exactly one PROGRAM_ACK through the modem bridge"
+    );
+
+    let updated = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let record = env
+                .e2e
+                .storage
+                .get_node("modem-program-update")
+                .await
+                .unwrap()
+                .unwrap();
+            if record.current_program_hash.is_some() {
+                break record;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("gateway must process PROGRAM_ACK promptly");
+    assert_eq!(updated.current_program_hash, Some(hash));
+}

--- a/crates/sonde-e2e/tests/modem_bridge_tests.rs
+++ b/crates/sonde-e2e/tests/modem_bridge_tests.rs
@@ -127,12 +127,10 @@ impl SerialPort for PipeSerial {
     fn read(&mut self, buf: &mut [u8]) -> (usize, bool) {
         self.drain_incoming();
 
-        let reconnected = if self.first_read {
+        if self.first_read {
             self.first_read = false;
-            self.pending.is_empty()
-        } else {
-            false
-        };
+        }
+        let reconnected = false;
 
         let n = buf.len().min(self.pending.len());
         for slot in &mut buf[..n] {

--- a/crates/sonde-gateway/tests/handler_config.rs
+++ b/crates/sonde-gateway/tests/handler_config.rs
@@ -1398,8 +1398,8 @@ async fn t0514_oversized_handler_message_rejected() {
     );
 }
 
-/// T-0514b: `read_message` accepts well-formed messages and rejects messages
-/// with a length prefix exceeding MAX_MESSAGE_SIZE. Tests the exact boundary.
+/// T-0514b: `read_message` accepts a well-formed message and rejects messages
+/// with a length prefix exceeding MAX_MESSAGE_SIZE.
 #[tokio::test]
 async fn t0514b_handler_message_size_boundary() {
     use sonde_gateway::handler::{read_message, HandlerMessage};

--- a/crates/sonde-gateway/tests/handler_config.rs
+++ b/crates/sonde-gateway/tests/handler_config.rs
@@ -1371,3 +1371,58 @@ handlers:
     assert_eq!(list.handlers[0].program_hash, HASH_A);
     assert_eq!(list.handlers[0].command, "/usr/bin/valid_handler");
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-0514: Oversized handler message rejection
+// ═══════════════════════════════════════════════════════════════════════
+
+/// T-0514: `read_message` rejects frames whose 4-byte length header declares
+/// a body larger than MAX_MESSAGE_SIZE (1 MiB), preventing memory exhaustion
+/// from a misbehaving handler process.
+#[tokio::test]
+async fn t0514_oversized_handler_message_rejected() {
+    use sonde_gateway::handler::read_message;
+
+    const MAX_MESSAGE_SIZE: u32 = 1_048_576;
+    // Length header one byte over the limit; no body needed — the reader
+    // must reject before attempting to allocate or read the body.
+    let data = (MAX_MESSAGE_SIZE + 1).to_be_bytes().to_vec();
+    let mut reader = std::io::Cursor::new(data);
+
+    let result = read_message(&mut reader).await;
+    assert!(result.is_err(), "oversized message must be rejected");
+    assert_eq!(
+        result.unwrap_err().kind(),
+        std::io::ErrorKind::InvalidData,
+        "rejection must use InvalidData error kind"
+    );
+}
+
+/// T-0514b: `read_message` accepts well-formed messages and rejects messages
+/// with a length prefix exceeding MAX_MESSAGE_SIZE. Tests the exact boundary.
+#[tokio::test]
+async fn t0514b_handler_message_size_boundary() {
+    use sonde_gateway::handler::{read_message, HandlerMessage};
+
+    // Build a valid LOG message frame manually: 4-byte BE length + CBOR body.
+    let msg = HandlerMessage::Log {
+        level: "info".to_string(),
+        message: "test".to_string(),
+    };
+    let cbor = msg.encode().unwrap();
+    let mut framed = (cbor.len() as u32).to_be_bytes().to_vec();
+    framed.extend_from_slice(&cbor);
+    let mut reader = std::io::Cursor::new(framed);
+    let decoded = read_message(&mut reader)
+        .await
+        .expect("valid message must decode");
+    assert_eq!(decoded, msg);
+
+    // A frame with length == MAX_MESSAGE_SIZE + 1 must be rejected.
+    const MAX_MESSAGE_SIZE: u32 = 1_048_576;
+    let data = (MAX_MESSAGE_SIZE + 1).to_be_bytes().to_vec();
+    let mut reader2 = std::io::Cursor::new(data);
+    let result = read_message(&mut reader2).await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+}

--- a/crates/sonde-modem/src/display.rs
+++ b/crates/sonde-modem/src/display.rs
@@ -372,7 +372,7 @@ mod tests {
         idle_power.note_frame_accepted_at(t0);
 
         assert_eq!(
-            idle_power.poll_at(
+            idle_power.desired_command_at(
                 t0 + DISPLAY_IDLE_TIMEOUT - Duration::from_secs(1),
                 false,
                 true
@@ -380,11 +380,12 @@ mod tests {
             PanelPowerCommand::None
         );
         assert_eq!(
-            idle_power.poll_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
+            idle_power.desired_command_at(t0 + DISPLAY_IDLE_TIMEOUT, false, true),
             PanelPowerCommand::Sleep
         );
+        idle_power.mark_sleep_succeeded();
         assert_eq!(
-            idle_power.poll_at(
+            idle_power.desired_command_at(
                 t0 + DISPLAY_IDLE_TIMEOUT + Duration::from_secs(1),
                 false,
                 true

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -586,7 +586,9 @@ fn get_chunk_with_retry<T: Transport, A: AeadProvider, S: Sha256Provider>(
         // attempt (F-003), but keep each attempt bounded by the original
         // RESPONSE_TIMEOUT_MS budget so a flood of stale frames cannot keep the
         // node awake indefinitely.
-        let deadline = clock.elapsed_ms().saturating_add(RESPONSE_TIMEOUT_MS as u64);
+        let deadline = clock
+            .elapsed_ms()
+            .saturating_add(RESPONSE_TIMEOUT_MS as u64);
         loop {
             let now = clock.elapsed_ms();
             if now >= deadline {

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -582,28 +582,41 @@ fn get_chunk_with_retry<T: Transport, A: AeadProvider, S: Sha256Provider>(
         );
         *current_seq += 1;
 
-        match transport.recv(RESPONSE_TIMEOUT_MS)? {
-            Some(raw_response) => {
-                match verify_and_decode_chunk(
-                    &raw_response,
-                    identity,
-                    attempt_seq,
-                    chunk_index,
-                    aead,
-                    sha,
-                ) {
-                    Ok(data) => {
-                        log::debug!(
-                            "CHUNK received chunk_index={} len={} (ND-1011)",
-                            chunk_index,
-                            data.len()
-                        );
-                        return Ok(data);
+        // Inner loop: drain stale wrong-type frames without consuming a retry
+        // attempt (F-003). A timeout (None) or a non-stale decode error breaks
+        // to the outer loop, which re-sends GET_CHUNK and counts as a retry.
+        loop {
+            match transport.recv(RESPONSE_TIMEOUT_MS)? {
+                None => break, // timeout — count as a retry attempt
+                Some(raw_response) => {
+                    match verify_and_decode_chunk(
+                        &raw_response,
+                        identity,
+                        attempt_seq,
+                        chunk_index,
+                        aead,
+                        sha,
+                    ) {
+                        Ok(data) => {
+                            log::debug!(
+                                "CHUNK received chunk_index={} len={} (ND-1011)",
+                                chunk_index,
+                                data.len()
+                            );
+                            return Ok(data);
+                        }
+                        Err(NodeError::UnexpectedMsgType(_)) => {
+                            // Stale frame from a different exchange — discard
+                            // and keep waiting without burning a retry attempt.
+                            log::debug!(
+                                "GET_CHUNK: discarding stale frame (wrong msg_type) chunk_index={}",
+                                chunk_index
+                            );
+                        }
+                        Err(_) => break, // auth failure, seq mismatch, etc.
                     }
-                    Err(_) => continue,
                 }
             }
-            None => continue,
         }
     }
 
@@ -1824,6 +1837,75 @@ mod tests {
             assert!(
                 result.is_err(),
                 "wrong chunk index should cause transfer failure"
+            );
+        }
+
+        /// F-003 regression: a stale frame with the wrong msg_type received
+        /// before the correct CHUNK does NOT consume a retry attempt or
+        /// advance `current_seq` a second time.
+        ///
+        /// Before the fix, the `UnexpectedMsgType` error path hit `continue`
+        /// in the outer retry loop, burning one retry for a stale frame.
+        #[test]
+        fn chunked_transfer_stale_wrong_type_frame_does_not_consume_retry() {
+            let psk = [0x55u8; 32];
+            let sha = crate::crypto::SoftwareSha256;
+            let aead = NodeAead;
+            let key_hint = sonde_protocol::key_hint_from_psk(&psk, &sha);
+            let identity = NodeIdentity { key_hint, psk };
+            let clock = MockClock;
+            let mut transport = MockTransport::new();
+
+            let image = sonde_protocol::ProgramImage {
+                bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+                maps: vec![],
+                map_initial_data: vec![],
+            };
+            let image_cbor = image.encode_deterministic().unwrap();
+            let chunk_size = image_cbor.len() as u32; // single chunk
+            let chunk_count = 1u32;
+            let starting_seq = 300u64;
+            let mut current_seq = starting_seq;
+
+            // Queue a stale COMMAND frame (wrong msg_type) then the correct CHUNK.
+            // The stale frame is encrypted with the same PSK so AEAD succeeds, but
+            // msg_type != MSG_CHUNK, triggering UnexpectedMsgType.
+            let stale_frame = make_command(&psk, starting_seq, &CommandPayload::Nop);
+            let correct_chunk = build_chunk_response(&psk, starting_seq, 0, &image_cbor);
+            transport.queue_response(Some(stale_frame));
+            transport.queue_response(Some(correct_chunk));
+
+            let result = chunked_transfer(
+                &mut transport,
+                &identity,
+                &mut current_seq,
+                image_cbor.len() as u32,
+                chunk_size,
+                chunk_count,
+                MAX_RESIDENT_IMAGE_SIZE,
+                &clock,
+                &aead,
+                &sha,
+            );
+
+            assert!(
+                result.is_ok(),
+                "transfer must succeed after discarding stale frame"
+            );
+            assert_eq!(result.unwrap(), image_cbor);
+            // Only one GET_CHUNK was sent (no retry triggered by the stale frame).
+            assert_eq!(
+                transport.outbound.len(),
+                1,
+                "only one GET_CHUNK should be sent"
+            );
+            // Two recv calls: one for the stale frame, one for the correct chunk.
+            assert_eq!(transport.recv_timeouts.len(), 2, "two recv calls expected");
+            // current_seq advanced by exactly 1 (one GET_CHUNK sent).
+            assert_eq!(
+                current_seq,
+                starting_seq + 1,
+                "seq must advance exactly once"
             );
         }
 

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -583,10 +583,17 @@ fn get_chunk_with_retry<T: Transport, A: AeadProvider, S: Sha256Provider>(
         *current_seq += 1;
 
         // Inner loop: drain stale wrong-type frames without consuming a retry
-        // attempt (F-003). A timeout (None) or a non-stale decode error breaks
-        // to the outer loop, which re-sends GET_CHUNK and counts as a retry.
+        // attempt (F-003), but keep each attempt bounded by the original
+        // RESPONSE_TIMEOUT_MS budget so a flood of stale frames cannot keep the
+        // node awake indefinitely.
+        let deadline = clock.elapsed_ms().saturating_add(RESPONSE_TIMEOUT_MS as u64);
         loop {
-            match transport.recv(RESPONSE_TIMEOUT_MS)? {
+            let now = clock.elapsed_ms();
+            if now >= deadline {
+                break;
+            }
+            let remaining = (deadline - now) as u32;
+            match transport.recv(remaining)? {
                 None => break, // timeout — count as a retry attempt
                 Some(raw_response) => {
                     match verify_and_decode_chunk(
@@ -1906,6 +1913,86 @@ mod tests {
                 current_seq,
                 starting_seq + 1,
                 "seq must advance exactly once"
+            );
+        }
+
+        struct AdvancingClock(std::cell::Cell<u64>);
+        impl Clock for AdvancingClock {
+            fn elapsed_ms(&self) -> u64 {
+                let now = self.0.get();
+                self.0.set(now + 1);
+                now
+            }
+
+            fn delay_ms(&self, _ms: u32) {}
+        }
+
+        struct InfiniteStaleTransport {
+            outbound: Vec<Vec<u8>>,
+            stale_frame: Vec<u8>,
+            recv_calls: usize,
+        }
+
+        impl Transport for InfiniteStaleTransport {
+            fn send(&mut self, frame: &[u8]) -> NodeResult<()> {
+                self.outbound.push(frame.to_vec());
+                Ok(())
+            }
+
+            fn recv(&mut self, timeout_ms: u32) -> NodeResult<Option<Vec<u8>>> {
+                self.recv_calls += 1;
+                if timeout_ms == 0 {
+                    return Ok(None);
+                }
+                Ok(Some(self.stale_frame.clone()))
+            }
+        }
+
+        #[test]
+        fn chunked_transfer_stale_wrong_type_frames_are_bounded_per_attempt() {
+            let psk = [0x56u8; 32];
+            let sha = crate::crypto::SoftwareSha256;
+            let aead = NodeAead;
+            let key_hint = sonde_protocol::key_hint_from_psk(&psk, &sha);
+            let identity = NodeIdentity { key_hint, psk };
+            let clock = AdvancingClock(std::cell::Cell::new(0));
+            let starting_seq = 700u64;
+            let stale_frame = make_command(&psk, starting_seq, &CommandPayload::Nop);
+            let mut transport = InfiniteStaleTransport {
+                outbound: Vec::new(),
+                stale_frame,
+                recv_calls: 0,
+            };
+            let mut current_seq = starting_seq;
+
+            let err = get_chunk_with_retry(
+                &mut transport,
+                &identity,
+                &mut current_seq,
+                0,
+                &clock,
+                &aead,
+                &sha,
+            )
+            .expect_err("stale-frame flood should eventually time out");
+
+            assert!(
+                matches!(err, NodeError::ChunkTransferFailed { chunk_index: 0 }),
+                "expected bounded retry exhaustion, got {err:?}"
+            );
+            assert_eq!(
+                transport.outbound.len(),
+                (MAX_RETRIES + 1) as usize,
+                "each attempt should still send at most one GET_CHUNK"
+            );
+            assert_eq!(
+                current_seq,
+                starting_seq + (MAX_RETRIES + 1) as u64,
+                "sequence should advance once per retry attempt"
+            );
+            assert!(
+                transport.recv_calls < 1000,
+                "per-attempt stale-frame draining must remain bounded"
             );
         }
 

--- a/crates/sonde-pair/src/android_store.rs
+++ b/crates/sonde-pair/src/android_store.rs
@@ -34,6 +34,7 @@ use tracing::debug;
 use zeroize::Zeroizing;
 
 use crate::error::PairingError;
+use crate::store::PairingStore;
 
 /// Cached JavaVM for creating stores on demand (set in `JNI_OnLoad`).
 static CACHED_STORE_VM: OnceLock<JavaVM> = OnceLock::new();
@@ -159,7 +160,7 @@ impl AndroidPairingStore {
 
     /// Save AEAD pairing artifacts to encrypted SharedPreferences.
     pub fn save_artifacts(
-        &mut self,
+        &self,
         artifacts: &crate::phase1::PairingArtifacts,
     ) -> Result<(), PairingError> {
         self.vm.attach_current_thread(|env| {
@@ -220,7 +221,7 @@ impl AndroidPairingStore {
     }
 
     /// Clear all pairing artifacts from encrypted SharedPreferences.
-    pub fn clear(&mut self) -> Result<(), PairingError> {
+    pub fn clear(&self) -> Result<(), PairingError> {
         self.vm
             .attach_current_thread(|env| {
                 env.call_method(self.store.as_obj(), jni_str!("clear"), jni_sig!("()V"), &[])
@@ -234,6 +235,27 @@ impl AndroidPairingStore {
                 }
                 other => other,
             })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PairingStore trait impl
+// ---------------------------------------------------------------------------
+
+impl PairingStore for AndroidPairingStore {
+    fn save_artifacts(
+        &self,
+        artifacts: &crate::phase1::PairingArtifacts,
+    ) -> Result<(), PairingError> {
+        self.save_artifacts(artifacts)
+    }
+
+    fn load_artifacts(&self) -> Result<Option<crate::phase1::PairingArtifacts>, PairingError> {
+        self.load_artifacts()
+    }
+
+    fn clear(&self) -> Result<(), PairingError> {
+        self.clear()
     }
 }
 

--- a/crates/sonde-pair/src/android_store.rs
+++ b/crates/sonde-pair/src/android_store.rs
@@ -247,15 +247,15 @@ impl PairingStore for AndroidPairingStore {
         &self,
         artifacts: &crate::phase1::PairingArtifacts,
     ) -> Result<(), PairingError> {
-        self.save_artifacts(artifacts)
+        AndroidPairingStore::save_artifacts(self, artifacts)
     }
 
     fn load_artifacts(&self) -> Result<Option<crate::phase1::PairingArtifacts>, PairingError> {
-        self.load_artifacts()
+        AndroidPairingStore::load_artifacts(self)
     }
 
     fn clear(&self) -> Result<(), PairingError> {
-        self.clear()
+        AndroidPairingStore::clear(self)
     }
 }
 

--- a/crates/sonde-pair/src/file_store.rs
+++ b/crates/sonde-pair/src/file_store.rs
@@ -17,9 +17,11 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::error::PairingError;
+use crate::store::PairingStore;
 
 // ---------------------------------------------------------------------------
 // PskProtector trait
@@ -80,9 +82,26 @@ pub fn default_protector() -> Option<Box<dyn PskProtector>> {
 // Serialisation types
 // ---------------------------------------------------------------------------
 
+/// On-disk pairing record.
+///
+/// Exactly one of `phone_psk` (legacy / no-protector) or `phone_psk_protected`
+/// (protector-encrypted) must be present on any valid record.  Both fields are
+/// optional in the schema to support the migration path:
+///
+/// | Field present         | Meaning                                       |
+/// |-----------------------|-----------------------------------------------|
+/// | `phone_psk` only      | Legacy plaintext; written before a protector  |
+/// |                       | was configured.                               |
+/// | `phone_psk_protected` | PSK encrypted by the configured protector.    |
+/// | neither               | Corrupted record — rejected on load.          |
 #[derive(Serialize, Deserialize)]
 struct StoredArtifacts {
-    phone_psk: String,
+    /// Plaintext hex PSK.  Present in legacy files or when no protector is attached.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    phone_psk: Option<String>,
+    /// Protector-encrypted PSK (hex-encoded opaque bytes).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    phone_psk_protected: Option<String>,
     phone_key_hint: u16,
     rf_channel: u8,
     phone_label: String,
@@ -135,6 +154,9 @@ impl FilePairingStore {
     }
 
     /// Save AEAD pairing artifacts to a companion file (`pairing-aead.json`).
+    ///
+    /// If a [`PskProtector`] is attached, the PSK is encrypted and stored in the
+    /// `phone_psk_protected` field; the plaintext `phone_psk` field is omitted.
     pub fn save_artifacts(
         &self,
         artifacts: &crate::phase1::PairingArtifacts,
@@ -144,8 +166,16 @@ impl FilePairingStore {
             fs::create_dir_all(parent).map_err(|e| PairingError::StoreSaveFailed(e.to_string()))?;
         }
 
+        let (phone_psk, phone_psk_protected) = if let Some(ref protector) = self.protector {
+            let protected = protector.protect(&artifacts.phone_psk)?;
+            (None, Some(to_hex(&protected)))
+        } else {
+            (Some(to_hex(&*artifacts.phone_psk)), None)
+        };
+
         let stored = StoredArtifacts {
-            phone_psk: to_hex(&*artifacts.phone_psk),
+            phone_psk,
+            phone_psk_protected,
             phone_key_hint: artifacts.phone_key_hint,
             rf_channel: artifacts.rf_channel,
             phone_label: artifacts.phone_label.clone(),
@@ -168,6 +198,11 @@ impl FilePairingStore {
     }
 
     /// Load AEAD pairing artifacts from the companion file.
+    ///
+    /// Handles both the current protected format and the legacy plaintext format.
+    /// When a [`PskProtector`] is configured and a plaintext `phone_psk` is found,
+    /// the PSK is decrypted from plaintext and a warning is emitted; the next call
+    /// to [`save_artifacts`](Self::save_artifacts) will re-write it in protected form.
     pub fn load_artifacts(&self) -> Result<Option<crate::phase1::PairingArtifacts>, PairingError> {
         let aead_path = self.aead_path();
         let bytes = match fs::read(&aead_path) {
@@ -180,10 +215,45 @@ impl FilePairingStore {
             PairingError::StoreCorrupted(format!("{e}: delete or fix {}", aead_path.display()))
         })?;
 
-        let mut psk_bytes = from_hex(&stored.phone_psk, 32)?;
         let mut psk = Zeroizing::new([0u8; 32]);
-        psk.copy_from_slice(&psk_bytes);
-        psk_bytes.zeroize();
+
+        match (
+            &stored.phone_psk_protected,
+            &stored.phone_psk,
+            &self.protector,
+        ) {
+            (Some(protected_hex), _, Some(protector)) => {
+                // Protected path: use the configured protector to decrypt.
+                let protected_bytes = from_hex(protected_hex, protected_hex.len() / 2)?;
+                let unprotected = protector.unprotect(&protected_bytes)?;
+                *psk = *unprotected;
+            }
+            (Some(_), _, None) => {
+                return Err(PairingError::StoreCorrupted(
+                    "phone_psk_protected present but no PskProtector is configured; \
+                     reconfigure with the correct protector or delete the store"
+                        .into(),
+                ));
+            }
+            (None, Some(plain_hex), Some(_)) => {
+                // Legacy migration: plaintext PSK with a protector now configured.
+                warn!("phone_psk stored in plaintext — will be encrypted on next save");
+                let mut psk_bytes = from_hex(plain_hex, 32)?;
+                psk.copy_from_slice(&psk_bytes);
+                psk_bytes.zeroize();
+            }
+            (None, Some(plain_hex), None) => {
+                // No protector configured; use plaintext as before.
+                let mut psk_bytes = from_hex(plain_hex, 32)?;
+                psk.copy_from_slice(&psk_bytes);
+                psk_bytes.zeroize();
+            }
+            (None, None, _) => {
+                return Err(PairingError::StoreCorrupted(
+                    "neither phone_psk nor phone_psk_protected is present in the store".into(),
+                ));
+            }
+        }
 
         // Recompute key_hint from PSK to detect corruption.
         let expected_hint = crate::validation::compute_key_hint(&psk);
@@ -202,20 +272,50 @@ impl FilePairingStore {
     }
 
     /// Clear AEAD artifacts file (`pairing-aead.json`).
+    ///
+    /// Also calls [`PskProtector::clear_protected`] if a protector is configured,
+    /// to remove any externally stored protected material.
     pub fn clear(&self) -> Result<(), PairingError> {
         let aead_path = self.aead_path();
         // Also remove any leftover temp file from a crashed save.
         let tmp_path = aead_path.with_extension("tmp");
         let _ = fs::remove_file(&tmp_path);
-        match fs::remove_file(&aead_path) {
+        let result = match fs::remove_file(&aead_path) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(PairingError::StoreSaveFailed(e.to_string())),
+        };
+        if result.is_ok() {
+            if let Some(ref protector) = self.protector {
+                protector.clear_protected()?;
+            }
         }
+        result
     }
 
     fn aead_path(&self) -> PathBuf {
         self.path.with_file_name("pairing-aead.json")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PairingStore trait impl
+// ---------------------------------------------------------------------------
+
+impl PairingStore for FilePairingStore {
+    fn save_artifacts(
+        &self,
+        artifacts: &crate::phase1::PairingArtifacts,
+    ) -> Result<(), PairingError> {
+        self.save_artifacts(artifacts)
+    }
+
+    fn load_artifacts(&self) -> Result<Option<crate::phase1::PairingArtifacts>, PairingError> {
+        self.load_artifacts()
+    }
+
+    fn clear(&self) -> Result<(), PairingError> {
+        self.clear()
     }
 }
 
@@ -278,6 +378,7 @@ fn default_path() -> Result<PathBuf, PairingError> {
 mod tests {
     use super::*;
     use crate::phase1::PairingArtifacts;
+    use crate::store::PairingStore;
     use crate::validation::compute_key_hint;
     use tempfile::TempDir;
 
@@ -296,6 +397,10 @@ mod tests {
         let store = FilePairingStore::with_path(dir.path().join("pairing.json"));
         (store, dir)
     }
+
+    // -----------------------------------------------------------------------
+    // Plaintext (no protector) round-trip — existing behaviour preserved
+    // -----------------------------------------------------------------------
 
     #[test]
     fn aead_save_and_load_round_trip() {
@@ -335,6 +440,191 @@ mod tests {
         let (store, _dir) = temp_store();
         store.clear().unwrap();
     }
+
+    // -----------------------------------------------------------------------
+    // PairingStore trait delegation
+    // -----------------------------------------------------------------------
+
+    /// Validates: PT-0802 — FilePairingStore works via the PairingStore trait object.
+    #[test]
+    fn file_store_implements_pairing_store_trait() {
+        let dir = TempDir::new().unwrap();
+        let store = FilePairingStore::with_path(dir.path().join("pairing.json"));
+        let dyn_store: &dyn PairingStore = &store;
+
+        let artifacts = test_artifacts();
+        dyn_store.save_artifacts(&artifacts).unwrap();
+        let loaded = dyn_store.load_artifacts().unwrap().unwrap();
+        assert_eq!(*loaded.phone_psk, *artifacts.phone_psk);
+
+        dyn_store.clear().unwrap();
+        assert!(dyn_store.load_artifacts().unwrap().is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // MockPskProtector — used for protector-path tests
+    // -----------------------------------------------------------------------
+
+    /// Identity protector for tests: protect = prepend 0xFF byte; unprotect = strip it.
+    struct MockPskProtector;
+
+    impl PskProtector for MockPskProtector {
+        fn protect(&self, psk: &[u8; 32]) -> Result<Vec<u8>, PairingError> {
+            let mut v = vec![0xFF];
+            v.extend_from_slice(psk);
+            Ok(v)
+        }
+
+        fn unprotect(&self, protected: &[u8]) -> Result<Zeroizing<[u8; 32]>, PairingError> {
+            if protected.len() != 33 || protected[0] != 0xFF {
+                return Err(PairingError::StoreCorrupted(
+                    "MockPskProtector: bad blob".into(),
+                ));
+            }
+            let mut out = Zeroizing::new([0u8; 32]);
+            out.copy_from_slice(&protected[1..]);
+            Ok(out)
+        }
+    }
+
+    fn temp_store_with_protector() -> (FilePairingStore, TempDir) {
+        let dir = TempDir::new().expect("failed to create temp dir");
+        let store = FilePairingStore::with_path(dir.path().join("pairing.json"))
+            .with_protector(Box::new(MockPskProtector));
+        (store, dir)
+    }
+
+    // -----------------------------------------------------------------------
+    // Protected round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn protected_save_writes_phone_psk_protected_field() {
+        let (store, dir) = temp_store_with_protector();
+        store.save_artifacts(&test_artifacts()).unwrap();
+
+        let raw = std::fs::read_to_string(dir.path().join("pairing-aead.json")).unwrap();
+        assert!(
+            raw.contains("phone_psk_protected"),
+            "expected phone_psk_protected in JSON: {raw}"
+        );
+        assert!(
+            !raw.contains("\"phone_psk\""),
+            "plaintext phone_psk must not appear in JSON: {raw}"
+        );
+    }
+
+    #[test]
+    fn protected_round_trip() {
+        let (store, _dir) = temp_store_with_protector();
+        let artifacts = test_artifacts();
+        store.save_artifacts(&artifacts).unwrap();
+
+        let loaded = store.load_artifacts().unwrap().unwrap();
+        assert_eq!(*loaded.phone_psk, *artifacts.phone_psk);
+        assert_eq!(loaded.phone_key_hint, artifacts.phone_key_hint);
+        assert_eq!(loaded.rf_channel, artifacts.rf_channel);
+        assert_eq!(loaded.phone_label, artifacts.phone_label);
+    }
+
+    // -----------------------------------------------------------------------
+    // Legacy migration: plaintext store loaded with protector configured
+    // -----------------------------------------------------------------------
+
+    /// Validates: PT-0801 migration path — plaintext PSK is accepted on load
+    /// when a protector is configured (and a warning is emitted).
+    #[test]
+    fn legacy_migration_plaintext_loaded_with_protector() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("pairing.json");
+        let artifacts = test_artifacts();
+
+        // Write a legacy plaintext store (no protector).
+        {
+            let store = FilePairingStore::with_path(path.clone());
+            store.save_artifacts(&artifacts).unwrap();
+        }
+
+        // Re-open with a protector — should accept the plaintext PSK.
+        let store = FilePairingStore::with_path(path).with_protector(Box::new(MockPskProtector));
+        let loaded = store.load_artifacts().unwrap().unwrap();
+        assert_eq!(*loaded.phone_psk, *artifacts.phone_psk);
+    }
+
+    /// Next save after migration writes protected form.
+    #[test]
+    fn legacy_migration_next_save_writes_protected() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("pairing.json");
+        let artifacts = test_artifacts();
+
+        // Write plaintext.
+        FilePairingStore::with_path(path.clone())
+            .save_artifacts(&artifacts)
+            .unwrap();
+
+        // Load with protector, then save again.
+        {
+            let store = FilePairingStore::with_path(path.clone())
+                .with_protector(Box::new(MockPskProtector));
+            let loaded = store.load_artifacts().unwrap().unwrap();
+            store.save_artifacts(&loaded).unwrap();
+        }
+
+        // Verify the file now contains phone_psk_protected.
+        let raw = std::fs::read_to_string(dir.path().join("pairing-aead.json")).unwrap();
+        assert!(
+            raw.contains("phone_psk_protected"),
+            "after migration save, expected phone_psk_protected: {raw}"
+        );
+        assert!(
+            !raw.contains("\"phone_psk\""),
+            "after migration save, plaintext phone_psk must be absent: {raw}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Error cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn protected_field_without_protector_is_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("pairing.json");
+
+        // Write protected store.
+        FilePairingStore::with_path(path.clone())
+            .with_protector(Box::new(MockPskProtector))
+            .save_artifacts(&test_artifacts())
+            .unwrap();
+
+        // Load without a protector — must return StoreCorrupted.
+        let store = FilePairingStore::with_path(path);
+        let err = store.load_artifacts().unwrap_err();
+        assert!(
+            err.to_string().contains("corrupted"),
+            "expected corrupted error: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_both_psk_fields_is_error() {
+        let dir = TempDir::new().unwrap();
+        let aead = dir.path().join("pairing-aead.json");
+        std::fs::write(
+            &aead,
+            r#"{"phone_key_hint":1234,"rf_channel":6,"phone_label":"x"}"#,
+        )
+        .unwrap();
+
+        let store = FilePairingStore::with_path(dir.path().join("pairing.json"));
+        let err = store.load_artifacts().unwrap_err();
+        assert!(err.to_string().contains("corrupted"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Hex helpers
+    // -----------------------------------------------------------------------
 
     #[test]
     fn hex_round_trip() {

--- a/crates/sonde-pair/src/file_store.rs
+++ b/crates/sonde-pair/src/file_store.rs
@@ -209,7 +209,7 @@ impl FilePairingStore {
     ///
     /// Handles both the current protected format and the legacy plaintext format.
     /// When a [`PskProtector`] is configured and a plaintext `phone_psk` is found,
-    /// the PSK is decrypted from plaintext and a warning is emitted; the next call
+    /// the PSK is loaded from plaintext and a warning is emitted; the next call
     /// to [`save_artifacts`](Self::save_artifacts) will re-write it in protected form.
     pub fn load_artifacts(&self) -> Result<Option<crate::phase1::PairingArtifacts>, PairingError> {
         let aead_path = self.aead_path();

--- a/crates/sonde-pair/src/file_store.rs
+++ b/crates/sonde-pair/src/file_store.rs
@@ -327,15 +327,15 @@ impl PairingStore for FilePairingStore {
         &self,
         artifacts: &crate::phase1::PairingArtifacts,
     ) -> Result<(), PairingError> {
-        self.save_artifacts(artifacts)
+        FilePairingStore::save_artifacts(self, artifacts)
     }
 
     fn load_artifacts(&self) -> Result<Option<crate::phase1::PairingArtifacts>, PairingError> {
-        self.load_artifacts()
+        FilePairingStore::load_artifacts(self)
     }
 
     fn clear(&self) -> Result<(), PairingError> {
-        self.clear()
+        FilePairingStore::clear(self)
     }
 }
 

--- a/crates/sonde-pair/src/file_store.rs
+++ b/crates/sonde-pair/src/file_store.rs
@@ -90,8 +90,8 @@ const MAX_PROTECTED_PSK_BLOB_LEN: usize = 4096;
 
 /// On-disk pairing record.
 ///
-/// Exactly one of `phone_psk` (legacy / no-protector) or `phone_psk_protected`
-/// (protector-encrypted) must be present on any valid record.  Both fields are
+/// At least one of `phone_psk` (legacy / no-protector) or `phone_psk_protected`
+/// (protector-encrypted) must be present on any valid record. Both fields are
 /// optional in the schema to support the migration path:
 ///
 /// | Field present         | Meaning                                       |
@@ -99,6 +99,8 @@ const MAX_PROTECTED_PSK_BLOB_LEN: usize = 4096;
 /// | `phone_psk` only      | Legacy plaintext; written before a protector  |
 /// |                       | was configured.                               |
 /// | `phone_psk_protected` | PSK encrypted by the configured protector.    |
+/// | both                  | Migration-compatible record; load logic       |
+/// |                       | selects the appropriate representation.       |
 /// | neither               | Corrupted record — rejected on load.          |
 #[derive(Serialize, Deserialize)]
 struct StoredArtifacts {

--- a/crates/sonde-pair/src/file_store.rs
+++ b/crates/sonde-pair/src/file_store.rs
@@ -78,6 +78,12 @@ pub fn default_protector() -> Option<Box<dyn PskProtector>> {
     None
 }
 
+/// Maximum accepted size for a protected PSK blob before hex decoding.
+///
+/// The protected form is opaque and backend-specific, but it should remain
+/// comfortably below this bound for the currently supported protectors.
+const MAX_PROTECTED_PSK_BLOB_LEN: usize = 4096;
+
 // ---------------------------------------------------------------------------
 // Serialisation types
 // ---------------------------------------------------------------------------
@@ -167,7 +173,7 @@ impl FilePairingStore {
         }
 
         let (phone_psk, phone_psk_protected) = if let Some(ref protector) = self.protector {
-            let protected = protector.protect(&artifacts.phone_psk)?;
+            let protected = Zeroizing::new(protector.protect(&artifacts.phone_psk)?);
             (None, Some(to_hex(&protected)))
         } else {
             (Some(to_hex(&*artifacts.phone_psk)), None)
@@ -224,7 +230,19 @@ impl FilePairingStore {
         ) {
             (Some(protected_hex), _, Some(protector)) => {
                 // Protected path: use the configured protector to decrypt.
-                let protected_bytes = from_hex(protected_hex, protected_hex.len() / 2)?;
+                if protected_hex.len() % 2 != 0 {
+                    return Err(PairingError::StoreCorrupted(
+                        "phone_psk_protected must contain an even number of hex chars".into(),
+                    ));
+                }
+                let protected_len = protected_hex.len() / 2;
+                if protected_len > MAX_PROTECTED_PSK_BLOB_LEN {
+                    return Err(PairingError::StoreCorrupted(format!(
+                        "phone_psk_protected exceeds maximum supported size ({} bytes)",
+                        MAX_PROTECTED_PSK_BLOB_LEN
+                    )));
+                }
+                let protected_bytes = Zeroizing::new(from_hex(protected_hex, protected_len)?);
                 let unprotected = protector.unprotect(&protected_bytes)?;
                 *psk = *unprotected;
             }

--- a/crates/sonde-pair/src/file_store.rs
+++ b/crates/sonde-pair/src/file_store.rs
@@ -248,7 +248,14 @@ impl FilePairingStore {
                 let unprotected = protector.unprotect(&protected_bytes)?;
                 *psk = *unprotected;
             }
-            (Some(_), _, None) => {
+            (Some(_), Some(plain_hex), None) => {
+                // Downgrade/migration path: a record may temporarily contain both
+                // forms. Without a protector, fall back to the plaintext copy.
+                let mut psk_bytes = from_hex(plain_hex, 32)?;
+                psk.copy_from_slice(&psk_bytes);
+                psk_bytes.zeroize();
+            }
+            (Some(_), None, None) => {
                 return Err(PairingError::StoreCorrupted(
                     "phone_psk_protected present but no PskProtector is configured; \
                      reconfigure with the correct protector or delete the store"
@@ -625,6 +632,35 @@ mod tests {
             err.to_string().contains("corrupted"),
             "expected corrupted error: {err}"
         );
+    }
+
+    #[test]
+    fn both_psk_fields_without_protector_fall_back_to_plaintext() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("pairing.json");
+        let store = FilePairingStore::with_path(path.clone());
+        let artifacts = test_artifacts();
+        let mut protected_blob = vec![0x55; 16];
+
+        std::fs::write(
+            store.aead_path(),
+            serde_json::json!({
+                "phone_psk": to_hex(&*artifacts.phone_psk),
+                "phone_psk_protected": to_hex(&protected_blob),
+                "phone_key_hint": artifacts.phone_key_hint,
+                "rf_channel": artifacts.rf_channel,
+                "phone_label": artifacts.phone_label,
+            })
+            .to_string(),
+        )
+        .unwrap();
+        protected_blob.zeroize();
+
+        let loaded = store.load_artifacts().unwrap().unwrap();
+        assert_eq!(*loaded.phone_psk, *artifacts.phone_psk);
+        assert_eq!(loaded.phone_key_hint, artifacts.phone_key_hint);
+        assert_eq!(loaded.rf_channel, artifacts.rf_channel);
+        assert_eq!(loaded.phone_label, artifacts.phone_label);
     }
 
     #[test]

--- a/crates/sonde-pair/src/lib.rs
+++ b/crates/sonde-pair/src/lib.rs
@@ -21,6 +21,10 @@ pub mod transport;
 pub mod types;
 pub mod validation;
 
+// Re-export the core storage trait and the in-memory mock so consumers can
+// use them without a fully-qualified path.
+pub use store::{MockPairingStore, PairingStore};
+
 #[cfg(feature = "btleplug")]
 pub mod btleplug_transport;
 

--- a/crates/sonde-pair/src/store.rs
+++ b/crates/sonde-pair/src/store.rs
@@ -95,8 +95,7 @@ impl MockPairingStore {
     ///
     /// The injected error is consumed once; subsequent calls return the stored value.
     pub fn set_load_error(&self, error: PairingError) {
-        self
-            .lock_inner()
+        self.lock_inner()
             .expect("MockPairingStore mutex poisoned during test setup")
             .load_error = Some(error);
     }

--- a/crates/sonde-pair/src/store.rs
+++ b/crates/sonde-pair/src/store.rs
@@ -1,2 +1,215 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 sonde contributors
+
+//! `PairingStore` trait and [`MockPairingStore`] in-memory implementation.
+//!
+//! # Trait
+//!
+//! All platform-specific storage backends implement [`PairingStore`] (PT-0802):
+//!
+//! - [`crate::file_store::FilePairingStore`] — JSON file (desktop, `file-store` feature).
+//! - [`crate::android_store::AndroidPairingStore`] — `EncryptedSharedPreferences` via JNI
+//!   (`android` feature).
+//! - [`MockPairingStore`] — in-memory implementation for tests.
+//!
+//! # Testing
+//!
+//! [`MockPairingStore`] is an in-memory implementation backed by a `Mutex`.  It can be
+//! pre-loaded with test data and optionally configured to inject a corruption error on
+//! `load_artifacts()`.
+
+use std::sync::Mutex;
+
+use crate::error::PairingError;
+use crate::phase1::PairingArtifacts;
+
+// ---------------------------------------------------------------------------
+// PairingStore trait
+// ---------------------------------------------------------------------------
+
+/// Abstraction over persistent pairing-artifact storage (PT-0802).
+///
+/// Every method takes `&self` — implementations that need internal mutation
+/// (e.g. `Mutex`-protected state) do so internally.
+pub trait PairingStore: Send + Sync {
+    /// Persist pairing artifacts, overwriting any previously stored value.
+    fn save_artifacts(&self, artifacts: &PairingArtifacts) -> Result<(), PairingError>;
+
+    /// Load previously persisted artifacts.
+    ///
+    /// Returns `Ok(None)` if nothing has been saved yet.
+    fn load_artifacts(&self) -> Result<Option<PairingArtifacts>, PairingError>;
+
+    /// Erase all persisted artifacts.
+    ///
+    /// Idempotent — returns `Ok(())` even if nothing was stored.
+    fn clear(&self) -> Result<(), PairingError>;
+}
+
+// ---------------------------------------------------------------------------
+// MockPairingStore
+// ---------------------------------------------------------------------------
+
+struct MockInner {
+    artifacts: Option<PairingArtifacts>,
+    /// When `Some`, the next `load_artifacts` call returns this error.
+    load_error: Option<PairingError>,
+}
+
+/// In-memory [`PairingStore`] for tests (PT-0802).
+///
+/// Thread-safe via an internal `Mutex`.  Can be pre-loaded with artifacts
+/// and optionally configured to simulate corruption on the next load.
+pub struct MockPairingStore {
+    inner: Mutex<MockInner>,
+}
+
+impl Default for MockPairingStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MockPairingStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(MockInner {
+                artifacts: None,
+                load_error: None,
+            }),
+        }
+    }
+
+    /// Create a store pre-loaded with `artifacts`.
+    pub fn with_artifacts(artifacts: PairingArtifacts) -> Self {
+        Self {
+            inner: Mutex::new(MockInner {
+                artifacts: Some(artifacts),
+                load_error: None,
+            }),
+        }
+    }
+
+    /// Configure the store to return `error` on the **next** `load_artifacts` call.
+    ///
+    /// The injected error is consumed once; subsequent calls return the stored value.
+    pub fn set_load_error(&self, error: PairingError) {
+        self.inner.lock().unwrap().load_error = Some(error);
+    }
+}
+
+impl PairingStore for MockPairingStore {
+    fn save_artifacts(&self, artifacts: &PairingArtifacts) -> Result<(), PairingError> {
+        self.inner.lock().unwrap().artifacts = Some(artifacts.clone());
+        Ok(())
+    }
+
+    fn load_artifacts(&self) -> Result<Option<PairingArtifacts>, PairingError> {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(err) = inner.load_error.take() {
+            return Err(err);
+        }
+        Ok(inner.artifacts.clone())
+    }
+
+    fn clear(&self) -> Result<(), PairingError> {
+        self.inner.lock().unwrap().artifacts = None;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::phase1::PairingArtifacts;
+    use crate::validation::compute_key_hint;
+    use zeroize::Zeroizing;
+
+    fn test_artifacts() -> PairingArtifacts {
+        let psk = [0x42u8; 32];
+        PairingArtifacts {
+            phone_psk: Zeroizing::new(psk),
+            phone_key_hint: compute_key_hint(&psk),
+            rf_channel: 6,
+            phone_label: "test-phone".into(),
+        }
+    }
+
+    /// Validates: PT-0802 (T-PT-601) — MockPairingStore implements PairingStore trait.
+    ///
+    /// Accepts a `&dyn PairingStore` to confirm trait-object dispatch works.
+    fn exercise_store(store: &dyn PairingStore) {
+        let artifacts = test_artifacts();
+        store.save_artifacts(&artifacts).unwrap();
+
+        let loaded = store
+            .load_artifacts()
+            .unwrap()
+            .expect("should have artifacts");
+        assert_eq!(*loaded.phone_psk, *artifacts.phone_psk);
+        assert_eq!(loaded.phone_key_hint, artifacts.phone_key_hint);
+        assert_eq!(loaded.rf_channel, artifacts.rf_channel);
+        assert_eq!(loaded.phone_label, artifacts.phone_label);
+
+        store.clear().unwrap();
+        assert!(store.load_artifacts().unwrap().is_none());
+    }
+
+    /// Validates: PT-0802 — mock store works via `PairingStore` trait object.
+    #[test]
+    fn t_pt_601_mock_store_implements_pairing_store_trait() {
+        let store = MockPairingStore::new();
+        exercise_store(&store);
+    }
+
+    #[test]
+    fn mock_store_load_missing_returns_none() {
+        let store = MockPairingStore::new();
+        assert!(store.load_artifacts().unwrap().is_none());
+    }
+
+    #[test]
+    fn mock_store_clear_missing_is_ok() {
+        let store = MockPairingStore::new();
+        store.clear().unwrap();
+    }
+
+    #[test]
+    fn mock_store_with_artifacts_preloaded() {
+        let artifacts = test_artifacts();
+        let store = MockPairingStore::with_artifacts(artifacts.clone());
+        let loaded = store.load_artifacts().unwrap().unwrap();
+        assert_eq!(*loaded.phone_psk, *artifacts.phone_psk);
+    }
+
+    #[test]
+    fn mock_store_load_error_injection() {
+        let store = MockPairingStore::new();
+        store.set_load_error(PairingError::StoreCorrupted("injected".into()));
+
+        let err = store.load_artifacts().unwrap_err();
+        assert!(err.to_string().contains("corrupted"));
+
+        // Error consumed — subsequent load returns None (empty store).
+        assert!(store.load_artifacts().unwrap().is_none());
+    }
+
+    #[test]
+    fn mock_store_overwrite() {
+        let store = MockPairingStore::new();
+        let artifacts = test_artifacts();
+        store.save_artifacts(&artifacts).unwrap();
+
+        let mut updated = artifacts.clone();
+        updated.rf_channel = 11;
+        store.save_artifacts(&updated).unwrap();
+
+        let loaded = store.load_artifacts().unwrap().unwrap();
+        assert_eq!(loaded.rf_channel, 11);
+    }
+}

--- a/crates/sonde-pair/src/store.rs
+++ b/crates/sonde-pair/src/store.rs
@@ -18,7 +18,7 @@
 //! pre-loaded with test data and optionally configured to inject a corruption error on
 //! `load_artifacts()`.
 
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 use crate::error::PairingError;
 use crate::phase1::PairingArtifacts;
@@ -95,18 +95,27 @@ impl MockPairingStore {
     ///
     /// The injected error is consumed once; subsequent calls return the stored value.
     pub fn set_load_error(&self, error: PairingError) {
-        self.inner.lock().unwrap().load_error = Some(error);
+        self
+            .lock_inner()
+            .expect("MockPairingStore mutex poisoned during test setup")
+            .load_error = Some(error);
+    }
+
+    fn lock_inner(&self) -> Result<MutexGuard<'_, MockInner>, PairingError> {
+        self.inner
+            .lock()
+            .map_err(|_| PairingError::StoreCorrupted("MockPairingStore mutex poisoned".into()))
     }
 }
 
 impl PairingStore for MockPairingStore {
     fn save_artifacts(&self, artifacts: &PairingArtifacts) -> Result<(), PairingError> {
-        self.inner.lock().unwrap().artifacts = Some(artifacts.clone());
+        self.lock_inner()?.artifacts = Some(artifacts.clone());
         Ok(())
     }
 
     fn load_artifacts(&self) -> Result<Option<PairingArtifacts>, PairingError> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock_inner()?;
         if let Some(err) = inner.load_error.take() {
             return Err(err);
         }
@@ -114,7 +123,7 @@ impl PairingStore for MockPairingStore {
     }
 
     fn clear(&self) -> Result<(), PairingError> {
-        self.inner.lock().unwrap().artifacts = None;
+        self.lock_inner()?.artifacts = None;
         Ok(())
     }
 }

--- a/crates/sonde-protocol/tests/validation.rs
+++ b/crates/sonde-protocol/tests/validation.rs
@@ -1518,13 +1518,13 @@ fn test_p064() {
 }
 
 // ---------------------------------------------------------------------------
-// T-P090: CommandPayload::command_type() derivation covers all variants
+// T-P091: CommandPayload::command_type() derivation covers all variants
 // ---------------------------------------------------------------------------
 
 /// Verify that `CommandPayload::command_type()` returns the correct wire code
 /// for every variant, and that encode → decode round-trips preserve it.
 #[test]
-fn test_p090_command_type_derived_from_payload() {
+fn test_p091_command_type_derived_from_payload() {
     let variants: Vec<(CommandPayload, u8)> = vec![
         (CommandPayload::Nop, CMD_NOP),
         (
@@ -2574,4 +2574,287 @@ fn test_p019a_decode_frame_too_long() {
         matches!(result, Err(DecodeError::TooLong)),
         "decode_frame must return DecodeError::TooLong for frames exceeding 250 bytes"
     );
+}
+
+// ---------------------------------------------------------------------------
+// 8  Modem serial codec integration tests (T-P080 – T-P090)
+// ---------------------------------------------------------------------------
+
+mod modem_serial_tests {
+    use sonde_protocol::modem::{
+        decode_modem_frame, encode_modem_frame, FrameDecoder, ModemCodecError, ModemMessage,
+        SendFrame, MODEM_MSG_SET_CHANNEL,
+    };
+
+    /// T-P080: ModemMessage round-trip — RESET
+    #[test]
+    fn test_p080_reset_round_trip() {
+        let msg = ModemMessage::Reset;
+        let frame = encode_modem_frame(&msg).unwrap();
+        let (decoded, consumed) = decode_modem_frame(&frame).unwrap();
+        assert_eq!(decoded, msg);
+        assert_eq!(consumed, frame.len());
+    }
+
+    /// T-P081: ModemMessage round-trip — SEND_FRAME
+    #[test]
+    fn test_p081_send_frame_round_trip() {
+        let msg = ModemMessage::SendFrame(SendFrame {
+            peer_mac: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+            frame_data: vec![0x01, 0x02, 0x03, 0x04, 0x05],
+        });
+        let frame = encode_modem_frame(&msg).unwrap();
+        let (decoded, consumed) = decode_modem_frame(&frame).unwrap();
+        assert_eq!(decoded, msg);
+        assert_eq!(consumed, frame.len());
+    }
+
+    /// T-P082: ModemMessage round-trip — SET_CHANNEL
+    #[test]
+    fn test_p082_set_channel_round_trip() {
+        let msg = ModemMessage::SetChannel(6);
+        let frame = encode_modem_frame(&msg).unwrap();
+        let (decoded, consumed) = decode_modem_frame(&frame).unwrap();
+        assert_eq!(decoded, msg);
+        assert_eq!(consumed, frame.len());
+    }
+
+    /// T-P083: Frame envelope structure — LEN (2B BE) || TYPE || BODY
+    #[test]
+    fn test_p083_frame_envelope_structure() {
+        let msg = ModemMessage::SetChannel(6);
+        let frame = encode_modem_frame(&msg).unwrap();
+        // LEN = 2 (1 TYPE byte + 1 BODY byte)
+        let len = u16::from_be_bytes([frame[0], frame[1]]);
+        assert_eq!(len, 2, "LEN must be 2 for SET_CHANNEL with 1-byte body");
+        assert_eq!(
+            frame[2], MODEM_MSG_SET_CHANNEL,
+            "TYPE byte must be SET_CHANNEL"
+        );
+        assert_eq!(frame[3], 6, "BODY must contain the channel value");
+        assert_eq!(
+            frame.len(),
+            4,
+            "total frame must be LEN_FIELD(2) + LEN(2) = 4 bytes"
+        );
+    }
+
+    /// T-P084: Decode frame with len=0 returns EmptyFrame
+    #[test]
+    fn test_p084_decode_empty_frame_rejected() {
+        let data = [0x00u8, 0x00]; // len = 0
+        let err = decode_modem_frame(&data).unwrap_err();
+        assert_eq!(err, ModemCodecError::EmptyFrame);
+    }
+
+    /// T-P085: Decode frame with len > SERIAL_MAX_LEN (1025) returns FrameTooLarge
+    #[test]
+    fn test_p085_decode_oversized_frame_rejected() {
+        // big-endian 1026 → exceeds SERIAL_MAX_LEN (1025)
+        let data = [0x04u8, 0x02];
+        let err = decode_modem_frame(&data).unwrap_err();
+        assert_eq!(err, ModemCodecError::FrameTooLarge(1026));
+    }
+
+    /// T-P086: FrameDecoder — single complete frame is fully consumed
+    #[test]
+    fn test_p086_streaming_decoder_complete_frame() {
+        let mut decoder = FrameDecoder::new();
+        let frame = encode_modem_frame(&ModemMessage::GetStatus).unwrap();
+        decoder.push(&frame);
+        let msg = decoder.decode().unwrap().unwrap();
+        assert_eq!(msg, ModemMessage::GetStatus);
+        assert_eq!(decoder.buffered(), 0, "all bytes must be consumed");
+    }
+
+    /// T-P087: FrameDecoder — three frames pushed as one buffer, decoded in order
+    #[test]
+    fn test_p087_streaming_decoder_multiple_frames() {
+        let mut decoder = FrameDecoder::new();
+        let f1 = encode_modem_frame(&ModemMessage::Reset).unwrap();
+        let f2 = encode_modem_frame(&ModemMessage::GetStatus).unwrap();
+        let f3 = encode_modem_frame(&ModemMessage::SetChannel(11)).unwrap();
+
+        let mut combined = Vec::new();
+        combined.extend_from_slice(&f1);
+        combined.extend_from_slice(&f2);
+        combined.extend_from_slice(&f3);
+        decoder.push(&combined);
+
+        assert_eq!(decoder.decode().unwrap().unwrap(), ModemMessage::Reset);
+        assert_eq!(decoder.decode().unwrap().unwrap(), ModemMessage::GetStatus);
+        assert_eq!(
+            decoder.decode().unwrap().unwrap(),
+            ModemMessage::SetChannel(11)
+        );
+        assert_eq!(
+            decoder.decode().unwrap(),
+            None,
+            "buffer must be empty after 3 frames"
+        );
+    }
+
+    /// T-P090: ModemMessage::Unknown preserves msg_type and body bytes verbatim.
+    ///
+    /// Any type code not recognised by the codec must be decoded as
+    /// `ModemMessage::Unknown { msg_type, body }` and round-trip through
+    /// encode_modem_frame / decode_modem_frame without loss.
+    #[test]
+    fn test_p090_modem_unknown_type() {
+        let msg = ModemMessage::Unknown {
+            msg_type: 0x7F,
+            body: vec![0x01, 0x02, 0x03],
+        };
+        let frame = encode_modem_frame(&msg).unwrap();
+        let (decoded, consumed) = decode_modem_frame(&frame).unwrap();
+        assert_eq!(decoded, msg);
+        assert_eq!(consumed, frame.len());
+
+        // Wire format: LEN(2B BE) | TYPE(1B) | BODY(3B)
+        // LEN = 1 (TYPE) + 3 (BODY) = 4 → 0x00 0x04
+        assert_eq!(
+            u16::from_be_bytes([frame[0], frame[1]]),
+            4,
+            "LEN must be 4 (1 TYPE + 3 BODY)"
+        );
+        assert_eq!(frame[2], 0x7F, "msg_type must be preserved verbatim");
+        assert_eq!(
+            &frame[3..],
+            &[0x01u8, 0x02, 0x03],
+            "body bytes must be preserved verbatim"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 9  BLE envelope integration tests (T-P100 – T-P104)
+// ---------------------------------------------------------------------------
+
+/// T-P100: BLE envelope encode → parse round-trip preserves type and body
+#[test]
+fn test_p100_ble_envelope_round_trip() {
+    let body = [0x42u8; 10];
+    let encoded = encode_ble_envelope(0x01, &body).unwrap();
+    let (msg_type, decoded_body) = parse_ble_envelope(&encoded).unwrap();
+    assert_eq!(msg_type, 0x01);
+    assert_eq!(decoded_body, &body);
+    // Wire format: TYPE(1B) | LEN(2B BE) | BODY
+    assert_eq!(encoded[0], 0x01, "first byte must be TYPE");
+    assert_eq!(
+        u16::from_be_bytes([encoded[1], encoded[2]]) as usize,
+        body.len(),
+        "LEN field must equal body length"
+    );
+    assert_eq!(
+        encoded.len(),
+        3 + body.len(),
+        "total length must be 3 + body.len()"
+    );
+}
+
+/// T-P101: BLE envelope with empty body round-trips correctly (3-byte frame)
+#[test]
+fn test_p101_ble_envelope_empty_body() {
+    let encoded = encode_ble_envelope(0x81, &[]).unwrap();
+    let (msg_type, body) = parse_ble_envelope(&encoded).unwrap();
+    assert_eq!(msg_type, 0x81);
+    assert!(body.is_empty());
+    assert_eq!(encoded.len(), 3, "empty body frame must be exactly 3 bytes");
+}
+
+/// T-P102: parse_ble_envelope rejects buffers shorter than 3 bytes
+#[test]
+fn test_p102_ble_envelope_too_short_rejected() {
+    assert!(
+        parse_ble_envelope(&[]).is_none(),
+        "0-byte input must be rejected"
+    );
+    assert!(
+        parse_ble_envelope(&[0x01]).is_none(),
+        "1-byte input must be rejected"
+    );
+    assert!(
+        parse_ble_envelope(&[0x01, 0x00]).is_none(),
+        "2-byte input must be rejected"
+    );
+}
+
+/// T-P103: parse_ble_envelope rejects a frame whose LEN exceeds available bytes
+#[test]
+fn test_p103_ble_envelope_truncated_body_rejected() {
+    // LEN=4 but only 2 body bytes follow
+    assert!(parse_ble_envelope(&[0x01, 0x00, 0x04, 0xAA, 0xBB]).is_none());
+}
+
+/// T-P104: parse_ble_envelope rejects a frame with trailing bytes after the body
+#[test]
+fn test_p104_ble_envelope_trailing_bytes_rejected() {
+    // LEN=2 but 3 body bytes follow
+    assert!(parse_ble_envelope(&[0x01, 0x00, 0x02, 0xAA, 0xBB, 0xCC]).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// 10  DIAG relay integration tests (T-P114 – T-P116)
+// ---------------------------------------------------------------------------
+
+/// T-P114: DIAG_RELAY_REQUEST encode → BLE envelope → decode round-trip
+#[test]
+fn test_p114_diag_relay_request_round_trip() {
+    let payload = [0x42u8; 50];
+    let body = encode_diag_relay_request(6, &payload).unwrap();
+    let envelope = encode_ble_envelope(BLE_DIAG_RELAY_REQUEST, &body).unwrap();
+    let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
+    assert_eq!(msg_type, BLE_DIAG_RELAY_REQUEST);
+    let (rf_channel, decoded_payload) = decode_diag_relay_request(decoded_body).unwrap();
+    assert_eq!(rf_channel, 6);
+    assert_eq!(decoded_payload, &payload);
+}
+
+/// T-P115: DIAG_RELAY_REQUEST rejects channels outside 1–13 (boundary-inclusive check)
+#[test]
+fn test_p115_diag_relay_request_invalid_channel_rejected() {
+    let payload = [0x42u8; 10];
+    assert!(
+        encode_diag_relay_request(0, &payload).is_err(),
+        "channel 0 must be rejected"
+    );
+    assert!(
+        encode_diag_relay_request(14, &payload).is_err(),
+        "channel 14 must be rejected"
+    );
+    // Boundary values: channels 1 and 13 are the valid extremes
+    assert!(
+        encode_diag_relay_request(1, &payload).is_ok(),
+        "channel 1 (lower boundary) must succeed"
+    );
+    assert!(
+        encode_diag_relay_request(13, &payload).is_ok(),
+        "channel 13 (upper boundary) must succeed"
+    );
+}
+
+/// T-P116: DIAG_RELAY_RESPONSE — OK with payload, non-OK statuses require empty payload
+#[test]
+fn test_p116_diag_relay_response_round_trip() {
+    // status=OK with non-empty payload
+    let payload = [0xABu8; 30];
+    let body = encode_diag_relay_response(DIAG_RELAY_STATUS_OK, &payload).unwrap();
+    let envelope = encode_ble_envelope(BLE_DIAG_RELAY_RESPONSE, &body).unwrap();
+    let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
+    assert_eq!(msg_type, BLE_DIAG_RELAY_RESPONSE);
+    let (status, decoded_payload) = decode_diag_relay_response(decoded_body).unwrap();
+    assert_eq!(status, DIAG_RELAY_STATUS_OK);
+    assert_eq!(decoded_payload, &payload);
+
+    // status=TIMEOUT, empty payload
+    let body_timeout = encode_diag_relay_response(DIAG_RELAY_STATUS_TIMEOUT, &[]).unwrap();
+    let (status_t, payload_t) = decode_diag_relay_response(&body_timeout).unwrap();
+    assert_eq!(status_t, DIAG_RELAY_STATUS_TIMEOUT);
+    assert!(payload_t.is_empty());
+
+    // status=CHANNEL_ERROR, empty payload
+    let body_chan = encode_diag_relay_response(DIAG_RELAY_STATUS_CHANNEL_ERROR, &[]).unwrap();
+    let (status_c, payload_c) = decode_diag_relay_response(&body_chan).unwrap();
+    assert_eq!(status_c, DIAG_RELAY_STATUS_CHANNEL_ERROR);
+    assert!(payload_c.is_empty());
 }

--- a/docs/ble-pairing-protocol.md
+++ b/docs/ble-pairing-protocol.md
@@ -708,7 +708,7 @@ For even higher assurance, BLE Passkey Entry can be used in place of Numeric Com
 | Node BLE advertising name | `"sonde-XXXX"` | XXXX = last 4 hex digits of BLE MAC. |
 | Max node_id length | 64 bytes | UTF-8. |
 | Max sensor label length | 64 bytes | UTF-8. |
-| Max encrypted_payload size | 218 bytes | Must fit in ESP-NOW frame (250B max), see §11.1. |
+| Max encrypted_payload size | 202 bytes (tool-enforced) | Must fit in ESP-NOW frame (250B max). The theoretical protocol ceiling is 218 bytes (see §11.1); the pairing tool enforces 202 bytes to maintain headroom for future CBOR key expansion. |
 
 ### 11.1  Encrypted payload size budget
 
@@ -725,6 +725,8 @@ Available for encrypted_payload:  219 bytes (exact)
 ```
 
 The constant `MAX_ENCRYPTED_PAYLOAD` is set to **218 bytes** (conservative, reserving 1 byte for possible future CBOR keys).  The `protocol.md` payload budget of 223 bytes (250 − 11 − 16) is 4 bytes larger because it does not include CBOR framing overhead.
+
+> **Tool-enforced limit:** The pairing tool (`sonde-pair`) applies a stricter **202-byte** limit (`PEER_PAYLOAD_MAX_LEN = 202`) on the encrypted payload to maintain additional headroom for future protocol fields. The 218-byte figure above describes the theoretical protocol ceiling; 202 bytes is the operative bound enforced by PT-0406.
 
 The encrypted payload contains:
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -466,7 +466,7 @@ pub trait PairingStore: Send + Sync {
 
 Concrete implementations:
 
-- `store::MockPairingStore` — in-memory, `Arc<Mutex<…>>`-backed, for tests.
+- `store::MockPairingStore` — in-memory, `Mutex<…>`-backed; can be wrapped in `Arc` for sharing in tests.
 - `file_store::FilePairingStore` — JSON file, desktop (`file-store` feature), with optional `PskProtector` for at-rest PSK encryption.
 - `android_store::AndroidPairingStore` — `EncryptedSharedPreferences` via JNI (`android` feature).
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -59,7 +59,7 @@ crates/sonde-pair/
     ├── cbor.rs                 # PairingRequest CBOR construction (deterministic encoding)
     ├── validation.rs           # Input validation (node_id, rf_channel, label, payload size)
     ├── transport.rs            # BleTransport trait definition
-    ├── store.rs                # (reserved — persistence is caller-managed, see §7.1)
+    ├── store.rs                # PairingStore trait + MockPairingStore (PT-0802)
     └── rng.rs                  # RngProvider trait (injectable CSPRNG for testing)
 ```
 
@@ -72,7 +72,7 @@ crates/sonde-pair/
 | `sonde-node` | ❌ No node dependency (PT-0103) |
 | `sonde-modem` | ❌ No modem dependency (PT-0103) |
 | Platform BLE APIs | ❌ Not in `sonde-pair` — injected via `BleTransport` trait |
-| Platform storage APIs | ❌ Not in `sonde-pair` — persistence is caller-managed (see §7.1) |
+| Platform storage APIs | ❌ Not in `sonde-pair` — injected via `PairingStore` trait (PT-0802) |
 
 ### 3.2  Cargo.toml dependencies
 
@@ -448,9 +448,27 @@ All values above are wrapped in `Zeroizing<[u8; N]>` to ensure zeroing on drop e
 
 ### 7.1  Pairing artifact persistence
 
-Pairing artifacts are returned as plain data from the core protocol functions (`pair_with_gateway()` and `provision_node()`).  The core crate does **not** define a `PairingStore` trait — persistence is caller-managed.  The Tauri UI layer (or any other consumer) is responsible for saving, loading, and clearing artifacts using whatever secure storage is appropriate for the platform (PT-0802).
+Pairing artifacts are returned as plain data from the core protocol functions (`pair_with_gateway()` and `provision_node()`).  The core crate defines a `PairingStore` trait so that platform-specific secure storage can be injected and tests can use an in-memory implementation (PT-0802).
 
-On Android, `AndroidPairingStore` in `android_store.rs` provides a concrete implementation backed by `EncryptedSharedPreferences` via a JNI bridge to the companion `SecureStore` Java class.
+```rust
+/// Abstraction over persistent pairing-artifact storage (PT-0802).
+pub trait PairingStore: Send + Sync {
+    /// Persist pairing artifacts, overwriting any previously stored value.
+    fn save_artifacts(&self, artifacts: &PairingArtifacts) -> Result<(), PairingError>;
+
+    /// Load previously persisted artifacts, or `None` if nothing has been saved.
+    fn load_artifacts(&self) -> Result<Option<PairingArtifacts>, PairingError>;
+
+    /// Erase all persisted artifacts.  Idempotent.
+    fn clear(&self) -> Result<(), PairingError>;
+}
+```
+
+Concrete implementations:
+
+- `store::MockPairingStore` — in-memory, `Arc<Mutex<…>>`-backed, for tests.
+- `file_store::FilePairingStore` — JSON file, desktop (`file-store` feature), with optional `PskProtector` for at-rest PSK encryption.
+- `android_store::AndroidPairingStore` — `EncryptedSharedPreferences` via JNI (`android` feature).
 
 ```rust
 /// Pairing artifacts returned by Phase 1.

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -964,7 +964,7 @@ A test MUST exercise the complete Phase 2 flow: construct PairingRequest CBOR โ
 **Source:** ble-pairing-protocol.md ยง6
 
 **Description:**  
-Tests MUST cover: `NODE_ACK(0x01)` (already paired), `NODE_ACK(0x02)` (storage error), timeout on `NODE_ACK` (5 s), no prior Phase 1, payload size exceeds 218 bytes, wrong PSK (GCM tag mismatch on gateway side), AAD mismatch.
+Tests MUST cover: `NODE_ACK(0x01)` (already paired), `NODE_ACK(0x02)` (storage error), timeout on `NODE_ACK` (5 s), no prior Phase 1, payload size exceeds 202 bytes, wrong PSK (GCM tag mismatch on gateway side), AAD mismatch.
 
 **Acceptance criteria:**
 

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1643,7 +1643,7 @@ TestNode {
 | T-PT-307 | PT-1102 | Phone PSK authentication (AES-256-GCM) |
 | T-PT-308 | PT-0407, PT-1102 | Payload encryption (AES-256-GCM with phone_psk) |
 | T-PT-309 | ~~PT-0405, PT-0902~~ | ~~Ed25519 → X25519 low-order point rejection~~ — RETIRED |
-| T-PT-310 | PT-0406 | Payload size > 218 bytes rejected |
+| T-PT-310 | PT-0406 | Payload size > 202 bytes rejected |
 | T-PT-311 | PT-0407 | NODE_PROVISION happy path → NODE_ACK(0x00) |
 | T-PT-312 | PT-0407 | NODE_ACK(0x01) — already paired |
 | T-PT-313 | PT-0407 | NODE_ACK(0x02) — storage error |

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -446,7 +446,7 @@ Look up a value in a BPF map.
 
 **Returns:** Pointer to the value on success, `NULL` if the key is not found.
 
-**Availability:** Resident and ephemeral.
+**Availability:** Resident only. Ephemeral programs cannot declare maps and therefore cannot use map helpers (see §2.2 and §7).
 
 #### `map_update_elem`
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -633,11 +633,11 @@ The firmware MUST support a provisioned board layout so that a single firmware b
 **Source:** issue #134, hw/carrier-board netlists
 
 **Description:**  
-The firmware MUST use the provisioned board layout to control sensor power and capture the current-cycle battery value after the `WAKE` / `COMMAND` exchange. If the provisioned board layout assigns `sensor_enable`, the firmware asserts that GPIO active after a valid `COMMAND` is received, waits for the provisioned buses and battery divider to settle, then captures the battery value for the current cycle. If `battery_adc` is assigned to a GPIO that the current ESP32-C3 target can sample, the firmware samples that configured ADC pin; otherwise it uses the known fallback value (`3300` mV). The captured current-cycle value is stored in RTC-retained state for the next wake and exposed to the current-cycle BPF execution context and helpers.
+The firmware MUST use the provisioned board layout to control sensor power and capture the current-cycle battery value after the `WAKE` / `COMMAND` exchange. If the provisioned board layout assigns `sensor_enable`, the firmware drives that GPIO low (active-low) after a valid `COMMAND` is received, waits for the provisioned buses and battery divider to settle, then captures the battery value for the current cycle. If `battery_adc` is assigned to a GPIO that the current ESP32-C3 target can sample, the firmware samples that configured ADC pin; otherwise it uses the known fallback value (`3300` mV). The captured current-cycle value is stored in RTC-retained state for the next wake and exposed to the current-cycle BPF execution context and helpers.
 
 **Acceptance criteria:**
 
-1. When `sensor_enable` is assigned, the firmware asserts the configured GPIO only after a valid `COMMAND` is received and before executing BPF or other post-WAKE command work.
+1. When `sensor_enable` is assigned, the firmware drives the configured GPIO low (active-low) only after a valid `COMMAND` is received and before executing BPF or other post-WAKE command work.
 2. When `sensor_enable` is assigned, the firmware waits for the sensor rail and attached buses to settle before taking a battery measurement or using the provisioned bus helpers.
 3. When `battery_adc` is assigned to an ADC-capable GPIO supported on the current ESP32-C3 target, the firmware samples the configured ADC pin and stores the resulting battery value in RTC-retained state for the next wake.
 4. When `battery_adc` is unassigned, or assigned to a GPIO that is not ADC-capable on the current target, the firmware stores the known fallback value (`3300` mV) in RTC-retained state for the next wake.

--- a/docs/protocol-crate-design.md
+++ b/docs/protocol-crate-design.md
@@ -261,6 +261,10 @@ pub enum NodeMessage {
         program_hash: Vec<u8>,
         battery_mv: u32,
         firmware_version: String,
+        /// Optional opaque bytes piggybacked on the Wake message (CBOR key 10).
+        /// Present when the node has pending sensor data from the previous BPF execution.
+        /// Absent (`None`) if the node has no data to return.
+        blob: Option<Vec<u8>>,
     },
     GetChunk {
         chunk_index: u32,
@@ -312,6 +316,10 @@ pub enum GatewayMessage {
         starting_seq: u64,
         timestamp_ms: u64,
         payload: CommandPayload,
+        /// Optional opaque bytes piggybacked on a `CommandPayload::Nop` command (CBOR key 10).
+        /// Used by the gateway to deliver a deferred reply without a dedicated APP_DATA_REPLY frame.
+        /// Must be `None` for all non-`Nop` payload variants.
+        blob: Option<Vec<u8>>,
     },
     Chunk {
         chunk_index: u32,
@@ -416,7 +424,11 @@ pub struct ProgramImage {
 
 ```rust
 impl ProgramImage {
-    pub fn encode_deterministic(&self) -> Vec<u8> { ... }
+    /// Encode the program image using deterministic CBOR (RFC 8949 §4.2).
+    ///
+    /// Returns `Err(EncodeError)` if `map_initial_data.len() != maps.len()` or
+    /// another encoding constraint is violated.
+    pub fn encode_deterministic(&self) -> Result<Vec<u8>, EncodeError> { ... }
 }
 ```
 


### PR DESCRIPTION
## Summary
- apply approved maintenance-audit fixes for spec, implementation, and test drift
- restore pairing store abstraction and protected persistence migration
- fix node chunk retry handling, modem test breakage, and gateway oversized-handler regression coverage
- add protocol, admin, and modem-bridge E2E coverage
- align protocol, pairing, BPF-environment, and node documentation to current behavior

## Audit classification
- 14 drift findings detected
- 8 classified as `fix-impl`
- 4 classified as `fix-spec`
- 2 deferred

## Key corrections
- add `PairingStore` / `MockPairingStore` and activate `phone_psk_protected` migration-safe persistence
- fix stale wrong-`msg_type` handling in node chunk transfer retries
- repair the modem display test API mismatch
- add gateway T-0514 oversized handler message regression tests
- restore missing protocol validation coverage and resolve the T-P090 collision
- add modem-bridge E2E coverage and expand admin CLI/integration coverage
- document the operative 202-byte pairing payload limit and align spec text

## Deferred
- F-002: BLE UUID replacement
- F-009: KiCad IR scope mismatch