### PR TITLE
Bootstrap Azure companion container and login flow

### DIFF
--- a/.github/docker/Dockerfile.azure-companion
+++ b/.github/docker/Dockerfile.azure-companion
@@ -1,22 +1,15 @@
-FROM rust:1.87-bookworm AS builder
+FROM rust:alpine AS builder
+
+RUN apk add --no-cache build-base musl-dev protobuf pkgconf
 
 WORKDIR /sonde
 COPY . .
 RUN cargo build --release -p sonde-azure-companion
 
-FROM debian:bookworm-slim
+FROM alpine:3.21
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl gnupg lsb-release \
-    && mkdir -p /etc/apt/keyrings \
-    && curl -sLS https://packages.microsoft.com/keys/microsoft.asc \
-        | gpg --dearmor > /etc/apt/keyrings/microsoft.gpg \
-    && chmod go+r /etc/apt/keyrings/microsoft.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \
-        > /etc/apt/sources.list.d/azure-cli.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends azure-cli \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates \
+    && mkdir -p /var/lib/sonde-azure-companion /var/run/sonde
 
 COPY --from=builder /sonde/target/release/sonde-azure-companion /usr/local/bin/sonde-azure-companion
 COPY deploy/azure-companion/bootstrap.sh /opt/sonde/deploy/azure-companion/bootstrap.sh
@@ -24,8 +17,7 @@ COPY deploy/azure-companion/entrypoint.sh /opt/sonde/deploy/azure-companion/entr
 
 RUN chmod +x /usr/local/bin/sonde-azure-companion \
     /opt/sonde/deploy/azure-companion/bootstrap.sh \
-    /opt/sonde/deploy/azure-companion/entrypoint.sh \
-    && mkdir -p /var/lib/sonde-azure-companion /var/run/sonde
+    /opt/sonde/deploy/azure-companion/entrypoint.sh
 
 ENV SONDE_AZURE_COMPANION_STATE_DIR=/var/lib/sonde-azure-companion
 ENV SONDE_GATEWAY_COMPANION_SOCKET=/var/run/sonde/companion.sock

--- a/.github/docker/Dockerfile.azure-companion
+++ b/.github/docker/Dockerfile.azure-companion
@@ -1,0 +1,34 @@
+FROM rust:1.87-bookworm AS builder
+
+WORKDIR /sonde
+COPY . .
+RUN cargo build --release -p sonde-azure-companion
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg lsb-release \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -sLS https://packages.microsoft.com/keys/microsoft.asc \
+        | gpg --dearmor > /etc/apt/keyrings/microsoft.gpg \
+    && chmod go+r /etc/apt/keyrings/microsoft.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \
+        > /etc/apt/sources.list.d/azure-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends azure-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /sonde/target/release/sonde-azure-companion /usr/local/bin/sonde-azure-companion
+COPY deploy/azure-companion/bootstrap.sh /opt/sonde/deploy/azure-companion/bootstrap.sh
+COPY deploy/azure-companion/entrypoint.sh /opt/sonde/deploy/azure-companion/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/sonde-azure-companion \
+    /opt/sonde/deploy/azure-companion/bootstrap.sh \
+    /opt/sonde/deploy/azure-companion/entrypoint.sh \
+    && mkdir -p /var/lib/sonde-azure-companion /var/run/sonde
+
+ENV SONDE_AZURE_COMPANION_STATE_DIR=/var/lib/sonde-azure-companion
+ENV SONDE_GATEWAY_COMPANION_SOCKET=/var/run/sonde/companion.sock
+
+WORKDIR /var/lib/sonde-azure-companion
+ENTRYPOINT ["/opt/sonde/deploy/azure-companion/entrypoint.sh"]

--- a/.github/docker/Dockerfile.azure-companion
+++ b/.github/docker/Dockerfile.azure-companion
@@ -1,4 +1,13 @@
-FROM rust:alpine AS builder
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Multi-stage Dockerfile for the Azure companion container image.
+# Produces a minimal Alpine-based image containing the
+# `sonde-azure-companion` binary plus bootstrap scripts.
+
+# ── Stage 1: build ──────────────────────────────────────────────────────────
+# rust:alpine — pinned by digest for reproducible builds.
+FROM rust:alpine@sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334 AS builder
 
 RUN apk add --no-cache build-base musl-dev protobuf pkgconf
 
@@ -6,7 +15,9 @@ WORKDIR /sonde
 COPY . .
 RUN cargo build --release -p sonde-azure-companion
 
-FROM alpine:3.21
+# ── Stage 2: runtime ────────────────────────────────────────────────────────
+# alpine:3.21 — pinned by digest for reproducible builds.
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 RUN apk add --no-cache ca-certificates \
     && mkdir -p /var/lib/sonde-azure-companion /var/run/sonde

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1214,24 @@ dependencies = [
  "libc",
  "tokio",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "defmt"
@@ -2274,8 +2302,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2285,9 +2315,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2607,6 +2639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2745,6 +2783,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3356,6 +3410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,6 +3762,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3721,6 +3791,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "oauth-device-flows"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20dd669fa331a18d6d83a31bbea02ec9d0ab494cfee6a474935106997986964"
+dependencies = [
+ "base64 0.22.1",
+ "reqwest 0.12.28",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "tokio",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4549,6 +4637,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4595,6 +4738,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4615,6 +4768,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4630,6 +4793,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4750,6 +4922,44 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -4780,6 +4990,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4870,6 +5094,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4946,6 +5205,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "secret-service"
@@ -5118,6 +5387,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -5409,12 +5690,15 @@ dependencies = [
  "clap",
  "futures",
  "hyper-util",
+ "oauth-device-flows",
  "sonde-gateway",
  "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",
  "tower",
+ "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -5933,7 +6217,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6248,6 +6532,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6274,6 +6573,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -6809,6 +7118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7088,6 +7403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7141,6 +7466,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7728,6 +8062,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5403,6 +5403,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sonde-azure-companion"
+version = "0.5.0"
+dependencies = [
+ "clap",
+ "futures",
+ "hyper-util",
+ "sonde-gateway",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tower",
+]
+
+[[package]]
 name = "sonde-bpf"
 version = "0.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/sonde-tmp102-handler",
     "crates/sonde-sht40-handler",
     "crates/sonde-kicad",
+    "crates/sonde-azure-companion",
 ]
 default-members = [
     "crates/sonde-protocol",

--- a/crates/sonde-azure-companion/Cargo.toml
+++ b/crates/sonde-azure-companion/Cargo.toml
@@ -7,12 +7,15 @@ license = "MIT"
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 hyper-util = "0.1"
+oauth-device-flows = { version = "0.1", default-features = false }
 sonde-gateway = { path = "../sonde-gateway", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tonic = "0.14"
 tower = "0.5"
+url = "2"
 
 [dev-dependencies]
 futures = "0.3"
 tempfile = "3"
 tokio-stream = "0.1"
+wiremock = "0.6"

--- a/crates/sonde-azure-companion/Cargo.toml
+++ b/crates/sonde-azure-companion/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sonde-azure-companion"
+edition = "2021"
+version.workspace = true
+license = "MIT"
+
+[dependencies]
+clap = { version = "4", features = ["derive", "env"] }
+hyper-util = "0.1"
+sonde-gateway = { path = "../sonde-gateway", default-features = false }
+tokio = { version = "1", features = ["full"] }
+tonic = "0.14"
+tower = "0.5"
+
+[dev-dependencies]
+futures = "0.3"
+tempfile = "3"
+tokio-stream = "0.1"

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+use std::error::Error;
+
+use clap::{Parser, Subcommand};
+use tonic::transport::{Channel, Endpoint, Uri};
+
+use sonde_gateway::companion::pb::gateway_companion_client::GatewayCompanionClient;
+use sonde_gateway::companion::pb::{
+    CompanionListNodesRequest, CompanionShowModemDisplayMessageRequest,
+};
+
+#[cfg(unix)]
+const DEFAULT_COMPANION_SOCKET: &str = "/var/run/sonde/companion.sock";
+#[cfg(windows)]
+const DEFAULT_COMPANION_SOCKET: &str = r"\\.\pipe\sonde-companion";
+
+#[derive(Debug, Parser)]
+#[command(name = "sonde-azure-companion")]
+struct Cli {
+    /// Gateway companion socket path (UDS on Unix, named pipe on Windows).
+    #[arg(long, env = "SONDE_GATEWAY_COMPANION_SOCKET", default_value = DEFAULT_COMPANION_SOCKET)]
+    companion_socket: String,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Start the long-running Azure companion process.
+    Run,
+    /// Ask the gateway companion API to render a transient modem display message.
+    DisplayMessage {
+        /// Between 1 and 4 text lines to render.
+        lines: Vec<String>,
+    },
+}
+
+#[cfg(unix)]
+async fn connect_companion(
+    socket_path: &str,
+) -> Result<GatewayCompanionClient<Channel>, Box<dyn Error>> {
+    use hyper_util::rt::TokioIo;
+
+    let socket_path = socket_path.to_owned();
+    let channel = Endpoint::from_static("http://[::]:50051")
+        .connect_with_connector(tower::service_fn(move |_: Uri| {
+            let path = socket_path.clone();
+            async move {
+                let stream = tokio::net::UnixStream::connect(path).await?;
+                Ok::<_, std::io::Error>(TokioIo::new(stream))
+            }
+        }))
+        .await?;
+    Ok(GatewayCompanionClient::new(channel))
+}
+
+#[cfg(windows)]
+async fn connect_companion(
+    pipe_name: &str,
+) -> Result<GatewayCompanionClient<Channel>, Box<dyn Error>> {
+    use hyper_util::rt::TokioIo;
+    use std::time::Duration;
+    use tokio::net::windows::named_pipe::ClientOptions;
+
+    let pipe_name = pipe_name.to_owned();
+    let channel = Endpoint::from_static("http://[::]:50051")
+        .connect_with_connector(tower::service_fn(move |_: Uri| {
+            let name = pipe_name.clone();
+            async move {
+                let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+                let client = loop {
+                    match ClientOptions::new().open(&name) {
+                        Ok(client) => break client,
+                        Err(e) if e.raw_os_error() == Some(231) => {}
+                        Err(e) => return Err(e),
+                    }
+                    if tokio::time::Instant::now() >= deadline {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "named pipe busy — timed out after 5s",
+                        ));
+                    }
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                };
+                Ok::<_, std::io::Error>(TokioIo::new(client))
+            }
+        }))
+        .await?;
+    Ok(GatewayCompanionClient::new(channel))
+}
+
+#[cfg(not(any(unix, windows)))]
+compile_error!(
+    "sonde-azure-companion requires Unix (UDS) or Windows (named pipes) — this platform is not supported"
+);
+
+fn validate_display_lines(lines: &[String]) -> Result<(), String> {
+    if (1..=4).contains(&lines.len()) {
+        Ok(())
+    } else {
+        Err("display-message requires between 1 and 4 lines".to_string())
+    }
+}
+
+async fn run(socket_path: &str) -> Result<(), Box<dyn Error>> {
+    let mut client = connect_companion(socket_path).await?;
+    let response = client
+        .list_nodes(CompanionListNodesRequest {})
+        .await?
+        .into_inner();
+    eprintln!(
+        "connected to gateway companion API at {socket_path}; {} nodes known",
+        response.nodes.len()
+    );
+    std::future::pending::<()>().await;
+    #[allow(unreachable_code)]
+    Ok(())
+}
+
+async fn display_message(socket_path: &str, lines: Vec<String>) -> Result<(), Box<dyn Error>> {
+    validate_display_lines(&lines)
+        .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg))?;
+    let mut client = connect_companion(socket_path).await?;
+    client
+        .show_modem_display_message(CompanionShowModemDisplayMessageRequest { lines })
+        .await?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let cli = Cli::parse();
+    match cli.command.unwrap_or(Command::Run) {
+        Command::Run => run(&cli.companion_socket).await?,
+        Command::DisplayMessage { lines } => display_message(&cli.companion_socket, lines).await?,
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_display_lines;
+
+    fn lines(values: &[&str]) -> Vec<String> {
+        values.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn display_lines_accept_one_to_four_entries() {
+        for line_count in 1..=4 {
+            let values = (0..line_count).map(|_| "line").collect::<Vec<_>>();
+            assert!(validate_display_lines(&lines(&values)).is_ok());
+        }
+    }
+
+    #[test]
+    fn display_lines_reject_zero_or_more_than_four_entries() {
+        assert!(validate_display_lines(&lines(&[])).is_err());
+        assert!(validate_display_lines(&lines(&["1", "2", "3", "4", "5"])).is_err());
+    }
+}

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -154,6 +154,16 @@ fn validate_display_lines(lines: &[String]) -> Result<(), String> {
 fn validate_device_scopes(scopes: &[String]) -> Result<(), String> {
     if scopes.is_empty() {
         Err("bootstrap-auth requires at least one device scope".to_string())
+    } else if scopes.iter().any(|scope| scope.trim().is_empty()) {
+        Err("bootstrap-auth device scopes must not be empty".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_device_client_id(client_id: &str) -> Result<(), String> {
+    if client_id.trim().is_empty() {
+        Err("bootstrap-auth requires a non-empty device client ID".to_string())
     } else {
         Ok(())
     }
@@ -162,12 +172,21 @@ fn validate_device_scopes(scopes: &[String]) -> Result<(), String> {
 fn bootstrap_provider_and_config(
     args: &BootstrapAuthArgs,
 ) -> Result<(Provider, DeviceFlowConfig), Box<dyn Error>> {
+    validate_device_client_id(&args.device_client_id)
+        .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg))?;
     validate_device_scopes(&args.device_scopes)
         .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg))?;
 
+    let device_client_id = args.device_client_id.trim().to_string();
+    let device_scopes: Vec<String> = args
+        .device_scopes
+        .iter()
+        .map(|scope| scope.trim().to_string())
+        .collect();
+
     let config = DeviceFlowConfig::new()
-        .client_id(args.device_client_id.clone())
-        .scopes(args.device_scopes.clone())
+        .client_id(device_client_id)
+        .scopes(device_scopes.clone())
         .poll_interval(Duration::from_secs(args.poll_interval_secs))
         .max_attempts(args.max_attempts);
 
@@ -178,7 +197,7 @@ fn bootstrap_provider_and_config(
                 Url::parse(device_token_url)?,
                 "Microsoft test override".to_string(),
             )
-            .with_default_scopes(args.device_scopes.clone());
+            .with_default_scopes(device_scopes);
             Ok((Provider::Generic, config.generic_provider(provider)))
         }
         (None, None) => Ok((Provider::Microsoft, config)),
@@ -267,8 +286,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        bootstrap_provider_and_config, validate_device_scopes, validate_display_lines,
-        BootstrapAuthArgs,
+        bootstrap_provider_and_config, validate_device_client_id, validate_device_scopes,
+        validate_display_lines, BootstrapAuthArgs,
     };
     use oauth_device_flows::Provider;
     use std::path::PathBuf;
@@ -307,6 +326,19 @@ mod tests {
     fn bootstrap_auth_requires_at_least_one_scope() {
         assert!(validate_device_scopes(&[]).is_err());
         assert!(validate_device_scopes(&["scope".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn bootstrap_auth_rejects_blank_scope_entries() {
+        assert!(validate_device_scopes(&[" ".to_string()]).is_err());
+        assert!(validate_device_scopes(&["scope".to_string(), "".to_string()]).is_err());
+    }
+
+    #[test]
+    fn bootstrap_auth_requires_non_empty_client_id() {
+        assert!(validate_device_client_id("").is_err());
+        assert!(validate_device_client_id("   ").is_err());
+        assert!(validate_device_client_id("client-id").is_ok());
     }
 
     #[test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -2,9 +2,14 @@
 // Copyright (c) 2026 sonde contributors
 
 use std::error::Error;
+use std::path::PathBuf;
+use std::time::Duration;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
+use oauth_device_flows::provider::GenericProviderConfig;
+use oauth_device_flows::{DeviceFlow, DeviceFlowConfig, Provider};
 use tonic::transport::{Channel, Endpoint, Uri};
+use url::Url;
 
 use sonde_gateway::companion::pb::gateway_companion_client::GatewayCompanionClient;
 use sonde_gateway::companion::pb::{
@@ -15,6 +20,11 @@ use sonde_gateway::companion::pb::{
 const DEFAULT_COMPANION_SOCKET: &str = "/var/run/sonde/companion.sock";
 #[cfg(windows)]
 const DEFAULT_COMPANION_SOCKET: &str = r"\\.\pipe\sonde-companion";
+
+#[cfg(unix)]
+const DEFAULT_STATE_DIR: &str = "/var/lib/sonde-azure-companion";
+#[cfg(windows)]
+const DEFAULT_STATE_DIR: &str = r"C:\ProgramData\sonde-azure-companion";
 
 #[derive(Debug, Parser)]
 #[command(name = "sonde-azure-companion")]
@@ -31,11 +41,48 @@ struct Cli {
 enum Command {
     /// Start the long-running Azure companion process.
     Run,
+    /// Perform Microsoft device auth, display the user code, and discard the token on success.
+    BootstrapAuth(BootstrapAuthArgs),
     /// Ask the gateway companion API to render a transient modem display message.
     DisplayMessage {
         /// Between 1 and 4 text lines to render.
         lines: Vec<String>,
     },
+}
+
+#[derive(Debug, Args)]
+struct BootstrapAuthArgs {
+    /// Mounted state directory reserved for later provisioning output.
+    #[arg(long, env = "SONDE_AZURE_COMPANION_STATE_DIR", default_value = DEFAULT_STATE_DIR)]
+    state_dir: PathBuf,
+
+    /// Microsoft Entra application client ID used for device auth.
+    #[arg(long, env = "SONDE_AZURE_DEVICE_CLIENT_ID")]
+    device_client_id: String,
+
+    /// Comma-delimited OAuth scopes to request during device auth.
+    #[arg(long, env = "SONDE_AZURE_DEVICE_SCOPES", value_delimiter = ',', num_args = 1..)]
+    device_scopes: Vec<String>,
+
+    /// Poll interval in seconds for the device auth token endpoint.
+    #[arg(
+        long,
+        env = "SONDE_AZURE_DEVICE_POLL_INTERVAL_SECS",
+        default_value_t = 5
+    )]
+    poll_interval_secs: u64,
+
+    /// Maximum number of token polling attempts before bootstrap fails.
+    #[arg(long, env = "SONDE_AZURE_DEVICE_MAX_ATTEMPTS", default_value_t = 60)]
+    max_attempts: u32,
+
+    /// Optional override for the device authorization endpoint, primarily for tests.
+    #[arg(long, env = "SONDE_AZURE_DEVICE_AUTH_URL")]
+    device_auth_url: Option<String>,
+
+    /// Optional override for the token endpoint, primarily for tests.
+    #[arg(long, env = "SONDE_AZURE_DEVICE_TOKEN_URL")]
+    device_token_url: Option<String>,
 }
 
 #[cfg(unix)]
@@ -62,7 +109,6 @@ async fn connect_companion(
     pipe_name: &str,
 ) -> Result<GatewayCompanionClient<Channel>, Box<dyn Error>> {
     use hyper_util::rt::TokioIo;
-    use std::time::Duration;
     use tokio::net::windows::named_pipe::ClientOptions;
 
     let pipe_name = pipe_name.to_owned();
@@ -105,6 +151,45 @@ fn validate_display_lines(lines: &[String]) -> Result<(), String> {
     }
 }
 
+fn validate_device_scopes(scopes: &[String]) -> Result<(), String> {
+    if scopes.is_empty() {
+        Err("bootstrap-auth requires at least one device scope".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+fn bootstrap_provider_and_config(
+    args: &BootstrapAuthArgs,
+) -> Result<(Provider, DeviceFlowConfig), Box<dyn Error>> {
+    validate_device_scopes(&args.device_scopes)
+        .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg))?;
+
+    let config = DeviceFlowConfig::new()
+        .client_id(args.device_client_id.clone())
+        .scopes(args.device_scopes.clone())
+        .poll_interval(Duration::from_secs(args.poll_interval_secs))
+        .max_attempts(args.max_attempts);
+
+    match (&args.device_auth_url, &args.device_token_url) {
+        (Some(device_auth_url), Some(device_token_url)) => {
+            let provider = GenericProviderConfig::new(
+                Url::parse(device_auth_url)?,
+                Url::parse(device_token_url)?,
+                "Microsoft test override".to_string(),
+            )
+            .with_default_scopes(args.device_scopes.clone());
+            Ok((Provider::Generic, config.generic_provider(provider)))
+        }
+        (None, None) => Ok((Provider::Microsoft, config)),
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "device auth and token endpoint overrides must be provided together",
+        )
+        .into()),
+    }
+}
+
 async fn run(socket_path: &str) -> Result<(), Box<dyn Error>> {
     let mut client = connect_companion(socket_path).await?;
     let response = client
@@ -130,11 +215,50 @@ async fn display_message(socket_path: &str, lines: Vec<String>) -> Result<(), Bo
     Ok(())
 }
 
+async fn bootstrap_auth(socket_path: &str, args: BootstrapAuthArgs) -> Result<(), Box<dyn Error>> {
+    std::fs::create_dir_all(&args.state_dir)?;
+
+    let (provider, config) = bootstrap_provider_and_config(&args)?;
+    let mut flow = DeviceFlow::new(provider, config)?;
+    let auth = flow.initialize().await?;
+
+    eprintln!(
+        "Azure device auth required. Open {} and enter code {}",
+        auth.verification_uri(),
+        auth.user_code()
+    );
+    if let Some(verification_uri_complete) = auth.verification_uri_complete() {
+        eprintln!("Complete verification URL: {verification_uri_complete}");
+    }
+
+    display_message(
+        socket_path,
+        vec!["Azure login".to_string(), auth.user_code().to_string()],
+    )
+    .await?;
+
+    let token = flow.poll_for_token().await?;
+    if let Some(expires_in) = token.expires_in {
+        eprintln!(
+            "Azure device auth succeeded; received temporary {} token valid for {} seconds",
+            token.token_type, expires_in
+        );
+    } else {
+        eprintln!(
+            "Azure device auth succeeded; received temporary {} token",
+            token.token_type
+        );
+    }
+
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     match cli.command.unwrap_or(Command::Run) {
         Command::Run => run(&cli.companion_socket).await?,
+        Command::BootstrapAuth(args) => bootstrap_auth(&cli.companion_socket, args).await?,
         Command::DisplayMessage { lines } => display_message(&cli.companion_socket, lines).await?,
     }
     Ok(())
@@ -142,10 +266,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_display_lines;
+    use super::{
+        bootstrap_provider_and_config, validate_device_scopes, validate_display_lines,
+        BootstrapAuthArgs,
+    };
+    use oauth_device_flows::Provider;
+    use std::path::PathBuf;
 
     fn lines(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn bootstrap_args() -> BootstrapAuthArgs {
+        BootstrapAuthArgs {
+            state_dir: PathBuf::from("state"),
+            device_client_id: "client-id".to_string(),
+            device_scopes: vec!["scope-a".to_string()],
+            poll_interval_secs: 5,
+            max_attempts: 60,
+            device_auth_url: None,
+            device_token_url: None,
+        }
     }
 
     #[test]
@@ -160,5 +301,35 @@ mod tests {
     fn display_lines_reject_zero_or_more_than_four_entries() {
         assert!(validate_display_lines(&lines(&[])).is_err());
         assert!(validate_display_lines(&lines(&["1", "2", "3", "4", "5"])).is_err());
+    }
+
+    #[test]
+    fn bootstrap_auth_requires_at_least_one_scope() {
+        assert!(validate_device_scopes(&[]).is_err());
+        assert!(validate_device_scopes(&["scope".to_string()]).is_ok());
+    }
+
+    #[test]
+    fn bootstrap_auth_uses_microsoft_provider_by_default() {
+        let (provider, _config) = bootstrap_provider_and_config(&bootstrap_args()).unwrap();
+        assert_eq!(provider, Provider::Microsoft);
+    }
+
+    #[test]
+    fn bootstrap_auth_accepts_explicit_endpoint_overrides() {
+        let mut args = bootstrap_args();
+        args.device_auth_url = Some("http://127.0.0.1/device".to_string());
+        args.device_token_url = Some("http://127.0.0.1/token".to_string());
+
+        let (provider, _config) = bootstrap_provider_and_config(&args).unwrap();
+        assert_eq!(provider, Provider::Generic);
+    }
+
+    #[test]
+    fn bootstrap_auth_rejects_partial_endpoint_override() {
+        let mut args = bootstrap_args();
+        args.device_auth_url = Some("http://127.0.0.1/device".to_string());
+
+        assert!(bootstrap_provider_and_config(&args).is_err());
     }
 }

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -225,18 +225,7 @@ async fn mount_successful_device_flow(
     user_code: &str,
     expected_count: u64,
 ) {
-    Mock::given(method("POST"))
-        .and(path("/device"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .append_header("content-type", "application/json")
-                .set_body_string(format!(
-                    "{{\"device_code\":\"device-code-{user_code}\",\"user_code\":\"{user_code}\",\"verification_uri\":\"https://microsoft.com/devicelogin\",\"verification_uri_complete\":\"https://microsoft.com/devicelogin?code={user_code}\",\"expires_in\":900,\"interval\":1}}"
-                )),
-        )
-        .expect(expected_count)
-        .mount(oauth_server)
-        .await;
+    mount_device_code_request(oauth_server, user_code, expected_count).await;
 
     Mock::given(method("POST"))
         .and(path("/token"))
@@ -252,19 +241,27 @@ async fn mount_successful_device_flow(
         .await;
 }
 
-async fn mount_failed_token_poll(oauth_server: &MockServer, user_code: &str) {
+async fn mount_device_code_request(
+    oauth_server: &MockServer,
+    user_code: &str,
+    expected_count: u64,
+) {
     Mock::given(method("POST"))
         .and(path("/device"))
         .respond_with(
             ResponseTemplate::new(200)
                 .append_header("content-type", "application/json")
                 .set_body_string(format!(
-                    "{{\"device_code\":\"device-code-{user_code}\",\"user_code\":\"{user_code}\",\"verification_uri\":\"https://microsoft.com/devicelogin\",\"expires_in\":900,\"interval\":1}}"
+                    "{{\"device_code\":\"device-code-{user_code}\",\"user_code\":\"{user_code}\",\"verification_uri\":\"https://microsoft.com/devicelogin\",\"verification_uri_complete\":\"https://microsoft.com/devicelogin?code={user_code}\",\"expires_in\":900,\"interval\":1}}"
                 )),
         )
-        .expect(1)
+        .expect(expected_count)
         .mount(oauth_server)
         .await;
+}
+
+async fn mount_failed_token_poll(oauth_server: &MockServer, user_code: &str) {
+    mount_device_code_request(oauth_server, user_code, 1).await;
 
     Mock::given(method("POST"))
         .and(path("/token"))
@@ -339,7 +336,7 @@ async fn t_azc_0203_display_failure_aborts_bootstrap() {
         let socket_path = temp.path().join("companion.sock");
         let display_requests = spawn_companion_server(&socket_path, Some(code)).await;
         let oauth_server = MockServer::start().await;
-        mount_successful_device_flow(&oauth_server, "ZXCV-1234", 1).await;
+        mount_device_code_request(&oauth_server, "ZXCV-1234", 1).await;
 
         let wrapper_log = temp.path().join("wrapper.log");
         write_companion_wrapper(&bin_dir, &wrapper_log);
@@ -614,7 +611,7 @@ fn container_bootstrap_forwards_sigterm_to_bootstrap_auth_child() {
     write_executable(
         &bin_dir.join("sonde-azure-companion"),
         &format!(
-            "#!/bin/sh\nset -eu\nif [ \"$1\" = \"--companion-socket\" ]; then\n  shift 2\nfi\ncase \"$1\" in\n  bootstrap-auth)\n    printf '%s\\n' \"$$\" > \"{}\"\n    trap 'printf TERM\\n >> \"{}\"; exit 143' TERM\n    trap 'printf INT\\n >> \"{}\"; exit 130' INT\n    while :; do\n      sleep 1\n    done\n    ;;\n  run)\n    printf 'run\\n' >> \"{}\"\n    exit 0\n    ;;\n  *)\n    exit 64\n    ;;\nesac\n",
+            "#!/bin/sh\nset -eu\nif [ \"$1\" = \"--companion-socket\" ]; then\n  shift 2\nfi\ncase \"$1\" in\n  bootstrap-auth)\n    printf '%s\\n' \"$$\" > \"{}\"\n    trap 'printf \"%s\\n\" TERM >> \"{}\"; exit 143' TERM\n    trap 'printf \"%s\\n\" INT >> \"{}\"; exit 130' INT\n    while :; do\n      sleep 1\n    done\n    ;;\n  run)\n    printf 'run\\n' >> \"{}\"\n    exit 0\n    ;;\n  *)\n    exit 64\n    ;;\nesac\n",
             pid_file.display(),
             signal_log.display(),
             signal_log.display(),

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::process::Command;
+use std::sync::Arc;
+
+use futures::stream;
+use hyper_util::rt::TokioIo;
+use tempfile::TempDir;
+use tokio::net::UnixListener;
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::{Request, Response, Status};
+
+use sonde_gateway::companion::pb::gateway_companion_server::{
+    GatewayCompanion, GatewayCompanionServer,
+};
+use sonde_gateway::companion::pb::*;
+
+type EventStream = Pin<Box<dyn futures::Stream<Item = Result<CompanionEvent, Status>> + Send>>;
+
+#[derive(Clone)]
+struct TestCompanionServer {
+    display_requests: Arc<Mutex<Vec<Vec<String>>>>,
+    display_error: Option<tonic::Code>,
+}
+
+#[tonic::async_trait]
+impl GatewayCompanion for TestCompanionServer {
+    type StreamEventsStream = EventStream;
+
+    async fn stream_events(
+        &self,
+        _request: Request<CompanionStreamEventsRequest>,
+    ) -> Result<Response<Self::StreamEventsStream>, Status> {
+        Ok(Response::new(Box::pin(stream::empty())))
+    }
+
+    async fn list_nodes(
+        &self,
+        _request: Request<CompanionListNodesRequest>,
+    ) -> Result<Response<CompanionListNodesResponse>, Status> {
+        Ok(Response::new(CompanionListNodesResponse {
+            nodes: Vec::new(),
+        }))
+    }
+
+    async fn get_node(
+        &self,
+        _request: Request<CompanionGetNodeRequest>,
+    ) -> Result<Response<CompanionNodeInfo>, Status> {
+        Err(Status::unimplemented("not used in test"))
+    }
+
+    async fn assign_program(
+        &self,
+        _request: Request<CompanionAssignProgramRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        Err(Status::unimplemented("not used in test"))
+    }
+
+    async fn set_schedule(
+        &self,
+        _request: Request<CompanionSetScheduleRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        Err(Status::unimplemented("not used in test"))
+    }
+
+    async fn queue_reboot(
+        &self,
+        _request: Request<CompanionQueueRebootRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        Err(Status::unimplemented("not used in test"))
+    }
+
+    async fn queue_ephemeral(
+        &self,
+        _request: Request<CompanionQueueEphemeralRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        Err(Status::unimplemented("not used in test"))
+    }
+
+    async fn get_node_status(
+        &self,
+        _request: Request<CompanionGetNodeStatusRequest>,
+    ) -> Result<Response<CompanionNodeStatus>, Status> {
+        Err(Status::unimplemented("not used in test"))
+    }
+
+    async fn show_modem_display_message(
+        &self,
+        request: Request<CompanionShowModemDisplayMessageRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        self.display_requests
+            .lock()
+            .await
+            .push(request.into_inner().lines);
+        if let Some(code) = self.display_error {
+            return Err(Status::new(code, "injected display failure"));
+        }
+        Ok(Response::new(CompanionEmpty {}))
+    }
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .unwrap()
+        .to_path_buf()
+}
+
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).unwrap();
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+async fn spawn_companion_server(
+    socket_path: &Path,
+    display_error: Option<tonic::Code>,
+) -> Arc<Mutex<Vec<Vec<String>>>> {
+    let display_requests = Arc::new(Mutex::new(Vec::new()));
+    let service = TestCompanionServer {
+        display_requests: Arc::clone(&display_requests),
+        display_error,
+    };
+    let listener = UnixListener::bind(socket_path).unwrap();
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(GatewayCompanionServer::new(service))
+            .serve_with_incoming(UnixListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+    display_requests
+}
+
+fn prepare_path_dir(temp: &TempDir) -> PathBuf {
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    bin_dir
+}
+
+fn bootstrap_env(bin_dir: &Path, state_dir: &Path, socket_path: &Path) -> Vec<(String, String)> {
+    let mut path = std::env::var("PATH").unwrap_or_default();
+    path = format!("{}:{}", bin_dir.display(), path);
+    vec![
+        ("PATH".to_string(), path),
+        (
+            "SONDE_AZURE_COMPANION_IN_CONTAINER".to_string(),
+            "1".to_string(),
+        ),
+        (
+            "SONDE_AZURE_COMPANION_STATE_DIR".to_string(),
+            state_dir.display().to_string(),
+        ),
+        (
+            "SONDE_GATEWAY_COMPANION_SOCKET".to_string(),
+            socket_path.display().to_string(),
+        ),
+    ]
+}
+
+fn bootstrap_script_path() -> PathBuf {
+    repo_root().join("deploy/azure-companion/bootstrap.sh")
+}
+
+#[tokio::test]
+async fn t_azc_0101_0102_0200_0201_0202_bootstrap_success_path() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    let socket_path = temp.path().join("companion.sock");
+    let display_requests = spawn_companion_server(&socket_path, None).await;
+
+    let wrapper_log = temp.path().join("wrapper.log");
+    write_executable(
+        &bin_dir.join("sonde-azure-companion"),
+        &format!(
+            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
+            wrapper_log.display(),
+            env!("CARGO_BIN_EXE_sonde-azure-companion")
+        ),
+    );
+    write_executable(
+        &bin_dir.join("az"),
+        "#!/bin/sh\nset -eu\nprintf 'To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code ABCD-EFGH to authenticate.\\n'\ntouch \"$AZURE_CONFIG_DIR/msal_token_cache.json\"\n",
+    );
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().unwrap();
+    assert!(output.status.success(), "bootstrap failed: {output:?}");
+
+    let requests = display_requests.lock().await.clone();
+    assert_eq!(
+        requests,
+        vec![vec!["Azure login".to_string(), "ABCD-EFGH".to_string()]]
+    );
+    assert!(wrapper_log.exists());
+    assert!(fs::read_to_string(&wrapper_log).unwrap().contains("run "));
+    assert!(state_dir.join("azure/msal_token_cache.json").exists());
+}
+
+#[tokio::test]
+async fn t_azc_0203_display_failure_aborts_bootstrap() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    let socket_path = temp.path().join("companion.sock");
+    let display_requests =
+        spawn_companion_server(&socket_path, Some(tonic::Code::FailedPrecondition)).await;
+
+    let wrapper_log = temp.path().join("wrapper.log");
+    write_executable(
+        &bin_dir.join("sonde-azure-companion"),
+        &format!(
+            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
+            wrapper_log.display(),
+            env!("CARGO_BIN_EXE_sonde-azure-companion")
+        ),
+    );
+    write_executable(
+        &bin_dir.join("az"),
+        "#!/bin/sh\nset -eu\nprintf 'To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code ZXCV-1234 to authenticate.\\n'\nsleep 1\n",
+    );
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().unwrap();
+    assert!(!output.status.success());
+    assert!(
+        wrapper_log.exists() == false
+            || fs::read_to_string(&wrapper_log)
+                .unwrap_or_default()
+                .is_empty()
+    );
+    assert_eq!(
+        display_requests.lock().await.clone(),
+        vec![vec!["Azure login".to_string(), "ZXCV-1234".to_string()]]
+    );
+}
+
+#[tokio::test]
+async fn t_azc_0104_persisted_state_skips_login_and_display() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(state_dir.join("azure")).unwrap();
+    fs::write(state_dir.join("azure/msal_token_cache.json"), b"cached").unwrap();
+    let socket_path = temp.path().join("companion.sock");
+    let display_requests = spawn_companion_server(&socket_path, None).await;
+
+    let wrapper_log = temp.path().join("wrapper.log");
+    write_executable(
+        &bin_dir.join("sonde-azure-companion"),
+        &format!(
+            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
+            wrapper_log.display(),
+            env!("CARGO_BIN_EXE_sonde-azure-companion")
+        ),
+    );
+    write_executable(
+        &bin_dir.join("az"),
+        "#!/bin/sh\nset -eu\nprintf 'az should not be invoked\\n' >&2\nexit 9\n",
+    );
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().unwrap();
+    assert!(output.status.success(), "bootstrap failed: {output:?}");
+    assert_eq!(display_requests.lock().await.len(), 0);
+    assert!(fs::read_to_string(&wrapper_log).unwrap().contains("run "));
+}
+
+#[tokio::test]
+async fn t_azc_0105_missing_state_reenters_login() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(state_dir.join("azure")).unwrap();
+    let marker = state_dir.join("az-invoked");
+    let socket_path = temp.path().join("companion.sock");
+    let _display_requests = spawn_companion_server(&socket_path, None).await;
+
+    let wrapper_log = temp.path().join("wrapper.log");
+    write_executable(
+        &bin_dir.join("sonde-azure-companion"),
+        &format!(
+            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
+            wrapper_log.display(),
+            env!("CARGO_BIN_EXE_sonde-azure-companion")
+        ),
+    );
+    write_executable(
+        &bin_dir.join("az"),
+        &format!(
+            "#!/bin/sh\nset -eu\nprintf 'To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code QWER-5678 to authenticate.\\n'\ntouch \"{}\"\ntouch \"$AZURE_CONFIG_DIR/msal_token_cache.json\"\n",
+            marker.display()
+        ),
+    );
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().unwrap();
+    assert!(output.status.success(), "bootstrap failed: {output:?}");
+    assert!(marker.exists());
+}
+
+#[tokio::test]
+async fn t_azc_0106_login_failure_aborts_bootstrap() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    let socket_path = temp.path().join("companion.sock");
+    let _display_requests = spawn_companion_server(&socket_path, None).await;
+
+    let wrapper_log = temp.path().join("wrapper.log");
+    write_executable(
+        &bin_dir.join("sonde-azure-companion"),
+        &format!(
+            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
+            wrapper_log.display(),
+            env!("CARGO_BIN_EXE_sonde-azure-companion")
+        ),
+    );
+    write_executable(
+        &bin_dir.join("az"),
+        "#!/bin/sh\nset -eu\nprintf 'To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code FAIL-0001 to authenticate.\\n'\nexit 42\n",
+    );
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().unwrap();
+    assert_eq!(output.status.code(), Some(42));
+    assert!(!wrapper_log.exists());
+}
+
+#[test]
+fn host_bootstrap_invokes_docker_with_expected_mounts() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    let runtime_dir = temp.path().join("runtime");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::create_dir_all(&runtime_dir).unwrap();
+    let docker_log = temp.path().join("docker.log");
+
+    write_executable(
+        &bin_dir.join("docker"),
+        &format!(
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" > \"{}\"\n",
+            docker_log.display()
+        ),
+    );
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    cmd.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        ),
+    );
+    cmd.env("SONDE_AZURE_COMPANION_IMAGE", "sonde-azure-companion:test");
+    cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
+    cmd.env("SONDE_GATEWAY_RUNTIME_DIR", &runtime_dir);
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success(), "host bootstrap failed: {output:?}");
+    let logged = fs::read_to_string(docker_log).unwrap();
+    assert!(logged.contains("run --rm"));
+    assert!(logged.contains("sonde-azure-companion:test"));
+    assert!(logged.contains(&format!(
+        "-v {}:/var/lib/sonde-azure-companion",
+        state_dir.display()
+    )));
+    assert!(logged.contains(&format!("-v {}:/var/run/sonde", runtime_dir.display())));
+}
+
+#[test]
+fn t_azc_0100_container_image_smoke() {
+    let repo = repo_root();
+    let status = Command::new("docker")
+        .current_dir(&repo)
+        .args([
+            "build",
+            "-f",
+            ".github/docker/Dockerfile.azure-companion",
+            "-t",
+            "sonde-azure-companion:test",
+            ".",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "docker build failed");
+
+    let status = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "sonde-azure-companion:test",
+            "sonde-azure-companion",
+            "--help",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success(), "binary smoke test failed");
+
+    let status = Command::new("docker")
+        .args(["run", "--rm", "sonde-azure-companion:test", "az", "version"])
+        .status()
+        .unwrap();
+    assert!(status.success(), "azure-cli smoke test failed");
+}

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -9,10 +9,13 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::process::Command;
 use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use futures::stream;
 use tempfile::TempDir;
 use tokio::net::UnixListener;
+use tokio::process::Command as TokioCommand;
 use tokio::sync::Mutex;
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::{Request, Response, Status};
@@ -154,6 +157,17 @@ fn bootstrap_script_path() -> PathBuf {
     repo_root().join("deploy/azure-companion/bootstrap.sh")
 }
 
+fn wait_for_path(path: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
 fn write_companion_wrapper(bin_dir: &Path, wrapper_log: &Path) {
     write_executable(
         &bin_dir.join("sonde-azure-companion"),
@@ -266,13 +280,13 @@ async fn mount_failed_token_poll(oauth_server: &MockServer, user_code: &str) {
         .await;
 }
 
-fn run_bootstrap_with_env(env: &[(String, String)]) -> std::process::Output {
-    let mut cmd = Command::new("sh");
+async fn run_bootstrap_with_env(env: &[(String, String)]) -> std::process::Output {
+    let mut cmd = TokioCommand::new("sh");
     cmd.arg(bootstrap_script_path());
     for (key, value) in env {
         cmd.env(key, value);
     }
-    cmd.output().unwrap()
+    cmd.output().await.unwrap()
 }
 
 fn docker_available() -> bool {
@@ -302,7 +316,8 @@ async fn t_azc_0101_0102_0200_0201_0202_bootstrap_success_path() {
         &state_dir,
         &socket_path,
         &oauth_server,
-    ));
+    ))
+    .await;
     assert!(output.status.success(), "bootstrap failed: {output:?}");
 
     let requests = display_requests.lock().await.clone();
@@ -334,7 +349,8 @@ async fn t_azc_0203_display_failure_aborts_bootstrap() {
             &state_dir,
             &socket_path,
             &oauth_server,
-        ));
+        ))
+        .await;
         assert!(!output.status.success());
         assert!(!wrapper_log.exists() || fs::read_to_string(&wrapper_log).unwrap().is_empty());
         assert_eq!(
@@ -368,7 +384,8 @@ async fn t_azc_0104_previously_used_state_still_runs_device_auth() {
         &state_dir,
         &socket_path,
         &oauth_server,
-    ));
+    ))
+    .await;
     assert!(output.status.success(), "bootstrap failed: {output:?}");
     assert_eq!(
         display_requests.lock().await.clone(),
@@ -392,10 +409,10 @@ async fn t_azc_0105_repeated_starts_repeat_device_auth() {
     write_companion_wrapper(&bin_dir, &wrapper_log);
     let env = bootstrap_env(&bin_dir, &state_dir, &socket_path, &oauth_server);
 
-    let first = run_bootstrap_with_env(&env);
+    let first = run_bootstrap_with_env(&env).await;
     assert!(first.status.success(), "first bootstrap failed: {first:?}");
 
-    let second = run_bootstrap_with_env(&env);
+    let second = run_bootstrap_with_env(&env).await;
     assert!(
         second.status.success(),
         "second bootstrap failed: {second:?}"
@@ -425,7 +442,8 @@ async fn t_azc_0106_login_failure_aborts_bootstrap() {
         &state_dir,
         &socket_path,
         &oauth_server,
-    ));
+    ))
+    .await;
     assert!(!output.status.success());
     assert!(!wrapper_log.exists());
 }
@@ -581,4 +599,58 @@ fn t_azc_0100_container_image_smoke() {
         .status()
         .unwrap();
     assert!(status.success(), "bootstrap-auth smoke test failed");
+}
+
+#[test]
+fn container_bootstrap_forwards_sigterm_to_bootstrap_auth_child() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    let pid_file = temp.path().join("bootstrap.pid");
+    let signal_log = temp.path().join("signal.log");
+    let run_log = temp.path().join("run.log");
+
+    write_executable(
+        &bin_dir.join("sonde-azure-companion"),
+        &format!(
+            "#!/bin/sh\nset -eu\nif [ \"$1\" = \"--companion-socket\" ]; then\n  shift 2\nfi\ncase \"$1\" in\n  bootstrap-auth)\n    printf '%s\\n' \"$$\" > \"{}\"\n    trap 'printf TERM\\n >> \"{}\"; exit 143' TERM\n    trap 'printf INT\\n >> \"{}\"; exit 130' INT\n    while :; do\n      sleep 1\n    done\n    ;;\n  run)\n    printf 'run\\n' >> \"{}\"\n    exit 0\n    ;;\n  *)\n    exit 64\n    ;;\nesac\n",
+            pid_file.display(),
+            signal_log.display(),
+            signal_log.display(),
+            run_log.display(),
+        ),
+    );
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    cmd.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        ),
+    );
+    cmd.env("SONDE_AZURE_COMPANION_IN_CONTAINER", "1");
+    cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
+    cmd.env(
+        "SONDE_GATEWAY_COMPANION_SOCKET",
+        temp.path().join("companion.sock"),
+    );
+
+    let mut child = cmd.spawn().unwrap();
+    wait_for_path(&pid_file);
+
+    let status = Command::new("kill")
+        .args(["-TERM", &child.id().to_string()])
+        .status()
+        .unwrap();
+    assert!(status.success(), "failed to signal bootstrap script");
+
+    let exit_status = child.wait().unwrap();
+    assert_eq!(exit_status.code(), Some(143));
+    wait_for_path(&signal_log);
+    assert_eq!(fs::read_to_string(&signal_log).unwrap(), "TERM\n");
+    assert!(!run_log.exists(), "run should not start after SIGTERM");
 }

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -11,12 +11,13 @@ use std::process::Command;
 use std::sync::Arc;
 
 use futures::stream;
-use hyper_util::rt::TokioIo;
 use tempfile::TempDir;
 use tokio::net::UnixListener;
 use tokio::sync::Mutex;
 use tokio_stream::wrappers::UnixListenerStream;
 use tonic::{Request, Response, Status};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use sonde_gateway::companion::pb::gateway_companion_server::{
     GatewayCompanion, GatewayCompanionServer,
@@ -149,11 +150,31 @@ fn prepare_path_dir(temp: &TempDir) -> PathBuf {
     bin_dir
 }
 
-fn bootstrap_env(bin_dir: &Path, state_dir: &Path, socket_path: &Path) -> Vec<(String, String)> {
-    let mut path = std::env::var("PATH").unwrap_or_default();
-    path = format!("{}:{}", bin_dir.display(), path);
+fn bootstrap_script_path() -> PathBuf {
+    repo_root().join("deploy/azure-companion/bootstrap.sh")
+}
+
+fn write_companion_wrapper(bin_dir: &Path, wrapper_log: &Path) {
+    write_executable(
+        &bin_dir.join("sonde-azure-companion"),
+        &format!(
+            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
+            wrapper_log.display(),
+            env!("CARGO_BIN_EXE_sonde-azure-companion")
+        ),
+    );
+}
+
+fn bootstrap_env(
+    bin_dir: &Path,
+    state_dir: &Path,
+    socket_path: &Path,
+    oauth_server: &MockServer,
+) -> Vec<(String, String)> {
+    let mut path_value = std::env::var("PATH").unwrap_or_default();
+    path_value = format!("{}:{}", bin_dir.display(), path_value);
     vec![
-        ("PATH".to_string(), path),
+        ("PATH".to_string(), path_value),
         (
             "SONDE_AZURE_COMPANION_IN_CONTAINER".to_string(),
             "1".to_string(),
@@ -166,11 +187,92 @@ fn bootstrap_env(bin_dir: &Path, state_dir: &Path, socket_path: &Path) -> Vec<(S
             "SONDE_GATEWAY_COMPANION_SOCKET".to_string(),
             socket_path.display().to_string(),
         ),
+        (
+            "SONDE_AZURE_DEVICE_CLIENT_ID".to_string(),
+            "test-client-id".to_string(),
+        ),
+        (
+            "SONDE_AZURE_DEVICE_SCOPES".to_string(),
+            "https://management.azure.com/.default".to_string(),
+        ),
+        (
+            "SONDE_AZURE_DEVICE_AUTH_URL".to_string(),
+            format!("{}/device", oauth_server.uri()),
+        ),
+        (
+            "SONDE_AZURE_DEVICE_TOKEN_URL".to_string(),
+            format!("{}/token", oauth_server.uri()),
+        ),
     ]
 }
 
-fn bootstrap_script_path() -> PathBuf {
-    repo_root().join("deploy/azure-companion/bootstrap.sh")
+async fn mount_successful_device_flow(
+    oauth_server: &MockServer,
+    user_code: &str,
+    expected_count: u64,
+) {
+    Mock::given(method("POST"))
+        .and(path("/device"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .append_header("content-type", "application/json")
+                .set_body_string(format!(
+                    "{{\"device_code\":\"device-code-{user_code}\",\"user_code\":\"{user_code}\",\"verification_uri\":\"https://microsoft.com/devicelogin\",\"verification_uri_complete\":\"https://microsoft.com/devicelogin?code={user_code}\",\"expires_in\":900,\"interval\":1}}"
+                )),
+        )
+        .expect(expected_count)
+        .mount(oauth_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .append_header("content-type", "application/json")
+                .set_body_string(
+                    "{\"access_token\":\"temporary-token\",\"token_type\":\"Bearer\",\"expires_in\":300}",
+                ),
+        )
+        .expect(expected_count)
+        .mount(oauth_server)
+        .await;
+}
+
+async fn mount_failed_token_poll(oauth_server: &MockServer, user_code: &str) {
+    Mock::given(method("POST"))
+        .and(path("/device"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .append_header("content-type", "application/json")
+                .set_body_string(format!(
+                    "{{\"device_code\":\"device-code-{user_code}\",\"user_code\":\"{user_code}\",\"verification_uri\":\"https://microsoft.com/devicelogin\",\"expires_in\":900,\"interval\":1}}"
+                )),
+        )
+        .expect(1)
+        .mount(oauth_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .append_header("content-type", "application/json")
+                .set_body_string(
+                    "{\"error\":\"expired_token\",\"error_description\":\"expired for test\"}",
+                ),
+        )
+        .expect(1)
+        .mount(oauth_server)
+        .await;
+}
+
+fn run_bootstrap_with_env(env: &[(String, String)]) -> std::process::Output {
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+    cmd.output().unwrap()
 }
 
 #[tokio::test]
@@ -181,27 +283,18 @@ async fn t_azc_0101_0102_0200_0201_0202_bootstrap_success_path() {
     fs::create_dir_all(&state_dir).unwrap();
     let socket_path = temp.path().join("companion.sock");
     let display_requests = spawn_companion_server(&socket_path, None).await;
+    let oauth_server = MockServer::start().await;
+    mount_successful_device_flow(&oauth_server, "ABCD-EFGH", 1).await;
 
     let wrapper_log = temp.path().join("wrapper.log");
-    write_executable(
-        &bin_dir.join("sonde-azure-companion"),
-        &format!(
-            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
-            wrapper_log.display(),
-            env!("CARGO_BIN_EXE_sonde-azure-companion")
-        ),
-    );
-    write_executable(
-        &bin_dir.join("az"),
-        "#!/bin/sh\nset -eu\nprintf 'To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code ABCD-EFGH to authenticate.\\n'\ntouch \"$AZURE_CONFIG_DIR/msal_token_cache.json\"\n",
-    );
+    write_companion_wrapper(&bin_dir, &wrapper_log);
 
-    let mut cmd = Command::new("sh");
-    cmd.arg(bootstrap_script_path());
-    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
-        cmd.env(key, value);
-    }
-    let output = cmd.output().unwrap();
+    let output = run_bootstrap_with_env(&bootstrap_env(
+        &bin_dir,
+        &state_dir,
+        &socket_path,
+        &oauth_server,
+    ));
     assert!(output.status.success(), "bootstrap failed: {output:?}");
 
     let requests = display_requests.lock().await.clone();
@@ -211,122 +304,98 @@ async fn t_azc_0101_0102_0200_0201_0202_bootstrap_success_path() {
     );
     assert!(wrapper_log.exists());
     assert!(fs::read_to_string(&wrapper_log).unwrap().contains("run "));
-    assert!(state_dir.join("azure/msal_token_cache.json").exists());
 }
 
 #[tokio::test]
 async fn t_azc_0203_display_failure_aborts_bootstrap() {
+    for code in [tonic::Code::FailedPrecondition, tonic::Code::Unavailable] {
+        let temp = TempDir::new().unwrap();
+        let bin_dir = prepare_path_dir(&temp);
+        let state_dir = temp.path().join("state");
+        fs::create_dir_all(&state_dir).unwrap();
+        let socket_path = temp.path().join("companion.sock");
+        let display_requests = spawn_companion_server(&socket_path, Some(code)).await;
+        let oauth_server = MockServer::start().await;
+        mount_successful_device_flow(&oauth_server, "ZXCV-1234", 1).await;
+
+        let wrapper_log = temp.path().join("wrapper.log");
+        write_companion_wrapper(&bin_dir, &wrapper_log);
+
+        let output = run_bootstrap_with_env(&bootstrap_env(
+            &bin_dir,
+            &state_dir,
+            &socket_path,
+            &oauth_server,
+        ));
+        assert!(!output.status.success());
+        assert!(!wrapper_log.exists() || fs::read_to_string(&wrapper_log).unwrap().is_empty());
+        assert_eq!(
+            display_requests.lock().await.clone(),
+            vec![vec!["Azure login".to_string(), "ZXCV-1234".to_string()]]
+        );
+    }
+}
+
+#[tokio::test]
+async fn t_azc_0104_previously_used_state_still_runs_device_auth() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("managed-identity.json"),
+        b"{\"tenant\":\"placeholder\"}",
+    )
+    .unwrap();
+    let socket_path = temp.path().join("companion.sock");
+    let display_requests = spawn_companion_server(&socket_path, None).await;
+    let oauth_server = MockServer::start().await;
+    mount_successful_device_flow(&oauth_server, "QWER-5678", 1).await;
+
+    let wrapper_log = temp.path().join("wrapper.log");
+    write_companion_wrapper(&bin_dir, &wrapper_log);
+
+    let output = run_bootstrap_with_env(&bootstrap_env(
+        &bin_dir,
+        &state_dir,
+        &socket_path,
+        &oauth_server,
+    ));
+    assert!(output.status.success(), "bootstrap failed: {output:?}");
+    assert_eq!(
+        display_requests.lock().await.clone(),
+        vec![vec!["Azure login".to_string(), "QWER-5678".to_string()]]
+    );
+    assert!(fs::read_to_string(&wrapper_log).unwrap().contains("run "));
+}
+
+#[tokio::test]
+async fn t_azc_0105_repeated_starts_repeat_device_auth() {
     let temp = TempDir::new().unwrap();
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
     fs::create_dir_all(&state_dir).unwrap();
     let socket_path = temp.path().join("companion.sock");
-    let display_requests =
-        spawn_companion_server(&socket_path, Some(tonic::Code::FailedPrecondition)).await;
-
-    let wrapper_log = temp.path().join("wrapper.log");
-    write_executable(
-        &bin_dir.join("sonde-azure-companion"),
-        &format!(
-            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
-            wrapper_log.display(),
-            env!("CARGO_BIN_EXE_sonde-azure-companion")
-        ),
-    );
-    write_executable(
-        &bin_dir.join("az"),
-        "#!/bin/sh\nset -eu\nprintf 'To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code ZXCV-1234 to authenticate.\\n'\nsleep 1\n",
-    );
-
-    let mut cmd = Command::new("sh");
-    cmd.arg(bootstrap_script_path());
-    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
-        cmd.env(key, value);
-    }
-    let output = cmd.output().unwrap();
-    assert!(!output.status.success());
-    assert!(
-        wrapper_log.exists() == false
-            || fs::read_to_string(&wrapper_log)
-                .unwrap_or_default()
-                .is_empty()
-    );
-    assert_eq!(
-        display_requests.lock().await.clone(),
-        vec![vec!["Azure login".to_string(), "ZXCV-1234".to_string()]]
-    );
-}
-
-#[tokio::test]
-async fn t_azc_0104_persisted_state_skips_login_and_display() {
-    let temp = TempDir::new().unwrap();
-    let bin_dir = prepare_path_dir(&temp);
-    let state_dir = temp.path().join("state");
-    fs::create_dir_all(state_dir.join("azure")).unwrap();
-    fs::write(state_dir.join("azure/msal_token_cache.json"), b"cached").unwrap();
-    let socket_path = temp.path().join("companion.sock");
     let display_requests = spawn_companion_server(&socket_path, None).await;
+    let oauth_server = MockServer::start().await;
+    mount_successful_device_flow(&oauth_server, "REPEAT-1", 2).await;
 
     let wrapper_log = temp.path().join("wrapper.log");
-    write_executable(
-        &bin_dir.join("sonde-azure-companion"),
-        &format!(
-            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
-            wrapper_log.display(),
-            env!("CARGO_BIN_EXE_sonde-azure-companion")
-        ),
-    );
-    write_executable(
-        &bin_dir.join("az"),
-        "#!/bin/sh\nset -eu\nprintf 'az should not be invoked\\n' >&2\nexit 9\n",
-    );
+    write_companion_wrapper(&bin_dir, &wrapper_log);
+    let env = bootstrap_env(&bin_dir, &state_dir, &socket_path, &oauth_server);
 
-    let mut cmd = Command::new("sh");
-    cmd.arg(bootstrap_script_path());
-    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
-        cmd.env(key, value);
-    }
-    let output = cmd.output().unwrap();
-    assert!(output.status.success(), "bootstrap failed: {output:?}");
-    assert_eq!(display_requests.lock().await.len(), 0);
-    assert!(fs::read_to_string(&wrapper_log).unwrap().contains("run "));
-}
+    let first = run_bootstrap_with_env(&env);
+    assert!(first.status.success(), "first bootstrap failed: {first:?}");
 
-#[tokio::test]
-async fn t_azc_0105_missing_state_reenters_login() {
-    let temp = TempDir::new().unwrap();
-    let bin_dir = prepare_path_dir(&temp);
-    let state_dir = temp.path().join("state");
-    fs::create_dir_all(state_dir.join("azure")).unwrap();
-    let marker = state_dir.join("az-invoked");
-    let socket_path = temp.path().join("companion.sock");
-    let _display_requests = spawn_companion_server(&socket_path, None).await;
-
-    let wrapper_log = temp.path().join("wrapper.log");
-    write_executable(
-        &bin_dir.join("sonde-azure-companion"),
-        &format!(
-            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
-            wrapper_log.display(),
-            env!("CARGO_BIN_EXE_sonde-azure-companion")
-        ),
-    );
-    write_executable(
-        &bin_dir.join("az"),
-        &format!(
-            "#!/bin/sh\nset -eu\nprintf 'To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code QWER-5678 to authenticate.\\n'\ntouch \"{}\"\ntouch \"$AZURE_CONFIG_DIR/msal_token_cache.json\"\n",
-            marker.display()
-        ),
+    let second = run_bootstrap_with_env(&env);
+    assert!(
+        second.status.success(),
+        "second bootstrap failed: {second:?}"
     );
 
-    let mut cmd = Command::new("sh");
-    cmd.arg(bootstrap_script_path());
-    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
-        cmd.env(key, value);
-    }
-    let output = cmd.output().unwrap();
-    assert!(output.status.success(), "bootstrap failed: {output:?}");
-    assert!(marker.exists());
+    assert_eq!(display_requests.lock().await.len(), 2);
+    let wrapper_contents = fs::read_to_string(&wrapper_log).unwrap();
+    assert_eq!(wrapper_contents.lines().count(), 2);
 }
 
 #[tokio::test]
@@ -337,28 +406,19 @@ async fn t_azc_0106_login_failure_aborts_bootstrap() {
     fs::create_dir_all(&state_dir).unwrap();
     let socket_path = temp.path().join("companion.sock");
     let _display_requests = spawn_companion_server(&socket_path, None).await;
+    let oauth_server = MockServer::start().await;
+    mount_failed_token_poll(&oauth_server, "FAIL-0001").await;
 
     let wrapper_log = temp.path().join("wrapper.log");
-    write_executable(
-        &bin_dir.join("sonde-azure-companion"),
-        &format!(
-            "#!/bin/sh\nset -eu\nsocket=\"\"\nif [ \"$1\" = \"--companion-socket\" ]; then\n  socket=\"$2\"\n  shift 2\nfi\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s\\n' \"$socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --companion-socket \"$socket\" \"$@\"\n",
-            wrapper_log.display(),
-            env!("CARGO_BIN_EXE_sonde-azure-companion")
-        ),
-    );
-    write_executable(
-        &bin_dir.join("az"),
-        "#!/bin/sh\nset -eu\nprintf 'To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code FAIL-0001 to authenticate.\\n'\nexit 42\n",
-    );
+    write_companion_wrapper(&bin_dir, &wrapper_log);
 
-    let mut cmd = Command::new("sh");
-    cmd.arg(bootstrap_script_path());
-    for (key, value) in bootstrap_env(&bin_dir, &state_dir, &socket_path) {
-        cmd.env(key, value);
-    }
-    let output = cmd.output().unwrap();
-    assert_eq!(output.status.code(), Some(42));
+    let output = run_bootstrap_with_env(&bootstrap_env(
+        &bin_dir,
+        &state_dir,
+        &socket_path,
+        &oauth_server,
+    ));
+    assert!(!output.status.success());
     assert!(!wrapper_log.exists());
 }
 
@@ -393,12 +453,19 @@ fn host_bootstrap_invokes_docker_with_expected_mounts() {
     cmd.env("SONDE_AZURE_COMPANION_IMAGE", "sonde-azure-companion:test");
     cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
     cmd.env("SONDE_GATEWAY_RUNTIME_DIR", &runtime_dir);
+    cmd.env("SONDE_AZURE_DEVICE_CLIENT_ID", "test-client-id");
+    cmd.env(
+        "SONDE_AZURE_DEVICE_SCOPES",
+        "https://management.azure.com/.default",
+    );
 
     let output = cmd.output().unwrap();
     assert!(output.status.success(), "host bootstrap failed: {output:?}");
     let logged = fs::read_to_string(docker_log).unwrap();
     assert!(logged.contains("run --rm"));
     assert!(logged.contains("sonde-azure-companion:test"));
+    assert!(logged.contains("-e SONDE_AZURE_DEVICE_CLIENT_ID"));
+    assert!(logged.contains("-e SONDE_AZURE_DEVICE_SCOPES"));
     assert!(logged.contains(&format!(
         "-v {}:/var/lib/sonde-azure-companion",
         state_dir.display()
@@ -436,8 +503,15 @@ fn t_azc_0100_container_image_smoke() {
     assert!(status.success(), "binary smoke test failed");
 
     let status = Command::new("docker")
-        .args(["run", "--rm", "sonde-azure-companion:test", "az", "version"])
+        .args([
+            "run",
+            "--rm",
+            "sonde-azure-companion:test",
+            "sonde-azure-companion",
+            "bootstrap-auth",
+            "--help",
+        ])
         .status()
         .unwrap();
-    assert!(status.success(), "azure-cli smoke test failed");
+    assert!(status.success(), "bootstrap-auth smoke test failed");
 }

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -451,10 +451,12 @@ fn host_bootstrap_invokes_docker_with_expected_mounts() {
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
     let runtime_dir = temp.path().join("runtime");
+    let companion_socket_path = runtime_dir.join("companion.sock");
+    let _admin_socket_path = runtime_dir.join("admin.sock");
     fs::create_dir_all(&state_dir).unwrap();
     fs::create_dir_all(&runtime_dir).unwrap();
-    let _socket =
-        std::os::unix::net::UnixListener::bind(runtime_dir.join("companion.sock")).unwrap();
+    let _socket = std::os::unix::net::UnixListener::bind(&companion_socket_path).unwrap();
+    let _admin_socket = std::os::unix::net::UnixListener::bind(&_admin_socket_path).unwrap();
     let docker_log = temp.path().join("docker.log");
 
     write_executable(
@@ -495,7 +497,11 @@ fn host_bootstrap_invokes_docker_with_expected_mounts() {
         "-v {}:/var/lib/sonde-azure-companion",
         state_dir.display()
     )));
-    assert!(logged.contains(&format!("-v {}:/var/run/sonde", runtime_dir.display())));
+    assert!(logged.contains(&format!(
+        "-v {}:/var/run/sonde/companion.sock",
+        companion_socket_path.display()
+    )));
+    assert!(!logged.contains(&format!("-v {}:/var/run/sonde", runtime_dir.display())));
 }
 
 #[test]

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -275,6 +275,14 @@ fn run_bootstrap_with_env(env: &[(String, String)]) -> std::process::Output {
     cmd.output().unwrap()
 }
 
+fn docker_available() -> bool {
+    Command::new("docker")
+        .arg("version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
 #[tokio::test]
 async fn t_azc_0101_0102_0200_0201_0202_bootstrap_success_path() {
     let temp = TempDir::new().unwrap();
@@ -430,6 +438,8 @@ fn host_bootstrap_invokes_docker_with_expected_mounts() {
     let runtime_dir = temp.path().join("runtime");
     fs::create_dir_all(&state_dir).unwrap();
     fs::create_dir_all(&runtime_dir).unwrap();
+    let _socket =
+        std::os::unix::net::UnixListener::bind(runtime_dir.join("companion.sock")).unwrap();
     let docker_log = temp.path().join("docker.log");
 
     write_executable(
@@ -475,6 +485,11 @@ fn host_bootstrap_invokes_docker_with_expected_mounts() {
 
 #[test]
 fn t_azc_0100_container_image_smoke() {
+    if !docker_available() {
+        eprintln!("skipping Docker smoke test because docker is unavailable");
+        return;
+    }
+
     let repo = repo_root();
     let status = Command::new("docker")
         .current_dir(&repo)

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -484,6 +484,58 @@ fn host_bootstrap_invokes_docker_with_expected_mounts() {
 }
 
 #[test]
+fn host_bootstrap_requires_non_empty_bootstrap_env() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    let runtime_dir = temp.path().join("runtime");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::create_dir_all(&runtime_dir).unwrap();
+    let _socket =
+        std::os::unix::net::UnixListener::bind(runtime_dir.join("companion.sock")).unwrap();
+    let docker_log = temp.path().join("docker.log");
+
+    write_executable(
+        &bin_dir.join("docker"),
+        &format!(
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" > \"{}\"\n",
+            docker_log.display()
+        ),
+    );
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    cmd.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        ),
+    );
+    cmd.env("SONDE_AZURE_COMPANION_IMAGE", "sonde-azure-companion:test");
+    cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
+    cmd.env("SONDE_GATEWAY_RUNTIME_DIR", &runtime_dir);
+    cmd.env("SONDE_AZURE_DEVICE_CLIENT_ID", "");
+    cmd.env(
+        "SONDE_AZURE_DEVICE_SCOPES",
+        "https://management.azure.com/.default",
+    );
+
+    let output = cmd.output().unwrap();
+    assert!(
+        !output.status.success(),
+        "host bootstrap unexpectedly succeeded"
+    );
+    assert!(
+        !docker_log.exists(),
+        "docker should not be invoked when required bootstrap env is missing"
+    );
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("SONDE_AZURE_DEVICE_CLIENT_ID must be set"));
+}
+
+#[test]
 fn t_azc_0100_container_image_smoke() {
     if !docker_available() {
         eprintln!("skipping Docker smoke test because docker is unavailable");

--- a/crates/sonde-gateway/proto/companion.proto
+++ b/crates/sonde-gateway/proto/companion.proto
@@ -10,6 +10,7 @@ service GatewayCompanion {
     rpc QueueReboot(CompanionQueueRebootRequest) returns (CompanionEmpty);
     rpc QueueEphemeral(CompanionQueueEphemeralRequest) returns (CompanionEmpty);
     rpc GetNodeStatus(CompanionGetNodeStatusRequest) returns (CompanionNodeStatus);
+    rpc ShowModemDisplayMessage(CompanionShowModemDisplayMessageRequest) returns (CompanionEmpty);
 }
 
 message CompanionEmpty {}
@@ -22,6 +23,7 @@ message CompanionSetScheduleRequest { string node_id = 1; uint32 interval_s = 2;
 message CompanionQueueRebootRequest { string node_id = 1; }
 message CompanionQueueEphemeralRequest { string node_id = 1; bytes program_hash = 2; }
 message CompanionGetNodeStatusRequest { string node_id = 1; }
+message CompanionShowModemDisplayMessageRequest { repeated string lines = 1; }
 
 message CompanionEvent {
     oneof event {

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -80,21 +80,22 @@ impl AdminService {
         status_page_cycle: Arc<tokio::sync::Mutex<StatusPageCycle>>,
         status_page_scroll_task: StatusPageScrollTask,
     ) -> Self {
-        let transport = self
-            .transport
-            .clone()
-            .expect("with_display_state requires transport to be configured first");
-        let controller = self
-            .ble_controller
-            .clone()
-            .expect("with_display_state requires BLE controller to be configured first");
-        self.display_state = Some(ActiveDisplayState::new(
-            transport,
-            controller,
-            display_generation,
-            status_page_cycle,
-            status_page_scroll_task,
-        ));
+        match (&self.transport, &self.ble_controller) {
+            (Some(transport), Some(controller)) => {
+                self.display_state = Some(ActiveDisplayState::new(
+                    Arc::clone(transport),
+                    Arc::clone(controller),
+                    display_generation,
+                    status_page_cycle,
+                    status_page_scroll_task,
+                ));
+            }
+            _ => {
+                warn!(
+                    "with_display_state called before BLE transport/controller were configured; leaving display_state unset"
+                );
+            }
+        }
         self
     }
 

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -2,8 +2,7 @@
 // Copyright (c) 2026 sonde contributors
 
 use std::collections::HashMap;
-use std::sync::atomic::AtomicU64;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
 use tokio::sync::RwLock;
@@ -12,11 +11,7 @@ use tracing::warn;
 use zeroize::Zeroizing;
 
 use crate::ble_pairing::BlePairingController;
-use crate::display_banner::{send_display_message, send_gateway_version_banner};
-use crate::display_control::{
-    cancel_status_page_scroll, claim_display_generation, reset_status_page_cycle,
-    try_claim_display_restore, StatusPageCycle, StatusPageScrollTask, STATUS_PAGE_TIMEOUT,
-};
+use crate::display_control::{StatusPageCycle, StatusPageScrollTask};
 use crate::engine::PendingCommand;
 use crate::handler::HandlerConfig;
 use crate::handler::HandlerRouter;
@@ -26,6 +21,7 @@ use crate::program::{ProgramLibrary, VerificationProfile};
 use crate::registry::NodeRecord;
 use crate::session::SessionManager;
 use crate::storage::{HandlerRecord, Storage};
+use crate::transient_display::{show_modem_display_message, ActiveDisplayState};
 
 pub mod pb {
     tonic::include_proto!("sonde.admin");
@@ -42,9 +38,7 @@ pub struct AdminService {
     session_manager: Arc<SessionManager>,
     ble_controller: Option<Arc<BlePairingController>>,
     transport: Option<Arc<UsbEspNowTransport>>,
-    display_generation: Option<Arc<AtomicU64>>,
-    status_page_cycle: Option<Arc<tokio::sync::Mutex<StatusPageCycle>>>,
-    status_page_scroll_task: Option<StatusPageScrollTask>,
+    display_state: Option<ActiveDisplayState>,
     handler_configs: RwLock<Vec<HandlerConfig>>,
     /// Shared handler router for live reload (GW-1404, GW-1407).
     handler_router: Option<Arc<tokio::sync::RwLock<HandlerRouter>>>,
@@ -63,9 +57,7 @@ impl AdminService {
             session_manager,
             ble_controller: None,
             transport: None,
-            display_generation: None,
-            status_page_cycle: None,
-            status_page_scroll_task: None,
+            display_state: None,
             handler_configs: RwLock::new(Vec::new()),
             handler_router: None,
         }
@@ -84,13 +76,25 @@ impl AdminService {
 
     pub fn with_display_state(
         mut self,
-        display_generation: Arc<AtomicU64>,
+        display_generation: Arc<std::sync::atomic::AtomicU64>,
         status_page_cycle: Arc<tokio::sync::Mutex<StatusPageCycle>>,
         status_page_scroll_task: StatusPageScrollTask,
     ) -> Self {
-        self.display_generation = Some(display_generation);
-        self.status_page_cycle = Some(status_page_cycle);
-        self.status_page_scroll_task = Some(status_page_scroll_task);
+        let transport = self
+            .transport
+            .clone()
+            .expect("with_display_state requires transport to be configured first");
+        let controller = self
+            .ble_controller
+            .clone()
+            .expect("with_display_state requires BLE controller to be configured first");
+        self.display_state = Some(ActiveDisplayState::new(
+            transport,
+            controller,
+            display_generation,
+            status_page_cycle,
+            status_page_scroll_task,
+        ));
         self
     }
 
@@ -130,55 +134,6 @@ impl AdminService {
                 warn!("failed to reload handler configs: {e}");
             }
         }
-    }
-}
-
-fn schedule_admin_display_restore(
-    transport: &Arc<UsbEspNowTransport>,
-    controller: &Arc<BlePairingController>,
-    display_generation: &Arc<AtomicU64>,
-    status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
-    status_page_scroll_task: &StatusPageScrollTask,
-    generation: u64,
-) {
-    let transport: Weak<UsbEspNowTransport> = Arc::downgrade(transport);
-    let controller = Arc::clone(controller);
-    let display_generation = Arc::clone(display_generation);
-    let status_page_cycle = Arc::clone(status_page_cycle);
-    let status_page_scroll_task = Arc::clone(status_page_scroll_task);
-
-    tokio::spawn(async move {
-        tokio::time::sleep(STATUS_PAGE_TIMEOUT).await;
-        if controller.session_origin().await.is_some() {
-            return;
-        }
-        if !try_claim_display_restore(display_generation.as_ref(), generation) {
-            return;
-        }
-        cancel_status_page_scroll(&status_page_scroll_task).await;
-        reset_status_page_cycle(&status_page_cycle).await;
-        let Some(transport) = transport.upgrade() else {
-            return;
-        };
-        if let Err(e) = send_gateway_version_banner(&transport).await {
-            warn!(error = %e, "failed to restore gateway version banner after admin display");
-        }
-    });
-}
-
-async fn restore_admin_display_failure(
-    transport: &Arc<UsbEspNowTransport>,
-    display_generation: &Arc<AtomicU64>,
-    generation: u64,
-) {
-    if !try_claim_display_restore(display_generation.as_ref(), generation) {
-        return;
-    }
-    if let Err(e) = send_gateway_version_banner(transport).await {
-        warn!(
-            error = %e,
-            "failed to restore gateway version banner after admin display error"
-        );
     }
 }
 
@@ -1339,60 +1294,12 @@ impl GatewayAdmin for AdminService {
         &self,
         request: Request<ShowModemDisplayMessageRequest>,
     ) -> Result<Response<Empty>, Status> {
-        let transport = self
-            .transport
+        let display_state = self
+            .display_state
             .as_ref()
             .ok_or_else(|| Status::unavailable("no modem transport configured"))?;
-        let controller = self
-            .ble_controller
-            .as_ref()
-            .ok_or_else(|| Status::unavailable("no BLE controller configured"))?;
-        let display_generation = self
-            .display_generation
-            .as_ref()
-            .ok_or_else(|| Status::internal("modem display control not configured"))?;
-        let status_page_cycle = self
-            .status_page_cycle
-            .as_ref()
-            .ok_or_else(|| Status::internal("modem display control not configured"))?;
-        let status_page_scroll_task = self
-            .status_page_scroll_task
-            .as_ref()
-            .ok_or_else(|| Status::internal("modem display control not configured"))?;
-
-        if controller.session_origin().await.is_some() {
-            return Err(Status::failed_precondition(
-                "BLE pairing session owns the modem display",
-            ));
-        }
-
         let lines = request.into_inner().lines;
-        if lines.is_empty() || lines.len() > 4 {
-            return Err(Status::invalid_argument(
-                "lines must contain between 1 and 4 entries",
-            ));
-        }
-
-        cancel_status_page_scroll(status_page_scroll_task).await;
-        let generation = claim_display_generation(display_generation);
-        reset_status_page_cycle(status_page_cycle).await;
-
-        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
-        if let Err(e) = send_display_message(transport, &line_refs).await {
-            restore_admin_display_failure(transport, display_generation, generation).await;
-            return Err(Status::internal(format!(
-                "show modem display message failed: {e}"
-            )));
-        }
-
-        schedule_admin_display_restore(
-            transport,
-            controller,
-            display_generation,
-            status_page_cycle,
-            status_page_scroll_task,
-            generation,
-        );
+        show_modem_display_message(display_state, &lines).await?;
 
         Ok(Response::new(Empty {}))
     }

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -33,6 +33,7 @@ use sonde_gateway::registry::NodeRecord;
 use sonde_gateway::session::SessionManager;
 use sonde_gateway::sqlite_storage::SqliteStorage;
 use sonde_gateway::storage::Storage;
+use sonde_gateway::transient_display::{ActiveDisplayState, DisplayStateHandle};
 use sonde_gateway::transport::Transport;
 use sonde_gateway::{AdminService, CompanionService};
 use zeroize::Zeroizing;
@@ -935,11 +936,13 @@ async fn run_gateway(
         gw.set_rssi_thresholds(cli.rssi_good_threshold, cli.rssi_bad_threshold);
         gw
     });
+    let companion_display_state = DisplayStateHandle::new();
     let companion_service = CompanionService::new(
         storage.clone(),
         pending_commands.clone(),
         session_manager.clone(),
         gateway.companion_event_hub(),
+        companion_display_state.clone(),
     );
     let companion_socket = cli.companion_socket.clone();
     let mut companion_handle = tokio::spawn(async move {
@@ -960,6 +963,8 @@ async fn run_gateway(
     const MAX_BACKOFF: Duration = Duration::from_secs(30);
 
     loop {
+        companion_display_state.clear().await;
+
         // 6. Open serial port and create modem transport
         let serial_port = match async {
             let port = serial2_tokio::SerialPort::open(&cli.port, cli.baud_rate)?;
@@ -1070,6 +1075,15 @@ async fn run_gateway(
         )
         .with_handler_configs(handler_configs_from_db.clone())
         .with_handler_router(handler_router.clone());
+        companion_display_state
+            .set(ActiveDisplayState::new(
+                Arc::clone(&transport),
+                Arc::clone(&ble_controller),
+                Arc::clone(&display_generation),
+                Arc::clone(&status_page_cycle),
+                Arc::clone(&status_page_scroll_task),
+            ))
+            .await;
         let admin_socket = cli.admin_socket.clone();
 
         let mut grpc_handle = tokio::spawn(async move {
@@ -1380,6 +1394,7 @@ async fn run_gateway(
         tokio::select! {
             _ = &mut shutdown => {
                 info!("shutdown signal received, stopping gateway");
+                companion_display_state.clear().await;
                 // Abort all subsystem tasks so the tokio runtime does not
                 // block on orphaned futures during teardown (GW-1400).
                 ble_controller.cancel_and_wait().await;
@@ -1414,6 +1429,7 @@ async fn run_gateway(
             }
             _ = &mut grpc_handle => {
                 error!("gRPC server exited unexpectedly");
+                companion_display_state.clear().await;
                 // Abort all subsystem tasks so the tokio runtime does not
                 // block on orphaned futures during teardown (GW-1400).
                 ble_controller.cancel_and_wait().await;
@@ -1438,6 +1454,7 @@ async fn run_gateway(
             }
             _ = &mut companion_handle => {
                 error!("companion gRPC server exited unexpectedly");
+                companion_display_state.clear().await;
                 ble_controller.cancel_and_wait().await;
                 health_cancel.cancel();
                 frame_loop.abort();
@@ -1475,6 +1492,7 @@ async fn run_gateway(
         // GW-1103 AC7-9: warm reboot recovery — re-run full startup immediately.
         if warm_reboot_flag.load(std::sync::atomic::Ordering::Acquire) {
             info!("modem warm reboot detected — reconnecting immediately");
+            companion_display_state.clear().await;
             // Cancel the BLE pairing session before dropping the transport so
             // the event-forwarding task releases its Arc<UsbEspNowTransport>.
             ble_controller.cancel_and_wait().await;
@@ -1509,6 +1527,7 @@ async fn run_gateway(
         // the old gRPC server releases its UDS/named-pipe socket and its
         // Arc<UsbEspNowTransport> clone, preventing bind failures and transport
         // leaks on the next reconnect iteration (GW-1103, GW-1301).
+        companion_display_state.clear().await;
         ble_controller.cancel_and_wait().await;
         health_cancel.cancel();
         frame_loop.abort();

--- a/crates/sonde-gateway/src/companion.rs
+++ b/crates/sonde-gateway/src/companion.rs
@@ -19,6 +19,7 @@ use crate::engine::PendingCommand;
 use crate::registry::NodeRecord;
 use crate::session::SessionManager;
 use crate::storage::Storage;
+use crate::transient_display::{show_modem_display_message, DisplayStateHandle};
 
 pub mod pb {
     tonic::include_proto!("sonde.companion");
@@ -101,6 +102,7 @@ pub struct CompanionService {
     pending_commands: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>>,
     session_manager: Arc<SessionManager>,
     event_hub: Arc<CompanionEventHub>,
+    display_state: DisplayStateHandle,
 }
 
 impl CompanionService {
@@ -109,12 +111,14 @@ impl CompanionService {
         pending_commands: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>>,
         session_manager: Arc<SessionManager>,
         event_hub: Arc<CompanionEventHub>,
+        display_state: DisplayStateHandle,
     ) -> Self {
         Self {
             storage,
             pending_commands,
             session_manager,
             event_hub,
+            display_state,
         }
     }
 }
@@ -263,6 +267,20 @@ impl GatewayCompanion for CompanionService {
         )
         .await?;
         Ok(Response::new(node_status_to_proto(status)))
+    }
+
+    async fn show_modem_display_message(
+        &self,
+        request: Request<CompanionShowModemDisplayMessageRequest>,
+    ) -> Result<Response<CompanionEmpty>, Status> {
+        let display_state = self
+            .display_state
+            .get()
+            .await
+            .ok_or_else(|| Status::unavailable("no modem transport configured"))?;
+        let lines = request.into_inner().lines;
+        show_modem_display_message(&display_state, &lines).await?;
+        Ok(Response::new(CompanionEmpty {}))
     }
 }
 

--- a/crates/sonde-gateway/src/lib.rs
+++ b/crates/sonde-gateway/src/lib.rs
@@ -21,6 +21,7 @@ pub mod sonde_platform;
 pub mod sqlite_storage;
 pub mod state_bundle;
 pub mod storage;
+pub mod transient_display;
 pub mod transport;
 
 pub use admin::AdminService;

--- a/crates/sonde-gateway/src/transient_display.rs
+++ b/crates/sonde-gateway/src/transient_display.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+use std::sync::atomic::AtomicU64;
+use std::sync::{Arc, Weak};
+
+use tokio::sync::RwLock;
+use tonic::Status;
+use tracing::warn;
+
+use crate::ble_pairing::BlePairingController;
+use crate::display_banner::{send_display_message, send_gateway_version_banner};
+use crate::display_control::{
+    cancel_status_page_scroll, claim_display_generation, reset_status_page_cycle,
+    try_claim_display_restore, StatusPageCycle, StatusPageScrollTask, STATUS_PAGE_TIMEOUT,
+};
+use crate::modem::UsbEspNowTransport;
+
+#[derive(Clone)]
+pub struct ActiveDisplayState {
+    transport: Arc<UsbEspNowTransport>,
+    controller: Arc<BlePairingController>,
+    display_generation: Arc<AtomicU64>,
+    status_page_cycle: Arc<tokio::sync::Mutex<StatusPageCycle>>,
+    status_page_scroll_task: StatusPageScrollTask,
+}
+
+impl ActiveDisplayState {
+    pub fn new(
+        transport: Arc<UsbEspNowTransport>,
+        controller: Arc<BlePairingController>,
+        display_generation: Arc<AtomicU64>,
+        status_page_cycle: Arc<tokio::sync::Mutex<StatusPageCycle>>,
+        status_page_scroll_task: StatusPageScrollTask,
+    ) -> Self {
+        Self {
+            transport,
+            controller,
+            display_generation,
+            status_page_cycle,
+            status_page_scroll_task,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct DisplayStateHandle {
+    inner: Arc<RwLock<Option<ActiveDisplayState>>>,
+}
+
+impl DisplayStateHandle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn set(&self, state: ActiveDisplayState) {
+        *self.inner.write().await = Some(state);
+    }
+
+    pub async fn clear(&self) {
+        *self.inner.write().await = None;
+    }
+
+    pub async fn get(&self) -> Option<ActiveDisplayState> {
+        self.inner.read().await.clone()
+    }
+}
+
+fn schedule_display_restore(state: &ActiveDisplayState, generation: u64) {
+    let transport: Weak<UsbEspNowTransport> = Arc::downgrade(&state.transport);
+    let controller = Arc::clone(&state.controller);
+    let display_generation = Arc::clone(&state.display_generation);
+    let status_page_cycle = Arc::clone(&state.status_page_cycle);
+    let status_page_scroll_task = Arc::clone(&state.status_page_scroll_task);
+
+    tokio::spawn(async move {
+        tokio::time::sleep(STATUS_PAGE_TIMEOUT).await;
+        if controller.session_origin().await.is_some() {
+            return;
+        }
+        if !try_claim_display_restore(display_generation.as_ref(), generation) {
+            return;
+        }
+        cancel_status_page_scroll(&status_page_scroll_task).await;
+        reset_status_page_cycle(&status_page_cycle).await;
+        let Some(transport) = transport.upgrade() else {
+            return;
+        };
+        if let Err(e) = send_gateway_version_banner(&transport).await {
+            warn!(error = %e, "failed to restore gateway version banner after transient display");
+        }
+    });
+}
+
+async fn restore_display_failure(state: &ActiveDisplayState, generation: u64) {
+    if !try_claim_display_restore(state.display_generation.as_ref(), generation) {
+        return;
+    }
+    if let Err(e) = send_gateway_version_banner(&state.transport).await {
+        warn!(
+            error = %e,
+            "failed to restore gateway version banner after transient display error"
+        );
+    }
+}
+
+pub async fn show_modem_display_message(
+    state: &ActiveDisplayState,
+    lines: &[String],
+) -> Result<(), Status> {
+    if state.controller.session_origin().await.is_some() {
+        return Err(Status::failed_precondition(
+            "BLE pairing session owns the modem display",
+        ));
+    }
+
+    if lines.is_empty() || lines.len() > 4 {
+        return Err(Status::invalid_argument(
+            "lines must contain between 1 and 4 entries",
+        ));
+    }
+
+    cancel_status_page_scroll(&state.status_page_scroll_task).await;
+    let generation = claim_display_generation(&state.display_generation);
+    reset_status_page_cycle(&state.status_page_cycle).await;
+
+    let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+    if let Err(e) = send_display_message(&state.transport, &line_refs).await {
+        restore_display_failure(state, generation).await;
+        return Err(Status::internal(format!(
+            "show modem display message failed: {e}"
+        )));
+    }
+
+    schedule_display_restore(state, generation);
+    Ok(())
+}

--- a/crates/sonde-gateway/tests/companion_api.rs
+++ b/crates/sonde-gateway/tests/companion_api.rs
@@ -29,6 +29,7 @@ use sonde_gateway::program::{ProgramRecord, VerificationProfile};
 use sonde_gateway::registry::NodeRecord;
 use sonde_gateway::session::SessionManager;
 use sonde_gateway::storage::{InMemoryStorage, Storage};
+use sonde_gateway::transient_display::DisplayStateHandle;
 use sonde_gateway::transport::PeerAddress;
 use sonde_gateway::GatewayAead;
 
@@ -119,6 +120,7 @@ impl CompanionHarness {
             pending_commands.clone(),
             session_manager.clone(),
             event_hub.clone(),
+            DisplayStateHandle::new(),
         );
         Self {
             storage,
@@ -676,6 +678,7 @@ fn t0825_companion_contract_excludes_operator_only_workflows() {
         "rpc QueueReboot",
         "rpc QueueEphemeral",
         "rpc GetNodeStatus",
+        "rpc ShowModemDisplayMessage",
     ] {
         assert!(
             proto.contains(rpc),

--- a/crates/sonde-gateway/tests/companion_display.rs
+++ b/crates/sonde-gateway/tests/companion_display.rs
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Companion transient display tests (T-0826).
+
+mod common;
+
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+use tokio::sync::RwLock;
+use tonic::{Code, Request};
+
+use sonde_gateway::admin::pb::gateway_admin_server::GatewayAdmin;
+use sonde_gateway::admin::pb::ShowModemDisplayMessageRequest;
+use sonde_gateway::admin::AdminService;
+use sonde_gateway::ble_pairing::{BlePairingController, PairingOrigin};
+use sonde_gateway::companion::pb::gateway_companion_server::GatewayCompanion;
+use sonde_gateway::companion::pb::*;
+use sonde_gateway::companion::{CompanionEventHub, CompanionService};
+use sonde_gateway::display_banner::{render_display_message, render_gateway_version_banner};
+use sonde_gateway::display_control::{StatusPageCycle, StatusPageScrollTask};
+use sonde_gateway::engine::PendingCommand;
+use sonde_gateway::session::SessionManager;
+use sonde_gateway::storage::{InMemoryStorage, Storage};
+use sonde_gateway::transient_display::{ActiveDisplayState, DisplayStateHandle};
+
+use sonde_protocol::modem::{
+    encode_modem_frame, DisplayFrameAck, FrameDecoder, ModemMessage, DISPLAY_FRAME_BODY_SIZE,
+    DISPLAY_FRAME_CHUNK_COUNT, DISPLAY_FRAME_CHUNK_SIZE,
+};
+
+use common::{create_transport_and_server, read_modem_msg};
+
+async fn receive_display_transfer(
+    server: &mut DuplexStream,
+    decoder: &mut FrameDecoder,
+    buf: &mut [u8],
+) -> [u8; DISPLAY_FRAME_BODY_SIZE] {
+    let mut framebuffer = [0u8; DISPLAY_FRAME_BODY_SIZE];
+
+    let begin = read_modem_msg(server, decoder, buf).await;
+    let transfer_id = match begin {
+        ModemMessage::DisplayFrameBegin(begin) => begin.transfer_id,
+        other => panic!("expected DisplayFrameBegin, got {other:?}"),
+    };
+    server
+        .write_all(
+            &encode_modem_frame(&ModemMessage::DisplayFrameAck(DisplayFrameAck {
+                transfer_id,
+                next_chunk_index: 0,
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    for expected_chunk_index in 0..DISPLAY_FRAME_CHUNK_COUNT {
+        let msg = read_modem_msg(server, decoder, buf).await;
+        match msg {
+            ModemMessage::DisplayFrameChunk(chunk) => {
+                assert_eq!(chunk.transfer_id, transfer_id);
+                assert_eq!(chunk.chunk_index, expected_chunk_index);
+                let start = usize::from(expected_chunk_index) * DISPLAY_FRAME_CHUNK_SIZE;
+                let end = start + DISPLAY_FRAME_CHUNK_SIZE;
+                framebuffer[start..end].copy_from_slice(&chunk.chunk_data);
+            }
+            other => panic!("expected DisplayFrameChunk, got {other:?}"),
+        }
+        server
+            .write_all(
+                &encode_modem_frame(&ModemMessage::DisplayFrameAck(DisplayFrameAck {
+                    transfer_id,
+                    next_chunk_index: expected_chunk_index + 1,
+                }))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    framebuffer
+}
+
+async fn assert_no_stream_data_while_time_paused(
+    server: &mut DuplexStream,
+    buf: &mut [u8],
+    duration: Duration,
+    message: &str,
+) {
+    let no_data = tokio::time::timeout(duration, server.read(buf));
+    tokio::pin!(no_data);
+    tokio::time::advance(duration).await;
+    assert!(no_data.await.is_err(), "{message}");
+}
+
+async fn build_services_with_modem(
+    channel: u8,
+) -> (
+    AdminService,
+    CompanionService,
+    DuplexStream,
+    Arc<BlePairingController>,
+    Arc<dyn Storage>,
+) {
+    let (transport, server) = create_transport_and_server(channel).await;
+    let transport = Arc::new(transport);
+    let controller = Arc::new(BlePairingController::new());
+    let storage: Arc<dyn Storage> = Arc::new(InMemoryStorage::new());
+    let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+    let pending: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
+        Arc::new(RwLock::new(HashMap::new()));
+    let display_generation = Arc::new(AtomicU64::new(0));
+    let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
+    let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
+
+    let display_handle = DisplayStateHandle::new();
+    display_handle
+        .set(ActiveDisplayState::new(
+            Arc::clone(&transport),
+            Arc::clone(&controller),
+            Arc::clone(&display_generation),
+            Arc::clone(&status_page_cycle),
+            Arc::clone(&status_page_scroll_task),
+        ))
+        .await;
+
+    let admin = AdminService::new(storage.clone(), pending.clone(), session_manager.clone())
+        .with_ble(Arc::clone(&controller), Arc::clone(&transport))
+        .with_display_state(
+            display_generation,
+            status_page_cycle,
+            status_page_scroll_task,
+        );
+    let companion = CompanionService::new(
+        storage.clone(),
+        pending,
+        session_manager,
+        Arc::new(CompanionEventHub::default()),
+        display_handle,
+    );
+
+    (admin, companion, server, controller, storage)
+}
+
+#[tokio::test]
+async fn t0826_companion_transient_display_reuses_gateway_display_semantics() {
+    tokio::time::pause();
+
+    let (admin, companion, mut server, _controller, _storage) = build_services_with_modem(6).await;
+    let admin = Arc::new(admin);
+    let companion = Arc::new(companion);
+    let mut decoder = FrameDecoder::new();
+    let mut buf = [0u8; 2048];
+
+    let first = tokio::spawn({
+        let companion = Arc::clone(&companion);
+        async move {
+            companion
+                .show_modem_display_message(Request::new(CompanionShowModemDisplayMessageRequest {
+                    lines: vec!["Azure login".to_string(), "ABCD-EFGH".to_string()],
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(
+        framebuffer,
+        render_display_message(&["Azure login", "ABCD-EFGH"])
+    );
+    first.await.unwrap().unwrap();
+
+    tokio::time::advance(Duration::from_secs(30)).await;
+
+    let second = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec!["Admin override".to_string()],
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(framebuffer, render_display_message(&["Admin override"]));
+    second.await.unwrap().unwrap();
+
+    assert_no_stream_data_while_time_paused(
+        &mut server,
+        &mut buf,
+        Duration::from_secs(30) + Duration::from_millis(100),
+        "the earlier companion timer must not restore the banner after admin replacement",
+    )
+    .await;
+
+    tokio::time::advance(Duration::from_secs(30) + Duration::from_millis(100)).await;
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(
+        framebuffer,
+        render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[tokio::test]
+async fn companion_display_rejected_during_ble_pairing() {
+    let (_admin, companion, mut server, controller, _storage) = build_services_with_modem(6).await;
+    assert!(controller.open_window(120, PairingOrigin::Admin).await);
+
+    let err = companion
+        .show_modem_display_message(Request::new(CompanionShowModemDisplayMessageRequest {
+            lines: vec!["Blocked".to_string()],
+        }))
+        .await
+        .expect_err("display request must fail during active BLE pairing");
+    assert_eq!(err.code(), Code::FailedPrecondition);
+
+    let mut buf = [0u8; 256];
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), server.read(&mut buf))
+            .await
+            .is_err(),
+        "rejected display request must not emit modem traffic"
+    );
+}
+
+#[tokio::test]
+async fn companion_display_rejects_invalid_line_count() {
+    let (_admin, companion, mut server, _controller, _storage) = build_services_with_modem(6).await;
+
+    let err = companion
+        .show_modem_display_message(Request::new(CompanionShowModemDisplayMessageRequest {
+            lines: vec![],
+        }))
+        .await
+        .expect_err("empty line set must be rejected");
+    assert_eq!(err.code(), Code::InvalidArgument);
+
+    let err = companion
+        .show_modem_display_message(Request::new(CompanionShowModemDisplayMessageRequest {
+            lines: vec![
+                "1".to_string(),
+                "2".to_string(),
+                "3".to_string(),
+                "4".to_string(),
+                "5".to_string(),
+            ],
+        }))
+        .await
+        .expect_err("more than four lines must be rejected");
+    assert_eq!(err.code(), Code::InvalidArgument);
+
+    let mut buf = [0u8; 256];
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), server.read(&mut buf))
+            .await
+            .is_err(),
+        "invalid requests must not emit modem traffic"
+    );
+}
+
+#[tokio::test]
+async fn companion_display_without_transport_is_unavailable() {
+    let storage: Arc<dyn Storage> = Arc::new(InMemoryStorage::new());
+    let pending: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
+        Arc::new(RwLock::new(HashMap::new()));
+    let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+    let companion = CompanionService::new(
+        storage,
+        pending,
+        session_manager,
+        Arc::new(CompanionEventHub::default()),
+        DisplayStateHandle::new(),
+    );
+
+    let err = companion
+        .show_modem_display_message(Request::new(CompanionShowModemDisplayMessageRequest {
+            lines: vec!["Unavailable".to_string()],
+        }))
+        .await
+        .expect_err("missing modem transport must produce UNAVAILABLE");
+    assert_eq!(err.code(), Code::Unavailable);
+}

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -eu
+
+if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
+    image="${SONDE_AZURE_COMPANION_IMAGE:-sonde-azure-companion:local}"
+    state_dir="${SONDE_AZURE_COMPANION_STATE_DIR:-$PWD/.sonde-azure-companion}"
+    runtime_dir="${SONDE_GATEWAY_RUNTIME_DIR:-/var/run/sonde}"
+    container_state_dir="/var/lib/sonde-azure-companion"
+    container_runtime_dir="/var/run/sonde"
+
+    mkdir -p "$state_dir"
+    if [ ! -d "$runtime_dir" ]; then
+        echo "gateway runtime directory not found: $runtime_dir" >&2
+        exit 1
+    fi
+
+    exec docker run --rm \
+        --name "${SONDE_AZURE_COMPANION_CONTAINER_NAME:-sonde-azure-companion}" \
+        -e SONDE_AZURE_COMPANION_IN_CONTAINER=1 \
+        -e SONDE_AZURE_COMPANION_STATE_DIR="$container_state_dir" \
+        -e SONDE_GATEWAY_COMPANION_SOCKET="$container_runtime_dir/companion.sock" \
+        -v "$state_dir:$container_state_dir" \
+        -v "$runtime_dir:$container_runtime_dir" \
+        "$image" "$@"
+fi
+
+state_dir="${SONDE_AZURE_COMPANION_STATE_DIR:-/var/lib/sonde-azure-companion}"
+socket_path="${SONDE_GATEWAY_COMPANION_SOCKET:-/var/run/sonde/companion.sock}"
+azure_config_dir="$state_dir/azure"
+pipe_path="$state_dir/az-login.pipe.$$"
+
+mkdir -p "$azure_config_dir"
+export AZURE_CONFIG_DIR="$azure_config_dir"
+
+has_auth_state() {
+    [ -f "$AZURE_CONFIG_DIR/msal_token_cache.json" ] || [ -f "$AZURE_CONFIG_DIR/accessTokens.json" ]
+}
+
+cleanup() {
+    rm -f "$pipe_path"
+}
+
+trap cleanup EXIT INT TERM
+
+if has_auth_state; then
+    exec sonde-azure-companion --companion-socket "$socket_path" run
+fi
+
+rm -f "$pipe_path"
+mkfifo "$pipe_path"
+
+az login --use-device-code >"$pipe_path" 2>&1 &
+az_pid=$!
+shown=0
+
+while IFS= read -r line; do
+    printf '%s\n' "$line"
+    if [ "$shown" -eq 0 ]; then
+        device_code="$(printf '%s\n' "$line" | sed -nE 's/.*[Cc]ode ([A-Z0-9-]+).*/\1/p')"
+        if [ -n "$device_code" ]; then
+            if ! sonde-azure-companion --companion-socket "$socket_path" display-message "Azure login" "$device_code"; then
+                kill "$az_pid" 2>/dev/null || true
+                wait "$az_pid" 2>/dev/null || true
+                echo "failed to display Azure device code on the modem; retry when the display is available" >&2
+                exit 1
+            fi
+            shown=1
+        fi
+    fi
+done <"$pipe_path"
+
+if wait "$az_pid"; then
+    :
+else
+    status=$?
+    exit "$status"
+fi
+
+if [ "$shown" -eq 0 ]; then
+    echo "Azure device-code login succeeded but no device code was extracted for modem display" >&2
+    exit 1
+fi
+
+exec sonde-azure-companion --companion-socket "$socket_path" run

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -7,7 +7,7 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
     runtime_dir="${SONDE_GATEWAY_RUNTIME_DIR:-/var/run/sonde}"
     socket_path="$runtime_dir/companion.sock"
     container_state_dir="/var/lib/sonde-azure-companion"
-    container_runtime_dir="/var/run/sonde"
+    container_socket_path="/var/run/sonde/companion.sock"
 
     mkdir -p "$state_dir"
     if [ ! -d "$runtime_dir" ]; then
@@ -33,13 +33,13 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         --name "${SONDE_AZURE_COMPANION_CONTAINER_NAME:-sonde-azure-companion}" \
         -e SONDE_AZURE_COMPANION_IN_CONTAINER=1 \
         -e SONDE_AZURE_COMPANION_STATE_DIR="$container_state_dir" \
-        -e SONDE_GATEWAY_COMPANION_SOCKET="$container_runtime_dir/companion.sock" \
+        -e SONDE_GATEWAY_COMPANION_SOCKET="$container_socket_path" \
         -e SONDE_AZURE_DEVICE_CLIENT_ID \
         -e SONDE_AZURE_DEVICE_SCOPES \
         -e SONDE_AZURE_DEVICE_POLL_INTERVAL_SECS \
         -e SONDE_AZURE_DEVICE_MAX_ATTEMPTS \
         -v "$state_dir:$container_state_dir" \
-        -v "$runtime_dir:$container_runtime_dir" \
+        -v "$socket_path:$container_socket_path" \
         "$image" "$@"
 fi
 

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -19,6 +19,10 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         -e SONDE_AZURE_COMPANION_IN_CONTAINER=1 \
         -e SONDE_AZURE_COMPANION_STATE_DIR="$container_state_dir" \
         -e SONDE_GATEWAY_COMPANION_SOCKET="$container_runtime_dir/companion.sock" \
+        -e SONDE_AZURE_DEVICE_CLIENT_ID \
+        -e SONDE_AZURE_DEVICE_SCOPES \
+        -e SONDE_AZURE_DEVICE_POLL_INTERVAL_SECS \
+        -e SONDE_AZURE_DEVICE_MAX_ATTEMPTS \
         -v "$state_dir:$container_state_dir" \
         -v "$runtime_dir:$container_runtime_dir" \
         "$image" "$@"
@@ -26,59 +30,16 @@ fi
 
 state_dir="${SONDE_AZURE_COMPANION_STATE_DIR:-/var/lib/sonde-azure-companion}"
 socket_path="${SONDE_GATEWAY_COMPANION_SOCKET:-/var/run/sonde/companion.sock}"
-azure_config_dir="$state_dir/azure"
-pipe_path="$state_dir/az-login.pipe.$$"
 
-mkdir -p "$azure_config_dir"
-export AZURE_CONFIG_DIR="$azure_config_dir"
-
-has_auth_state() {
-    [ -f "$AZURE_CONFIG_DIR/msal_token_cache.json" ] || [ -f "$AZURE_CONFIG_DIR/accessTokens.json" ]
-}
-
-cleanup() {
-    rm -f "$pipe_path"
-}
-
-trap cleanup EXIT INT TERM
-
-if has_auth_state; then
-    exec sonde-azure-companion --companion-socket "$socket_path" run
+if [ "$#" -gt 0 ]; then
+    exec "$@"
 fi
 
-rm -f "$pipe_path"
-mkfifo "$pipe_path"
+mkdir -p "$state_dir"
 
-az login --use-device-code >"$pipe_path" 2>&1 &
-az_pid=$!
-shown=0
-
-while IFS= read -r line; do
-    printf '%s\n' "$line"
-    if [ "$shown" -eq 0 ]; then
-        device_code="$(printf '%s\n' "$line" | sed -nE 's/.*[Cc]ode ([A-Z0-9-]+).*/\1/p')"
-        if [ -n "$device_code" ]; then
-            if ! sonde-azure-companion --companion-socket "$socket_path" display-message "Azure login" "$device_code"; then
-                kill "$az_pid" 2>/dev/null || true
-                wait "$az_pid" 2>/dev/null || true
-                echo "failed to display Azure device code on the modem; retry when the display is available" >&2
-                exit 1
-            fi
-            shown=1
-        fi
-    fi
-done <"$pipe_path"
-
-if wait "$az_pid"; then
-    :
-else
-    status=$?
-    exit "$status"
-fi
-
-if [ "$shown" -eq 0 ]; then
-    echo "Azure device-code login succeeded but no device code was extracted for modem display" >&2
-    exit 1
-fi
+sonde-azure-companion \
+    --companion-socket "$socket_path" \
+    bootstrap-auth \
+    --state-dir "$state_dir"
 
 exec sonde-azure-companion --companion-socket "$socket_path" run

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -52,9 +52,36 @@ fi
 
 mkdir -p "$state_dir"
 
+bootstrap_pid=
+
+forward_signal() {
+    signal="$1"
+    if [ -n "${bootstrap_pid:-}" ]; then
+        kill "-$signal" "$bootstrap_pid" 2>/dev/null || true
+        wait "$bootstrap_pid" 2>/dev/null || true
+    fi
+}
+
+trap 'forward_signal TERM; exit 143' TERM
+trap 'forward_signal INT; exit 130' INT
+
 sonde-azure-companion \
     --companion-socket "$socket_path" \
     bootstrap-auth \
-    --state-dir "$state_dir"
+    --state-dir "$state_dir" &
+bootstrap_pid=$!
+
+if wait "$bootstrap_pid"; then
+    bootstrap_status=0
+else
+    bootstrap_status=$?
+fi
+
+trap - TERM INT
+bootstrap_pid=
+
+if [ "$bootstrap_status" -ne 0 ]; then
+    exit "$bootstrap_status"
+fi
 
 exec sonde-azure-companion --companion-socket "$socket_path" run

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -5,12 +5,17 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
     image="${SONDE_AZURE_COMPANION_IMAGE:-sonde-azure-companion:local}"
     state_dir="${SONDE_AZURE_COMPANION_STATE_DIR:-$PWD/.sonde-azure-companion}"
     runtime_dir="${SONDE_GATEWAY_RUNTIME_DIR:-/var/run/sonde}"
+    socket_path="$runtime_dir/companion.sock"
     container_state_dir="/var/lib/sonde-azure-companion"
     container_runtime_dir="/var/run/sonde"
 
     mkdir -p "$state_dir"
     if [ ! -d "$runtime_dir" ]; then
         echo "gateway runtime directory not found: $runtime_dir" >&2
+        exit 1
+    fi
+    if [ ! -S "$socket_path" ]; then
+        echo "gateway companion socket not found: $socket_path" >&2
         exit 1
     fi
 

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -18,6 +18,16 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         echo "gateway companion socket not found: $socket_path" >&2
         exit 1
     fi
+    if [ "$#" -eq 0 ]; then
+        if [ -z "${SONDE_AZURE_DEVICE_CLIENT_ID:-}" ]; then
+            echo "SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap" >&2
+            exit 1
+        fi
+        if [ -z "${SONDE_AZURE_DEVICE_SCOPES:-}" ]; then
+            echo "SONDE_AZURE_DEVICE_SCOPES must be set for bootstrap" >&2
+            exit 1
+        fi
+    fi
 
     exec docker run --rm \
         --name "${SONDE_AZURE_COMPANION_CONTAINER_NAME:-sonde-azure-companion}" \

--- a/deploy/azure-companion/entrypoint.sh
+++ b/deploy/azure-companion/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+export SONDE_AZURE_COMPANION_IN_CONTAINER=1
+exec /opt/sonde/deploy/azure-companion/bootstrap.sh "$@"

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -17,7 +17,7 @@ initial slice does not yet provision Azure resources or bridge data into Azure
 services. Its responsibility is limited to:
 
 1. starting in a dedicated container,
-2. detecting first-run bootstrap from a mounted auth state volume,
+2. preparing a mounted persistent state volume for later provisioning slices,
 3. obtaining Azure authentication via device-code login,
 4. showing a short prompt plus the device code on the modem display through the
    gateway companion API, and
@@ -38,7 +38,7 @@ The implementation adds the following artifacts:
 |----------|---------|
 | `crates/sonde-azure-companion/` | New Rust crate containing the Azure companion binary. |
 | `.github/docker/Dockerfile.azure-companion` | Dockerfile for the dedicated Azure companion image. |
-| `deploy/azure-companion/bootstrap.sh` | Host/container bootstrap script that prepares the mounted auth state volume and runs first-login bootstrap when needed. |
+| `deploy/azure-companion/bootstrap.sh` | Host/container bootstrap script that prepares the mounted state volume and runs the Rust-owned device-auth bootstrap before normal runtime starts. |
 | `deploy/azure-companion/entrypoint.sh` | In-container entrypoint that orchestrates bootstrap before starting the long-running process. |
 
 The long-running binary is named `sonde-azure-companion`.
@@ -54,13 +54,14 @@ The long-running binary is named `sonde-azure-companion`.
 The container runs a small shell entrypoint that performs bootstrap orchestration
 and then execs the Rust binary. The split is intentional:
 
-1. **Shell script** handles environment preparation, filesystem setup, and Azure
-   CLI invocation.
-2. **Rust binary** owns gateway companion gRPC communication and the future
-   Azure-integration runtime.
+1. **Shell script** handles environment preparation, filesystem setup, and
+   container-vs-host orchestration.
+2. **Rust binary** owns gateway companion gRPC communication, Microsoft device
+   flow, and the future Azure-integration runtime.
 
-This keeps the gateway-facing logic in typed Rust while still using the Azure
-CLI directly for the initial device-code login flow required by issue #771.
+This keeps the gateway-facing logic and the Azure device-code flow in typed
+Rust, which removes the Azure CLI dependency and allows an Alpine runtime
+image.
 
 ### 3.2  Mounted inputs
 
@@ -68,11 +69,11 @@ The container expects two mounted host resources:
 
 | Mount | Purpose |
 |-------|---------|
-| Auth state volume | Persistent storage for Azure CLI authentication state. |
+| State volume | Persistent storage reserved for later managed-identity bootstrap output and other local provisioning artifacts. |
 | Gateway companion socket | Local IPC path used to call `GatewayCompanion` RPCs, including `ShowModemDisplayMessage`. |
 
-The auth state volume is the only persistent state required by this initial
-slice. The image itself is replaceable.
+The current slice prepares the state volume but does not persist Azure access
+tokens there. The image itself is replaceable.
 
 ---
 
@@ -82,29 +83,26 @@ slice. The image itself is replaceable.
 
 ### 4.1  Startup decision
 
-At container start, `entrypoint.sh` checks the mounted auth state volume for
-usable Azure authentication state.
-
-- If usable state is present, the script skips device-code login and starts the
-  long-running Rust process.
-- If usable state is absent, the script runs `bootstrap.sh` to perform first-run
-  login.
+At container start, `entrypoint.sh` delegates to `bootstrap.sh`. The in-container
+bootstrap path creates the mounted state directory and then invokes the Rust
+binary's `bootstrap-auth` mode before starting the normal long-running process.
+This slice does not inspect the state directory to skip login on restart.
 
 ### 4.2  Device-code login sequence
 
 The first-run bootstrap sequence is:
 
-1. Ensure the auth state directory exists and is writable.
-2. Invoke Azure CLI device-code login with `az login --use-device-code`.
-3. Capture the device-code output emitted by Azure CLI.
-4. Extract the device code from that output.
-5. Call `sonde-azure-companion display-message <prompt> <code>` so the Rust
-   binary connects to the gateway companion socket and issues
-   `ShowModemDisplayMessage`.
-6. Wait for Azure CLI to complete successfully.
-7. Leave the resulting Azure authentication state in the mounted auth state
-   volume.
-8. Start the long-running Rust process.
+1. Ensure the mounted state directory exists and is writable.
+2. Invoke `sonde-azure-companion bootstrap-auth`.
+3. Inside Rust, construct a Microsoft device-flow client from explicit
+   environment-provided client ID and scopes.
+4. Request a device code from Microsoft's device authorization endpoint.
+5. Log the verification URI to stdout/stderr for operator visibility.
+6. Call the gateway companion `ShowModemDisplayMessage` RPC with a short prompt
+   plus the exact device code.
+7. Poll the token endpoint until the operator completes device auth or the flow
+   fails.
+8. Discard the short-lived token and exec the long-running `run` mode.
 
 The full Azure verification URL remains in stdout/stderr logs; the modem display
 shows only the short prompt plus the device code.
@@ -120,18 +118,26 @@ headless operator workflow required by the discovery review.
 
 ## 5  Rust binary interface
 
-> **Requirements:** AZC-0100, AZC-0102, AZC-0202, AZC-0300
+> **Requirements:** AZC-0100, AZC-0102, AZC-0201, AZC-0202, AZC-0300
 
-The initial `sonde-azure-companion` binary exposes two modes:
+The initial `sonde-azure-companion` binary exposes three modes:
 
 1. **`run`** — default long-running companion mode. In this initial slice it
    establishes gateway companion connectivity and remains ready for later Azure
    integration work.
-2. **`display-message`** — helper mode used by the bootstrap scripts to call the
+2. **`bootstrap-auth`** — performs Microsoft OAuth device flow in Rust, logs the
+   verification URI, requests the modem display update, waits for operator
+   completion, and discards the resulting token.
+3. **`display-message`** — helper mode used by the bootstrap logic to call the
    gateway companion `ShowModemDisplayMessage` RPC with 1 to 4 lines of text.
 
-The helper mode keeps gateway IPC out of shell-script string munging and ensures
-the same Rust client stack is used during bootstrap and later runtime work.
+The helper modes keep gateway IPC and OAuth error handling out of shell-script
+string munging and ensure the same Rust client stack is used during bootstrap
+and later runtime work.
+
+`bootstrap-auth` requires the caller to provide the Azure device-flow client ID
+and scopes explicitly through environment variables or CLI flags. This slice
+does not guess Azure application defaults.
 
 ---
 

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -109,7 +109,7 @@ shows only the short prompt plus the device code.
 
 ### 4.3  Display failure handling
 
-If step 5 fails because the gateway rejects the display request or no modem
+If step 6 fails because the gateway rejects the display request or no modem
 transport is available, the bootstrap flow exits immediately with a non-zero
 status. It does not continue to a console-only fallback. This preserves the
 headless operator workflow required by the discovery review.

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -1,0 +1,169 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Azure Companion Design Specification
+
+> **Document status:** Draft
+> **Scope:** Internal design for the initial Azure companion slice: container packaging, bootstrap scripts, gateway companion integration, and Azure device-code login.
+> **Audience:** Implementers building the new Azure companion crate and its deployment artifacts.
+> **Related:** [azure-companion-requirements.md](azure-companion-requirements.md), [gateway-companion-api.md](gateway-companion-api.md), [gateway-design.md](gateway-design.md)
+
+---
+
+## 1  Overview
+
+The Azure companion is a new Rust workspace crate that runs in its own Docker
+container and talks to `sonde-gateway` over the local companion gRPC API. This
+initial slice does not yet provision Azure resources or bridge data into Azure
+services. Its responsibility is limited to:
+
+1. starting in a dedicated container,
+2. detecting first-run bootstrap from a mounted auth state volume,
+3. obtaining Azure authentication via device-code login,
+4. showing a short prompt plus the device code on the modem display through the
+   gateway companion API, and
+5. starting a minimal long-running companion process after bootstrap completes.
+
+Terraform provisioning, managed-identity creation, gateway configuration
+generation, and Azure-side message forwarding are deferred to later issues.
+
+---
+
+## 2  Repository layout
+
+> **Requirements:** AZC-0100, AZC-0102
+
+The implementation adds the following artifacts:
+
+| Artifact | Purpose |
+|----------|---------|
+| `crates/sonde-azure-companion/` | New Rust crate containing the Azure companion binary. |
+| `.github/docker/Dockerfile.azure-companion` | Dockerfile for the dedicated Azure companion image. |
+| `deploy/azure-companion/bootstrap.sh` | Host/container bootstrap script that prepares the mounted auth state volume and runs first-login bootstrap when needed. |
+| `deploy/azure-companion/entrypoint.sh` | In-container entrypoint that orchestrates bootstrap before starting the long-running process. |
+
+The long-running binary is named `sonde-azure-companion`.
+
+---
+
+## 3  Runtime architecture
+
+> **Requirements:** AZC-0100, AZC-0101, AZC-0300
+
+### 3.1  Process model
+
+The container runs a small shell entrypoint that performs bootstrap orchestration
+and then execs the Rust binary. The split is intentional:
+
+1. **Shell script** handles environment preparation, filesystem setup, and Azure
+   CLI invocation.
+2. **Rust binary** owns gateway companion gRPC communication and the future
+   Azure-integration runtime.
+
+This keeps the gateway-facing logic in typed Rust while still using the Azure
+CLI directly for the initial device-code login flow required by issue #771.
+
+### 3.2  Mounted inputs
+
+The container expects two mounted host resources:
+
+| Mount | Purpose |
+|-------|---------|
+| Auth state volume | Persistent storage for Azure CLI authentication state. |
+| Gateway companion socket | Local IPC path used to call `GatewayCompanion` RPCs, including `ShowModemDisplayMessage`. |
+
+The auth state volume is the only persistent state required by this initial
+slice. The image itself is replaceable.
+
+---
+
+## 4  Bootstrap flow
+
+> **Requirements:** AZC-0101, AZC-0102, AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204
+
+### 4.1  Startup decision
+
+At container start, `entrypoint.sh` checks the mounted auth state volume for
+usable Azure authentication state.
+
+- If usable state is present, the script skips device-code login and starts the
+  long-running Rust process.
+- If usable state is absent, the script runs `bootstrap.sh` to perform first-run
+  login.
+
+### 4.2  Device-code login sequence
+
+The first-run bootstrap sequence is:
+
+1. Ensure the auth state directory exists and is writable.
+2. Invoke Azure CLI device-code login with `az login --use-device-code`.
+3. Capture the device-code output emitted by Azure CLI.
+4. Extract the device code from that output.
+5. Call `sonde-azure-companion display-message <prompt> <code>` so the Rust
+   binary connects to the gateway companion socket and issues
+   `ShowModemDisplayMessage`.
+6. Wait for Azure CLI to complete successfully.
+7. Leave the resulting Azure authentication state in the mounted auth state
+   volume.
+8. Start the long-running Rust process.
+
+The full Azure verification URL remains in stdout/stderr logs; the modem display
+shows only the short prompt plus the device code.
+
+### 4.3  Display failure handling
+
+If step 5 fails because the gateway rejects the display request or no modem
+transport is available, the bootstrap flow exits immediately with a non-zero
+status. It does not continue to a console-only fallback. This preserves the
+headless operator workflow required by the discovery review.
+
+---
+
+## 5  Rust binary interface
+
+> **Requirements:** AZC-0100, AZC-0102, AZC-0202, AZC-0300
+
+The initial `sonde-azure-companion` binary exposes two modes:
+
+1. **`run`** — default long-running companion mode. In this initial slice it
+   establishes gateway companion connectivity and remains ready for later Azure
+   integration work.
+2. **`display-message`** — helper mode used by the bootstrap scripts to call the
+   gateway companion `ShowModemDisplayMessage` RPC with 1 to 4 lines of text.
+
+The helper mode keeps gateway IPC out of shell-script string munging and ensures
+the same Rust client stack is used during bootstrap and later runtime work.
+
+---
+
+## 6  Gateway integration
+
+> **Requirements:** AZC-0202, AZC-0203, AZC-0300
+
+### 6.1  Companion client
+
+The Rust binary connects only to the gateway companion socket. It does not use
+the admin socket. The gRPC client uses the published `GatewayCompanion` contract
+and companion-specific message types.
+
+### 6.2  Shared display path
+
+The gateway-side `ShowModemDisplayMessage` companion RPC reuses the same display
+helper as the existing admin RPC. The Azure companion therefore gains no special
+display privileges:
+
+1. BLE pairing still preempts transient display requests.
+2. Line-count validation remains 1 to 4 lines.
+3. The gateway retains rendering, display ownership, and banner-restore logic.
+4. The Azure companion cannot issue raw modem commands or upload framebuffers.
+
+---
+
+## 7  Long-running process behavior in this slice
+
+> **Requirements:** AZC-0102, AZC-0300
+
+After bootstrap succeeds, the `run` mode starts and validates gateway companion
+connectivity. This first slice does not yet forward events to Azure services or
+pull cloud-issued commands. Those behaviors are deferred to the later Terraform
+and cloud-integration issues.
+

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -1,0 +1,205 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Azure Companion Requirements Specification
+
+> **Document status:** Draft
+> **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771) and companion-bootstrap discovery review.
+> **Scope:** This document covers only the initial Azure companion slice: a new Rust companion app in its own Docker container plus bootstrap scripts for Azure device-code login. Terraform, managed-identity creation, gateway configuration generation, and handler wiring are out of scope for this document.
+> **Related:** [gateway-companion-api.md](gateway-companion-api.md), [gateway-requirements.md](gateway-requirements.md), [gateway-design.md](gateway-design.md)
+
+---
+
+## 1  Definitions
+
+| Term | Definition |
+|------|------------|
+| **Azure companion** | The new Rust process that runs in its own container and integrates with `sonde-gateway` through the local companion API. |
+| **Auth state volume** | A mounted persistent directory used to hold Azure authentication state across container restarts. |
+| **Bootstrap login** | The initial Azure device-code login flow performed when the auth state volume does not yet contain usable authentication state. |
+| **Device code prompt** | The short operator-facing text shown on the modem display during bootstrap, consisting of a prompt plus the Azure device code. |
+
+---
+
+## 2  Requirement format
+
+Each requirement uses the following fields:
+
+- **ID** — Unique identifier (`AZC-XXXX`).
+- **Title** — Short name.
+- **Description** — What the Azure companion must do.
+- **Acceptance criteria** — Observable, testable conditions that confirm the requirement is met.
+- **Priority** — MoSCoW: **Must**, **Should**, **May**.
+- **Source** — Issue, gateway specification, or reviewed discovery output that motivates the requirement.
+
+---
+
+## 3  Container packaging and bootstrap entrypoints
+
+### AZC-0100  Dedicated companion container image
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771)
+
+**Description:**
+The repository MUST build a dedicated Docker container image for the Azure
+companion. The image MUST be separate from the gateway image and MUST contain
+the Azure companion binary, Azure CLI tooling required for device-code login,
+and the bootstrap scripts needed to initialize authentication state.
+
+**Acceptance criteria:**
+
+1. Building the Azure companion Dockerfile produces an image that starts the Azure companion container without requiring the gateway image.
+2. The image contains the Azure companion binary.
+3. The image contains Azure CLI tooling sufficient to perform `az login --use-device-code`.
+4. The image contains the bootstrap scripts used by the initial login flow.
+
+---
+
+### AZC-0101  Persistent auth state volume
+
+**Priority:** Must
+**Source:** Discovery review
+
+**Description:**
+The Azure companion container MUST use a mounted persistent auth state volume so
+Azure authentication state survives container restarts. The image itself MUST
+remain stateless with respect to bootstrap progress and acquired credentials.
+
+**Acceptance criteria:**
+
+1. When the container is started with a mounted auth state volume, Azure authentication state is written into that mounted directory rather than remaining only in the image filesystem.
+2. Restarting the container with the same mounted auth state volume preserves previously acquired authentication state.
+3. Starting the container with a fresh empty auth state volume is treated as a first-run bootstrap case.
+
+---
+
+### AZC-0102  Bootstrap entrypoint scripts
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
+
+**Description:**
+The repository MUST provide bootstrap scripts that prepare the auth state
+volume, run the first-login flow when needed, and then start the long-running
+Azure companion process inside its dedicated container.
+
+**Acceptance criteria:**
+
+1. A provided bootstrap script can start the Azure companion container with the expected auth state volume and gateway companion socket bindings.
+2. The bootstrap path initializes the auth state volume before invoking the login logic.
+3. After bootstrap prerequisites are satisfied, the scripts start the Azure companion process without requiring manual in-container steps.
+
+---
+
+## 4  Azure device-code login bootstrap
+
+### AZC-0200  Empty-state bootstrap detection
+
+**Priority:** Must
+**Source:** Discovery review
+
+**Description:**
+When the mounted auth state volume does not contain usable Azure authentication
+state, the bootstrap flow MUST treat startup as a first-run bootstrap and enter
+Azure device-code login.
+
+**Acceptance criteria:**
+
+1. Starting the container with an empty auth state volume enters the bootstrap login path.
+2. Starting the container with usable persisted authentication state does not enter the bootstrap login path.
+3. The bootstrap decision is based on the mounted auth state volume, not on transient in-memory state.
+
+---
+
+### AZC-0201  Azure device-code login
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771)
+
+**Description:**
+The bootstrap flow MUST obtain Azure authentication through Azure device-code
+login. The initial implementation MUST use `az login --use-device-code`.
+
+**Acceptance criteria:**
+
+1. First-run bootstrap invokes Azure device-code login without requiring a local browser on the gateway host.
+2. The login flow waits for successful operator completion before reporting bootstrap success.
+3. If Azure device-code login fails, bootstrap exits with a non-zero status and does not report success.
+
+---
+
+### AZC-0202  Device code display via gateway companion API
+
+**Priority:** Must
+**Source:** Discovery review, [gateway-companion-api.md](gateway-companion-api.md)
+
+**Description:**
+When Azure device-code login produces a device code, the bootstrap flow MUST
+request a modem display update through the gateway companion API. The displayed
+message MUST include a short prompt and the exact device code. The Azure
+companion MUST NOT attempt raw modem control or bypass the gateway's display
+ownership rules.
+
+**Acceptance criteria:**
+
+1. During first-run bootstrap, the Azure companion calls the gateway companion `ShowModemDisplayMessage` RPC with text that includes both a short prompt and the exact device code.
+2. The displayed device code matches the value produced by Azure device-code login without modification.
+3. The Azure companion uses the gateway companion socket, not the admin socket, for this display request.
+4. The bootstrap flow does not invoke raw modem serial commands or direct framebuffer upload.
+
+---
+
+### AZC-0203  Display failure aborts bootstrap
+
+**Priority:** Must
+**Source:** Discovery review
+
+**Description:**
+If the Azure companion cannot display the device code on the modem through the
+gateway companion API, bootstrap MUST fail closed. It MUST surface the failure
+to the operator and require a retry after the display becomes available.
+
+**Acceptance criteria:**
+
+1. If the gateway returns `FAILED_PRECONDITION` because BLE pairing owns the display, bootstrap exits with a non-zero status.
+2. If the gateway returns `UNAVAILABLE` because no modem transport is configured, bootstrap exits with a non-zero status.
+3. Bootstrap does not silently continue with a console-only fallback when the modem display request fails.
+
+---
+
+### AZC-0204  Persisted authentication reuse
+
+**Priority:** Must
+**Source:** Discovery review
+
+**Description:**
+After a successful bootstrap login, the Azure companion MUST reuse the persisted
+authentication state from the mounted auth state volume on later starts instead
+of requiring device-code login again.
+
+**Acceptance criteria:**
+
+1. After a successful first-run bootstrap, restarting the container with the same auth state volume skips Azure device-code login.
+2. On a restart that skips device-code login, the bootstrap flow does not request a modem display update for a new device code.
+3. If persisted authentication state is missing or unusable, the next start re-enters the bootstrap login path.
+
+---
+
+## 5  Gateway integration
+
+### AZC-0300  Companion-socket integration
+
+**Priority:** Must
+**Source:** Discovery review, [gateway-companion-api.md](gateway-companion-api.md) §2
+
+**Description:**
+The Azure companion MUST integrate with the gateway through the local companion
+socket exposed by the `GatewayCompanion` service. It MUST NOT depend on the
+gateway admin socket for its normal runtime integration.
+
+**Acceptance criteria:**
+
+1. The Azure companion can connect to the configured companion socket when the gateway is running.
+2. The Azure companion uses the companion socket for the modem display request defined by AZC-0202.
+3. Normal Azure companion startup does not require access to the gateway admin socket.
+

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -14,8 +14,8 @@
 | Term | Definition |
 |------|------------|
 | **Azure companion** | The new Rust process that runs in its own container and integrates with `sonde-gateway` through the local companion API. |
-| **Auth state volume** | A mounted persistent directory used to hold Azure authentication state across container restarts. |
-| **Bootstrap login** | The initial Azure device-code login flow performed when the auth state volume does not yet contain usable authentication state. |
+| **State volume** | A mounted persistent directory reserved for Azure companion bootstrap output such as local credentials, managed-identity identifiers, and related provisioning artifacts once later slices implement them. |
+| **Bootstrap login** | The Azure device-code login flow performed by the current slice before the long-running companion process starts. |
 | **Device code prompt** | The short operator-facing text shown on the modem display during bootstrap, consisting of a prompt plus the Azure device code. |
 
 ---
@@ -43,33 +43,35 @@ Each requirement uses the following fields:
 **Description:**
 The repository MUST build a dedicated Docker container image for the Azure
 companion. The image MUST be separate from the gateway image and MUST contain
-the Azure companion binary, Azure CLI tooling required for device-code login,
-and the bootstrap scripts needed to initialize authentication state.
+the Azure companion binary, the Rust-owned device-auth implementation required
+for device-code login, and the bootstrap scripts needed to initialize the
+mounted state volume.
 
 **Acceptance criteria:**
 
 1. Building the Azure companion Dockerfile produces an image that starts the Azure companion container without requiring the gateway image.
 2. The image contains the Azure companion binary.
-3. The image contains Azure CLI tooling sufficient to perform `az login --use-device-code`.
+3. The image is based on Alpine Linux and does not require Azure CLI tooling to perform device-code login.
 4. The image contains the bootstrap scripts used by the initial login flow.
 
 ---
 
-### AZC-0101  Persistent auth state volume
+### AZC-0101  Persistent state volume
 
 **Priority:** Must
 **Source:** Discovery review
 
 **Description:**
-The Azure companion container MUST use a mounted persistent auth state volume so
-Azure authentication state survives container restarts. The image itself MUST
-remain stateless with respect to bootstrap progress and acquired credentials.
+The Azure companion container MUST use a mounted persistent state volume so
+later slices can store local provisioning output there. The image itself MUST
+remain stateless. The current slice MUST prepare and mount that directory but
+MUST NOT persist Azure access tokens there.
 
 **Acceptance criteria:**
 
-1. When the container is started with a mounted auth state volume, Azure authentication state is written into that mounted directory rather than remaining only in the image filesystem.
-2. Restarting the container with the same mounted auth state volume preserves previously acquired authentication state.
-3. Starting the container with a fresh empty auth state volume is treated as a first-run bootstrap case.
+1. The bootstrap scripts create and use the mounted state directory rather than relying on image-local writable paths.
+2. The container image does not depend on a baked-in token cache or Azure CLI profile directory.
+3. The current slice does not write persisted Azure access tokens into the mounted state volume.
 
 ---
 
@@ -79,35 +81,35 @@ remain stateless with respect to bootstrap progress and acquired credentials.
 **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
 
 **Description:**
-The repository MUST provide bootstrap scripts that prepare the auth state
-volume, run the first-login flow when needed, and then start the long-running
+The repository MUST provide bootstrap scripts that prepare the mounted state
+volume, run the Rust-owned device-auth flow, and then start the long-running
 Azure companion process inside its dedicated container.
 
 **Acceptance criteria:**
 
-1. A provided bootstrap script can start the Azure companion container with the expected auth state volume and gateway companion socket bindings.
-2. The bootstrap path initializes the auth state volume before invoking the login logic.
+1. A provided bootstrap script can start the Azure companion container with the expected state volume and gateway companion socket bindings.
+2. The bootstrap path initializes the state volume before invoking the login logic.
 3. After bootstrap prerequisites are satisfied, the scripts start the Azure companion process without requiring manual in-container steps.
 
 ---
 
 ## 4  Azure device-code login bootstrap
 
-### AZC-0200  Empty-state bootstrap detection
+### AZC-0200  Current-slice bootstrap always performs device auth
 
 **Priority:** Must
 **Source:** Discovery review
 
 **Description:**
-When the mounted auth state volume does not contain usable Azure authentication
-state, the bootstrap flow MUST treat startup as a first-run bootstrap and enter
-Azure device-code login.
+Until later slices implement persistent provisioning output, the bootstrap flow
+MUST perform Azure device-code login on every start. The current slice MUST NOT
+treat any existing volume contents as reusable login state.
 
 **Acceptance criteria:**
 
-1. Starting the container with an empty auth state volume enters the bootstrap login path.
-2. Starting the container with usable persisted authentication state does not enter the bootstrap login path.
-3. The bootstrap decision is based on the mounted auth state volume, not on transient in-memory state.
+1. Starting the container with an empty state volume enters the bootstrap login path.
+2. Starting the container with a previously used state volume still enters the bootstrap login path.
+3. The current slice does not inspect Azure CLI token caches or similar login-state artifacts to skip device auth.
 
 ---
 
@@ -118,7 +120,8 @@ Azure device-code login.
 
 **Description:**
 The bootstrap flow MUST obtain Azure authentication through Azure device-code
-login. The initial implementation MUST use `az login --use-device-code`.
+login. The initial implementation MUST use an in-process Rust OAuth device-flow
+client rather than shelling out to Azure CLI.
 
 **Acceptance criteria:**
 
@@ -134,7 +137,7 @@ login. The initial implementation MUST use `az login --use-device-code`.
 **Source:** Discovery review, [gateway-companion-api.md](gateway-companion-api.md)
 
 **Description:**
-When Azure device-code login produces a device code, the bootstrap flow MUST
+When Azure device-code login produces a device code, the Rust bootstrap flow MUST
 request a modem display update through the gateway companion API. The displayed
 message MUST include a short prompt and the exact device code. The Azure
 companion MUST NOT attempt raw modem control or bypass the gateway's display
@@ -167,21 +170,23 @@ to the operator and require a retry after the display becomes available.
 
 ---
 
-### AZC-0204  Persisted authentication reuse
+### AZC-0204  Persisted login reuse deferred
 
 **Priority:** Must
 **Source:** Discovery review
 
 **Description:**
-After a successful bootstrap login, the Azure companion MUST reuse the persisted
-authentication state from the mounted auth state volume on later starts instead
-of requiring device-code login again.
+Because this slice does not yet provision Azure resources or persist the
+managed-identity bootstrap artifacts that later slices will rely on, it MUST
+NOT treat the mounted state volume as reusable login state. Every start MUST
+repeat device-code login until the provisioning slice defines the persisted
+state format.
 
 **Acceptance criteria:**
 
-1. After a successful first-run bootstrap, restarting the container with the same auth state volume skips Azure device-code login.
-2. On a restart that skips device-code login, the bootstrap flow does not request a modem display update for a new device code.
-3. If persisted authentication state is missing or unusable, the next start re-enters the bootstrap login path.
+1. Restarting the container with the same state volume still performs device-code login.
+2. Each restart that performs device-code login issues a fresh modem display request for the new device code.
+3. No current-slice behavior depends on token caches or other persisted login state.
 
 ---
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -1,0 +1,102 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Azure Companion Validation Plan
+
+> **Document status:** Draft
+> **Scope:** Validation for the initial Azure companion slice: container packaging, bootstrap scripts, gateway companion display integration, and Azure device-code login state handling.
+> **Audience:** Implementers and reviewers validating the Azure companion bootstrap flow.
+> **Related:** [azure-companion-requirements.md](azure-companion-requirements.md), [azure-companion-design.md](azure-companion-design.md), [gateway-validation.md](gateway-validation.md)
+
+---
+
+## 1  Test cases
+
+### T-AZC-0100  Azure companion container image smoke test
+
+**Validates:** AZC-0100
+
+**Procedure:**
+1. Build the Azure companion Docker image from the repository Dockerfile.
+2. Run `docker run --rm <image> sonde-azure-companion --help`.
+3. Run `docker run --rm <image> az version`.
+4. Assert: both commands succeed.
+
+---
+
+### T-AZC-0101  Empty auth state volume enters bootstrap login
+
+**Validates:** AZC-0101, AZC-0102, AZC-0200, AZC-0201
+
+**Procedure:**
+1. Create an empty temporary directory to use as the mounted auth state volume.
+2. Invoke the provided Azure companion bootstrap script with that directory mounted as the auth state volume and with Azure CLI device-code login stubbed or intercepted for test control.
+3. Assert: the bootstrap path runs before the long-running process starts.
+4. Assert: the bootstrap path invokes `az login --use-device-code`.
+5. Complete the stubbed login successfully.
+6. Assert: the bootstrap path starts the long-running Azure companion process without requiring manual in-container steps.
+
+---
+
+### T-AZC-0102  Device code is shown through the gateway companion display RPC
+
+**Validates:** AZC-0202, AZC-0300
+
+**Procedure:**
+1. Start a test gateway exposing the companion socket and instrument the companion `ShowModemDisplayMessage` RPC.
+2. Start the Azure companion bootstrap path with Azure device-code login stubbed to emit a known device code.
+3. Assert: the Azure companion connects to the gateway companion socket.
+4. Assert: it issues `ShowModemDisplayMessage` through the companion API with text containing both a short prompt and the exact known device code.
+5. Assert: the bootstrap path does not attempt raw modem control.
+
+---
+
+### T-AZC-0103  Display failure aborts bootstrap
+
+**Validates:** AZC-0203
+
+**Procedure:**
+1. Start a test gateway whose companion `ShowModemDisplayMessage` RPC returns `FAILED_PRECONDITION` in one sub-case and `UNAVAILABLE` in another.
+2. Start the Azure companion bootstrap path with Azure device-code login stubbed to emit a device code.
+3. Assert: bootstrap exits with a non-zero status in both sub-cases.
+4. Assert: bootstrap reports the display failure to the operator.
+5. Assert: bootstrap does not continue with a console-only fallback.
+
+---
+
+### T-AZC-0104  Persisted auth state skips device login
+
+**Validates:** AZC-0101, AZC-0200, AZC-0204
+
+**Procedure:**
+1. Populate the mounted auth state volume with usable Azure authentication state.
+2. Start the Azure companion container with that mounted directory.
+3. Assert: startup skips Azure device-code login.
+4. Assert: startup does not issue a new modem display request for a device code.
+5. Assert: the long-running Azure companion process starts normally.
+6. Assert: startup succeeds without requiring access to the gateway admin socket.
+
+---
+
+### T-AZC-0105  Missing or unusable auth state re-enters bootstrap
+
+**Validates:** AZC-0204
+
+**Procedure:**
+1. Start from a previously working auth state volume, then remove or corrupt the persisted authentication state.
+2. Start the Azure companion container with that volume mounted.
+3. Assert: startup re-enters the bootstrap login path.
+4. Assert: a new Azure device-code login attempt is invoked.
+
+---
+
+### T-AZC-0106  Azure login failure aborts bootstrap
+
+**Validates:** AZC-0201
+
+**Procedure:**
+1. Create an empty auth state volume.
+2. Invoke the Azure companion bootstrap path with Azure CLI device-code login stubbed to fail.
+3. Assert: bootstrap exits with a non-zero status.
+4. Assert: the long-running Azure companion process is not started.
+5. Assert: bootstrap does not report success.
+

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -18,20 +18,20 @@
 **Procedure:**
 1. Build the Azure companion Docker image from the repository Dockerfile.
 2. Run `docker run --rm <image> sonde-azure-companion --help`.
-3. Run `docker run --rm <image> az version`.
+3. Run `docker run --rm <image> sonde-azure-companion bootstrap-auth --help`.
 4. Assert: both commands succeed.
 
 ---
 
-### T-AZC-0101  Empty auth state volume enters bootstrap login
+### T-AZC-0101  Bootstrap initializes the mounted state volume and enters device auth
 
 **Validates:** AZC-0101, AZC-0102, AZC-0200, AZC-0201
 
 **Procedure:**
-1. Create an empty temporary directory to use as the mounted auth state volume.
-2. Invoke the provided Azure companion bootstrap script with that directory mounted as the auth state volume and with Azure CLI device-code login stubbed or intercepted for test control.
+1. Create an empty temporary directory to use as the mounted state volume.
+2. Invoke the provided Azure companion bootstrap script with that directory mounted as the state volume and with the Rust device-flow HTTP endpoints stubbed or intercepted for test control.
 3. Assert: the bootstrap path runs before the long-running process starts.
-4. Assert: the bootstrap path invokes `az login --use-device-code`.
+4. Assert: the bootstrap path invokes the Rust `bootstrap-auth` flow and requests a device code from the configured OAuth endpoint.
 5. Complete the stubbed login successfully.
 6. Assert: the bootstrap path starts the long-running Azure companion process without requiring manual in-container steps.
 
@@ -43,7 +43,7 @@
 
 **Procedure:**
 1. Start a test gateway exposing the companion socket and instrument the companion `ShowModemDisplayMessage` RPC.
-2. Start the Azure companion bootstrap path with Azure device-code login stubbed to emit a known device code.
+2. Start the Azure companion bootstrap path with the Rust device-flow endpoint stubbed to emit a known device code.
 3. Assert: the Azure companion connects to the gateway companion socket.
 4. Assert: it issues `ShowModemDisplayMessage` through the companion API with text containing both a short prompt and the exact known device code.
 5. Assert: the bootstrap path does not attempt raw modem control.
@@ -56,35 +56,35 @@
 
 **Procedure:**
 1. Start a test gateway whose companion `ShowModemDisplayMessage` RPC returns `FAILED_PRECONDITION` in one sub-case and `UNAVAILABLE` in another.
-2. Start the Azure companion bootstrap path with Azure device-code login stubbed to emit a device code.
+2. Start the Azure companion bootstrap path with the Rust device-flow endpoint stubbed to emit a device code.
 3. Assert: bootstrap exits with a non-zero status in both sub-cases.
 4. Assert: bootstrap reports the display failure to the operator.
 5. Assert: bootstrap does not continue with a console-only fallback.
 
 ---
 
-### T-AZC-0104  Persisted auth state skips device login
+### T-AZC-0104  Previously used state volume still enters device login
 
 **Validates:** AZC-0101, AZC-0200, AZC-0204
 
 **Procedure:**
-1. Populate the mounted auth state volume with usable Azure authentication state.
+1. Populate the mounted state volume with unrelated placeholder files representing future provisioning output.
 2. Start the Azure companion container with that mounted directory.
-3. Assert: startup skips Azure device-code login.
-4. Assert: startup does not issue a new modem display request for a device code.
-5. Assert: the long-running Azure companion process starts normally.
+3. Assert: startup still performs Azure device-code login.
+4. Assert: startup issues a new modem display request for the new device code.
+5. Assert: the long-running Azure companion process starts normally after successful auth.
 6. Assert: startup succeeds without requiring access to the gateway admin socket.
 
 ---
 
-### T-AZC-0105  Missing or unusable auth state re-enters bootstrap
+### T-AZC-0105  Repeated starts continue to perform device login until provisioning exists
 
 **Validates:** AZC-0204
 
 **Procedure:**
-1. Start from a previously working auth state volume, then remove or corrupt the persisted authentication state.
-2. Start the Azure companion container with that volume mounted.
-3. Assert: startup re-enters the bootstrap login path.
+1. Start the Azure companion bootstrap flow successfully with a mounted state volume.
+2. Start it again with the same mounted state volume.
+3. Assert: the second startup re-enters the bootstrap login path.
 4. Assert: a new Azure device-code login attempt is invoked.
 
 ---
@@ -95,7 +95,7 @@
 
 **Procedure:**
 1. Create an empty auth state volume.
-2. Invoke the Azure companion bootstrap path with Azure CLI device-code login stubbed to fail.
+2. Invoke the Azure companion bootstrap path with the Rust device-flow token polling endpoint stubbed to fail.
 3. Assert: bootstrap exits with a non-zero status.
 4. Assert: the long-running Azure companion process is not started.
 5. Assert: bootstrap does not report success.

--- a/docs/gateway-companion-api.md
+++ b/docs/gateway-companion-api.md
@@ -19,7 +19,8 @@ The companion API is a **separate integration surface** from both:
 A companion process uses this API when it needs to:
 
 - subscribe to live gateway events such as node check-ins and payload arrivals, and
-- issue node-targeted commands through the gateway's existing control path.
+- issue node-targeted commands through the gateway's existing control path, and
+- request short gateway-owned modem display messages for headless operator workflows.
 
 Example use case: a bridge process authenticates to Azure, forwards `node_checkin` and `node_payload` events to a Service Bus queue, reads cloud-issued commands, and relays them to the gateway.
 
@@ -73,10 +74,11 @@ service GatewayCompanion {
     rpc QueueReboot(CompanionQueueRebootRequest) returns (CompanionEmpty);
     rpc QueueEphemeral(CompanionQueueEphemeralRequest) returns (CompanionEmpty);
     rpc GetNodeStatus(CompanionGetNodeStatusRequest) returns (CompanionNodeStatus);
+    rpc ShowModemDisplayMessage(CompanionShowModemDisplayMessageRequest) returns (CompanionEmpty);
 }
 ```
 
-The companion service intentionally omits operator-only workflows such as node registration/removal, program ingestion/removal, state export/import, modem control, BLE pairing, and handler configuration.
+The companion service intentionally omits operator-only workflows such as node registration/removal, program ingestion/removal, state export/import, raw modem control, BLE pairing, and handler configuration. It may request gateway-owned transient display text, but it does not upload raw framebuffers or bypass the gateway's display arbitration.
 
 ### 3.2  `node_checkin`
 
@@ -170,6 +172,30 @@ The companion API's command RPCs reuse the gateway's existing command semantics:
 
 These operations act on the same gateway state as the corresponding admin operations; the companion API does not define a separate command pipeline.
 
+### 3.5  Transient modem display RPC
+
+```protobuf
+message CompanionShowModemDisplayMessageRequest {
+    repeated string lines = 1;
+}
+```
+
+`ShowModemDisplayMessage` lets a companion request a short, gateway-owned modem
+display update for headless operator flows such as Azure device login. The
+request accepts 1 to 4 text lines. On success, the gateway renders the supplied
+lines using the same centered text renderer, reliable display-transfer path,
+display-ownership state, and 60-second banner-restore behavior used by the admin
+`ShowModemDisplayMessage` RPC.
+
+The RPC returns after the initial display update succeeds; it does not wait for
+the 60-second dwell timeout. A later successful transient-display request from
+either the admin or companion surface replaces any earlier one and restarts the
+restore timer.
+
+If a BLE pairing session currently owns the display, the RPC fails with
+`FAILED_PRECONDITION`. If no modem transport is configured, the RPC fails with
+`UNAVAILABLE`.
+
 ---
 
 ## 4  Behavioral notes
@@ -177,3 +203,4 @@ These operations act on the same gateway state as the corresponding admin operat
 1. `node_payload` is informational only. Companion clients do not reply to payload events; node replies continue to use the handler flow defined in [gateway-api.md](gateway-api.md).
 2. Message ordering is guaranteed only within a single live stream as produced by the gateway runtime. There is no replay cursor, durable offset, or exactly-once delivery guarantee.
 3. Companion clients are expected to provide their own persistence and retry behavior when forwarding events to external systems.
+4. Companion display requests reuse the same gateway-owned display arbitration and restore rules as admin display requests; companions do not gain raw modem-control privileges.

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -76,7 +76,7 @@ The gateway is composed of eleven functional modules grouped in two tiers. The u
 | **Handler Process** | Manage handler stdin/stdout lifecycle | GW-0502, GW-0503, GW-0506 |
 | **Storage** | Persist node registry, program library, configuration | GW-0700, GW-1000, GW-1001 |
 | **Admin API** | gRPC admin interface, CLI tool | GW-0800, GW-0801, GW-0802, GW-0803, GW-0804, GW-0805, GW-0806 |
-| **Companion API** | gRPC integration interface for companion processes | GW-0810, GW-0811, GW-0812, GW-0813, GW-0814 |
+| **Companion API** | gRPC integration interface for companion processes | GW-0810, GW-0811, GW-0812, GW-0813, GW-0814, GW-0815 |
 | **BLE Pairing Handler** | BLE pairing protocol logic via modem relay | GW-1200–GW-1222a |
 
 ---
@@ -1013,7 +1013,7 @@ All commands support `--format json` for machine-readable output.
 
 ## 13A  Companion API
 
-> **Requirements:** GW-0810 (companion API), GW-0811 (live event subscription), GW-0812 (`node_checkin`), GW-0813 (`node_payload`), GW-0814 (command/query operations).
+> **Requirements:** GW-0810 (companion API), GW-0811 (live event subscription), GW-0812 (`node_checkin`), GW-0813 (`node_payload`), GW-0814 (command/query operations), GW-0815 (transient modem display).
 
 The gateway exposes a second local gRPC API for companion processes that need a stable integration boundary distinct from the operator-focused `GatewayAdmin` surface. The companion API is specified in [gateway-companion-api.md](gateway-companion-api.md). It uses a separate socket, a separate protobuf service, and companion-specific message types so it can evolve independently without forcing `GatewayAdmin` changes.
 
@@ -1038,10 +1038,11 @@ service GatewayCompanion {
     rpc QueueReboot(CompanionQueueRebootRequest) returns (CompanionEmpty);
     rpc QueueEphemeral(CompanionQueueEphemeralRequest) returns (CompanionEmpty);
     rpc GetNodeStatus(CompanionGetNodeStatusRequest) returns (CompanionNodeStatus);
+    rpc ShowModemDisplayMessage(CompanionShowModemDisplayMessageRequest) returns (CompanionEmpty);
 }
 ```
 
-The companion service intentionally omits operator-only workflows such as program ingestion, node registration/removal, state export/import, modem control, BLE pairing, and handler management.
+The companion service intentionally omits operator-only workflows such as program ingestion, node registration/removal, state export/import, raw modem control, BLE pairing, and handler management. It may request gateway-owned transient display text, but it does not upload raw framebuffers or bypass the gateway's existing display ownership rules.
 
 ### 13A.2  Event publication path
 
@@ -1072,6 +1073,32 @@ This sharing is mandatory for:
 5. `ListNodes`, `GetNode`, and `GetNodeStatus` — surface the same node metadata/state as the gateway already maintains.
 
 The companion protobuf messages remain distinct from the admin protobuf messages even when fields overlap. This avoids coupling future companion-contract changes to the operator-facing admin contract.
+
+### 13A.4  Shared transient display path
+
+The companion API also exposes a `ShowModemDisplayMessage` RPC for headless
+automation flows such as Azure device login. This RPC does not introduce a new
+display implementation. Instead, the gateway factors transient-display behavior
+behind a shared helper that is invoked by both `GatewayAdmin` and
+`GatewayCompanion`.
+
+The shared display helper owns all of the behavior already defined for the admin
+display path:
+
+1. Validate that the request contains 1 to 4 text lines.
+2. Reject the request with `FAILED_PRECONDITION` if a BLE pairing session
+   currently owns the display.
+3. Reject the request with `UNAVAILABLE` if no modem transport is configured.
+4. Cancel any active `Nodes` page scroll task, claim a new `display_generation`,
+   and reset the status-page cycle.
+5. Render the supplied text using the existing centered 128×64 text renderer and
+   send it through the reliable display-transfer path.
+6. Spawn the normal 60-second restore task that returns the display to
+   `Sonde Gateway v<semver>` only if no newer display owner has superseded it.
+
+Because both admin and companion RPCs call the same helper, later successful
+transient-display requests replace earlier ones regardless of which surface
+originated them, while BLE pairing screens continue to preempt both.
 
 ---
 
@@ -1248,12 +1275,13 @@ If another `BUTTON_SHORT` arrives before the timeout fires, the gateway advances
 
 ### 17.4c  Admin-triggered transient display override
 
-The admin API also exposes a gateway-owned transient display override for
-operator prompts such as headless device-login codes. The
-`ShowModemDisplayMessage` RPC accepts 1 to 4 text lines. The gateway validates
-the line count before rendering and rejects the request with
-`FAILED_PRECONDITION` if a BLE pairing session currently owns the display, so
-pairing passkeys and terminal status screens remain visible.
+The admin API exposes a gateway-owned transient display override for operator
+prompts such as headless device-login codes. The companion API's
+`ShowModemDisplayMessage` RPC reuses the same helper and therefore follows the
+same ownership, validation, rendering, and restore behavior. The shared helper
+accepts 1 to 4 text lines and rejects the request with `FAILED_PRECONDITION` if
+a BLE pairing session currently owns the display, so pairing passkeys and
+terminal status screens remain visible.
 
 On success, the gateway renders the supplied lines with the same centered
 128×64 text renderer used for the startup banner and button-pairing status

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -1078,6 +1078,39 @@ The companion API MUST expose companion-specific RPCs for the node-targeted cont
 
 ---
 
+### GW-0815  Companion API — transient modem display message
+
+**Priority:** Must  
+**Source:** `gateway-companion-api.md` §3.5, §4
+
+**Description:**  
+The companion API MUST expose a gateway-owned transient display override for the
+modem-attached OLED so headless companion workflows such as Azure device login
+can surface short operator prompts. The operation accepts 1 to 4 text lines and
+MUST use the same gateway-owned renderer, display-ownership state, reliable
+display-transfer path, and 60-second banner-restore behavior as the admin
+`ShowModemDisplayMessage` operation defined by GW-0809. The companion RPC MUST
+return after the initial display update succeeds; it MUST NOT wait for the
+60-second timeout to expire. A later successful transient-display request from
+either the companion or admin surface replaces any earlier one and restarts the
+60-second timer.
+
+To avoid obscuring pairing prompts, the operation MUST fail with
+`FAILED_PRECONDITION` while a BLE pairing session owns the display. If no modem
+transport is configured, it MUST fail with `UNAVAILABLE`. The companion API
+MUST NOT introduce a parallel display state machine or a raw modem-control path.
+
+**Acceptance criteria:**
+
+1. Companion `ShowModemDisplayMessage` with 1 to 4 lines updates the modem display and returns before the 60-second timeout expires.
+2. Companion `ShowModemDisplayMessage` with fewer than 1 line or more than 4 lines returns `INVALID_ARGUMENT`.
+3. If no newer display owner claims the screen, the normal `Sonde Gateway v<semver>` banner is restored after 60 seconds.
+4. A second successful transient-display request received before the first timeout expires replaces the earlier text and restarts the 60-second timeout window, regardless of whether it arrives through the admin or companion surface.
+5. While a BLE pairing session owns the display, companion `ShowModemDisplayMessage` returns `FAILED_PRECONDITION`.
+6. Without a configured modem transport, companion `ShowModemDisplayMessage` returns `UNAVAILABLE`.
+
+---
+
 ## 10  Operational requirements
 
 ### GW-1000  Gateway failover / replaceability
@@ -2434,6 +2467,7 @@ The gateway container image MUST bundle the modem flashing assets needed for man
 | GW-0812 | Companion event — `node_checkin` | Must |
 | GW-0813 | Companion event — `node_payload` | Must |
 | GW-0814 | Companion API — command and query operations | Must |
+| GW-0815 | Companion API — transient modem display message | Must |
 | GW-1000 | Gateway failover / replaceability | Must |
 | GW-1004 | Program hash consistency across failover group | Must |
 | GW-1001 | Exportable / importable state | Should |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1707,13 +1707,33 @@ A configurable stub handler process (or in-process mock) that:
 
 ### T-0825  Companion API surface excludes operator-only workflows
 
-**Validates:** GW-0814
+**Validates:** GW-0814, GW-0815
 
 **Procedure:**
 1. Generate or compile a companion client from the published companion protobuf contract.
-2. Assert: the client exposes only the documented companion RPCs (`StreamEvents`, `ListNodes`, `GetNode`, `AssignProgram`, `SetSchedule`, `QueueReboot`, `QueueEphemeral`, `GetNodeStatus`).
+2. Assert: the client exposes only the documented companion RPCs (`StreamEvents`, `ListNodes`, `GetNode`, `AssignProgram`, `SetSchedule`, `QueueReboot`, `QueueEphemeral`, `GetNodeStatus`, `ShowModemDisplayMessage`).
 3. Assert: operator-only workflows such as node registration/removal, program ingestion/removal, state export/import, modem management, BLE pairing, and handler management are absent from the companion client surface.
 4. Assert: those operator-only workflows remain available through `GatewayAdmin`.
+
+---
+
+### T-0826  Companion transient display RPC reuses gateway display semantics
+
+**Validates:** GW-0815
+
+**Procedure:**
+1. Start the gateway with a modem transport, a BLE pairing controller, an admin client, and a companion client.
+2. Call companion `ShowModemDisplayMessage` with 2 lines.
+3. Assert: the modem display is updated and the RPC returns before the 60-second timeout expires.
+4. Before the timeout fires, call admin `ShowModemDisplayMessage` with different text.
+5. Assert: the later admin request replaces the earlier companion text and becomes the active transient display.
+6. Assert: after 60 seconds from the later successful request, the normal `Sonde Gateway v<semver>` banner is restored if no newer display owner has claimed the screen.
+7. Call companion `ShowModemDisplayMessage` with 0 lines and with 5 lines in separate sub-cases.
+8. Assert: both invalid-line-count sub-cases return `INVALID_ARGUMENT`.
+9. Open a BLE pairing session that owns the display, then call companion `ShowModemDisplayMessage`.
+10. Assert: the companion RPC returns `FAILED_PRECONDITION`.
+11. Start the gateway without a modem transport and call companion `ShowModemDisplayMessage`.
+12. Assert: the companion RPC returns `UNAVAILABLE`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add the initial Azure companion slice for #771 as a new sonde-azure-companion workspace crate
- add gateway companion modem-display support using shared transient display infrastructure with admin
- add bootstrap/container artifacts and Azure companion validation/docs for the device-code login flow

## Testing
- cargo test -p sonde-gateway --test admin_display --test companion_api --test companion_display
- cargo test -p sonde-azure-companion
- cargo build -p sonde-gateway -p sonde-azure-companion
- cargo clippy -p sonde-gateway -p sonde-azure-companion --tests -- -D warnings

## Notes
- Docker image execution could not be verified in this environment because docker is not installed here.
- Unix-only bootstrap integration tests were added under crates/sonde-azure-companion/tests/bootstrap_unix.rs.