### PR TITLE
Add Azure Service Bus AMQP bridge

### DIFF
--- a/.github/docker/Dockerfile.azure-companion
+++ b/.github/docker/Dockerfile.azure-companion
@@ -9,7 +9,7 @@
 # rust:alpine — pinned by digest for reproducible builds.
 FROM rust:alpine@sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334 AS builder
 
-RUN apk add --no-cache build-base musl-dev openssl-dev protobuf pkgconf
+RUN apk add --no-cache build-base musl-dev openssl-dev openssl-libs-static protobuf pkgconf
 
 WORKDIR /sonde
 COPY . .

--- a/.github/docker/Dockerfile.azure-companion
+++ b/.github/docker/Dockerfile.azure-companion
@@ -9,7 +9,7 @@
 # rust:alpine — pinned by digest for reproducible builds.
 FROM rust:alpine@sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334 AS builder
 
-RUN apk add --no-cache build-base musl-dev protobuf pkgconf
+RUN apk add --no-cache build-base musl-dev openssl-dev protobuf pkgconf
 
 WORKDIR /sonde
 COPY . .
@@ -19,7 +19,7 @@ RUN cargo build --release -p sonde-azure-companion
 # alpine:3.21 — pinned by digest for reproducible builds.
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
-RUN apk add --no-cache ca-certificates \
+RUN apk add --no-cache ca-certificates libstdc++ openssl \
     && mkdir -p /var/lib/sonde-azure-companion /var/run/sonde
 
 COPY --from=builder /sonde/target/release/sonde-azure-companion /usr/local/bin/sonde-azure-companion
@@ -31,7 +31,6 @@ RUN chmod +x /usr/local/bin/sonde-azure-companion \
     /opt/sonde/deploy/azure-companion/entrypoint.sh
 
 ENV SONDE_AZURE_COMPANION_STATE_DIR=/var/lib/sonde-azure-companion
-ENV SONDE_GATEWAY_COMPANION_SOCKET=/var/run/sonde/companion.sock
 
 WORKDIR /var/lib/sonde-azure-companion
 ENTRYPOINT ["/opt/sonde/deploy/azure-companion/entrypoint.sh"]

--- a/.github/docker/Dockerfile.azure-companion
+++ b/.github/docker/Dockerfile.azure-companion
@@ -19,7 +19,7 @@ RUN cargo build --release -p sonde-azure-companion
 # alpine:3.21 — pinned by digest for reproducible builds.
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
-RUN apk add --no-cache ca-certificates libstdc++ openssl \
+RUN apk add --no-cache ca-certificates \
     && mkdir -p /var/lib/sonde-azure-companion /var/run/sonde
 
 COPY --from=builder /sonde/target/release/sonde-azure-companion /usr/local/bin/sonde-azure-companion

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1096,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1477,6 +1496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1611,6 +1631,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1673,26 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embassy-futures"
@@ -2150,6 +2204,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2541,6 +2605,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2722,6 +2787,17 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4392,6 +4468,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4495,6 +4583,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -4872,6 +4969,15 @@ dependencies = [
  "object",
  "regex",
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -5421,6 +5527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5664,6 +5780,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secrecy"
@@ -6113,6 +6243,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6239,6 +6370,7 @@ dependencies = [
  "hyper-util",
  "jsonwebtoken",
  "oauth-device-flows",
+ "p256",
  "reqwest 0.12.28",
  "rustls-pemfile",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +321,61 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "azservicebus"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee87ee5702a4a33f760859859b15a80dbdd666871e6f6209b945910bb81bb8db"
+dependencies = [
+ "azure_core",
+ "base64 0.22.1",
+ "const_format",
+ "digest 0.10.7",
+ "fe2o3-amqp",
+ "fe2o3-amqp-cbs",
+ "fe2o3-amqp-management",
+ "fe2o3-amqp-types",
+ "fe2o3-amqp-ws",
+ "fluvio-wasm-timer",
+ "futures-util",
+ "getrandom 0.2.17",
+ "hmac 0.12.1",
+ "indexmap 2.13.0",
+ "js-sys",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_amqp",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "time",
+ "timer-kit",
+ "tokio",
+ "tokio-util",
+ "url",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
+name = "azure_core"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82c33c072c9d87777262f35abfe2a64b609437076551d4dac8373e60f0e3fde9"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tracing",
+ "typespec",
+ "typespec_client_core",
+]
 
 [[package]]
 name = "base64"
@@ -822,6 +900,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +958,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,7 +1001,7 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1111,6 +1215,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -1127,6 +1241,20 @@ checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core 0.23.0",
  "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1152,6 +1280,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1188,8 +1327,14 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbus"
@@ -1291,7 +1436,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1921,6 +2066,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "fe2o3-amqp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a579ef4f1fb186f04bcdc9caf0c335adedebe879227c96d56876d473aa3d20a"
+dependencies = [
+ "bytes",
+ "fe2o3-amqp-types",
+ "futures-util",
+ "getrandom 0.3.4",
+ "parking_lot 0.12.5",
+ "pin-project-lite",
+ "ring",
+ "rustls",
+ "serde",
+ "serde_amqp",
+ "serde_bytes",
+ "slab",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "wasmtimer",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "fe2o3-amqp-cbs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cae904b214ffa3c9bae26e4129d300fe79189d2ef70503071fb25ff9127531e"
+dependencies = [
+ "fe2o3-amqp",
+ "fe2o3-amqp-management",
+ "trait-variant",
+]
+
+[[package]]
+name = "fe2o3-amqp-management"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0582084762bdf022540c37868a0808e9f54dbcc51fe56f6212da59c167569cda"
+dependencies = [
+ "fe2o3-amqp",
+ "fe2o3-amqp-types",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "fe2o3-amqp-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bcc8d13ed13fbb2fb664a6df114bcc32f8ca85c9cb6b89d4e7576c47f583706"
+dependencies = [
+ "ordered-float",
+ "serde",
+ "serde_amqp",
+ "serde_bytes",
+ "serde_repr",
+]
+
+[[package]]
+name = "fe2o3-amqp-ws"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117053be08403ac3b36538bf5a4cf42d328cdcf09950142524dd9ca4b25121a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "getrandom 0.3.4",
+ "http",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "tungstenite",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2217,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluvio-wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b768c170dc045fa587a8f948c91f9bcfb87f774930477c6215addf54317f137f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,12 +2251,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -2025,6 +2278,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2795,10 +3054,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2811,6 +3071,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -3044,6 +3320,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "io-kit-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3525,21 @@ checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -3567,6 +3870,23 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nb"
@@ -4001,10 +4321,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -4049,12 +4424,37 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -4085,6 +4485,16 @@ dependencies = [
  "digest 0.11.2",
  "hmac 0.13.0",
  "sha2 0.11.0",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -4735,6 +5145,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -4793,6 +5204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+ "serde",
 ]
 
 [[package]]
@@ -4827,6 +5239,15 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4929,33 +5350,40 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4988,7 +5416,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -5099,12 +5527,34 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5147,6 +5597,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5236,6 +5695,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5314,6 +5796,45 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "xml",
+]
+
+[[package]]
+name = "serde_amqp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e76738e7a058df01b5b33194359930a1aa5bc233dc07e510f458aca47189aea2"
+dependencies = [
+ "bytes",
+ "indexmap 2.13.0",
+ "ordered-float",
+ "serde",
+ "serde_amqp_derive",
+ "serde_bytes",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "serde_amqp_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22da57ecf44834259b4416250608e11da620750be91305bf6ae5d398954ddc6d"
+dependencies = [
+ "convert_case 0.6.0",
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5529,6 +6050,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5605,6 +6137,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -5687,12 +6231,24 @@ dependencies = [
 name = "sonde-azure-companion"
 version = "0.5.0"
 dependencies = [
+ "azservicebus",
+ "azure_core",
+ "base64 0.22.1",
  "clap",
  "futures",
  "hyper-util",
+ "jsonwebtoken",
  "oauth-device-flows",
+ "reqwest 0.12.28",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
  "sonde-gateway",
+ "temp-env",
  "tempfile",
+ "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5959,7 +6515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.12.5",
  "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
@@ -5972,7 +6528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.12.5",
  "phf_shared 0.13.1",
  "precomputed-hash",
 ]
@@ -6149,7 +6705,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation 0.3.2",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.5",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -6403,6 +6959,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot 0.12.5",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6499,6 +7064,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6520,6 +7086,20 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timer-kit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1323065b94fee01a4049c46c671f87d4aef531d3d08f7ebe427ad07bb19a5b"
+dependencies = [
+ "fluvio-wasm-timer",
+ "futures-util",
+ "pin-project-lite",
+ "slab",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -6556,7 +7136,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -6574,6 +7154,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -6599,6 +7189,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6608,6 +7214,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -6809,13 +7416,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -6969,6 +7581,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6997,6 +7620,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7007,6 +7649,56 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typespec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c7a952f1f34257f945fc727b20defe7a3c01c05ddd42925977626cfa6e62ab"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5879ce67ba9e525fe088c882ede1337c32c3f80e83e72d9fd3cc6c8e05bcb3d7"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.2.17",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbccdbe531c8d553812a609bdb70c0d1002ad91333498e18df42c98744b15cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "uds_windows"
@@ -7136,6 +7828,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -7370,6 +8068,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -7391,6 +8102,20 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.12.5",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7467,6 +8192,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,8 +1435,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2251,6 +2264,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -3646,6 +3665,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -3711,6 +3733,12 @@ dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -4103,6 +4131,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4155,6 +4199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4829,6 +4874,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -5559,6 +5615,26 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -6366,17 +6442,20 @@ dependencies = [
  "azure_core",
  "base64 0.22.1",
  "clap",
+ "ed25519-dalek",
  "futures",
  "hyper-util",
  "jsonwebtoken",
  "oauth-device-flows",
  "p256",
  "reqwest 0.12.28",
+ "rsa",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "sonde-gateway",
+ "spki",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
@@ -6387,6 +6466,7 @@ dependencies = [
  "tower",
  "url",
  "wiremock",
+ "x509-cert",
 ]
 
 [[package]]
@@ -6605,6 +6685,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -7258,6 +7344,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tokio"
@@ -9123,6 +9230,18 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
 ]
 
 [[package]]

--- a/crates/sonde-azure-companion/Cargo.toml
+++ b/crates/sonde-azure-companion/Cargo.toml
@@ -12,12 +12,15 @@ clap = { version = "4", features = ["derive", "env"] }
 hyper-util = "0.1"
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
 oauth-device-flows = { version = "0.1", default-features = false }
+ed25519-dalek = { version = "2", features = ["pkcs8"] }
 p256 = { version = "0.13", features = ["pkcs8"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots-no-provider"] }
+rsa = "0.9"
 rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+spki = "0.7"
 sonde-gateway = { path = "../sonde-gateway", default-features = false }
 time = "0.3"
 tokio = { version = "1", features = ["full"] }
@@ -25,6 +28,7 @@ tonic = "0.14"
 tower = "0.5"
 thiserror = "2"
 url = "2"
+x509-cert = "0.2"
 
 [dev-dependencies]
 futures = "0.3"

--- a/crates/sonde-azure-companion/Cargo.toml
+++ b/crates/sonde-azure-companion/Cargo.toml
@@ -5,17 +5,29 @@ version.workspace = true
 license = "MIT"
 
 [dependencies]
+azservicebus = { version = "0.25.1", default-features = false, features = ["rustls"] }
+azure_core = { version = "0.25", default-features = false }
+base64 = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
 hyper-util = "0.1"
+jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
 oauth-device-flows = { version = "0.1", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots-no-provider"] }
+rustls-pemfile = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 sonde-gateway = { path = "../sonde-gateway", default-features = false }
+time = "0.3"
 tokio = { version = "1", features = ["full"] }
 tonic = "0.14"
 tower = "0.5"
+thiserror = "2"
 url = "2"
 
 [dev-dependencies]
 futures = "0.3"
 tempfile = "3"
+temp-env = "0.3"
 tokio-stream = "0.1"
 wiremock = "0.6"

--- a/crates/sonde-azure-companion/Cargo.toml
+++ b/crates/sonde-azure-companion/Cargo.toml
@@ -12,6 +12,7 @@ clap = { version = "4", features = ["derive", "env"] }
 hyper-util = "0.1"
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
 oauth-device-flows = { version = "0.1", default-features = false }
+p256 = { version = "0.13", features = ["pkcs8"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots-no-provider"] }
 rustls-pemfile = "2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -671,9 +671,18 @@ impl ClientAssertionCredential {
             ])
             .send()
             .await
-            .map_err(|err| azure_core::Error::new(ErrorKind::Credential, err))?
-            .error_for_status()
             .map_err(|err| azure_core::Error::new(ErrorKind::Credential, err))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|err| format!("<failed to read token error response body: {err}>"));
+            return Err(azure_core::Error::new(
+                ErrorKind::Credential,
+                std::io::Error::other(format!("token endpoint returned {status}: {body}")),
+            ));
+        }
         let response: OAuthTokenResponse = response
             .json()
             .await
@@ -1710,6 +1719,41 @@ mod tests {
         assert!(request_bodies
             .iter()
             .any(|body| body.contains("scope=scope-c")));
+    }
+
+    #[tokio::test]
+    async fn client_assertion_credential_surfaces_token_error_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .append_header("content-type", "application/json")
+                    .set_body_string(
+                        "{\"error\":\"invalid_scope\",\"error_description\":\"scope rejected for test\"}",
+                    ),
+            )
+            .mount(&server)
+            .await;
+
+        let credential = ClientAssertionCredential {
+            client_id: "test-client-id".to_string(),
+            token_endpoint: format!("{}/token", server.uri()),
+            signing_algorithm: Algorithm::HS256,
+            signing_key: EncodingKey::from_secret(b"test-secret"),
+            certificate_thumbprint: "thumbprint".to_string(),
+            http_client: reqwest::Client::builder().build().unwrap(),
+            cached_token: tokio::sync::Mutex::new(None),
+        };
+
+        let err = credential
+            .get_token(&["scope-a"], None)
+            .await
+            .expect_err("expected token request to fail");
+        let err_text = err.to_string();
+        assert!(err_text.contains("400 Bad Request"));
+        assert!(err_text.contains("invalid_scope"));
+        assert!(err_text.contains("scope rejected for test"));
     }
 
     #[tokio::test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -662,6 +662,12 @@ impl UpstreamPublisher for AzServiceBusPublisher {
 #[tonic::async_trait]
 impl DownstreamConsumer for AzServiceBusConsumer {
     async fn receive(&mut self) -> Result<Option<Vec<u8>>, CompanionError> {
+        if self.inflight.is_some() {
+            return Err(CompanionError::Config(
+                "cannot receive a new downstream message while another message is still inflight"
+                    .to_string(),
+            ));
+        }
         let message = self
             .receiver
             .receive_message_with_max_wait_time(Some(Duration::from_secs(
@@ -669,16 +675,29 @@ impl DownstreamConsumer for AzServiceBusConsumer {
             )))
             .await?;
         if let Some(message) = message {
-            let payload = message
+            self.inflight = Some(message);
+            let payload = self
+                .inflight
+                .as_ref()
+                .expect("inflight message must exist immediately after receive")
                 .body()
                 .map_err(|err| {
                     CompanionError::Config(format!(
                         "downstream Service Bus message body was not raw binary data: {err}"
                     ))
-                })?
-                .to_vec();
-            self.inflight = Some(message);
-            Ok(Some(payload))
+                })
+                .map(|body| body.to_vec());
+            match payload {
+                Ok(payload) => Ok(Some(payload)),
+                Err(err) => {
+                    if let Err(abandon_err) = self.abandon().await {
+                        eprintln!(
+                            "failed to abandon downstream Service Bus message after body decode error: {abandon_err}"
+                        );
+                    }
+                    Err(err)
+                }
+            }
         } else {
             Ok(None)
         }
@@ -767,10 +786,20 @@ where
     T: AsyncRead + Unpin,
 {
     let mut len = [0u8; 4];
-    match reader.read_exact(&mut len).await {
-        Ok(_) => {}
-        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
-        Err(err) => return Err(err.into()),
+    let mut read_len = 0usize;
+    while read_len < len.len() {
+        match reader.read(&mut len[read_len..]).await {
+            Ok(0) if read_len == 0 => return Ok(None),
+            Ok(0) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connector EOF while reading frame length prefix",
+                )
+                .into())
+            }
+            Ok(n) => read_len += n,
+            Err(err) => return Err(err.into()),
+        }
     }
     let len = usize::try_from(u32::from_be_bytes(len)).map_err(|_| {
         CompanionError::Config("connector frame length did not fit in usize".to_string())
@@ -836,7 +865,14 @@ where
         return Err(err);
     }
 
-    consumer.complete().await?;
+    if let Err(err) = consumer.complete().await {
+        if let Err(abandon_err) = consumer.abandon().await {
+            eprintln!(
+                "failed to abandon downstream Service Bus message after completion error: {abandon_err}"
+            );
+        }
+        return Err(err);
+    }
     Ok(())
 }
 
@@ -1104,6 +1140,7 @@ mod tests {
         inflight: Option<Vec<u8>>,
         completes: usize,
         abandons: usize,
+        fail_complete: bool,
     }
 
     impl FakeConsumer {
@@ -1113,6 +1150,17 @@ mod tests {
                 inflight: None,
                 completes: 0,
                 abandons: 0,
+                fail_complete: false,
+            }
+        }
+
+        fn with_complete_error(payloads: impl IntoIterator<Item = Vec<u8>>) -> Self {
+            Self {
+                queued: payloads.into_iter().collect(),
+                inflight: None,
+                completes: 0,
+                abandons: 0,
+                fail_complete: true,
             }
         }
     }
@@ -1126,6 +1174,11 @@ mod tests {
         }
 
         async fn complete(&mut self) -> Result<(), CompanionError> {
+            if self.fail_complete {
+                return Err(CompanionError::Config(
+                    "injected downstream completion failure".to_string(),
+                ));
+            }
             self.inflight.take();
             self.completes += 1;
             Ok(())
@@ -1626,6 +1679,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn downstream_pump_abandons_after_completion_failure() {
+        let (client, mut server) = duplex(64);
+        let mut client = client;
+        let mut consumer = FakeConsumer::with_complete_error([vec![4u8, 5, 6]]);
+
+        let err = pump_downstream_once(&mut client, &mut consumer)
+            .await
+            .unwrap_err();
+        let mut len = [0u8; 4];
+        server.read_exact(&mut len).await.unwrap();
+        let frame_len = usize::try_from(u32::from_be_bytes(len)).unwrap();
+        let mut payload = vec![0u8; frame_len];
+        server.read_exact(&mut payload).await.unwrap();
+
+        assert_eq!(payload, vec![4u8, 5, 6]);
+        assert!(err.to_string().contains("completion failure"));
+        assert_eq!(consumer.completes, 0);
+        assert_eq!(consumer.abandons, 1);
+    }
+
+    #[tokio::test]
     async fn read_framed_rejects_payloads_over_connector_limit() {
         let oversized_len = u32::try_from(CONNECTOR_MAX_FRAME_LENGTH + 1)
             .unwrap()
@@ -1639,6 +1713,29 @@ mod tests {
 
         let err = read_framed(&mut client).await.unwrap_err();
         assert!(err.to_string().contains("exceeds max"));
+    }
+
+    #[tokio::test]
+    async fn read_framed_returns_none_on_clean_eof() {
+        let (mut client, server) = duplex(16);
+        drop(server);
+
+        assert!(read_framed(&mut client).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn read_framed_rejects_truncated_length_prefix() {
+        let (mut client, mut server) = duplex(16);
+
+        tokio::spawn(async move {
+            server.write_all(&[0u8, 0u8]).await.unwrap();
+            server.shutdown().await.unwrap();
+        });
+
+        let err = read_framed(&mut client).await.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("connector EOF while reading frame length prefix"));
     }
 
     #[tokio::test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -1,13 +1,29 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 sonde contributors
 
-use std::error::Error;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
+use azservicebus::{
+    ServiceBusClient, ServiceBusClientOptions, ServiceBusMessage, ServiceBusReceiver,
+    ServiceBusReceiverOptions, ServiceBusSender, ServiceBusSenderOptions,
+};
+use azure_core::credentials::{AccessToken, TokenCredential, TokenRequestOptions};
+use azure_core::date::OffsetDateTime;
+use azure_core::error::ErrorKind;
+use azure_core::Uuid;
+use base64::Engine as _;
 use clap::{Args, Parser, Subcommand};
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use oauth_device_flows::provider::GenericProviderConfig;
 use oauth_device_flows::{DeviceFlow, DeviceFlowConfig, Provider};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use time::Duration as TimeDuration;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::Mutex;
 use tonic::transport::{Channel, Endpoint, Uri};
 use url::Url;
 
@@ -22,11 +38,43 @@ const DEFAULT_ADMIN_SOCKET: &str = r"\\.\pipe\sonde-admin";
 const DEFAULT_CONNECTOR_SOCKET: &str = "/var/run/sonde/connector.sock";
 #[cfg(windows)]
 const DEFAULT_CONNECTOR_SOCKET: &str = r"\\.\pipe\sonde-connector";
-
 #[cfg(unix)]
 const DEFAULT_STATE_DIR: &str = "/var/lib/sonde-azure-companion";
 #[cfg(windows)]
 const DEFAULT_STATE_DIR: &str = r"C:\ProgramData\sonde-azure-companion";
+
+const SERVICE_PRINCIPAL_STATE_FILENAME: &str = "service-principal.json";
+const DEFAULT_DOWNSTREAM_WAIT_SECS: u64 = 1;
+const ACCESS_TOKEN_REFRESH_MARGIN_SECS: i64 = 300;
+const CLIENT_ASSERTION_LIFETIME_SECS: i64 = 600;
+const CLIENT_ASSERTION_TYPE: &str = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+#[derive(Debug, Error)]
+enum CompanionError {
+    #[error("{0}")]
+    Config(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
+    #[error(transparent)]
+    TonicTransport(#[from] tonic::transport::Error),
+    #[error(transparent)]
+    TonicStatus(#[from] tonic::Status),
+    #[error(transparent)]
+    AzureCore(#[from] azure_core::Error),
+    #[error(transparent)]
+    OAuth(#[from] oauth_device_flows::DeviceFlowError),
+    #[error(transparent)]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}
+
+trait AsyncIo: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T> AsyncIo for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
 
 #[derive(Debug, Parser)]
 #[command(name = "sonde-azure-companion")]
@@ -39,6 +87,10 @@ struct Cli {
     #[arg(long, env = "SONDE_GATEWAY_CONNECTOR_SOCKET", default_value = DEFAULT_CONNECTOR_SOCKET)]
     connector_socket: String,
 
+    /// Mounted state directory reserved for bootstrap output and runtime auth material.
+    #[arg(long, env = "SONDE_AZURE_COMPANION_STATE_DIR", default_value = DEFAULT_STATE_DIR)]
+    state_dir: PathBuf,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -47,21 +99,20 @@ struct Cli {
 enum Command {
     /// Start the long-running Azure connector runtime.
     Run,
-    /// Perform Microsoft device auth, display the user code, and discard the token on success.
+    /// Perform Microsoft device auth and display the user code on the modem.
     BootstrapAuth(BootstrapAuthArgs),
     /// Ask the gateway admin API to render a transient modem display message.
     DisplayMessage {
         /// Between 1 and 4 text lines to render.
         lines: Vec<String>,
     },
+    /// Check whether the persisted runtime state and runtime configuration are present.
+    #[command(hide = true)]
+    CheckRuntimeReady,
 }
 
 #[derive(Debug, Args)]
 struct BootstrapAuthArgs {
-    /// Mounted state directory reserved for later provisioning output.
-    #[arg(long, env = "SONDE_AZURE_COMPANION_STATE_DIR", default_value = DEFAULT_STATE_DIR)]
-    state_dir: PathBuf,
-
     /// Microsoft Entra application client ID used for device auth.
     #[arg(long, env = "SONDE_AZURE_DEVICE_CLIENT_ID")]
     device_client_id: String,
@@ -91,8 +142,106 @@ struct BootstrapAuthArgs {
     device_token_url: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeConfig {
+    namespace: String,
+    upstream_queue: String,
+    downstream_queue: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+struct ServicePrincipalStateFile {
+    tenant_id: String,
+    client_id: String,
+    certificate_path: String,
+    private_key_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeCredentialState {
+    tenant_id: String,
+    client_id: String,
+    certificate_path: PathBuf,
+    private_key_path: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct ClientAssertionClaims {
+    aud: String,
+    iss: String,
+    sub: String,
+    jti: String,
+    nbf: i64,
+    iat: i64,
+    exp: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuthTokenResponse {
+    access_token: String,
+    expires_in: i64,
+}
+
+struct ClientAssertionCredential {
+    client_id: String,
+    token_endpoint: String,
+    signing_algorithm: Algorithm,
+    signing_key: EncodingKey,
+    certificate_thumbprint: String,
+    http_client: reqwest::Client,
+    cached_token: Mutex<Option<AccessToken>>,
+}
+
+impl std::fmt::Debug for ClientAssertionCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientAssertionCredential")
+            .field("client_id", &self.client_id)
+            .field("token_endpoint", &self.token_endpoint)
+            .field("signing_algorithm", &self.signing_algorithm)
+            .finish()
+    }
+}
+
+#[tonic::async_trait]
+trait UpstreamPublisher: Send {
+    async fn publish(&mut self, payload: Vec<u8>) -> Result<(), CompanionError>;
+}
+
+#[tonic::async_trait]
+trait DownstreamConsumer: Send {
+    async fn receive(&mut self) -> Result<Option<Vec<u8>>, CompanionError>;
+    async fn complete(&mut self) -> Result<(), CompanionError>;
+    async fn abandon(&mut self) -> Result<(), CompanionError>;
+}
+
+#[tonic::async_trait]
+trait BrokerTransportFactory {
+    type Publisher: UpstreamPublisher;
+    type Consumer: DownstreamConsumer;
+
+    async fn connect(
+        &self,
+        runtime_config: &RuntimeConfig,
+        runtime_state: &RuntimeCredentialState,
+    ) -> Result<(Self::Publisher, Self::Consumer), CompanionError>;
+}
+
+struct AzServiceBusTransportFactory;
+
+struct AzServiceBusPublisher {
+    _client: ServiceBusClient<azservicebus::core::BasicRetryPolicy>,
+    sender: ServiceBusSender,
+}
+
+struct AzServiceBusConsumer {
+    _client: ServiceBusClient<azservicebus::core::BasicRetryPolicy>,
+    receiver: ServiceBusReceiver,
+    inflight:
+        Option<azservicebus::primitives::service_bus_received_message::ServiceBusReceivedMessage>,
+}
+
 #[cfg(unix)]
-async fn connect_admin(socket_path: &str) -> Result<GatewayAdminClient<Channel>, Box<dyn Error>> {
+async fn connect_admin(socket_path: &str) -> Result<GatewayAdminClient<Channel>, CompanionError> {
     use hyper_util::rt::TokioIo;
 
     let socket_path = socket_path.to_owned();
@@ -109,7 +258,7 @@ async fn connect_admin(socket_path: &str) -> Result<GatewayAdminClient<Channel>,
 }
 
 #[cfg(windows)]
-async fn connect_admin(pipe_name: &str) -> Result<GatewayAdminClient<Channel>, Box<dyn Error>> {
+async fn connect_admin(pipe_name: &str) -> Result<GatewayAdminClient<Channel>, CompanionError> {
     use hyper_util::rt::TokioIo;
     use tokio::net::windows::named_pipe::ClientOptions;
 
@@ -122,8 +271,8 @@ async fn connect_admin(pipe_name: &str) -> Result<GatewayAdminClient<Channel>, B
                 let client = loop {
                     match ClientOptions::new().open(&name) {
                         Ok(client) => break client,
-                        Err(e) if e.raw_os_error() == Some(231) => {}
-                        Err(e) => return Err(e),
+                        Err(err) if err.raw_os_error() == Some(231) => {}
+                        Err(err) => return Err(err),
                     }
                     if tokio::time::Instant::now() >= deadline {
                         return Err(std::io::Error::new(
@@ -141,29 +290,28 @@ async fn connect_admin(pipe_name: &str) -> Result<GatewayAdminClient<Channel>, B
 }
 
 #[cfg(unix)]
-async fn connect_connector(socket_path: &str) -> Result<tokio::net::UnixStream, Box<dyn Error>> {
-    Ok(tokio::net::UnixStream::connect(socket_path).await?)
+async fn connect_connector(socket_path: &str) -> Result<Box<dyn AsyncIo>, CompanionError> {
+    Ok(Box::new(
+        tokio::net::UnixStream::connect(socket_path).await?,
+    ))
 }
 
 #[cfg(windows)]
-async fn connect_connector(
-    pipe_name: &str,
-) -> Result<tokio::net::windows::named_pipe::NamedPipeClient, Box<dyn Error>> {
+async fn connect_connector(pipe_name: &str) -> Result<Box<dyn AsyncIo>, CompanionError> {
     use tokio::net::windows::named_pipe::ClientOptions;
 
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
         match ClientOptions::new().open(pipe_name) {
-            Ok(client) => return Ok(client),
-            Err(e) if e.raw_os_error() == Some(231) => {}
-            Err(e) => return Err(e.into()),
+            Ok(client) => return Ok(Box::new(client)),
+            Err(err) if err.raw_os_error() == Some(231) => {}
+            Err(err) => return Err(err.into()),
         }
         if tokio::time::Instant::now() >= deadline {
-            return Err(std::io::Error::new(
+            return Err(CompanionError::Io(std::io::Error::new(
                 std::io::ErrorKind::TimedOut,
                 "named pipe busy — timed out after 5s",
-            )
-            .into());
+            )));
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
@@ -174,39 +322,122 @@ compile_error!(
     "sonde-azure-companion requires Unix (UDS) or Windows (named pipes) — this platform is not supported"
 );
 
-fn validate_display_lines(lines: &[String]) -> Result<(), String> {
+fn validate_display_lines(lines: &[String]) -> Result<(), CompanionError> {
     if (1..=4).contains(&lines.len()) {
         Ok(())
     } else {
-        Err("display-message requires between 1 and 4 lines".to_string())
+        Err(CompanionError::Config(
+            "display-message requires between 1 and 4 lines".to_string(),
+        ))
     }
 }
 
-fn validate_device_scopes(scopes: &[String]) -> Result<(), String> {
+fn validate_device_scopes(scopes: &[String]) -> Result<(), CompanionError> {
     if scopes.is_empty() {
-        Err("bootstrap-auth requires at least one device scope".to_string())
+        Err(CompanionError::Config(
+            "bootstrap-auth requires at least one device scope".to_string(),
+        ))
     } else if scopes.iter().any(|scope| scope.trim().is_empty()) {
-        Err("bootstrap-auth device scopes must not be empty".to_string())
+        Err(CompanionError::Config(
+            "bootstrap-auth device scopes must not be empty".to_string(),
+        ))
     } else {
         Ok(())
     }
 }
 
-fn validate_device_client_id(client_id: &str) -> Result<(), String> {
+fn validate_device_client_id(client_id: &str) -> Result<(), CompanionError> {
     if client_id.trim().is_empty() {
-        Err("bootstrap-auth requires a non-empty device client ID".to_string())
+        Err(CompanionError::Config(
+            "bootstrap-auth requires a non-empty device client ID".to_string(),
+        ))
     } else {
         Ok(())
     }
+}
+
+fn require_non_empty(value: String, env_name: &str) -> Result<String, CompanionError> {
+    if value.trim().is_empty() {
+        Err(CompanionError::Config(format!(
+            "{env_name} must be set and non-empty"
+        )))
+    } else {
+        Ok(value.trim().to_string())
+    }
+}
+
+fn load_runtime_config() -> Result<RuntimeConfig, CompanionError> {
+    Ok(RuntimeConfig {
+        namespace: require_non_empty(
+            std::env::var("SONDE_AZURE_SERVICEBUS_NAMESPACE").unwrap_or_default(),
+            "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+        )?,
+        upstream_queue: require_non_empty(
+            std::env::var("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE").unwrap_or_default(),
+            "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE",
+        )?,
+        downstream_queue: require_non_empty(
+            std::env::var("SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE").unwrap_or_default(),
+            "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+        )?,
+    })
+}
+
+fn service_principal_state_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME)
+}
+
+fn resolve_state_relative_path(state_dir: &Path, value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        path
+    } else {
+        state_dir.join(path)
+    }
+}
+
+fn load_runtime_credential_state(
+    state_dir: &Path,
+) -> Result<RuntimeCredentialState, CompanionError> {
+    let state_path = service_principal_state_path(state_dir);
+    let state: ServicePrincipalStateFile = serde_json::from_slice(&std::fs::read(&state_path)?)?;
+    let tenant_id = require_non_empty(state.tenant_id, "service principal tenant_id")?;
+    let client_id = require_non_empty(state.client_id, "service principal client_id")?;
+    let certificate_path = resolve_state_relative_path(state_dir, state.certificate_path.trim());
+    if !certificate_path.is_file() {
+        return Err(CompanionError::Config(format!(
+            "service principal certificate file not found: {}",
+            certificate_path.display()
+        )));
+    }
+    let private_key_path = resolve_state_relative_path(state_dir, state.private_key_path.trim());
+    if !private_key_path.is_file() {
+        return Err(CompanionError::Config(format!(
+            "service principal private key file not found: {}",
+            private_key_path.display()
+        )));
+    }
+    Ok(RuntimeCredentialState {
+        tenant_id,
+        client_id,
+        certificate_path,
+        private_key_path,
+    })
+}
+
+fn check_runtime_ready(
+    state_dir: &Path,
+) -> Result<(RuntimeConfig, RuntimeCredentialState), CompanionError> {
+    let runtime_config = load_runtime_config()?;
+    let runtime_state = load_runtime_credential_state(state_dir)?;
+    Ok((runtime_config, runtime_state))
 }
 
 fn bootstrap_provider_and_config(
     args: &BootstrapAuthArgs,
-) -> Result<(Provider, DeviceFlowConfig), Box<dyn Error>> {
-    validate_device_client_id(&args.device_client_id)
-        .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg))?;
-    validate_device_scopes(&args.device_scopes)
-        .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg))?;
+) -> Result<(Provider, DeviceFlowConfig), CompanionError> {
+    validate_device_client_id(&args.device_client_id)?;
+    validate_device_scopes(&args.device_scopes)?;
 
     let device_client_id = args.device_client_id.trim().to_string();
     let device_scopes: Vec<String> = args
@@ -232,27 +463,363 @@ fn bootstrap_provider_and_config(
             Ok((Provider::Generic, config.generic_provider(provider)))
         }
         (None, None) => Ok((Provider::Microsoft, config)),
-        _ => Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "device auth and token endpoint overrides must be provided together",
-        )
-        .into()),
+        _ => Err(CompanionError::Config(
+            "device auth and token endpoint overrides must be provided together".to_string(),
+        )),
     }
 }
 
-async fn run(connector_socket: &str) -> Result<(), Box<dyn Error>> {
-    let _stream = connect_connector(connector_socket).await?;
-    eprintln!(
-        "connected to gateway connector at {connector_socket}; runtime is idle until Azure transport integration is added"
+fn load_certificate_thumbprint(certificate_path: &Path) -> Result<String, CompanionError> {
+    let certificate_file = std::fs::File::open(certificate_path)?;
+    let mut reader = std::io::BufReader::new(certificate_file);
+    let certificate = rustls_pemfile::certs(&mut reader)
+        .next()
+        .transpose()?
+        .ok_or_else(|| {
+            CompanionError::Config(format!(
+                "service principal certificate file did not contain a PEM certificate: {}",
+                certificate_path.display()
+            ))
+        })?;
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(Sha256::digest(certificate.as_ref())))
+}
+
+fn load_signing_key(private_key_path: &Path) -> Result<(Algorithm, EncodingKey), CompanionError> {
+    let private_key_pem = std::fs::read(private_key_path)?;
+
+    if let Ok(key) = EncodingKey::from_rsa_pem(&private_key_pem) {
+        return Ok((Algorithm::RS256, key));
+    }
+    if let Ok(key) = EncodingKey::from_ec_pem(&private_key_pem) {
+        return Ok((Algorithm::ES256, key));
+    }
+    if let Ok(key) = EncodingKey::from_ed_pem(&private_key_pem) {
+        return Ok((Algorithm::EdDSA, key));
+    }
+
+    Err(CompanionError::Config(format!(
+        "service principal private key file must contain a PEM-encoded RSA, EC, or EdDSA private key: {}",
+        private_key_path.display()
+    )))
+}
+
+fn build_service_bus_credential(
+    runtime_state: &RuntimeCredentialState,
+) -> Result<Arc<dyn TokenCredential>, CompanionError> {
+    let certificate_thumbprint = load_certificate_thumbprint(&runtime_state.certificate_path)?;
+    let (signing_algorithm, signing_key) = load_signing_key(&runtime_state.private_key_path)?;
+    let token_endpoint = format!(
+        "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+        runtime_state.tenant_id
     );
-    std::future::pending::<()>().await;
-    #[allow(unreachable_code)]
+    let http_client = reqwest::Client::builder().build()?;
+    Ok(Arc::new(ClientAssertionCredential {
+        client_id: runtime_state.client_id.clone(),
+        token_endpoint,
+        signing_algorithm,
+        signing_key,
+        certificate_thumbprint,
+        http_client,
+        cached_token: Mutex::new(None),
+    }))
+}
+
+impl ClientAssertionCredential {
+    fn build_client_assertion(&self) -> Result<String, CompanionError> {
+        let now = OffsetDateTime::now_utc();
+        let now_unix = now.unix_timestamp();
+        let claims = ClientAssertionClaims {
+            aud: self.token_endpoint.clone(),
+            iss: self.client_id.clone(),
+            sub: self.client_id.clone(),
+            jti: Uuid::new_v4().to_string(),
+            nbf: now_unix,
+            iat: now_unix,
+            exp: (now + TimeDuration::seconds(CLIENT_ASSERTION_LIFETIME_SECS)).unix_timestamp(),
+        };
+        let mut header = Header::new(self.signing_algorithm);
+        header.x5t_s256 = Some(self.certificate_thumbprint.clone());
+        Ok(jsonwebtoken::encode(&header, &claims, &self.signing_key)?)
+    }
+
+    async fn fetch_token(&self, scope: &str) -> azure_core::Result<AccessToken> {
+        let client_assertion = self
+            .build_client_assertion()
+            .map_err(|err| azure_core::Error::new(ErrorKind::Credential, err))?;
+        let response = self
+            .http_client
+            .post(&self.token_endpoint)
+            .form(&[
+                ("client_id", self.client_id.as_str()),
+                ("scope", scope),
+                ("grant_type", "client_credentials"),
+                ("client_assertion_type", CLIENT_ASSERTION_TYPE),
+                ("client_assertion", client_assertion.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|err| azure_core::Error::new(ErrorKind::Credential, err))?
+            .error_for_status()
+            .map_err(|err| azure_core::Error::new(ErrorKind::Credential, err))?;
+        let response: OAuthTokenResponse = response
+            .json()
+            .await
+            .map_err(|err| azure_core::Error::new(ErrorKind::Credential, err))?;
+        let expires_on = OffsetDateTime::now_utc() + TimeDuration::seconds(response.expires_in);
+        Ok(AccessToken::new(response.access_token, expires_on))
+    }
+}
+
+#[tonic::async_trait]
+impl TokenCredential for ClientAssertionCredential {
+    async fn get_token(
+        &self,
+        scopes: &[&str],
+        _options: Option<TokenRequestOptions>,
+    ) -> azure_core::Result<AccessToken> {
+        let scope = scopes.first().copied().ok_or_else(|| {
+            azure_core::Error::message(ErrorKind::Credential, "missing Azure token scope")
+        })?;
+        let refresh_after =
+            OffsetDateTime::now_utc() + TimeDuration::seconds(ACCESS_TOKEN_REFRESH_MARGIN_SECS);
+        {
+            let cached_token = self.cached_token.lock().await;
+            if let Some(token) = cached_token.as_ref() {
+                if token.expires_on > refresh_after {
+                    return Ok(token.clone());
+                }
+            }
+        }
+
+        let token = self.fetch_token(scope).await?;
+        let mut cached_token = self.cached_token.lock().await;
+        *cached_token = Some(token.clone());
+        Ok(token)
+    }
+}
+
+#[tonic::async_trait]
+impl UpstreamPublisher for AzServiceBusPublisher {
+    async fn publish(&mut self, payload: Vec<u8>) -> Result<(), CompanionError> {
+        let message = ServiceBusMessage::new(payload);
+        self.sender.send_message(message).await?;
+        Ok(())
+    }
+}
+
+#[tonic::async_trait]
+impl DownstreamConsumer for AzServiceBusConsumer {
+    async fn receive(&mut self) -> Result<Option<Vec<u8>>, CompanionError> {
+        let message = self
+            .receiver
+            .receive_message_with_max_wait_time(Some(Duration::from_secs(
+                DEFAULT_DOWNSTREAM_WAIT_SECS,
+            )))
+            .await?;
+        if let Some(message) = message {
+            let payload = message
+                .body()
+                .map_err(|err| {
+                    CompanionError::Config(format!(
+                        "downstream Service Bus message body was not raw binary data: {err}"
+                    ))
+                })?
+                .to_vec();
+            self.inflight = Some(message);
+            Ok(Some(payload))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn complete(&mut self) -> Result<(), CompanionError> {
+        let inflight = self.inflight.take().ok_or_else(|| {
+            CompanionError::Config("no inflight downstream message to complete".to_string())
+        })?;
+        self.receiver.complete_message(&inflight).await?;
+        Ok(())
+    }
+
+    async fn abandon(&mut self) -> Result<(), CompanionError> {
+        let inflight = self.inflight.take().ok_or_else(|| {
+            CompanionError::Config("no inflight downstream message to abandon".to_string())
+        })?;
+        self.receiver.abandon_message(&inflight, None).await?;
+        Ok(())
+    }
+}
+
+#[tonic::async_trait]
+impl BrokerTransportFactory for AzServiceBusTransportFactory {
+    type Publisher = AzServiceBusPublisher;
+    type Consumer = AzServiceBusConsumer;
+
+    async fn connect(
+        &self,
+        runtime_config: &RuntimeConfig,
+        runtime_state: &RuntimeCredentialState,
+    ) -> Result<(Self::Publisher, Self::Consumer), CompanionError> {
+        let credential = build_service_bus_credential(runtime_state)?;
+
+        let mut sender_client = ServiceBusClient::new_from_token_credential(
+            runtime_config.namespace.clone(),
+            Arc::clone(&credential),
+            ServiceBusClientOptions::default(),
+        )
+        .await?;
+        let sender = sender_client
+            .create_sender(
+                runtime_config.upstream_queue.clone(),
+                ServiceBusSenderOptions::default(),
+            )
+            .await?;
+
+        let mut receiver_client = ServiceBusClient::new_from_token_credential(
+            runtime_config.namespace.clone(),
+            credential,
+            ServiceBusClientOptions::default(),
+        )
+        .await?;
+        let receiver = receiver_client
+            .create_receiver_for_queue(
+                runtime_config.downstream_queue.clone(),
+                ServiceBusReceiverOptions::default(),
+            )
+            .await?;
+
+        Ok((
+            AzServiceBusPublisher {
+                _client: sender_client,
+                sender,
+            },
+            AzServiceBusConsumer {
+                _client: receiver_client,
+                receiver,
+                inflight: None,
+            },
+        ))
+    }
+}
+
+async fn read_framed<T>(reader: &mut T) -> Result<Option<Vec<u8>>, CompanionError>
+where
+    T: AsyncRead + Unpin,
+{
+    let mut len = [0u8; 4];
+    match reader.read_exact(&mut len).await {
+        Ok(_) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err.into()),
+    }
+    let len = usize::try_from(u32::from_be_bytes(len)).map_err(|_| {
+        CompanionError::Config("connector frame length did not fit in usize".to_string())
+    })?;
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload).await?;
+    Ok(Some(payload))
+}
+
+async fn write_framed<T>(writer: &mut T, payload: &[u8]) -> Result<(), CompanionError>
+where
+    T: AsyncWrite + Unpin,
+{
+    let len = u32::try_from(payload.len()).map_err(|_| {
+        CompanionError::Config("connector payload exceeded 32-bit framed length".to_string())
+    })?;
+    writer.write_all(&len.to_be_bytes()).await?;
+    writer.write_all(payload).await?;
+    writer.flush().await?;
     Ok(())
 }
 
-async fn display_message(admin_socket: &str, lines: Vec<String>) -> Result<(), Box<dyn Error>> {
-    validate_display_lines(&lines)
-        .map_err(|msg| std::io::Error::new(std::io::ErrorKind::InvalidInput, msg))?;
+async fn pump_upstream_once<T, P>(reader: &mut T, publisher: &mut P) -> Result<bool, CompanionError>
+where
+    T: AsyncRead + Unpin,
+    P: UpstreamPublisher,
+{
+    match read_framed(reader).await? {
+        Some(payload) => {
+            publisher.publish(payload).await?;
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
+async fn pump_downstream_once<T, C>(writer: &mut T, consumer: &mut C) -> Result<(), CompanionError>
+where
+    T: AsyncWrite + Unpin,
+    C: DownstreamConsumer,
+{
+    let Some(payload) = consumer.receive().await? else {
+        return Ok(());
+    };
+
+    if let Err(err) = write_framed(writer, &payload).await {
+        if let Err(abandon_err) = consumer.abandon().await {
+            eprintln!("failed to abandon downstream Service Bus message after connector write error: {abandon_err}");
+        }
+        return Err(err);
+    }
+
+    consumer.complete().await?;
+    Ok(())
+}
+
+async fn bridge_runtime<T, P, C>(
+    stream: T,
+    mut publisher: P,
+    mut consumer: C,
+) -> Result<(), CompanionError>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    P: UpstreamPublisher + 'static,
+    C: DownstreamConsumer + 'static,
+{
+    let (mut reader, mut writer) = tokio::io::split(stream);
+    let upstream = async move {
+        while pump_upstream_once(&mut reader, &mut publisher).await? {}
+        Ok::<(), CompanionError>(())
+    };
+    let downstream = async move {
+        loop {
+            pump_downstream_once(&mut writer, &mut consumer).await?;
+        }
+    };
+
+    tokio::select! {
+        result = upstream => result,
+        result = downstream => result,
+    }
+}
+
+async fn run_with_factory<F>(
+    connector_socket: &str,
+    state_dir: &Path,
+    factory: &F,
+) -> Result<(), CompanionError>
+where
+    F: BrokerTransportFactory,
+    F::Publisher: 'static,
+    F::Consumer: 'static,
+{
+    let (runtime_config, runtime_state) = check_runtime_ready(state_dir)?;
+    let stream = connect_connector(connector_socket).await?;
+    let (publisher, consumer) = factory.connect(&runtime_config, &runtime_state).await?;
+    eprintln!(
+        "connected to gateway connector at {connector_socket} and Azure Service Bus namespace {}",
+        runtime_config.namespace
+    );
+    bridge_runtime(stream, publisher, consumer).await
+}
+
+async fn run(connector_socket: &str, state_dir: &Path) -> Result<(), CompanionError> {
+    run_with_factory(connector_socket, state_dir, &AzServiceBusTransportFactory).await
+}
+
+async fn display_message(admin_socket: &str, lines: Vec<String>) -> Result<(), CompanionError> {
+    validate_display_lines(&lines)?;
     let mut client = connect_admin(admin_socket).await?;
     client
         .show_modem_display_message(ShowModemDisplayMessageRequest { lines })
@@ -260,8 +827,12 @@ async fn display_message(admin_socket: &str, lines: Vec<String>) -> Result<(), B
     Ok(())
 }
 
-async fn bootstrap_auth(admin_socket: &str, args: BootstrapAuthArgs) -> Result<(), Box<dyn Error>> {
-    std::fs::create_dir_all(&args.state_dir)?;
+async fn bootstrap_auth(
+    admin_socket: &str,
+    state_dir: &Path,
+    args: BootstrapAuthArgs,
+) -> Result<(), CompanionError> {
+    std::fs::create_dir_all(state_dir)?;
 
     let (provider, config) = bootstrap_provider_and_config(&args)?;
     let mut flow = DeviceFlow::new(provider, config)?;
@@ -299,12 +870,17 @@ async fn bootstrap_auth(admin_socket: &str, args: BootstrapAuthArgs) -> Result<(
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> Result<(), CompanionError> {
     let cli = Cli::parse();
     match cli.command.unwrap_or(Command::Run) {
-        Command::Run => run(&cli.connector_socket).await?,
-        Command::BootstrapAuth(args) => bootstrap_auth(&cli.admin_socket, args).await?,
+        Command::Run => run(&cli.connector_socket, &cli.state_dir).await?,
+        Command::BootstrapAuth(args) => {
+            bootstrap_auth(&cli.admin_socket, &cli.state_dir, args).await?
+        }
         Command::DisplayMessage { lines } => display_message(&cli.admin_socket, lines).await?,
+        Command::CheckRuntimeReady => {
+            check_runtime_ready(&cli.state_dir)?;
+        }
     }
     Ok(())
 }
@@ -312,11 +888,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        bootstrap_provider_and_config, validate_device_client_id, validate_device_scopes,
-        validate_display_lines, BootstrapAuthArgs,
+        bootstrap_provider_and_config, check_runtime_ready, load_runtime_config,
+        pump_downstream_once, pump_upstream_once, resolve_state_relative_path,
+        validate_device_client_id, validate_device_scopes, validate_display_lines,
+        BootstrapAuthArgs, CompanionError, DownstreamConsumer, RuntimeConfig,
+        RuntimeCredentialState, ServicePrincipalStateFile, UpstreamPublisher,
     };
     use oauth_device_flows::Provider;
+    use std::collections::VecDeque;
+    use std::path::Path;
     use std::path::PathBuf;
+    use tempfile::TempDir;
+    use tokio::io::duplex;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     fn lines(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| (*s).to_string()).collect()
@@ -324,13 +908,106 @@ mod tests {
 
     fn bootstrap_args() -> BootstrapAuthArgs {
         BootstrapAuthArgs {
-            state_dir: PathBuf::from("state"),
             device_client_id: "client-id".to_string(),
             device_scopes: vec!["scope-a".to_string()],
             poll_interval_secs: 5,
             max_attempts: 60,
             device_auth_url: None,
             device_token_url: None,
+        }
+    }
+
+    fn write_service_principal_state(temp: &TempDir) -> PathBuf {
+        let cert_path = temp.path().join("client-cert.pem");
+        let key_path = temp.path().join("client-key.pem");
+        std::fs::write(
+            &cert_path,
+            concat!(
+                "-----BEGIN CERTIFICATE-----\n",
+                "MIIBszCCAVmgAwIBAgIUAlA4D2+fMZ5I2mv8VLK0sgM4nWkwCgYIKoZIzj0EAwIw\n",
+                "GDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MB4XDTI2MDEwMTAwMDAwMFoXDTM2\n",
+                "MDEwMTAwMDAwMFowGDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MFkwEwYHKoZI\n",
+                "zj0CAQYIKoZIzj0DAQcDQgAErTVS8gkGqkT1vqe8LTTlYF+XNfL7+uJ+9fwbH3P9\n",
+                "SiJrjN4J1wzqP8cP6lP0wtD+u2E4b4W0QW+E3ajQe8rW+6NTMFEwHQYDVR0OBBYE\n",
+                "FCn5Pw3Ozl7pJ1mJtqQv5Xz6vbALMB8GA1UdIwQYMBaAFCn5Pw3Ozl7pJ1mJtqQv\n",
+                "5Xz6vbALMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAJNL5l3C\n",
+                "tI6X5x4c4x6pI0vA6PfXzL5K5ll4D7OQyZcAAiA1dQXJk0v6qY+Mi8XGcX6Z7J5u\n",
+                "gW4Y8d+4T2oD7j9m0Q==\n",
+                "-----END CERTIFICATE-----\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            &key_path,
+            concat!(
+                "-----BEGIN PRIVATE KEY-----\n",
+                "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg2X8i4lE4hM2t0b5Y\n",
+                "fI7xW0ZzM3ZrY4L3s67qG8R0uYWhRANCAAStNVLyCQaqRPW+p7wtNOVgX5c18vv6\n",
+                "4n71/Bsfc/1KImuM3gnXDOo/xw/qU/TC0P67YThvhbRBb4TdqNB7ytb7\n",
+                "-----END PRIVATE KEY-----\n"
+            ),
+        )
+        .unwrap();
+        let state_path = temp.path().join("service-principal.json");
+        let state = ServicePrincipalStateFile {
+            tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            certificate_path: "client-cert.pem".to_string(),
+            private_key_path: "client-key.pem".to_string(),
+        };
+        std::fs::write(&state_path, serde_json::to_vec(&state).unwrap()).unwrap();
+        state_path
+    }
+
+    #[derive(Default)]
+    struct FakePublisher {
+        published: Vec<Vec<u8>>,
+    }
+
+    #[tonic::async_trait]
+    impl UpstreamPublisher for FakePublisher {
+        async fn publish(&mut self, payload: Vec<u8>) -> Result<(), CompanionError> {
+            self.published.push(payload);
+            Ok(())
+        }
+    }
+
+    struct FakeConsumer {
+        queued: VecDeque<Vec<u8>>,
+        inflight: Option<Vec<u8>>,
+        completes: usize,
+        abandons: usize,
+    }
+
+    impl FakeConsumer {
+        fn new(payloads: impl IntoIterator<Item = Vec<u8>>) -> Self {
+            Self {
+                queued: payloads.into_iter().collect(),
+                inflight: None,
+                completes: 0,
+                abandons: 0,
+            }
+        }
+    }
+
+    #[tonic::async_trait]
+    impl DownstreamConsumer for FakeConsumer {
+        async fn receive(&mut self) -> Result<Option<Vec<u8>>, CompanionError> {
+            let payload = self.queued.pop_front();
+            self.inflight = payload.clone();
+            Ok(payload)
+        }
+
+        async fn complete(&mut self) -> Result<(), CompanionError> {
+            self.inflight.take();
+            self.completes += 1;
+            Ok(())
+        }
+
+        async fn abandon(&mut self) -> Result<(), CompanionError> {
+            self.inflight.take();
+            self.abandons += 1;
+            Ok(())
         }
     }
 
@@ -389,5 +1066,123 @@ mod tests {
         args.device_auth_url = Some("http://127.0.0.1/device".to_string());
 
         assert!(bootstrap_provider_and_config(&args).is_err());
+    }
+
+    #[test]
+    fn runtime_ready_requires_namespace_and_queue_config() {
+        temp_env::with_vars_unset(
+            [
+                "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE",
+                "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+            ],
+            || {
+                let err = load_runtime_config().unwrap_err();
+                assert!(matches!(err, CompanionError::Config(_)));
+            },
+        );
+    }
+
+    #[test]
+    fn runtime_ready_uses_service_principal_state_file() {
+        let temp = TempDir::new().unwrap();
+        write_service_principal_state(&temp);
+        temp_env::with_vars(
+            [
+                (
+                    "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                    Some("example.servicebus.windows.net"),
+                ),
+                ("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE", Some("upstream")),
+                (
+                    "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+                    Some("downstream"),
+                ),
+            ],
+            || {
+                let (config, state) = check_runtime_ready(temp.path()).unwrap();
+                assert_eq!(
+                    config,
+                    RuntimeConfig {
+                        namespace: "example.servicebus.windows.net".to_string(),
+                        upstream_queue: "upstream".to_string(),
+                        downstream_queue: "downstream".to_string(),
+                    }
+                );
+                assert_eq!(
+                    state,
+                    RuntimeCredentialState {
+                        tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+                        client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                        certificate_path: temp.path().join("client-cert.pem"),
+                        private_key_path: temp.path().join("client-key.pem"),
+                    }
+                );
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn upstream_pump_publishes_one_framed_payload() {
+        let (mut client, server) = duplex(64);
+        let mut publisher = FakePublisher::default();
+        let payload = vec![1u8, 2, 3, 4];
+
+        tokio::spawn(async move {
+            let len = u32::try_from(payload.len()).unwrap().to_be_bytes();
+            let mut server = server;
+            server.write_all(&len).await.unwrap();
+            server.write_all(&payload).await.unwrap();
+            server.flush().await.unwrap();
+        });
+
+        assert!(pump_upstream_once(&mut client, &mut publisher)
+            .await
+            .unwrap());
+        assert_eq!(publisher.published, vec![vec![1u8, 2, 3, 4]]);
+    }
+
+    #[tokio::test]
+    async fn downstream_pump_completes_after_successful_local_write() {
+        let (client, mut server) = duplex(64);
+        let mut consumer = FakeConsumer::new([vec![9u8, 8, 7]]);
+        let mut client = client;
+
+        pump_downstream_once(&mut client, &mut consumer)
+            .await
+            .unwrap();
+
+        let mut len = [0u8; 4];
+        server.read_exact(&mut len).await.unwrap();
+        let frame_len = usize::try_from(u32::from_be_bytes(len)).unwrap();
+        let mut payload = vec![0u8; frame_len];
+        server.read_exact(&mut payload).await.unwrap();
+
+        assert_eq!(payload, vec![9u8, 8, 7]);
+        assert_eq!(consumer.completes, 1);
+        assert_eq!(consumer.abandons, 0);
+    }
+
+    #[tokio::test]
+    async fn downstream_pump_abandons_after_local_write_failure() {
+        let (client, server) = duplex(64);
+        drop(server);
+        let mut client = client;
+        let mut consumer = FakeConsumer::new([vec![1u8, 2, 3]]);
+
+        assert!(pump_downstream_once(&mut client, &mut consumer)
+            .await
+            .is_err());
+        assert_eq!(consumer.completes, 0);
+        assert_eq!(consumer.abandons, 1);
+    }
+
+    #[test]
+    fn relative_state_paths_resolve_under_state_directory() {
+        let state_dir = Path::new("/tmp/sonde-state");
+        assert_eq!(
+            resolve_state_relative_path(state_dir, "certs/client.pem"),
+            state_dir.join("certs/client.pem")
+        );
     }
 }

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -45,6 +45,8 @@ const DEFAULT_STATE_DIR: &str = r"C:\ProgramData\sonde-azure-companion";
 
 const SERVICE_PRINCIPAL_STATE_FILENAME: &str = "service-principal.json";
 const DEFAULT_DOWNSTREAM_WAIT_SECS: u64 = 1;
+const CONNECTOR_MAX_FRAME_LENGTH: usize =
+    sonde_gateway::connector::DEFAULT_CONNECTOR_MAX_MESSAGE_SIZE;
 const ACCESS_TOKEN_REFRESH_MARGIN_SECS: i64 = 300;
 const CLIENT_ASSERTION_LIFETIME_SECS: i64 = 600;
 const CLIENT_ASSERTION_TYPE: &str = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
@@ -403,14 +405,18 @@ fn load_runtime_credential_state(
     let state: ServicePrincipalStateFile = serde_json::from_slice(&std::fs::read(&state_path)?)?;
     let tenant_id = require_non_empty(state.tenant_id, "service principal tenant_id")?;
     let client_id = require_non_empty(state.client_id, "service principal client_id")?;
-    let certificate_path = resolve_state_relative_path(state_dir, state.certificate_path.trim());
+    let certificate_path_value =
+        require_non_empty(state.certificate_path, "service principal certificate_path")?;
+    let certificate_path = resolve_state_relative_path(state_dir, &certificate_path_value);
     if !certificate_path.is_file() {
         return Err(CompanionError::Config(format!(
             "service principal certificate file not found: {}",
             certificate_path.display()
         )));
     }
-    let private_key_path = resolve_state_relative_path(state_dir, state.private_key_path.trim());
+    let private_key_path_value =
+        require_non_empty(state.private_key_path, "service principal private_key_path")?;
+    let private_key_path = resolve_state_relative_path(state_dir, &private_key_path_value);
     if !private_key_path.is_file() {
         return Err(CompanionError::Config(format!(
             "service principal private key file not found: {}",
@@ -430,6 +436,8 @@ fn check_runtime_ready(
 ) -> Result<(RuntimeConfig, RuntimeCredentialState), CompanionError> {
     let runtime_config = load_runtime_config()?;
     let runtime_state = load_runtime_credential_state(state_dir)?;
+    let _ = load_certificate_thumbprint(&runtime_state.certificate_path)?;
+    let _ = load_signing_key(&runtime_state.private_key_path)?;
     Ok((runtime_config, runtime_state))
 }
 
@@ -634,18 +642,20 @@ impl DownstreamConsumer for AzServiceBusConsumer {
     }
 
     async fn complete(&mut self) -> Result<(), CompanionError> {
-        let inflight = self.inflight.take().ok_or_else(|| {
+        let inflight = self.inflight.as_ref().ok_or_else(|| {
             CompanionError::Config("no inflight downstream message to complete".to_string())
         })?;
-        self.receiver.complete_message(&inflight).await?;
+        self.receiver.complete_message(inflight).await?;
+        self.inflight = None;
         Ok(())
     }
 
     async fn abandon(&mut self) -> Result<(), CompanionError> {
-        let inflight = self.inflight.take().ok_or_else(|| {
+        let inflight = self.inflight.as_ref().ok_or_else(|| {
             CompanionError::Config("no inflight downstream message to abandon".to_string())
         })?;
-        self.receiver.abandon_message(&inflight, None).await?;
+        self.receiver.abandon_message(inflight, None).await?;
+        self.inflight = None;
         Ok(())
     }
 }
@@ -715,6 +725,12 @@ where
     let len = usize::try_from(u32::from_be_bytes(len)).map_err(|_| {
         CompanionError::Config("connector frame length did not fit in usize".to_string())
     })?;
+    if len > CONNECTOR_MAX_FRAME_LENGTH {
+        return Err(CompanionError::Config(format!(
+            "connector frame length {len} exceeds max {}",
+            CONNECTOR_MAX_FRAME_LENGTH
+        )));
+    }
     let mut payload = vec![0u8; len];
     reader.read_exact(&mut payload).await?;
     Ok(Some(payload))
@@ -724,6 +740,13 @@ async fn write_framed<T>(writer: &mut T, payload: &[u8]) -> Result<(), Companion
 where
     T: AsyncWrite + Unpin,
 {
+    if payload.len() > CONNECTOR_MAX_FRAME_LENGTH {
+        return Err(CompanionError::Config(format!(
+            "connector payload length {} exceeds max {}",
+            payload.len(),
+            CONNECTOR_MAX_FRAME_LENGTH
+        )));
+    }
     let len = u32::try_from(payload.len()).map_err(|_| {
         CompanionError::Config("connector payload exceeded 32-bit framed length".to_string())
     })?;
@@ -889,10 +912,11 @@ async fn main() -> Result<(), CompanionError> {
 mod tests {
     use super::{
         bootstrap_provider_and_config, check_runtime_ready, load_runtime_config,
-        pump_downstream_once, pump_upstream_once, resolve_state_relative_path,
-        validate_device_client_id, validate_device_scopes, validate_display_lines,
+        pump_downstream_once, pump_upstream_once, read_framed, resolve_state_relative_path,
+        validate_device_client_id, validate_device_scopes, validate_display_lines, write_framed,
         BootstrapAuthArgs, CompanionError, DownstreamConsumer, RuntimeConfig,
         RuntimeCredentialState, ServicePrincipalStateFile, UpstreamPublisher,
+        CONNECTOR_MAX_FRAME_LENGTH,
     };
     use oauth_device_flows::Provider;
     use std::collections::VecDeque;
@@ -957,6 +981,22 @@ mod tests {
         };
         std::fs::write(&state_path, serde_json::to_vec(&state).unwrap()).unwrap();
         state_path
+    }
+
+    fn write_invalid_service_principal_state(temp: &TempDir) {
+        std::fs::write(temp.path().join("client-cert.pem"), b"not-a-certificate").unwrap();
+        std::fs::write(temp.path().join("client-key.pem"), b"not-a-key").unwrap();
+        let state = ServicePrincipalStateFile {
+            tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            certificate_path: "client-cert.pem".to_string(),
+            private_key_path: "client-key.pem".to_string(),
+        };
+        std::fs::write(
+            temp.path().join("service-principal.json"),
+            serde_json::to_vec(&state).unwrap(),
+        )
+        .unwrap();
     }
 
     #[derive(Default)]
@@ -1122,6 +1162,64 @@ mod tests {
         );
     }
 
+    #[test]
+    fn runtime_ready_rejects_blank_state_paths() {
+        let temp = TempDir::new().unwrap();
+        let state = ServicePrincipalStateFile {
+            tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            certificate_path: " ".to_string(),
+            private_key_path: "client-key.pem".to_string(),
+        };
+        std::fs::write(
+            temp.path().join("service-principal.json"),
+            serde_json::to_vec(&state).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(temp.path().join("client-key.pem"), b"dummy").unwrap();
+        temp_env::with_vars(
+            [
+                (
+                    "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                    Some("example.servicebus.windows.net"),
+                ),
+                ("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE", Some("upstream")),
+                (
+                    "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+                    Some("downstream"),
+                ),
+            ],
+            || {
+                let err = check_runtime_ready(temp.path()).unwrap_err();
+                assert!(err
+                    .to_string()
+                    .contains("service principal certificate_path must be set and non-empty"));
+            },
+        );
+    }
+
+    #[test]
+    fn runtime_ready_rejects_unparseable_pem_material() {
+        let temp = TempDir::new().unwrap();
+        write_invalid_service_principal_state(&temp);
+        temp_env::with_vars(
+            [
+                (
+                    "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                    Some("example.servicebus.windows.net"),
+                ),
+                ("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE", Some("upstream")),
+                (
+                    "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+                    Some("downstream"),
+                ),
+            ],
+            || {
+                assert!(check_runtime_ready(temp.path()).is_err());
+            },
+        );
+    }
+
     #[tokio::test]
     async fn upstream_pump_publishes_one_framed_payload() {
         let (mut client, server) = duplex(64);
@@ -1175,6 +1273,31 @@ mod tests {
             .is_err());
         assert_eq!(consumer.completes, 0);
         assert_eq!(consumer.abandons, 1);
+    }
+
+    #[tokio::test]
+    async fn read_framed_rejects_payloads_over_connector_limit() {
+        let oversized_len = u32::try_from(CONNECTOR_MAX_FRAME_LENGTH + 1)
+            .unwrap()
+            .to_be_bytes();
+        let (mut client, mut server) = duplex(16);
+
+        tokio::spawn(async move {
+            server.write_all(&oversized_len).await.unwrap();
+            server.flush().await.unwrap();
+        });
+
+        let err = read_framed(&mut client).await.unwrap_err();
+        assert!(err.to_string().contains("exceeds max"));
+    }
+
+    #[tokio::test]
+    async fn write_framed_rejects_payloads_over_connector_limit() {
+        let (mut client, _server) = duplex(16);
+        let payload = vec![0u8; CONNECTOR_MAX_FRAME_LENGTH + 1];
+
+        let err = write_framed(&mut client, &payload).await.unwrap_err();
+        assert!(err.to_string().contains("exceeds max"));
     }
 
     #[test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -15,18 +15,22 @@ use azure_core::error::ErrorKind;
 use azure_core::Uuid;
 use base64::Engine as _;
 use clap::{Args, Parser, Subcommand};
+use ed25519_dalek::pkcs8::DecodePrivateKey as Ed25519DecodePrivateKey;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use oauth_device_flows::provider::GenericProviderConfig;
 use oauth_device_flows::{DeviceFlow, DeviceFlowConfig, Provider};
-use p256::pkcs8::DecodePrivateKey;
+use rsa::pkcs1::DecodeRsaPrivateKey;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use spki::EncodePublicKey;
 use thiserror::Error;
 use time::Duration as TimeDuration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::Mutex;
 use tonic::transport::{Channel, Endpoint, Uri};
 use url::Url;
+use x509_cert::der::{Decode, Encode};
+use x509_cert::Certificate;
 
 use sonde_gateway::admin::pb::gateway_admin_client::GatewayAdminClient;
 use sonde_gateway::admin::pb::ShowModemDisplayMessageRequest;
@@ -487,6 +491,10 @@ fn check_runtime_ready(
     let runtime_state = load_runtime_credential_state(state_dir)?;
     let _ = load_certificate_thumbprint(&runtime_state.certificate_path)?;
     let _ = load_signing_key(&runtime_state.private_key_path)?;
+    validate_certificate_matches_private_key(
+        &runtime_state.certificate_path,
+        &runtime_state.private_key_path,
+    )?;
     Ok((runtime_config, runtime_state))
 }
 
@@ -540,6 +548,38 @@ fn load_certificate_thumbprint(certificate_path: &Path) -> Result<String, Compan
         })?;
     Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD
         .encode(Sha256::digest(certificate.as_ref())))
+}
+
+fn load_certificate_subject_public_key_info(
+    certificate_path: &Path,
+) -> Result<Vec<u8>, CompanionError> {
+    let certificate_file = std::fs::File::open(certificate_path)?;
+    let mut reader = std::io::BufReader::new(certificate_file);
+    let certificate = rustls_pemfile::certs(&mut reader)
+        .next()
+        .transpose()?
+        .ok_or_else(|| {
+            CompanionError::Config(format!(
+                "service principal certificate file did not contain a PEM certificate: {}",
+                certificate_path.display()
+            ))
+        })?;
+    let certificate = Certificate::from_der(certificate.as_ref()).map_err(|err| {
+        CompanionError::Config(format!(
+            "service principal certificate file did not contain a parseable X.509 certificate: {} ({err})",
+            certificate_path.display()
+        ))
+    })?;
+    certificate
+        .tbs_certificate
+        .subject_public_key_info
+        .to_der()
+        .map_err(|err| {
+            CompanionError::Config(format!(
+                "failed to encode service principal certificate public key: {} ({err})",
+                certificate_path.display()
+            ))
+        })
 }
 
 fn load_signing_key(private_key_path: &Path) -> Result<(Algorithm, EncodingKey), CompanionError> {
@@ -599,6 +639,96 @@ fn ensure_p256_private_key(
         }
     }
 
+    Ok(())
+}
+
+fn encode_public_key_der<T>(
+    public_key: &T,
+    private_key_path: &Path,
+) -> Result<Vec<u8>, CompanionError>
+where
+    T: EncodePublicKey,
+{
+    public_key
+        .to_public_key_der()
+        .map(|der| der.as_ref().to_vec())
+        .map_err(|err| {
+            CompanionError::Config(format!(
+                "failed to encode service principal public key from private key: {} ({err})",
+                private_key_path.display()
+            ))
+        })
+}
+
+fn load_private_key_subject_public_key_info(
+    private_key_path: &Path,
+) -> Result<Vec<u8>, CompanionError> {
+    let private_key_pem = std::fs::read(private_key_path)?;
+    let mut reader = std::io::BufReader::new(private_key_pem.as_slice());
+    let private_key = rustls_pemfile::read_one(&mut reader)?.ok_or_else(|| {
+        CompanionError::Config(format!(
+            "service principal private key file did not contain a PEM private key: {}",
+            private_key_path.display()
+        ))
+    })?;
+
+    match private_key {
+        rustls_pemfile::Item::Pkcs1Key(key) => {
+            let private_key =
+                rsa::RsaPrivateKey::from_pkcs1_der(key.secret_pkcs1_der()).map_err(|err| {
+                    CompanionError::Config(format!(
+                        "service principal RSA private key could not be parsed: {} ({err})",
+                        private_key_path.display()
+                    ))
+                })?;
+            encode_public_key_der(&private_key.to_public_key(), private_key_path)
+        }
+        rustls_pemfile::Item::Pkcs8Key(key) => {
+            let der = key.secret_pkcs8_der();
+            if let Ok(private_key) = rsa::RsaPrivateKey::from_pkcs8_der(der) {
+                return encode_public_key_der(&private_key.to_public_key(), private_key_path);
+            }
+            if let Ok(private_key) = p256::SecretKey::from_pkcs8_der(der) {
+                return encode_public_key_der(&private_key.public_key(), private_key_path);
+            }
+            if let Ok(private_key) = ed25519_dalek::SigningKey::from_pkcs8_der(der) {
+                return encode_public_key_der(&private_key.verifying_key(), private_key_path);
+            }
+            Err(CompanionError::Config(format!(
+                "service principal private key file must contain a PEM-encoded RSA, EC, or EdDSA private key: {}",
+                private_key_path.display()
+            )))
+        }
+        rustls_pemfile::Item::Sec1Key(key) => {
+            let private_key =
+                p256::SecretKey::from_sec1_der(key.secret_sec1_der()).map_err(|err| {
+                    CompanionError::Config(format!(
+                        "service principal EC private key could not be parsed: {} ({err})",
+                        private_key_path.display()
+                    ))
+                })?;
+            encode_public_key_der(&private_key.public_key(), private_key_path)
+        }
+        _ => Err(CompanionError::Config(format!(
+            "service principal private key file must contain a PEM private key: {}",
+            private_key_path.display()
+        ))),
+    }
+}
+
+fn validate_certificate_matches_private_key(
+    certificate_path: &Path,
+    private_key_path: &Path,
+) -> Result<(), CompanionError> {
+    let certificate_public_key = load_certificate_subject_public_key_info(certificate_path)?;
+    let private_key_public_key = load_private_key_subject_public_key_info(private_key_path)?;
+    if certificate_public_key != private_key_public_key {
+        return Err(CompanionError::Config(format!(
+            "service principal certificate public key does not match private key: {} / {}",
+            certificate_path.display(),
+            private_key_path.display()
+        )));
+    }
     Ok(())
 }
 
@@ -1074,8 +1204,7 @@ async fn bootstrap_auth(
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> Result<(), CompanionError> {
+async fn run_cli() -> Result<(), CompanionError> {
     let cli = Cli::parse();
     match cli.command.unwrap_or(Command::Run) {
         Command::Run => run(&cli.connector_socket, &cli.state_dir).await?,
@@ -1088,6 +1217,14 @@ async fn main() -> Result<(), CompanionError> {
         }
     }
     Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(err) = run_cli().await {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
 }
 
 #[cfg(test)]
@@ -1149,15 +1286,14 @@ mod tests {
             &cert_path,
             concat!(
                 "-----BEGIN CERTIFICATE-----\n",
-                "MIIBszCCAVmgAwIBAgIUAlA4D2+fMZ5I2mv8VLK0sgM4nWkwCgYIKoZIzj0EAwIw\n",
-                "GDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MB4XDTI2MDEwMTAwMDAwMFoXDTM2\n",
-                "MDEwMTAwMDAwMFowGDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MFkwEwYHKoZI\n",
-                "zj0CAQYIKoZIzj0DAQcDQgAErTVS8gkGqkT1vqe8LTTlYF+XNfL7+uJ+9fwbH3P9\n",
-                "SiJrjN4J1wzqP8cP6lP0wtD+u2E4b4W0QW+E3ajQe8rW+6NTMFEwHQYDVR0OBBYE\n",
-                "FCn5Pw3Ozl7pJ1mJtqQv5Xz6vbALMB8GA1UdIwQYMBaAFCn5Pw3Ozl7pJ1mJtqQv\n",
-                "5Xz6vbALMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAJNL5l3C\n",
-                "tI6X5x4c4x6pI0vA6PfXzL5K5ll4D7OQyZcAAiA1dQXJk0v6qY+Mi8XGcX6Z7J5u\n",
-                "gW4Y8d+4T2oD7j9m0Q==\n",
+                "MIIBWDCB/6ADAgECAggbYn85Il496TAKBggqhkjOPQQDAjAaMRgwFgYDVQQDEw9z\n",
+                "b25kZS10ZXN0LWNlcnQwHhcNMjYwNDI4MTczNDAzWhcNMzYwNDI5MTczNDAzWjAa\n",
+                "MRgwFgYDVQQDEw9zb25kZS10ZXN0LWNlcnQwWTATBgcqhkjOPQIBBggqhkjOPQMB\n",
+                "BwNCAASvz+sAGz7/92glvERlQlom5OFgseIgMgvGZM04KsqOD+D/hwG3tzmpOu4U\n",
+                "AZyhAdrkAqvHWmfQkK5D8jdhgv33oy8wLTAMBgNVHRMBAf8EAjAAMB0GA1UdDgQW\n",
+                "BBQ4+jYZ/ddAOO7/msNIHh9f61IeFjAKBggqhkjOPQQDAgNIADBFAiBmBB/wP94s\n",
+                "DdBiCaUetVSkrk484rSijsJqpqnlJ/0H+QIhAMYgtEuZ8LcCsScdbwsFArve4TVN\n",
+                "yfVpQffskcauwpb9\n",
                 "-----END CERTIFICATE-----\n"
             ),
         )
@@ -1166,9 +1302,9 @@ mod tests {
             &key_path,
             concat!(
                 "-----BEGIN PRIVATE KEY-----\n",
-                "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgiHx55EC3Yiih4pAE\n",
-                "7x0NrlcsxiOH+SRn2I9N8+XzugihRANCAAS/bEotS4/FxoJf+T+jEGzlFQtYKea0\n",
-                "nmvBHE5F9GNfpDliGtxecWSjvICrTVwN0x4a5UuxfFF0rgL6I/2IGAWs\n",
+                "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgor2vT3esA5xTV1E4\n",
+                "IWCpH+V2pudlqDwiS4+LKEKy3X6hRANCAASvz+sAGz7/92glvERlQlom5OFgseIg\n",
+                "MgvGZM04KsqOD+D/hwG3tzmpOu4UAZyhAdrkAqvHWmfQkK5D8jdhgv33\n",
                 "-----END PRIVATE KEY-----\n"
             ),
         )
@@ -1196,6 +1332,21 @@ mod tests {
         std::fs::write(
             temp.path().join("service-principal.json"),
             serde_json::to_vec(&state).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn write_mismatched_service_principal_state(temp: &TempDir) {
+        write_service_principal_state(temp);
+        std::fs::write(
+            temp.path().join("client-key.pem"),
+            concat!(
+                "-----BEGIN PRIVATE KEY-----\n",
+                "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgwA92gZP+jHsasiyN\n",
+                "7EXLuqVG2dtgLXuEaEdJqKI9ueOhRANCAAQ3nLx4zRkZlPBKa53AJ9tc8SJeY6MI\n",
+                "f2Nv/cxwiGclvIa/mG/Rz9WYK+tAWhhjZnPJyRJ4YoiYPSvkPJGBYVD8\n",
+                "-----END PRIVATE KEY-----\n"
+            ),
         )
         .unwrap();
     }
@@ -1621,6 +1772,18 @@ mod tests {
         write_invalid_service_principal_state(&temp);
         with_runtime_env(|| {
             assert!(check_runtime_ready(temp.path()).is_err());
+        });
+    }
+
+    #[test]
+    fn runtime_ready_rejects_mismatched_certificate_private_key() {
+        let temp = TempDir::new().unwrap();
+        write_mismatched_service_principal_state(&temp);
+        with_runtime_env(|| {
+            let err = check_runtime_ready(temp.path()).unwrap_err();
+            assert!(err
+                .to_string()
+                .contains("service principal certificate public key does not match private key"));
         });
     }
 

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -1109,7 +1109,12 @@ where
                 return result;
             }
             result = pump_downstream_once(&mut writer, &mut consumer) => {
-                result?;
+                if let Err(err) = result {
+                    if let Err(abandon_err) = consumer.abandon_inflight().await {
+                        eprintln!("failed to abandon downstream Service Bus message after downstream error: {abandon_err}");
+                    }
+                    return Err(err);
+                }
             }
         }
     }
@@ -1581,6 +1586,54 @@ mod tests {
     }
 
     #[cfg(unix)]
+    struct DownstreamErrorCleanupConsumer {
+        payload: Option<Vec<u8>>,
+        inflight: bool,
+        first_abandon_fails: bool,
+        abandon_calls: Arc<AtomicUsize>,
+        abandon_inflight_calls: Arc<AtomicUsize>,
+    }
+
+    #[cfg(unix)]
+    #[tonic::async_trait]
+    impl DownstreamConsumer for DownstreamErrorCleanupConsumer {
+        async fn receive(&mut self) -> Result<Option<Vec<u8>>, CompanionError> {
+            let payload = self.payload.take();
+            if let Some(payload) = payload {
+                self.inflight = true;
+                Ok(Some(payload))
+            } else {
+                std::future::pending::<Result<Option<Vec<u8>>, CompanionError>>().await
+            }
+        }
+
+        async fn complete(&mut self) -> Result<(), CompanionError> {
+            self.inflight = false;
+            Ok(())
+        }
+
+        async fn abandon(&mut self) -> Result<(), CompanionError> {
+            self.abandon_calls.fetch_add(1, Ordering::SeqCst);
+            if self.first_abandon_fails {
+                self.first_abandon_fails = false;
+                return Err(CompanionError::Config(
+                    "injected downstream abandon failure".to_string(),
+                ));
+            }
+            self.inflight = false;
+            Ok(())
+        }
+
+        async fn abandon_inflight(&mut self) -> Result<(), CompanionError> {
+            self.abandon_inflight_calls.fetch_add(1, Ordering::SeqCst);
+            if self.inflight {
+                self.abandon().await?;
+            }
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
     struct ReaderState {
         eof: AtomicBool,
         waker: StdMutex<Option<Waker>>,
@@ -1634,6 +1687,42 @@ mod tests {
         ) -> Poll<std::io::Result<usize>> {
             self.write_started.notify_waiters();
             Poll::Pending
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[cfg(unix)]
+    struct FailingWriteStream;
+
+    #[cfg(unix)]
+    impl AsyncRead for FailingWriteStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    #[cfg(unix)]
+    impl AsyncWrite for FailingWriteStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "injected downstream write failure",
+            )))
         }
 
         fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
@@ -2073,6 +2162,30 @@ mod tests {
 
         bridge_task.await.unwrap().unwrap();
         assert_eq!(abandons.load(Ordering::SeqCst), 1);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bridge_runtime_abandons_inflight_message_after_downstream_error() {
+        let abandon_calls = Arc::new(AtomicUsize::new(0));
+        let abandon_inflight_calls = Arc::new(AtomicUsize::new(0));
+        let consumer = DownstreamErrorCleanupConsumer {
+            payload: Some(vec![1u8, 2, 3]),
+            inflight: false,
+            first_abandon_fails: true,
+            abandon_calls: Arc::clone(&abandon_calls),
+            abandon_inflight_calls: Arc::clone(&abandon_inflight_calls),
+        };
+
+        let err = super::bridge_runtime(FailingWriteStream, FakePublisher::default(), consumer)
+            .await
+            .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("injected downstream write failure"));
+        assert_eq!(abandon_inflight_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(abandon_calls.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -191,7 +191,12 @@ struct ClientAssertionCredential {
     signing_key: EncodingKey,
     certificate_thumbprint: String,
     http_client: reqwest::Client,
-    cached_token: Mutex<Option<AccessToken>>,
+    cached_token: Mutex<Option<CachedAccessToken>>,
+}
+
+struct CachedAccessToken {
+    scope: String,
+    token: AccessToken,
 }
 
 impl std::fmt::Debug for ClientAssertionCredential {
@@ -214,6 +219,7 @@ trait DownstreamConsumer: Send {
     async fn receive(&mut self) -> Result<Option<Vec<u8>>, CompanionError>;
     async fn complete(&mut self) -> Result<(), CompanionError>;
     async fn abandon(&mut self) -> Result<(), CompanionError>;
+    async fn abandon_inflight(&mut self) -> Result<(), CompanionError>;
 }
 
 #[tonic::async_trait]
@@ -616,23 +622,30 @@ impl TokenCredential for ClientAssertionCredential {
         scopes: &[&str],
         _options: Option<TokenRequestOptions>,
     ) -> azure_core::Result<AccessToken> {
-        let scope = scopes.first().copied().ok_or_else(|| {
-            azure_core::Error::message(ErrorKind::Credential, "missing Azure token scope")
-        })?;
+        if scopes.is_empty() {
+            return Err(azure_core::Error::message(
+                ErrorKind::Credential,
+                "missing Azure token scope",
+            ));
+        }
+        let scope = scopes.join(" ");
         let refresh_after =
             OffsetDateTime::now_utc() + TimeDuration::seconds(ACCESS_TOKEN_REFRESH_MARGIN_SECS);
         {
             let cached_token = self.cached_token.lock().await;
-            if let Some(token) = cached_token.as_ref() {
-                if token.expires_on > refresh_after {
-                    return Ok(token.clone());
+            if let Some(cached_token) = cached_token.as_ref() {
+                if cached_token.scope == scope && cached_token.token.expires_on > refresh_after {
+                    return Ok(cached_token.token.clone());
                 }
             }
         }
 
-        let token = self.fetch_token(scope).await?;
+        let token = self.fetch_token(&scope).await?;
         let mut cached_token = self.cached_token.lock().await;
-        *cached_token = Some(token.clone());
+        *cached_token = Some(CachedAccessToken {
+            scope,
+            token: token.clone(),
+        });
         Ok(token)
     }
 }
@@ -687,6 +700,13 @@ impl DownstreamConsumer for AzServiceBusConsumer {
         self.receiver.abandon_message(inflight, None).await?;
         self.inflight = None;
         Ok(())
+    }
+
+    async fn abandon_inflight(&mut self) -> Result<(), CompanionError> {
+        if self.inflight.is_none() {
+            return Ok(());
+        }
+        self.abandon().await
     }
 }
 
@@ -835,15 +855,20 @@ where
         while pump_upstream_once(&mut reader, &mut publisher).await? {}
         Ok::<(), CompanionError>(())
     };
-    let downstream = async move {
-        loop {
-            pump_downstream_once(&mut writer, &mut consumer).await?;
-        }
-    };
+    tokio::pin!(upstream);
 
-    tokio::select! {
-        result = upstream => result,
-        result = downstream => result,
+    loop {
+        tokio::select! {
+            result = &mut upstream => {
+                if let Err(abandon_err) = consumer.abandon_inflight().await {
+                    eprintln!("failed to abandon downstream Service Bus message during bridge shutdown: {abandon_err}");
+                }
+                return result;
+            }
+            result = pump_downstream_once(&mut writer, &mut consumer) => {
+                result?;
+            }
+        }
     }
 }
 
@@ -958,23 +983,35 @@ mod tests {
         bootstrap_provider_and_config, check_runtime_ready, load_runtime_config,
         pump_downstream_once, pump_upstream_once, read_framed, resolve_state_relative_path,
         validate_device_client_id, validate_device_scopes, validate_display_lines, write_framed,
-        BootstrapAuthArgs, CompanionError, DownstreamConsumer, RuntimeConfig,
-        RuntimeCredentialState, ServicePrincipalStateFile, UpstreamPublisher,
+        BootstrapAuthArgs, ClientAssertionCredential, CompanionError, DownstreamConsumer,
+        RuntimeConfig, RuntimeCredentialState, ServicePrincipalStateFile, UpstreamPublisher,
         CONNECTOR_MAX_FRAME_LENGTH,
     };
+    use azure_core::credentials::TokenCredential;
+    use jsonwebtoken::{Algorithm, EncodingKey};
     use oauth_device_flows::Provider;
     use std::collections::VecDeque;
     use std::path::Path;
     use std::path::PathBuf;
     #[cfg(unix)]
+    use std::pin::Pin;
+    #[cfg(unix)]
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     #[cfg(unix)]
     use std::sync::Arc;
+    #[cfg(unix)]
+    use std::sync::Mutex as StdMutex;
+    #[cfg(unix)]
+    use std::task::{Context, Poll, Waker};
     use tempfile::TempDir;
     use tokio::io::duplex;
+    #[cfg(unix)]
+    use tokio::io::{AsyncRead, AsyncWrite};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     #[cfg(unix)]
     use tokio::sync::{Mutex, Notify};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn lines(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| (*s).to_string()).collect()
@@ -1099,6 +1136,13 @@ mod tests {
             self.abandons += 1;
             Ok(())
         }
+
+        async fn abandon_inflight(&mut self) -> Result<(), CompanionError> {
+            if self.inflight.is_some() {
+                self.abandon().await?;
+            }
+            Ok(())
+        }
     }
 
     #[cfg(unix)]
@@ -1136,6 +1180,13 @@ mod tests {
 
         async fn abandon(&mut self) -> Result<(), CompanionError> {
             self.inflight.take();
+            Ok(())
+        }
+
+        async fn abandon_inflight(&mut self) -> Result<(), CompanionError> {
+            if self.inflight.is_some() {
+                self.abandon().await?;
+            }
             Ok(())
         }
     }
@@ -1187,6 +1238,111 @@ mod tests {
                 },
                 BlockingConsumer::new(self.downstream_payloads.clone()),
             ))
+        }
+    }
+
+    #[cfg(unix)]
+    struct ShutdownAwareConsumer {
+        payload: Option<Vec<u8>>,
+        inflight: bool,
+        inflight_set: Arc<Notify>,
+        abandons: Arc<AtomicUsize>,
+    }
+
+    #[cfg(unix)]
+    #[tonic::async_trait]
+    impl DownstreamConsumer for ShutdownAwareConsumer {
+        async fn receive(&mut self) -> Result<Option<Vec<u8>>, CompanionError> {
+            let payload = self.payload.take();
+            if let Some(payload) = payload {
+                self.inflight = true;
+                self.inflight_set.notify_waiters();
+                Ok(Some(payload))
+            } else {
+                std::future::pending::<Result<Option<Vec<u8>>, CompanionError>>().await
+            }
+        }
+
+        async fn complete(&mut self) -> Result<(), CompanionError> {
+            self.inflight = false;
+            Ok(())
+        }
+
+        async fn abandon(&mut self) -> Result<(), CompanionError> {
+            if self.inflight {
+                self.inflight = false;
+                self.abandons.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(())
+        }
+
+        async fn abandon_inflight(&mut self) -> Result<(), CompanionError> {
+            self.abandon().await
+        }
+    }
+
+    #[cfg(unix)]
+    struct ReaderState {
+        eof: AtomicBool,
+        waker: StdMutex<Option<Waker>>,
+    }
+
+    #[cfg(unix)]
+    impl ReaderState {
+        fn new() -> Self {
+            Self {
+                eof: AtomicBool::new(false),
+                waker: StdMutex::new(None),
+            }
+        }
+
+        fn finish(&self) {
+            self.eof.store(true, Ordering::SeqCst);
+            if let Some(waker) = self.waker.lock().unwrap().take() {
+                waker.wake();
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    struct ShutdownTestStream {
+        reader_state: Arc<ReaderState>,
+        write_started: Arc<Notify>,
+    }
+
+    #[cfg(unix)]
+    impl AsyncRead for ShutdownTestStream {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            if self.reader_state.eof.load(Ordering::SeqCst) {
+                Poll::Ready(Ok(()))
+            } else {
+                *self.reader_state.waker.lock().unwrap() = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    impl AsyncWrite for ShutdownTestStream {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            self.write_started.notify_waiters();
+            Poll::Pending
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
         }
     }
 
@@ -1368,6 +1524,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn client_assertion_credential_joins_scopes_and_caches_by_scope_set() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .append_header("content-type", "application/json")
+                    .set_body_string("{\"access_token\":\"cached-token\",\"expires_in\":3600}"),
+            )
+            .mount(&server)
+            .await;
+
+        let credential = ClientAssertionCredential {
+            client_id: "test-client-id".to_string(),
+            token_endpoint: format!("{}/token", server.uri()),
+            signing_algorithm: Algorithm::HS256,
+            signing_key: EncodingKey::from_secret(b"test-secret"),
+            certificate_thumbprint: "thumbprint".to_string(),
+            http_client: reqwest::Client::builder().build().unwrap(),
+            cached_token: tokio::sync::Mutex::new(None),
+        };
+
+        credential
+            .get_token(&["scope-a", "scope-b"], None)
+            .await
+            .unwrap();
+        credential
+            .get_token(&["scope-a", "scope-b"], None)
+            .await
+            .unwrap();
+        credential.get_token(&["scope-c"], None).await.unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        let request_bodies = requests
+            .iter()
+            .map(|request| String::from_utf8(request.body.clone()).unwrap())
+            .collect::<Vec<_>>();
+        assert!(request_bodies
+            .iter()
+            .any(|body| body.contains("scope=scope-a+scope-b")));
+        assert!(request_bodies
+            .iter()
+            .any(|body| body.contains("scope=scope-c")));
+    }
+
+    #[tokio::test]
     async fn upstream_pump_publishes_one_framed_payload() {
         let (mut client, server) = duplex(64);
         let mut publisher = FakePublisher::default();
@@ -1445,6 +1648,38 @@ mod tests {
 
         let err = write_framed(&mut client, &payload).await.unwrap_err();
         assert!(err.to_string().contains("exceeds max"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bridge_runtime_abandons_inflight_message_when_upstream_finishes() {
+        let reader_state = Arc::new(ReaderState::new());
+        let write_started = Arc::new(Notify::new());
+        let inflight_set = Arc::new(Notify::new());
+        let abandons = Arc::new(AtomicUsize::new(0));
+        let inflight_wait = inflight_set.notified();
+        let write_wait = write_started.notified();
+        let stream = ShutdownTestStream {
+            reader_state: Arc::clone(&reader_state),
+            write_started: Arc::clone(&write_started),
+        };
+        let consumer = ShutdownAwareConsumer {
+            payload: Some(vec![1u8, 2, 3]),
+            inflight: false,
+            inflight_set: Arc::clone(&inflight_set),
+            abandons: Arc::clone(&abandons),
+        };
+
+        let bridge_task = tokio::spawn(async move {
+            super::bridge_runtime(stream, FakePublisher::default(), consumer).await
+        });
+
+        inflight_wait.await;
+        write_wait.await;
+        reader_state.finish();
+
+        bridge_task.await.unwrap().unwrap();
+        assert_eq!(abandons.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 sonde contributors
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -389,13 +389,39 @@ fn service_principal_state_path(state_dir: &Path) -> PathBuf {
     state_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME)
 }
 
-fn resolve_state_relative_path(state_dir: &Path, value: &str) -> PathBuf {
+fn resolve_state_relative_path(state_dir: &Path, value: &str) -> Result<PathBuf, CompanionError> {
     let path = PathBuf::from(value);
     if path.is_absolute() {
-        path
-    } else {
-        state_dir.join(path)
+        return Err(CompanionError::Config(format!(
+            "service principal path `{value}` must be relative to the state directory"
+        )));
     }
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        return Err(CompanionError::Config(format!(
+            "service principal path `{value}` must stay within the state directory"
+        )));
+    }
+    Ok(state_dir.join(path))
+}
+
+fn canonicalize_state_file_path(
+    state_dir: &Path,
+    path: &Path,
+    value: &str,
+) -> Result<PathBuf, CompanionError> {
+    let canonical_state_dir = state_dir.canonicalize()?;
+    let canonical_path = path.canonicalize()?;
+    if !canonical_path.starts_with(&canonical_state_dir) {
+        return Err(CompanionError::Config(format!(
+            "service principal path `{value}` resolved outside the state directory"
+        )));
+    }
+    Ok(canonical_path)
 }
 
 fn load_runtime_credential_state(
@@ -407,22 +433,26 @@ fn load_runtime_credential_state(
     let client_id = require_non_empty(state.client_id, "service principal client_id")?;
     let certificate_path_value =
         require_non_empty(state.certificate_path, "service principal certificate_path")?;
-    let certificate_path = resolve_state_relative_path(state_dir, &certificate_path_value);
+    let certificate_path = resolve_state_relative_path(state_dir, &certificate_path_value)?;
     if !certificate_path.is_file() {
         return Err(CompanionError::Config(format!(
             "service principal certificate file not found: {}",
             certificate_path.display()
         )));
     }
+    let certificate_path =
+        canonicalize_state_file_path(state_dir, &certificate_path, &certificate_path_value)?;
     let private_key_path_value =
         require_non_empty(state.private_key_path, "service principal private_key_path")?;
-    let private_key_path = resolve_state_relative_path(state_dir, &private_key_path_value);
+    let private_key_path = resolve_state_relative_path(state_dir, &private_key_path_value)?;
     if !private_key_path.is_file() {
         return Err(CompanionError::Config(format!(
             "service principal private key file not found: {}",
             private_key_path.display()
         )));
     }
+    let private_key_path =
+        canonicalize_state_file_path(state_dir, &private_key_path, &private_key_path_value)?;
     Ok(RuntimeCredentialState {
         tenant_id,
         client_id,
@@ -828,8 +858,22 @@ where
     F::Consumer: 'static,
 {
     let (runtime_config, runtime_state) = check_runtime_ready(state_dir)?;
+    run_checked_with_factory(connector_socket, &runtime_config, &runtime_state, factory).await
+}
+
+async fn run_checked_with_factory<F>(
+    connector_socket: &str,
+    runtime_config: &RuntimeConfig,
+    runtime_state: &RuntimeCredentialState,
+    factory: &F,
+) -> Result<(), CompanionError>
+where
+    F: BrokerTransportFactory,
+    F::Publisher: 'static,
+    F::Consumer: 'static,
+{
+    let (publisher, consumer) = factory.connect(runtime_config, runtime_state).await?;
     let stream = connect_connector(connector_socket).await?;
-    let (publisher, consumer) = factory.connect(&runtime_config, &runtime_state).await?;
     eprintln!(
         "connected to gateway connector at {connector_socket} and Azure Service Bus namespace {}",
         runtime_config.namespace
@@ -922,9 +966,15 @@ mod tests {
     use std::collections::VecDeque;
     use std::path::Path;
     use std::path::PathBuf;
+    #[cfg(unix)]
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    #[cfg(unix)]
+    use std::sync::Arc;
     use tempfile::TempDir;
     use tokio::io::duplex;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    #[cfg(unix)]
+    use tokio::sync::{Mutex, Notify};
 
     fn lines(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| (*s).to_string()).collect()
@@ -1051,6 +1101,95 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    struct BlockingConsumer {
+        queued: VecDeque<Vec<u8>>,
+        inflight: Option<Vec<u8>>,
+    }
+
+    #[cfg(unix)]
+    impl BlockingConsumer {
+        fn new(payloads: impl IntoIterator<Item = Vec<u8>>) -> Self {
+            Self {
+                queued: payloads.into_iter().collect(),
+                inflight: None,
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[tonic::async_trait]
+    impl DownstreamConsumer for BlockingConsumer {
+        async fn receive(&mut self) -> Result<Option<Vec<u8>>, CompanionError> {
+            if let Some(payload) = self.queued.pop_front() {
+                self.inflight = Some(payload.clone());
+                Ok(Some(payload))
+            } else {
+                std::future::pending::<Result<Option<Vec<u8>>, CompanionError>>().await
+            }
+        }
+
+        async fn complete(&mut self) -> Result<(), CompanionError> {
+            self.inflight.take();
+            Ok(())
+        }
+
+        async fn abandon(&mut self) -> Result<(), CompanionError> {
+            self.inflight.take();
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    struct SharedPublisher {
+        published: Arc<Mutex<Vec<Vec<u8>>>>,
+    }
+
+    #[cfg(unix)]
+    #[tonic::async_trait]
+    impl UpstreamPublisher for SharedPublisher {
+        async fn publish(&mut self, payload: Vec<u8>) -> Result<(), CompanionError> {
+            self.published.lock().await.push(payload);
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    struct TestBrokerTransportFactory {
+        connect_started: Arc<Notify>,
+        release_connect: Arc<Notify>,
+        connect_calls: Arc<AtomicUsize>,
+        published: Arc<Mutex<Vec<Vec<u8>>>>,
+        downstream_payloads: Vec<Vec<u8>>,
+        allow_return: Arc<AtomicBool>,
+    }
+
+    #[cfg(unix)]
+    #[tonic::async_trait]
+    impl super::BrokerTransportFactory for TestBrokerTransportFactory {
+        type Publisher = SharedPublisher;
+        type Consumer = BlockingConsumer;
+
+        async fn connect(
+            &self,
+            _runtime_config: &RuntimeConfig,
+            _runtime_state: &RuntimeCredentialState,
+        ) -> Result<(Self::Publisher, Self::Consumer), CompanionError> {
+            self.connect_calls.fetch_add(1, Ordering::SeqCst);
+            self.connect_started.notify_waiters();
+            if !self.allow_return.load(Ordering::SeqCst) {
+                self.release_connect.notified().await;
+                self.allow_return.store(true, Ordering::SeqCst);
+            }
+            Ok((
+                SharedPublisher {
+                    published: Arc::clone(&self.published),
+                },
+                BlockingConsumer::new(self.downstream_payloads.clone()),
+            ))
+        }
+    }
+
     #[test]
     fn display_lines_accept_one_to_four_entries() {
         for line_count in 1..=4 {
@@ -1154,8 +1293,16 @@ mod tests {
                     RuntimeCredentialState {
                         tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
                         client_id: "22222222-2222-2222-2222-222222222222".to_string(),
-                        certificate_path: temp.path().join("client-cert.pem"),
-                        private_key_path: temp.path().join("client-key.pem"),
+                        certificate_path: temp
+                            .path()
+                            .join("client-cert.pem")
+                            .canonicalize()
+                            .unwrap(),
+                        private_key_path: temp
+                            .path()
+                            .join("client-key.pem")
+                            .canonicalize()
+                            .unwrap(),
                     }
                 );
             },
@@ -1304,8 +1451,139 @@ mod tests {
     fn relative_state_paths_resolve_under_state_directory() {
         let state_dir = Path::new("/tmp/sonde-state");
         assert_eq!(
-            resolve_state_relative_path(state_dir, "certs/client.pem"),
+            resolve_state_relative_path(state_dir, "certs/client.pem").unwrap(),
             state_dir.join("certs/client.pem")
         );
+    }
+
+    #[test]
+    fn resolve_state_relative_path_rejects_absolute_paths() {
+        let state_dir = Path::new("/tmp/sonde-state");
+        let absolute = std::env::current_dir().unwrap().join("client.pem");
+        let err =
+            resolve_state_relative_path(state_dir, &absolute.display().to_string()).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must be relative to the state directory"));
+    }
+
+    #[test]
+    fn resolve_state_relative_path_rejects_parent_directory_traversal() {
+        let state_dir = Path::new("/tmp/sonde-state");
+        let err = resolve_state_relative_path(state_dir, "../client.pem").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must stay within the state directory"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_ready_rejects_symlink_escape_from_state_directory() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let state_dir = temp.path().join("state");
+        let outside_dir = temp.path().join("outside");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::create_dir_all(&outside_dir).unwrap();
+
+        let outside_cert = outside_dir.join("client-cert.pem");
+        std::fs::write(&outside_cert, "dummy").unwrap();
+        symlink(&outside_cert, state_dir.join("client-cert.pem")).unwrap();
+        std::fs::write(state_dir.join("client-key.pem"), "dummy").unwrap();
+
+        let state = ServicePrincipalStateFile {
+            tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            certificate_path: "client-cert.pem".to_string(),
+            private_key_path: "client-key.pem".to_string(),
+        };
+        std::fs::write(
+            state_dir.join("service-principal.json"),
+            serde_json::to_vec(&state).unwrap(),
+        )
+        .unwrap();
+
+        let err = super::load_runtime_credential_state(&state_dir).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("resolved outside the state directory"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_checked_with_factory_waits_for_broker_before_opening_connector_and_bridges_frames()
+    {
+        use tokio::net::UnixListener;
+        use tokio::time::{timeout, Duration};
+
+        let temp = TempDir::new().unwrap();
+        let socket_path = temp.path().join("connector.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+
+        let connect_started = Arc::new(Notify::new());
+        let release_connect = Arc::new(Notify::new());
+        let connect_calls = Arc::new(AtomicUsize::new(0));
+        let published = Arc::new(Mutex::new(Vec::new()));
+        let connect_started_wait = connect_started.notified();
+        let factory = TestBrokerTransportFactory {
+            connect_started: Arc::clone(&connect_started),
+            release_connect: Arc::clone(&release_connect),
+            connect_calls: Arc::clone(&connect_calls),
+            published: Arc::clone(&published),
+            downstream_payloads: vec![vec![7u8, 8, 9]],
+            allow_return: Arc::new(AtomicBool::new(false)),
+        };
+        let connector_socket = socket_path.to_string_lossy().into_owned();
+        let runtime_config = RuntimeConfig {
+            namespace: "example.servicebus.windows.net".to_string(),
+            upstream_queue: "upstream".to_string(),
+            downstream_queue: "downstream".to_string(),
+        };
+        let runtime_state = RuntimeCredentialState {
+            tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            certificate_path: temp.path().join("client-cert.pem"),
+            private_key_path: temp.path().join("client-key.pem"),
+        };
+
+        let run_task = tokio::spawn(async move {
+            super::run_checked_with_factory(
+                &connector_socket,
+                &runtime_config,
+                &runtime_state,
+                &factory,
+            )
+            .await
+        });
+
+        connect_started_wait.await;
+        assert_eq!(connect_calls.load(Ordering::SeqCst), 1);
+        assert!(timeout(Duration::from_millis(100), listener.accept())
+            .await
+            .is_err());
+
+        release_connect.notify_waiters();
+        let (mut server, _) = timeout(Duration::from_secs(1), listener.accept())
+            .await
+            .unwrap()
+            .unwrap();
+
+        write_framed(&mut server, b"upstream-test").await.unwrap();
+        let downstream = read_framed(&mut server).await.unwrap().unwrap();
+        assert_eq!(downstream, vec![7u8, 8, 9]);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if published.lock().await.clone() == vec![b"upstream-test".to_vec()] {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        run_task.abort();
     }
 }

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -18,6 +18,7 @@ use clap::{Args, Parser, Subcommand};
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use oauth_device_flows::provider::GenericProviderConfig;
 use oauth_device_flows::{DeviceFlow, DeviceFlowConfig, Provider};
+use p256::pkcs8::DecodePrivateKey;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -50,6 +51,8 @@ const CONNECTOR_MAX_FRAME_LENGTH: usize =
 const ACCESS_TOKEN_REFRESH_MARGIN_SECS: i64 = 300;
 const CLIENT_ASSERTION_LIFETIME_SECS: i64 = 600;
 const CLIENT_ASSERTION_TYPE: &str = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+const TOKEN_HTTP_CONNECT_TIMEOUT_SECS: u64 = 10;
+const TOKEN_HTTP_TIMEOUT_SECS: u64 = 30;
 
 #[derive(Debug, Error)]
 enum CompanionError {
@@ -434,7 +437,17 @@ fn load_runtime_credential_state(
     state_dir: &Path,
 ) -> Result<RuntimeCredentialState, CompanionError> {
     let state_path = service_principal_state_path(state_dir);
-    let state: ServicePrincipalStateFile = serde_json::from_slice(&std::fs::read(&state_path)?)?;
+    let state_bytes = match std::fs::read(&state_path) {
+        Ok(state_bytes) => state_bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(CompanionError::Config(format!(
+                "service principal state file not found: {}",
+                state_path.display()
+            )));
+        }
+        Err(err) => return Err(err.into()),
+    };
+    let state: ServicePrincipalStateFile = serde_json::from_slice(&state_bytes)?;
     let tenant_id = require_non_empty(state.tenant_id, "service principal tenant_id")?;
     let client_id = require_non_empty(state.client_id, "service principal client_id")?;
     let certificate_path_value =
@@ -536,6 +549,7 @@ fn load_signing_key(private_key_path: &Path) -> Result<(Algorithm, EncodingKey),
         return Ok((Algorithm::RS256, key));
     }
     if let Ok(key) = EncodingKey::from_ec_pem(&private_key_pem) {
+        ensure_p256_private_key(&private_key_pem, private_key_path)?;
         return Ok((Algorithm::ES256, key));
     }
     if let Ok(key) = EncodingKey::from_ed_pem(&private_key_pem) {
@@ -548,6 +562,46 @@ fn load_signing_key(private_key_path: &Path) -> Result<(Algorithm, EncodingKey),
     )))
 }
 
+fn ensure_p256_private_key(
+    private_key_pem: &[u8],
+    private_key_path: &Path,
+) -> Result<(), CompanionError> {
+    let mut reader = std::io::BufReader::new(private_key_pem);
+    let private_key = rustls_pemfile::read_one(&mut reader)?.ok_or_else(|| {
+        CompanionError::Config(format!(
+            "service principal private key file did not contain a PEM private key: {}",
+            private_key_path.display()
+        ))
+    })?;
+
+    match private_key {
+        rustls_pemfile::Item::Pkcs8Key(key) => {
+            p256::SecretKey::from_pkcs8_der(key.secret_pkcs8_der()).map_err(|_| {
+                CompanionError::Config(format!(
+                    "service principal EC private key must use the P-256 curve for ES256 assertions: {}",
+                    private_key_path.display()
+                ))
+            })?;
+        }
+        rustls_pemfile::Item::Sec1Key(key) => {
+            p256::SecretKey::from_sec1_der(key.secret_sec1_der()).map_err(|_| {
+                CompanionError::Config(format!(
+                    "service principal EC private key must use the P-256 curve for ES256 assertions: {}",
+                    private_key_path.display()
+                ))
+            })?;
+        }
+        _ => {
+            return Err(CompanionError::Config(format!(
+                "service principal EC private key must be encoded as PKCS#8 or SEC1 PEM: {}",
+                private_key_path.display()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 fn build_service_bus_credential(
     runtime_state: &RuntimeCredentialState,
 ) -> Result<Arc<dyn TokenCredential>, CompanionError> {
@@ -557,7 +611,10 @@ fn build_service_bus_credential(
         "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
         runtime_state.tenant_id
     );
-    let http_client = reqwest::Client::builder().build()?;
+    let http_client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(TOKEN_HTTP_CONNECT_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(TOKEN_HTTP_TIMEOUT_SECS))
+        .build()?;
     Ok(Arc::new(ClientAssertionCredential {
         client_id: runtime_state.client_id.clone(),
         token_endpoint,
@@ -1016,7 +1073,7 @@ async fn main() -> Result<(), CompanionError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        bootstrap_provider_and_config, check_runtime_ready, load_runtime_config,
+        bootstrap_provider_and_config, check_runtime_ready, load_runtime_config, load_signing_key,
         pump_downstream_once, pump_upstream_once, read_framed, resolve_state_relative_path,
         validate_device_client_id, validate_device_scopes, validate_display_lines, write_framed,
         BootstrapAuthArgs, ClientAssertionCredential, CompanionError, DownstreamConsumer,
@@ -1088,9 +1145,9 @@ mod tests {
             &key_path,
             concat!(
                 "-----BEGIN PRIVATE KEY-----\n",
-                "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg2X8i4lE4hM2t0b5Y\n",
-                "fI7xW0ZzM3ZrY4L3s67qG8R0uYWhRANCAAStNVLyCQaqRPW+p7wtNOVgX5c18vv6\n",
-                "4n71/Bsfc/1KImuM3gnXDOo/xw/qU/TC0P67YThvhbRBb4TdqNB7ytb7\n",
+                "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgiHx55EC3Yiih4pAE\n",
+                "7x0NrlcsxiOH+SRn2I9N8+XzugihRANCAAS/bEotS4/FxoJf+T+jEGzlFQtYKea0\n",
+                "nmvBHE5F9GNfpDliGtxecWSjvICrTVwN0x4a5UuxfFF0rgL6I/2IGAWs\n",
                 "-----END PRIVATE KEY-----\n"
             ),
         )
@@ -1120,6 +1177,23 @@ mod tests {
             serde_json::to_vec(&state).unwrap(),
         )
         .unwrap();
+    }
+
+    fn with_runtime_env(test: impl FnOnce()) {
+        temp_env::with_vars(
+            [
+                (
+                    "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                    Some("example.servicebus.windows.net"),
+                ),
+                ("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE", Some("upstream")),
+                (
+                    "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+                    Some("downstream"),
+                ),
+            ],
+            test,
+        );
     }
 
     #[derive(Default)]
@@ -1475,47 +1549,26 @@ mod tests {
     fn runtime_ready_uses_service_principal_state_file() {
         let temp = TempDir::new().unwrap();
         write_service_principal_state(&temp);
-        temp_env::with_vars(
-            [
-                (
-                    "SONDE_AZURE_SERVICEBUS_NAMESPACE",
-                    Some("example.servicebus.windows.net"),
-                ),
-                ("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE", Some("upstream")),
-                (
-                    "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
-                    Some("downstream"),
-                ),
-            ],
-            || {
-                let (config, state) = check_runtime_ready(temp.path()).unwrap();
-                assert_eq!(
-                    config,
-                    RuntimeConfig {
-                        namespace: "example.servicebus.windows.net".to_string(),
-                        upstream_queue: "upstream".to_string(),
-                        downstream_queue: "downstream".to_string(),
-                    }
-                );
-                assert_eq!(
-                    state,
-                    RuntimeCredentialState {
-                        tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
-                        client_id: "22222222-2222-2222-2222-222222222222".to_string(),
-                        certificate_path: temp
-                            .path()
-                            .join("client-cert.pem")
-                            .canonicalize()
-                            .unwrap(),
-                        private_key_path: temp
-                            .path()
-                            .join("client-key.pem")
-                            .canonicalize()
-                            .unwrap(),
-                    }
-                );
-            },
-        );
+        with_runtime_env(|| {
+            let (config, state) = check_runtime_ready(temp.path()).unwrap();
+            assert_eq!(
+                config,
+                RuntimeConfig {
+                    namespace: "example.servicebus.windows.net".to_string(),
+                    upstream_queue: "upstream".to_string(),
+                    downstream_queue: "downstream".to_string(),
+                }
+            );
+            assert_eq!(
+                state,
+                RuntimeCredentialState {
+                    tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+                    client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                    certificate_path: temp.path().join("client-cert.pem").canonicalize().unwrap(),
+                    private_key_path: temp.path().join("client-key.pem").canonicalize().unwrap(),
+                }
+            );
+        });
     }
 
     #[test]
@@ -1533,47 +1586,62 @@ mod tests {
         )
         .unwrap();
         std::fs::write(temp.path().join("client-key.pem"), b"dummy").unwrap();
-        temp_env::with_vars(
-            [
-                (
-                    "SONDE_AZURE_SERVICEBUS_NAMESPACE",
-                    Some("example.servicebus.windows.net"),
-                ),
-                ("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE", Some("upstream")),
-                (
-                    "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
-                    Some("downstream"),
-                ),
-            ],
-            || {
-                let err = check_runtime_ready(temp.path()).unwrap_err();
-                assert!(err
-                    .to_string()
-                    .contains("service principal certificate_path must be set and non-empty"));
-            },
-        );
+        with_runtime_env(|| {
+            let err = check_runtime_ready(temp.path()).unwrap_err();
+            assert!(err
+                .to_string()
+                .contains("service principal certificate_path must be set and non-empty"));
+        });
     }
 
     #[test]
     fn runtime_ready_rejects_unparseable_pem_material() {
         let temp = TempDir::new().unwrap();
         write_invalid_service_principal_state(&temp);
-        temp_env::with_vars(
-            [
-                (
-                    "SONDE_AZURE_SERVICEBUS_NAMESPACE",
-                    Some("example.servicebus.windows.net"),
-                ),
-                ("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE", Some("upstream")),
-                (
-                    "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
-                    Some("downstream"),
-                ),
-            ],
-            || {
-                assert!(check_runtime_ready(temp.path()).is_err());
-            },
-        );
+        with_runtime_env(|| {
+            assert!(check_runtime_ready(temp.path()).is_err());
+        });
+    }
+
+    #[test]
+    fn runtime_ready_reports_missing_state_file_clearly() {
+        let temp = TempDir::new().unwrap();
+        with_runtime_env(|| {
+            let err = check_runtime_ready(temp.path()).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                format!(
+                    "service principal state file not found: {}",
+                    temp.path().join("service-principal.json").display()
+                )
+            );
+        });
+    }
+
+    #[test]
+    fn load_signing_key_rejects_non_p256_ec_private_keys() {
+        let temp = TempDir::new().unwrap();
+        let private_key_path = temp.path().join("client-key.pem");
+        std::fs::write(
+            &private_key_path,
+            concat!(
+                "-----BEGIN PRIVATE KEY-----\n",
+                "MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDD6GGUh9wwgHc1R0MYl\n",
+                "xZfpPwMaBFTrBgVlM+BwH5lDYPlcsiyN1yQxjtNvBGY9HRChZANiAARjYBFs2Isx\n",
+                "DAL8I6WJrqUHfWv3iFNkGaNXrJJSf2q5Qe1pmV4qURhQ9bvqcE/fjyRNui4vO9vZ\n",
+                "YpU8DwOw4WRFViavnnT+S7gi+MPx9LgM0Ol80YC4eaFWfPc1D11V0zs=\n",
+                "-----END PRIVATE KEY-----\n"
+            ),
+        )
+        .unwrap();
+
+        let err = match load_signing_key(&private_key_path) {
+            Ok(_) => panic!("expected non-P-256 EC private key to be rejected"),
+            Err(err) => err,
+        };
+        assert!(err
+            .to_string()
+            .contains("service principal EC private key must use the P-256 curve"));
     }
 
     #[tokio::test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -602,6 +602,17 @@ fn ensure_p256_private_key(
     Ok(())
 }
 
+fn downstream_body_to_connector_payload(body: &[u8]) -> Result<Vec<u8>, CompanionError> {
+    if body.len() > CONNECTOR_MAX_FRAME_LENGTH {
+        return Err(CompanionError::Config(format!(
+            "downstream Service Bus message body length {} exceeds connector max frame length {}",
+            body.len(),
+            CONNECTOR_MAX_FRAME_LENGTH
+        )));
+    }
+    Ok(body.to_vec())
+}
+
 fn build_service_bus_credential(
     runtime_state: &RuntimeCredentialState,
 ) -> Result<Arc<dyn TokenCredential>, CompanionError> {
@@ -743,7 +754,7 @@ impl DownstreamConsumer for AzServiceBusConsumer {
                         "downstream Service Bus message body was not raw binary data: {err}"
                     ))
                 })
-                .map(|body| body.to_vec());
+                .and_then(downstream_body_to_connector_payload);
             match payload {
                 Ok(payload) => Ok(Some(payload)),
                 Err(err) => {
@@ -1073,11 +1084,12 @@ async fn main() -> Result<(), CompanionError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        bootstrap_provider_and_config, check_runtime_ready, load_runtime_config, load_signing_key,
-        pump_downstream_once, pump_upstream_once, read_framed, resolve_state_relative_path,
-        validate_device_client_id, validate_device_scopes, validate_display_lines, write_framed,
-        BootstrapAuthArgs, ClientAssertionCredential, CompanionError, DownstreamConsumer,
-        RuntimeConfig, RuntimeCredentialState, ServicePrincipalStateFile, UpstreamPublisher,
+        bootstrap_provider_and_config, check_runtime_ready, downstream_body_to_connector_payload,
+        load_runtime_config, load_signing_key, pump_downstream_once, pump_upstream_once,
+        read_framed, resolve_state_relative_path, validate_device_client_id,
+        validate_device_scopes, validate_display_lines, write_framed, BootstrapAuthArgs,
+        ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
+        RuntimeCredentialState, ServicePrincipalStateFile, UpstreamPublisher,
         CONNECTOR_MAX_FRAME_LENGTH,
     };
     use azure_core::credentials::TokenCredential;
@@ -1642,6 +1654,15 @@ mod tests {
         assert!(err
             .to_string()
             .contains("service principal EC private key must use the P-256 curve"));
+    }
+
+    #[test]
+    fn downstream_body_to_connector_payload_rejects_oversized_messages() {
+        let body = vec![0u8; CONNECTOR_MAX_FRAME_LENGTH + 1];
+        let err = downstream_body_to_connector_payload(&body).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("exceeds connector max frame length"));
     }
 
     #[tokio::test]

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -697,7 +697,8 @@ async fn t_azc_0108_missing_runtime_config_beats_device_auth_env_error() {
     assert!(!wrapper_log.exists() || fs::read_to_string(&wrapper_log).unwrap().is_empty());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("SONDE_AZURE_SERVICEBUS_NAMESPACE must be set and non-empty"));
-    assert!(!stderr.contains("SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap"));
+    assert!(stderr.contains("SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap"));
+    assert!(stderr.contains("SONDE_AZURE_DEVICE_SCOPES must be set for bootstrap"));
 }
 
 #[test]

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -660,6 +660,11 @@ async fn t_azc_0107_bootstrap_without_runtime_state_fails_closed() {
     );
     assert!(!wrapper_log.exists() || fs::read_to_string(&wrapper_log).unwrap().is_empty());
     assert!(String::from_utf8_lossy(&output.stderr).contains("runtime state is still incomplete"));
+    assert!(fs::read_dir(&state_dir).unwrap().all(|entry| !entry
+        .unwrap()
+        .file_name()
+        .to_string_lossy()
+        .starts_with("check-runtime-ready.")));
 }
 
 #[test]

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -30,23 +30,22 @@ type BlePairingStream =
 
 const TEST_CERT_PEM: &str = concat!(
     "-----BEGIN CERTIFICATE-----\n",
-    "MIIBszCCAVmgAwIBAgIUAlA4D2+fMZ5I2mv8VLK0sgM4nWkwCgYIKoZIzj0EAwIw\n",
-    "GDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MB4XDTI2MDEwMTAwMDAwMFoXDTM2\n",
-    "MDEwMTAwMDAwMFowGDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MFkwEwYHKoZI\n",
-    "zj0CAQYIKoZIzj0DAQcDQgAErTVS8gkGqkT1vqe8LTTlYF+XNfL7+uJ+9fwbH3P9\n",
-    "SiJrjN4J1wzqP8cP6lP0wtD+u2E4b4W0QW+E3ajQe8rW+6NTMFEwHQYDVR0OBBYE\n",
-    "FCn5Pw3Ozl7pJ1mJtqQv5Xz6vbALMB8GA1UdIwQYMBaAFCn5Pw3Ozl7pJ1mJtqQv\n",
-    "5Xz6vbALMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAJNL5l3C\n",
-    "tI6X5x4c4x6pI0vA6PfXzL5K5ll4D7OQyZcAAiA1dQXJk0v6qY+Mi8XGcX6Z7J5u\n",
-    "gW4Y8d+4T2oD7j9m0Q==\n",
+    "MIIBWDCB/6ADAgECAggbYn85Il496TAKBggqhkjOPQQDAjAaMRgwFgYDVQQDEw9z\n",
+    "b25kZS10ZXN0LWNlcnQwHhcNMjYwNDI4MTczNDAzWhcNMzYwNDI5MTczNDAzWjAa\n",
+    "MRgwFgYDVQQDEw9zb25kZS10ZXN0LWNlcnQwWTATBgcqhkjOPQIBBggqhkjOPQMB\n",
+    "BwNCAASvz+sAGz7/92glvERlQlom5OFgseIgMgvGZM04KsqOD+D/hwG3tzmpOu4U\n",
+    "AZyhAdrkAqvHWmfQkK5D8jdhgv33oy8wLTAMBgNVHRMBAf8EAjAAMB0GA1UdDgQW\n",
+    "BBQ4+jYZ/ddAOO7/msNIHh9f61IeFjAKBggqhkjOPQQDAgNIADBFAiBmBB/wP94s\n",
+    "DdBiCaUetVSkrk484rSijsJqpqnlJ/0H+QIhAMYgtEuZ8LcCsScdbwsFArve4TVN\n",
+    "yfVpQffskcauwpb9\n",
     "-----END CERTIFICATE-----\n"
 );
 
 const TEST_KEY_PEM: &str = concat!(
     "-----BEGIN PRIVATE KEY-----\n",
-    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgiHx55EC3Yiih4pAE\n",
-    "7x0NrlcsxiOH+SRn2I9N8+XzugihRANCAAS/bEotS4/FxoJf+T+jEGzlFQtYKea0\n",
-    "nmvBHE5F9GNfpDliGtxecWSjvICrTVwN0x4a5UuxfFF0rgL6I/2IGAWs\n",
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgor2vT3esA5xTV1E4\n",
+    "IWCpH+V2pudlqDwiS4+LKEKy3X6hRANCAASvz+sAGz7/92glvERlQlom5OFgseIg\n",
+    "MgvGZM04KsqOD+D/hwG3tzmpOu4UAZyhAdrkAqvHWmfQkK5D8jdhgv33\n",
     "-----END PRIVATE KEY-----\n"
 );
 
@@ -665,6 +664,40 @@ async fn t_azc_0107_bootstrap_without_runtime_state_fails_closed() {
         .file_name()
         .to_string_lossy()
         .starts_with("check-runtime-ready.")));
+}
+
+#[tokio::test]
+async fn t_azc_0108_missing_runtime_config_beats_device_auth_env_error() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    write_runtime_ready_state(&state_dir);
+    let admin_socket_path = temp.path().join("admin.sock");
+    let connector_socket_path = temp.path().join("connector.sock");
+    let _display_requests = spawn_admin_server(&admin_socket_path, None).await;
+    let oauth_server = MockServer::start().await;
+
+    let wrapper_log = temp.path().join("wrapper.log");
+    write_runtime_wrapper(&bin_dir, &wrapper_log);
+    let mut env = bootstrap_env(
+        &bin_dir,
+        &state_dir,
+        &admin_socket_path,
+        &connector_socket_path,
+        &oauth_server,
+    );
+    env.retain(|(key, _)| {
+        key != "SONDE_AZURE_SERVICEBUS_NAMESPACE"
+            && key != "SONDE_AZURE_DEVICE_CLIENT_ID"
+            && key != "SONDE_AZURE_DEVICE_SCOPES"
+    });
+
+    let output = run_bootstrap_with_env(&env).await;
+    assert!(!output.status.success());
+    assert!(!wrapper_log.exists() || fs::read_to_string(&wrapper_log).unwrap().is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("SONDE_AZURE_SERVICEBUS_NAMESPACE must be set and non-empty"));
+    assert!(!stderr.contains("SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap"));
 }
 
 #[test]

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -28,6 +28,28 @@ use sonde_gateway::admin::pb::*;
 type BlePairingStream =
     Pin<Box<dyn futures::Stream<Item = Result<BlePairingEvent, Status>> + Send>>;
 
+const TEST_CERT_PEM: &str = concat!(
+    "-----BEGIN CERTIFICATE-----\n",
+    "MIIBszCCAVmgAwIBAgIUAlA4D2+fMZ5I2mv8VLK0sgM4nWkwCgYIKoZIzj0EAwIw\n",
+    "GDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MB4XDTI2MDEwMTAwMDAwMFoXDTM2\n",
+    "MDEwMTAwMDAwMFowGDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MFkwEwYHKoZI\n",
+    "zj0CAQYIKoZIzj0DAQcDQgAErTVS8gkGqkT1vqe8LTTlYF+XNfL7+uJ+9fwbH3P9\n",
+    "SiJrjN4J1wzqP8cP6lP0wtD+u2E4b4W0QW+E3ajQe8rW+6NTMFEwHQYDVR0OBBYE\n",
+    "FCn5Pw3Ozl7pJ1mJtqQv5Xz6vbALMB8GA1UdIwQYMBaAFCn5Pw3Ozl7pJ1mJtqQv\n",
+    "5Xz6vbALMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAJNL5l3C\n",
+    "tI6X5x4c4x6pI0vA6PfXzL5K5ll4D7OQyZcAAiA1dQXJk0v6qY+Mi8XGcX6Z7J5u\n",
+    "gW4Y8d+4T2oD7j9m0Q==\n",
+    "-----END CERTIFICATE-----\n"
+);
+
+const TEST_KEY_PEM: &str = concat!(
+    "-----BEGIN PRIVATE KEY-----\n",
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg2X8i4lE4hM2t0b5Y\n",
+    "fI7xW0ZzM3ZrY4L3s67qG8R0uYWhRANCAAStNVLyCQaqRPW+p7wtNOVgX5c18vv6\n",
+    "4n71/Bsfc/1KImuM3gnXDOo/xw/qU/TC0P67YThvhbRBb4TdqNB7ytb7\n",
+    "-----END PRIVATE KEY-----\n"
+);
+
 #[derive(Clone)]
 struct TestAdminServer {
     display_requests: Arc<Mutex<Vec<Vec<String>>>>,
@@ -292,9 +314,11 @@ fn write_runtime_wrapper(bin_dir: &Path, wrapper_log: &Path) {
     write_executable(
         &bin_dir.join("sonde-azure-companion"),
         &format!(
-            "#!/bin/sh\nset -eu\nadmin_socket=\"\"\nconnector_socket=\"\"\nstate_dir=\"\"\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket)\n      admin_socket=\"$2\"\n      shift 2\n      ;;\n    --connector-socket)\n      connector_socket=\"$2\"\n      shift 2\n      ;;\n    --state-dir)\n      state_dir=\"$2\"\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\ncase \"$1\" in\n  run)\n    printf 'run %s %s %s\\n' \"$admin_socket\" \"$connector_socket\" \"$state_dir\" >> \"{}\"\n    exit 0\n    ;;\n  bootstrap-auth)\n    \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" --state-dir \"$state_dir\" \"$@\"\n    status=$?\n    if [ \"$status\" -eq 0 ] && [ \"${{SONDE_TEST_WRITE_RUNTIME_STATE:-0}}\" = \"1\" ]; then\n      mkdir -p \"$state_dir\"\n      cat > \"$state_dir/client-cert.pem\" <<'EOF'\n-----BEGIN CERTIFICATE-----\nMIIBhTCCASugAwIBAgIUY0y4lG7kY7xKpD3xj0w4H0P0aQYwCgYIKoZIzj0EAwIw\nGDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MB4XDTI2MDEwMTAwMDAwMFoXDTM2\nMDEwMTAwMDAwMFowGDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MFkwEwYHKoZI\nzj0CAQYIKoZIzj0DAQcDQgAE4S0r6F8qLZ8w1+E3gD2d8EoV5Wb7c5d1u0S6m7nY\nkH0QwP2wG3g1rj0G4F2L4x0Fv8dB7p3gH2qkE3JQ3V+32KNTMFEwHQYDVR0OBBYE\nFDnJ2C4XhS9Rz4D0Hj2A0m0WjvYSMB8GA1UdIwQYMBaAFDnJ2C4XhS9Rz4D0Hj2A\n0m0WjvYSMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhAKF5N5kU\nn6u4iW4yW+z5AxpKxR4QYw8WQk3gk2mQY7fDAiEA0TjKx0sS7Y2f7g5mQ8b4G9nP\n8qS7xA6mQ9dL8f3J9xk=\n-----END CERTIFICATE-----\nEOF\n      cat > \"$state_dir/client-key.pem\" <<'EOF'\n-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgQ5z5Q4e0v7rN7m4K\nXW4bqM5dYt8G0S1G3Z4e1pY4JqKhRANCAAT hLSvoXyotnzDX4TeAPZ3wShXlZvtz\nl3W7RLqbudiQfRDA/bAbeDWuPQbgXYvjHQW/x0HuneAf aqQTclDdX7fY\n-----END PRIVATE KEY-----\nEOF\n      cat > \"$state_dir/service-principal.json\" <<'EOF'\n{{\"tenant_id\":\"11111111-1111-1111-1111-111111111111\",\"client_id\":\"22222222-2222-2222-2222-222222222222\",\"certificate_path\":\"client-cert.pem\",\"private_key_path\":\"client-key.pem\"}}\nEOF\n    fi\n    exit \"$status\"\n    ;;\n  *)\n    exec \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" --state-dir \"$state_dir\" \"$@\"\n    ;;\nesac\n",
+            "#!/bin/sh\nset -eu\nadmin_socket=\"\"\nconnector_socket=\"\"\nstate_dir=\"\"\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket)\n      admin_socket=\"$2\"\n      shift 2\n      ;;\n    --connector-socket)\n      connector_socket=\"$2\"\n      shift 2\n      ;;\n    --state-dir)\n      state_dir=\"$2\"\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\ncase \"$1\" in\n  run)\n    printf 'run %s %s %s\\n' \"$admin_socket\" \"$connector_socket\" \"$state_dir\" >> \"{}\"\n    exit 0\n    ;;\n  bootstrap-auth)\n    \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" --state-dir \"$state_dir\" \"$@\"\n    status=$?\n    if [ \"$status\" -eq 0 ] && [ \"${{SONDE_TEST_WRITE_RUNTIME_STATE:-0}}\" = \"1\" ]; then\n      mkdir -p \"$state_dir\"\n      cat > \"$state_dir/client-cert.pem\" <<'EOF'\n{}\nEOF\n      cat > \"$state_dir/client-key.pem\" <<'EOF'\n{}\nEOF\n      cat > \"$state_dir/service-principal.json\" <<'EOF'\n{{\"tenant_id\":\"11111111-1111-1111-1111-111111111111\",\"client_id\":\"22222222-2222-2222-2222-222222222222\",\"certificate_path\":\"client-cert.pem\",\"private_key_path\":\"client-key.pem\"}}\nEOF\n    fi\n    exit \"$status\"\n    ;;\n  *)\n    exec \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" --state-dir \"$state_dir\" \"$@\"\n    ;;\nesac\n",
             wrapper_log.display(),
             env!("CARGO_BIN_EXE_sonde-azure-companion"),
+            TEST_CERT_PEM,
+            TEST_KEY_PEM,
             env!("CARGO_BIN_EXE_sonde-azure-companion")
         ),
     );
@@ -302,8 +326,8 @@ fn write_runtime_wrapper(bin_dir: &Path, wrapper_log: &Path) {
 
 fn write_runtime_ready_state(state_dir: &Path) {
     fs::create_dir_all(state_dir).unwrap();
-    fs::write(state_dir.join("client-cert.pem"), b"dummy-cert").unwrap();
-    fs::write(state_dir.join("client-key.pem"), b"dummy-key").unwrap();
+    fs::write(state_dir.join("client-cert.pem"), TEST_CERT_PEM).unwrap();
+    fs::write(state_dir.join("client-key.pem"), TEST_KEY_PEM).unwrap();
     fs::write(
         state_dir.join("service-principal.json"),
         br#"{"tenant_id":"11111111-1111-1111-1111-111111111111","client_id":"22222222-2222-2222-2222-222222222222","certificate_path":"client-cert.pem","private_key_path":"client-key.pem"}"#,

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -292,11 +292,23 @@ fn write_runtime_wrapper(bin_dir: &Path, wrapper_log: &Path) {
     write_executable(
         &bin_dir.join("sonde-azure-companion"),
         &format!(
-            "#!/bin/sh\nset -eu\nadmin_socket=\"\"\nconnector_socket=\"\"\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket)\n      admin_socket=\"$2\"\n      shift 2\n      ;;\n    --connector-socket)\n      connector_socket=\"$2\"\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\nif [ \"$1\" = \"run\" ]; then\n  printf 'run %s %s\\n' \"$admin_socket\" \"$connector_socket\" >> \"{}\"\n  exit 0\nfi\nexec \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" \"$@\"\n",
+            "#!/bin/sh\nset -eu\nadmin_socket=\"\"\nconnector_socket=\"\"\nstate_dir=\"\"\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket)\n      admin_socket=\"$2\"\n      shift 2\n      ;;\n    --connector-socket)\n      connector_socket=\"$2\"\n      shift 2\n      ;;\n    --state-dir)\n      state_dir=\"$2\"\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\ncase \"$1\" in\n  run)\n    printf 'run %s %s %s\\n' \"$admin_socket\" \"$connector_socket\" \"$state_dir\" >> \"{}\"\n    exit 0\n    ;;\n  bootstrap-auth)\n    \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" --state-dir \"$state_dir\" \"$@\"\n    status=$?\n    if [ \"$status\" -eq 0 ] && [ \"${{SONDE_TEST_WRITE_RUNTIME_STATE:-0}}\" = \"1\" ]; then\n      mkdir -p \"$state_dir\"\n      cat > \"$state_dir/client-cert.pem\" <<'EOF'\n-----BEGIN CERTIFICATE-----\nMIIBhTCCASugAwIBAgIUY0y4lG7kY7xKpD3xj0w4H0P0aQYwCgYIKoZIzj0EAwIw\nGDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MB4XDTI2MDEwMTAwMDAwMFoXDTM2\nMDEwMTAwMDAwMFowGDEWMBQGA1UEAwwNc29uZGUtdGVzdC1jZXJ0MFkwEwYHKoZI\nzj0CAQYIKoZIzj0DAQcDQgAE4S0r6F8qLZ8w1+E3gD2d8EoV5Wb7c5d1u0S6m7nY\nkH0QwP2wG3g1rj0G4F2L4x0Fv8dB7p3gH2qkE3JQ3V+32KNTMFEwHQYDVR0OBBYE\nFDnJ2C4XhS9Rz4D0Hj2A0m0WjvYSMB8GA1UdIwQYMBaAFDnJ2C4XhS9Rz4D0Hj2A\n0m0WjvYSMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhAKF5N5kU\nn6u4iW4yW+z5AxpKxR4QYw8WQk3gk2mQY7fDAiEA0TjKx0sS7Y2f7g5mQ8b4G9nP\n8qS7xA6mQ9dL8f3J9xk=\n-----END CERTIFICATE-----\nEOF\n      cat > \"$state_dir/client-key.pem\" <<'EOF'\n-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgQ5z5Q4e0v7rN7m4K\nXW4bqM5dYt8G0S1G3Z4e1pY4JqKhRANCAAT hLSvoXyotnzDX4TeAPZ3wShXlZvtz\nl3W7RLqbudiQfRDA/bAbeDWuPQbgXYvjHQW/x0HuneAf aqQTclDdX7fY\n-----END PRIVATE KEY-----\nEOF\n      cat > \"$state_dir/service-principal.json\" <<'EOF'\n{{\"tenant_id\":\"11111111-1111-1111-1111-111111111111\",\"client_id\":\"22222222-2222-2222-2222-222222222222\",\"certificate_path\":\"client-cert.pem\",\"private_key_path\":\"client-key.pem\"}}\nEOF\n    fi\n    exit \"$status\"\n    ;;\n  *)\n    exec \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" --state-dir \"$state_dir\" \"$@\"\n    ;;\nesac\n",
             wrapper_log.display(),
+            env!("CARGO_BIN_EXE_sonde-azure-companion"),
             env!("CARGO_BIN_EXE_sonde-azure-companion")
         ),
     );
+}
+
+fn write_runtime_ready_state(state_dir: &Path) {
+    fs::create_dir_all(state_dir).unwrap();
+    fs::write(state_dir.join("client-cert.pem"), b"dummy-cert").unwrap();
+    fs::write(state_dir.join("client-key.pem"), b"dummy-key").unwrap();
+    fs::write(
+        state_dir.join("service-principal.json"),
+        br#"{"tenant_id":"11111111-1111-1111-1111-111111111111","client_id":"22222222-2222-2222-2222-222222222222","certificate_path":"client-cert.pem","private_key_path":"client-key.pem"}"#,
+    )
+    .unwrap();
 }
 
 fn bootstrap_env(
@@ -341,6 +353,18 @@ fn bootstrap_env(
         (
             "SONDE_AZURE_DEVICE_TOKEN_URL".to_string(),
             format!("{}/token", oauth_server.uri()),
+        ),
+        (
+            "SONDE_AZURE_SERVICEBUS_NAMESPACE".to_string(),
+            "example.servicebus.windows.net".to_string(),
+        ),
+        (
+            "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE".to_string(),
+            "upstream".to_string(),
+        ),
+        (
+            "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE".to_string(),
+            "downstream".to_string(),
         ),
     ]
 }
@@ -433,15 +457,19 @@ async fn t_azc_0101_0102_0200_0201_0202_bootstrap_success_path() {
 
     let wrapper_log = temp.path().join("wrapper.log");
     write_runtime_wrapper(&bin_dir, &wrapper_log);
-
-    let output = run_bootstrap_with_env(&bootstrap_env(
+    let mut env = bootstrap_env(
         &bin_dir,
         &state_dir,
         &admin_socket_path,
         &connector_socket_path,
         &oauth_server,
-    ))
-    .await;
+    );
+    env.push((
+        "SONDE_TEST_WRITE_RUNTIME_STATE".to_string(),
+        "1".to_string(),
+    ));
+
+    let output = run_bootstrap_with_env(&env).await;
     assert!(output.status.success(), "bootstrap failed: {output:?}");
 
     let requests = display_requests.lock().await.clone();
@@ -453,6 +481,7 @@ async fn t_azc_0101_0102_0200_0201_0202_bootstrap_success_path() {
     assert!(wrapper_contents.contains("run "));
     assert!(wrapper_contents.contains(&admin_socket_path.display().to_string()));
     assert!(wrapper_contents.contains(&connector_socket_path.display().to_string()));
+    assert!(wrapper_contents.contains(&state_dir.display().to_string()));
 }
 
 #[tokio::test]
@@ -489,21 +518,15 @@ async fn t_azc_0203_display_failure_aborts_bootstrap() {
 }
 
 #[tokio::test]
-async fn t_azc_0104_previously_used_state_still_runs_device_auth() {
+async fn t_azc_0104_ready_state_skips_device_auth() {
     let temp = TempDir::new().unwrap();
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
-    fs::create_dir_all(&state_dir).unwrap();
-    fs::write(
-        state_dir.join("managed-identity.json"),
-        b"{\"tenant\":\"placeholder\"}",
-    )
-    .unwrap();
+    write_runtime_ready_state(&state_dir);
     let admin_socket_path = temp.path().join("admin.sock");
     let connector_socket_path = temp.path().join("connector.sock");
     let display_requests = spawn_admin_server(&admin_socket_path, None).await;
     let oauth_server = MockServer::start().await;
-    mount_successful_device_flow(&oauth_server, "QWER-5678", 1).await;
 
     let wrapper_log = temp.path().join("wrapper.log");
     write_runtime_wrapper(&bin_dir, &wrapper_log);
@@ -516,25 +539,21 @@ async fn t_azc_0104_previously_used_state_still_runs_device_auth() {
         &oauth_server,
     ))
     .await;
-    assert!(output.status.success(), "bootstrap failed: {output:?}");
-    assert_eq!(
-        display_requests.lock().await.clone(),
-        vec![vec!["Azure login".to_string(), "QWER-5678".to_string()]]
-    );
+    assert!(output.status.success(), "runtime start failed: {output:?}");
+    assert!(display_requests.lock().await.is_empty());
     assert!(fs::read_to_string(&wrapper_log).unwrap().contains("run "));
 }
 
 #[tokio::test]
-async fn t_azc_0105_repeated_starts_repeat_device_auth() {
+async fn t_azc_0105_repeated_starts_reuse_ready_state() {
     let temp = TempDir::new().unwrap();
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
-    fs::create_dir_all(&state_dir).unwrap();
+    write_runtime_ready_state(&state_dir);
     let admin_socket_path = temp.path().join("admin.sock");
     let connector_socket_path = temp.path().join("connector.sock");
     let display_requests = spawn_admin_server(&admin_socket_path, None).await;
     let oauth_server = MockServer::start().await;
-    mount_successful_device_flow(&oauth_server, "REPEAT-1", 2).await;
 
     let wrapper_log = temp.path().join("wrapper.log");
     write_runtime_wrapper(&bin_dir, &wrapper_log);
@@ -552,10 +571,10 @@ async fn t_azc_0105_repeated_starts_repeat_device_auth() {
     let second = run_bootstrap_with_env(&env).await;
     assert!(
         second.status.success(),
-        "second bootstrap failed: {second:?}"
+        "second runtime start failed: {second:?}"
     );
 
-    assert_eq!(display_requests.lock().await.len(), 2);
+    assert!(display_requests.lock().await.is_empty());
     let wrapper_contents = fs::read_to_string(&wrapper_log).unwrap();
     assert_eq!(wrapper_contents.lines().count(), 2);
 }
@@ -588,27 +607,35 @@ async fn t_azc_0106_login_failure_aborts_bootstrap() {
 }
 
 #[tokio::test]
-async fn t_azc_0107_runtime_connects_to_connector_socket() {
+async fn t_azc_0107_bootstrap_without_runtime_state_fails_closed() {
     let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    let admin_socket_path = temp.path().join("admin.sock");
     let connector_socket_path = temp.path().join("connector.sock");
-    let listener = UnixListener::bind(&connector_socket_path).unwrap();
+    let display_requests = spawn_admin_server(&admin_socket_path, None).await;
+    let oauth_server = MockServer::start().await;
+    mount_successful_device_flow(&oauth_server, "POST-BOOT", 1).await;
 
-    let mut child = TokioCommand::new(env!("CARGO_BIN_EXE_sonde-azure-companion"))
-        .arg("--connector-socket")
-        .arg(&connector_socket_path)
-        .arg("run")
-        .spawn()
-        .unwrap();
+    let wrapper_log = temp.path().join("wrapper.log");
+    write_runtime_wrapper(&bin_dir, &wrapper_log);
 
-    let accepted = tokio::time::timeout(Duration::from_secs(5), listener.accept())
-        .await
-        .expect("timed out waiting for runtime connector connection")
-        .unwrap();
-    drop(accepted);
-
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    assert!(child.try_wait().unwrap().is_none());
-    child.kill().await.unwrap();
+    let output = run_bootstrap_with_env(&bootstrap_env(
+        &bin_dir,
+        &state_dir,
+        &admin_socket_path,
+        &connector_socket_path,
+        &oauth_server,
+    ))
+    .await;
+    assert!(!output.status.success());
+    assert_eq!(
+        display_requests.lock().await.clone(),
+        vec![vec!["Azure login".to_string(), "POST-BOOT".to_string()]]
+    );
+    assert!(!wrapper_log.exists() || fs::read_to_string(&wrapper_log).unwrap().is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("runtime state is still incomplete"));
 }
 
 #[test]
@@ -675,7 +702,7 @@ fn host_bootstrap_invokes_docker_with_expected_mounts() {
 }
 
 #[test]
-fn host_bootstrap_requires_non_empty_bootstrap_env() {
+fn host_bootstrap_defers_bootstrap_env_validation_to_container() {
     let temp = TempDir::new().unwrap();
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
@@ -710,22 +737,14 @@ fn host_bootstrap_requires_non_empty_bootstrap_env() {
     cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
     cmd.env("SONDE_GATEWAY_RUNTIME_DIR", &runtime_dir);
     cmd.env("SONDE_AZURE_DEVICE_CLIENT_ID", "");
-    cmd.env(
-        "SONDE_AZURE_DEVICE_SCOPES",
-        "https://management.azure.com/.default",
-    );
+    cmd.env("SONDE_AZURE_DEVICE_SCOPES", "");
 
     let output = cmd.output().unwrap();
+    assert!(output.status.success(), "host bootstrap failed: {output:?}");
     assert!(
-        !output.status.success(),
-        "host bootstrap unexpectedly succeeded"
+        docker_log.exists(),
+        "docker should still be invoked by the host wrapper"
     );
-    assert!(
-        !docker_log.exists(),
-        "docker should not be invoked when required bootstrap env is missing"
-    );
-    assert!(String::from_utf8_lossy(&output.stderr)
-        .contains("SONDE_AZURE_DEVICE_CLIENT_ID must be set"));
 }
 
 #[test]
@@ -813,6 +832,11 @@ fn container_bootstrap_forwards_sigterm_to_bootstrap_auth_child() {
     cmd.env(
         "SONDE_GATEWAY_CONNECTOR_SOCKET",
         temp.path().join("connector.sock"),
+    );
+    cmd.env("SONDE_AZURE_DEVICE_CLIENT_ID", "test-client-id");
+    cmd.env(
+        "SONDE_AZURE_DEVICE_SCOPES",
+        "https://management.azure.com/.default",
     );
 
     let mut child = cmd.spawn().unwrap();

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -832,7 +832,7 @@ fn container_bootstrap_forwards_sigterm_to_bootstrap_auth_child() {
     write_executable(
         &bin_dir.join("sonde-azure-companion"),
         &format!(
-            "#!/bin/sh\nset -eu\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket|--connector-socket)\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\ncase \"$1\" in\n  bootstrap-auth)\n    printf '%s\\n' \"$$\" > \"{}\"\n    trap 'printf \"%s\\n\" TERM >> \"{}\"; exit 143' TERM\n    trap 'printf \"%s\\n\" INT >> \"{}\"; exit 130' INT\n    while :; do\n      sleep 1\n    done\n    ;;\n  run)\n    printf 'run\\n' >> \"{}\"\n    exit 0\n    ;;\n  *)\n    exit 64\n    ;;\nesac\n",
+            "#!/bin/sh\nset -eu\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket|--connector-socket|--state-dir)\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\ncase \"$1\" in\n  bootstrap-auth)\n    printf '%s\\n' \"$$\" > \"{}\"\n    trap 'printf \"%s\\n\" TERM >> \"{}\"; exit 143' TERM\n    trap 'printf \"%s\\n\" INT >> \"{}\"; exit 130' INT\n    while :; do\n      sleep 1\n    done\n    ;;\n  run)\n    printf 'run\\n' >> \"{}\"\n    exit 0\n    ;;\n  *)\n    exit 64\n    ;;\nesac\n",
             pid_file.display(),
             signal_log.display(),
             signal_log.display(),

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -44,9 +44,9 @@ const TEST_CERT_PEM: &str = concat!(
 
 const TEST_KEY_PEM: &str = concat!(
     "-----BEGIN PRIVATE KEY-----\n",
-    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg2X8i4lE4hM2t0b5Y\n",
-    "fI7xW0ZzM3ZrY4L3s67qG8R0uYWhRANCAAStNVLyCQaqRPW+p7wtNOVgX5c18vv6\n",
-    "4n71/Bsfc/1KImuM3gnXDOo/xw/qU/TC0P67YThvhbRBb4TdqNB7ytb7\n",
+    "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgiHx55EC3Yiih4pAE\n",
+    "7x0NrlcsxiOH+SRn2I9N8+XzugihRANCAAS/bEotS4/FxoJf+T+jEGzlFQtYKea0\n",
+    "nmvBHE5F9GNfpDliGtxecWSjvICrTVwN0x4a5UuxfFF0rgL6I/2IGAWs\n",
     "-----END PRIVATE KEY-----\n"
 );
 

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -54,6 +54,24 @@ fi
 
 mkdir -p "$state_dir"
 
+check_runtime_ready_with_log() {
+    runtime_ready_log="$state_dir/check-runtime-ready.$$.log"
+    if sonde-azure-companion \
+        --admin-socket "$admin_socket_path" \
+        --connector-socket "$connector_socket_path" \
+        --state-dir "$state_dir" \
+        check-runtime-ready >"$runtime_ready_log" 2>&1; then
+        rm -f "$runtime_ready_log"
+        return 0
+    fi
+
+    if [ -s "$runtime_ready_log" ]; then
+        cat "$runtime_ready_log" >&2 || true
+    fi
+    rm -f "$runtime_ready_log"
+    return 1
+}
+
 if sonde-azure-companion \
     --admin-socket "$admin_socket_path" \
     --connector-socket "$connector_socket_path" \
@@ -108,11 +126,7 @@ if [ "$bootstrap_status" -ne 0 ]; then
     exit "$bootstrap_status"
 fi
 
-if ! sonde-azure-companion \
-    --admin-socket "$admin_socket_path" \
-    --connector-socket "$connector_socket_path" \
-    --state-dir "$state_dir" \
-    check-runtime-ready >/dev/null 2>&1; then
+if ! check_runtime_ready_with_log; then
     echo "bootstrap completed device auth, but runtime state is still incomplete" >&2
     exit 1
 fi

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -84,6 +84,10 @@ if sonde-azure-companion \
         run
 fi
 
+if [ -z "${SONDE_AZURE_DEVICE_CLIENT_ID:-}" ] || [ -z "${SONDE_AZURE_DEVICE_SCOPES:-}" ]; then
+    check_runtime_ready_with_log || exit 1
+fi
+
 if [ -z "${SONDE_AZURE_DEVICE_CLIENT_ID:-}" ]; then
     echo "SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap" >&2
     exit 1

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -84,16 +84,19 @@ if sonde-azure-companion \
         run
 fi
 
-if [ -z "${SONDE_AZURE_DEVICE_CLIENT_ID:-}" ] || [ -z "${SONDE_AZURE_DEVICE_SCOPES:-}" ]; then
-    check_runtime_ready_with_log || exit 1
-fi
-
+missing_bootstrap_env=0
 if [ -z "${SONDE_AZURE_DEVICE_CLIENT_ID:-}" ]; then
     echo "SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap" >&2
-    exit 1
+    missing_bootstrap_env=1
 fi
 if [ -z "${SONDE_AZURE_DEVICE_SCOPES:-}" ]; then
     echo "SONDE_AZURE_DEVICE_SCOPES must be set for bootstrap" >&2
+    missing_bootstrap_env=1
+fi
+if [ "$missing_bootstrap_env" -ne 0 ]; then
+    if [ -f "$state_dir/service-principal.json" ]; then
+        check_runtime_ready_with_log || true
+    fi
     exit 1
 fi
 

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -24,16 +24,6 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         echo "gateway connector socket not found: $connector_socket_path" >&2
         exit 1
     fi
-    if [ "$#" -eq 0 ]; then
-        if [ -z "${SONDE_AZURE_DEVICE_CLIENT_ID:-}" ]; then
-            echo "SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap" >&2
-            exit 1
-        fi
-        if [ -z "${SONDE_AZURE_DEVICE_SCOPES:-}" ]; then
-            echo "SONDE_AZURE_DEVICE_SCOPES must be set for bootstrap" >&2
-            exit 1
-        fi
-    fi
 
     exec docker run --rm \
         --name "${SONDE_AZURE_COMPANION_CONTAINER_NAME:-sonde-azure-companion}" \
@@ -41,6 +31,9 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         -e SONDE_AZURE_COMPANION_STATE_DIR="$container_state_dir" \
         -e SONDE_GATEWAY_ADMIN_SOCKET="$container_admin_socket_path" \
         -e SONDE_GATEWAY_CONNECTOR_SOCKET="$container_connector_socket_path" \
+        -e SONDE_AZURE_SERVICEBUS_NAMESPACE \
+        -e SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE \
+        -e SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE \
         -e SONDE_AZURE_DEVICE_CLIENT_ID \
         -e SONDE_AZURE_DEVICE_SCOPES \
         -e SONDE_AZURE_DEVICE_POLL_INTERVAL_SECS \
@@ -61,6 +54,27 @@ fi
 
 mkdir -p "$state_dir"
 
+if sonde-azure-companion \
+    --admin-socket "$admin_socket_path" \
+    --connector-socket "$connector_socket_path" \
+    --state-dir "$state_dir" \
+    check-runtime-ready >/dev/null 2>&1; then
+    exec sonde-azure-companion \
+        --admin-socket "$admin_socket_path" \
+        --connector-socket "$connector_socket_path" \
+        --state-dir "$state_dir" \
+        run
+fi
+
+if [ -z "${SONDE_AZURE_DEVICE_CLIENT_ID:-}" ]; then
+    echo "SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap" >&2
+    exit 1
+fi
+if [ -z "${SONDE_AZURE_DEVICE_SCOPES:-}" ]; then
+    echo "SONDE_AZURE_DEVICE_SCOPES must be set for bootstrap" >&2
+    exit 1
+fi
+
 bootstrap_pid=
 
 forward_signal() {
@@ -77,8 +91,8 @@ trap 'forward_signal INT; exit 130' INT
 sonde-azure-companion \
     --admin-socket "$admin_socket_path" \
     --connector-socket "$connector_socket_path" \
-    bootstrap-auth \
-    --state-dir "$state_dir" &
+    --state-dir "$state_dir" \
+    bootstrap-auth &
 bootstrap_pid=$!
 
 if wait "$bootstrap_pid"; then
@@ -94,7 +108,17 @@ if [ "$bootstrap_status" -ne 0 ]; then
     exit "$bootstrap_status"
 fi
 
+if ! sonde-azure-companion \
+    --admin-socket "$admin_socket_path" \
+    --connector-socket "$connector_socket_path" \
+    --state-dir "$state_dir" \
+    check-runtime-ready >/dev/null 2>&1; then
+    echo "bootstrap completed device auth, but runtime state is still incomplete" >&2
+    exit 1
+fi
+
 exec sonde-azure-companion \
     --admin-socket "$admin_socket_path" \
     --connector-socket "$connector_socket_path" \
+    --state-dir "$state_dir" \
     run

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -55,7 +55,7 @@ fi
 mkdir -p "$state_dir"
 
 check_runtime_ready_with_log() {
-    runtime_ready_log="$state_dir/check-runtime-ready.$$.log"
+    runtime_ready_log="$(mktemp "${TMPDIR:-/tmp}/sonde-azure-companion-runtime-ready.XXXXXX")"
     if sonde-azure-companion \
         --admin-socket "$admin_socket_path" \
         --connector-socket "$connector_socket_path" \

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -3,32 +3,36 @@
 # Azure Companion Design Specification
 
 > **Document status:** Draft
-> **Scope:** Internal design for the current Azure companion slice: container
-> packaging, bootstrap scripts, gateway admin/connector integration, and Azure
-> device-code login.
-> **Audience:** Implementers building the new Azure companion crate and its deployment artifacts.
-> **Related:** [azure-companion-requirements.md](azure-companion-requirements.md), [gateway-companion-api.md](gateway-companion-api.md), [gateway-design.md](gateway-design.md)
+> **Scope:** Internal design for the Azure companion container, bootstrap-state
+> detection, bootstrap trigger behavior, and the Service Bus AMQP runtime bridge.
+> The internal Azure provisioning workflow that creates the runtime certificate
+> and broker resources is outside this document's scope.
+> **Audience:** Implementers building the Azure companion crate and its
+> deployment artifacts.
+> **Related:** [azure-companion-requirements.md](azure-companion-requirements.md),
+> [gateway-companion-api.md](gateway-companion-api.md),
+> [gateway-design.md](gateway-design.md)
 
 ---
 
 ## 1  Overview
 
-The Azure companion is a new Rust workspace crate that runs in its own Docker
-container and talks to `sonde-gateway` over two local gateway-facing surfaces:
-the admin gRPC API for bootstrap-only operator-visible actions and the local
-framed connector API for long-running runtime traffic. This slice does not yet
-provision Azure resources or bridge data into Azure services. Its responsibility
-is limited to:
+The Azure companion is a Rust workspace crate that runs in its own container and
+talks to `sonde-gateway` over two local gateway-facing surfaces:
 
-1. starting in a dedicated container,
-2. preparing a mounted persistent state volume for later provisioning slices,
-3. obtaining Azure authentication via device-code login,
-4. showing a short prompt plus the device code on the modem display through the
-   gateway admin API, and
-5. starting a minimal long-running connector process after bootstrap completes.
+1. the admin gRPC API for bootstrap-only operator-visible actions, and
+2. the local framed connector API for long-running runtime traffic.
 
-Terraform provisioning, managed-identity creation, gateway configuration
-generation, and Azure-side message forwarding are deferred to later issues.
+The Azure companion now has two distinct responsibilities:
+
+1. detect whether bootstrap has already completed,
+2. invoke bootstrap when the required local provisioning artifacts are missing,
+3. use the gateway admin API to display the device code during bootstrap, and
+4. when bootstrap-complete state exists, bridge the gateway connector session to
+   Azure Service Bus over AMQP.
+
+The gateway-facing connector contract remains cloud-agnostic. Azure-specific
+logic is confined to the Azure companion.
 
 ---
 
@@ -36,14 +40,14 @@ generation, and Azure-side message forwarding are deferred to later issues.
 
 > **Requirements:** AZC-0100, AZC-0102
 
-The implementation adds the following artifacts:
+The implementation adds or updates the following artifacts:
 
 | Artifact | Purpose |
 |----------|---------|
-| `crates/sonde-azure-companion/` | New Rust crate containing the Azure companion binary. |
+| `crates/sonde-azure-companion/` | Rust crate containing the Azure companion binary. |
 | `.github/docker/Dockerfile.azure-companion` | Dockerfile for the dedicated Azure companion image. |
-| `deploy/azure-companion/bootstrap.sh` | Host/container bootstrap script that prepares the mounted state volume and runs the Rust-owned device-auth bootstrap before normal runtime starts. |
-| `deploy/azure-companion/entrypoint.sh` | In-container entrypoint that orchestrates bootstrap before starting the long-running process. |
+| `deploy/azure-companion/bootstrap.sh` | Host/container bootstrap script that prepares the mounted state volume, evaluates bootstrap-complete state, and starts either bootstrap or runtime. |
+| `deploy/azure-companion/entrypoint.sh` | In-container entrypoint that orchestrates bootstrap-state detection before starting the Rust binary. |
 
 The long-running binary is named `sonde-azure-companion`.
 
@@ -51,105 +55,119 @@ The long-running binary is named `sonde-azure-companion`.
 
 ## 3  Runtime architecture
 
-> **Requirements:** AZC-0100, AZC-0101, AZC-0300
+> **Requirements:** AZC-0100, AZC-0101, AZC-0102, AZC-0301, AZC-0302, AZC-0303, AZC-0304, AZC-0305
 
 ### 3.1  Process model
 
-The container runs a small shell entrypoint that performs bootstrap orchestration
-and then execs the Rust binary. The split is intentional:
+The container runs a small shell entrypoint that performs filesystem and startup
+orchestration and then execs the Rust binary. The split is intentional:
 
-1. **Shell script** handles environment preparation, filesystem setup, and
-   container-vs-host orchestration.
-2. **Rust binary** owns gateway admin gRPC communication for bootstrap,
-   connector-socket runtime communication, Microsoft device flow, and the future
-   Azure-integration runtime.
+1. **Shell script** handles environment preparation, state-directory setup, and
+   bootstrap-state detection orchestration.
+2. **Rust binary** owns gateway admin gRPC communication, connector-socket
+   runtime communication, bootstrap device flow, and broker integration.
 
-This keeps the gateway-facing logic and the Azure device-code flow in typed
-Rust, which removes the Azure CLI dependency and allows an Alpine runtime
-image.
+This keeps the gateway-facing logic and Azure-facing runtime in typed Rust while
+still allowing a small Alpine-oriented container image.
 
-### 3.2  Mounted inputs
+### 3.2  Mounted and configured inputs
 
-The container expects two mounted host resources:
+The container expects the following runtime inputs:
 
-| Mount | Purpose |
+| Input | Purpose |
 |-------|---------|
-| State volume | Persistent storage reserved for later managed-identity bootstrap output and other local provisioning artifacts. |
+| State volume | Persistent storage for local provisioning artifacts such as the runtime certificate PEM, private-key PEM, and service-principal metadata file. |
 | Gateway admin socket | Local IPC path used by bootstrap to call `GatewayAdmin` RPCs such as `ShowModemDisplayMessage`. |
 | Gateway connector socket | Local framed IPC path used by the long-running runtime after bootstrap succeeds. |
+| Service Bus namespace | Explicit runtime configuration for the Azure Service Bus namespace. |
+| Upstream queue name | Explicit runtime configuration for the queue that carries gateway-originated connector messages. |
+| Downstream queue name | Explicit runtime configuration for the queue that carries cloud-originated desired-state messages. |
 
-The current slice prepares the state volume but does not persist Azure access
-tokens there. The image itself is replaceable.
+Bootstrap-complete state is defined by the combination of:
+
+1. the required local provisioning artifacts in the state volume, and
+2. the required explicit queue configuration.
+
+The current runtime artifact shape is a companion-owned `service-principal.json`
+file containing the Entra tenant ID, client ID, PEM certificate path, and PEM
+private-key path, plus the referenced certificate and key files in the mounted
+state directory.
+
+### 3.3  Bootstrap-state decision
+
+Startup follows this decision:
+
+1. Ensure the mounted state directory exists and is writable.
+2. Check whether the required local provisioning artifacts exist.
+3. Check whether the required Service Bus namespace and queue configuration are present.
+4. If both are present, skip bootstrap and start `run`.
+5. Otherwise, start `bootstrap-auth`.
+
+The internal Azure provisioning workflow that consumes the bootstrap token and
+produces the runtime artifacts is outside this document's scope. The Azure
+companion only defines the startup decision and the interfaces around it.
 
 ---
 
 ## 4  Bootstrap flow
 
-> **Requirements:** AZC-0101, AZC-0102, AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204
+> **Requirements:** AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204, AZC-0300
 
-### 4.1  Startup decision
+### 4.1  Bootstrap trigger
 
-At container start, `entrypoint.sh` delegates to `bootstrap.sh`. The in-container
-bootstrap path creates the mounted state directory and then invokes the Rust
-binary's `bootstrap-auth` mode before starting the normal long-running process.
-This slice does not inspect the state directory to skip login on restart.
+Bootstrap is entered only when bootstrap-complete state is absent. This differs
+from the earlier draft, which always re-entered device-code login on restart.
 
 ### 4.2  Device-code login sequence
 
-The first-run bootstrap sequence is:
+When bootstrap is required, the Azure companion performs this sequence:
 
-1. Ensure the mounted state directory exists and is writable.
-2. Invoke `sonde-azure-companion bootstrap-auth`.
-3. Inside Rust, construct a Microsoft device-flow client from explicit
+1. Invoke `sonde-azure-companion bootstrap-auth`.
+2. Inside Rust, construct a Microsoft device-flow client from explicit
    environment-provided client ID and scopes.
-4. Request a device code from Microsoft's device authorization endpoint.
-5. Log the verification URI to stdout/stderr for operator visibility.
-6. Call the gateway admin `ShowModemDisplayMessage` RPC with a short prompt plus
+3. Request a device code from Microsoft's device authorization endpoint.
+4. Log the verification URI to stdout/stderr for operator visibility.
+5. Call the gateway admin `ShowModemDisplayMessage` RPC with a short prompt plus
    the exact device code.
-7. Poll the token endpoint until the operator completes device auth or the flow
+6. Poll the token endpoint until the operator completes device auth or the flow
    fails.
-8. Discard the short-lived token and exec the long-running `run` mode.
+7. Hand off to the out-of-scope provisioning workflow that creates the runtime
+   certificate and broker resources.
+8. Return success only after bootstrap-complete state has been established.
 
-The full Azure verification URL remains in stdout/stderr logs; the modem display
-shows only the short prompt plus the device code.
+The modem display shows only the short prompt plus the device code; the full
+verification URL remains in stdout/stderr logs.
 
 ### 4.3  Display failure handling
 
-If step 6 fails because the gateway rejects the display request or no modem
-transport is available, the bootstrap flow exits immediately with a non-zero
-status. It does not continue to a console-only fallback. This preserves the
-headless operator workflow required by the discovery review.
+If the display update fails because the gateway rejects the transient display
+request or no modem transport is available, bootstrap exits immediately with a
+non-zero status. It does not continue to a console-only fallback.
 
 ---
 
 ## 5  Rust binary interface
 
-> **Requirements:** AZC-0100, AZC-0102, AZC-0201, AZC-0202, AZC-0300, AZC-0301
+> **Requirements:** AZC-0100, AZC-0102, AZC-0201, AZC-0202, AZC-0300, AZC-0301, AZC-0302, AZC-0304, AZC-0305
 
-The initial `sonde-azure-companion` binary exposes three modes:
+The `sonde-azure-companion` binary exposes three modes:
 
-1. **`run`** — default long-running runtime mode. In this initial slice it
-   establishes gateway connector connectivity and remains ready for later Azure
-   integration work.
+1. **`run`** — default long-running runtime mode. It connects to the gateway
+   connector socket and bridges connector traffic to Azure Service Bus.
 2. **`bootstrap-auth`** — performs Microsoft OAuth device flow in Rust, logs the
    verification URI, requests the modem display update, waits for operator
-   completion, and discards the resulting token.
-3. **`display-message`** — helper mode used by the bootstrap logic to call the
+   completion, and then returns control to the bootstrap workflow.
+3. **`display-message`** — helper mode used by bootstrap logic to call the
    gateway admin `ShowModemDisplayMessage` RPC with 1 to 4 lines of text.
 
-The helper modes keep gateway IPC and OAuth error handling out of shell-script
-string munging and ensure the same Rust client stack is used during bootstrap
-and later runtime work.
-
-`bootstrap-auth` requires the caller to provide the Azure device-flow client ID
-and scopes explicitly through environment variables or CLI flags. This slice
-does not guess Azure application defaults.
+The companion receives explicit runtime configuration for the Service Bus
+namespace and queue names rather than inferring deployment-specific defaults.
 
 ---
 
 ## 6  Gateway integration
 
-> **Requirements:** AZC-0202, AZC-0203, AZC-0300
+> **Requirements:** AZC-0202, AZC-0203, AZC-0300, AZC-0301
 
 ### 6.1  Bootstrap admin client
 
@@ -167,8 +185,6 @@ special display privileges:
 3. The gateway retains rendering, display ownership, and banner-restore logic.
 4. The Azure companion cannot issue raw modem commands or upload framebuffers.
 
----
-
 ### 6.3  Runtime connector client
 
 After bootstrap succeeds, the `run` mode connects to the gateway connector
@@ -178,13 +194,65 @@ does not depend on a separate companion runtime socket.
 
 ---
 
-## 7  Long-running process behavior in this slice
+## 7  Azure broker transport architecture
 
-> **Requirements:** AZC-0102, AZC-0301
+> **Requirements:** AZC-0302, AZC-0303, AZC-0304, AZC-0305, AZC-0306, AZC-0307, AZC-0308, AZC-0309
 
-After bootstrap succeeds, the `run` mode starts and validates gateway connector
-connectivity. This first slice does not yet forward events to Azure services or
-pull cloud-issued commands. Those behaviors are deferred to the later Terraform
-and cloud-integration issues, but the long-running process already uses the
-connector surface rather than a legacy companion runtime API.
+### 7.1  Transport abstraction boundary
 
+The runtime is divided into two internal responsibilities:
+
+1. **Gateway connector side** — reads and writes framed Sonde connector payloads
+   on the local connector socket.
+2. **Broker transport side** — publishes and receives opaque payload bytes on the
+   external control-plane transport.
+
+These responsibilities are separated by an internal transport abstraction
+boundary so the gateway-facing logic does not depend directly on one Azure SDK
+crate. `azservicebus` is the first required broker transport implementation.
+
+### 7.2  Azure Service Bus runtime
+
+The Azure Service Bus transport implementation uses AMQP to connect to:
+
+1. one upstream queue for gateway-originated connector messages, and
+2. one downstream queue for desired-state requests coming from the control plane.
+
+All gateway-originated connector message types that travel upstream through the
+connector session — including actual-state, app-data, and connector-health
+messages — share the upstream queue. The downstream queue is reserved for
+desired-state messages destined for the gateway.
+
+### 7.3  Azure authentication
+
+Normal runtime starts use the provisioned certificate and private-key material
+from the bootstrap-complete state and authenticate to Azure as an Entra
+application / service principal. Interactive device auth is bootstrap-only and
+is not part of normal runtime operation.
+
+### 7.4  Transparent message bodies
+
+The Service Bus message body carries the raw Sonde connector payload bytes
+unchanged. The Azure companion may attach minimal broker metadata in message
+properties for diagnostics or routing hints, but the broker representation does
+not replace the connector payload with an Azure-specific schema.
+
+### 7.5  Downstream settlement
+
+For downstream desired-state requests, the Azure companion settles the Service
+Bus message as successful only after the raw connector payload has been written
+successfully to the local connector socket. This design intentionally stops at
+local handoff; the gateway connector protocol does not grow a separate
+round-trip acknowledgement just for Azure.
+
+### 7.6  Fault handling
+
+Detected failures on either side of the bridge are surfaced rather than masked:
+
+1. upstream publish failures,
+2. downstream receive failures,
+3. downstream settlement failures, and
+4. local connector write failures.
+
+The runtime may reconnect or exit, but it must not silently claim success after
+a detected bridge failure.

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -133,7 +133,8 @@ When bootstrap is required, the Azure companion performs this sequence:
    fails.
 7. Hand off to the out-of-scope provisioning workflow that creates the runtime
    certificate and broker resources.
-8. Return success only after bootstrap-complete state has been established.
+8. The bootstrap wrapper/entrypoint reports overall success only after
+   bootstrap-complete state has been established.
 
 The modem display shows only the short prompt plus the device code; the full
 verification URL remains in stdout/stderr logs.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -3,13 +3,18 @@
 # Azure Companion Requirements Specification
 
 > **Document status:** Draft
-> **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771) and companion-bootstrap discovery review.
-> **Scope:** This document covers the current Azure companion slice: a new Rust
-> connector app in its own Docker container plus bootstrap scripts for Azure
-> device-code login. Terraform, managed-identity creation, gateway configuration
-> generation, and Azure-side message handling beyond local gateway integration
-> are out of scope for this document.
-> **Related:** [gateway-companion-api.md](gateway-companion-api.md), [gateway-requirements.md](gateway-requirements.md), [gateway-design.md](gateway-design.md)
+> **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771),
+> connector redesign discovery review, and Azure Service Bus discovery review.
+> **Scope:** This document covers the Azure companion container, bootstrap-state
+> detection, bootstrap-trigger behavior, and the long-running Azure Service Bus
+> runtime bridge between `sonde-gateway` and an external Azure control plane.
+> The internal Azure provisioning workflow that creates the runtime certificate,
+> private key,
+> Entra application/service principal, and Service Bus resources is out of scope
+> for this document.
+> **Related:** [gateway-companion-api.md](gateway-companion-api.md),
+> [gateway-requirements.md](gateway-requirements.md),
+> [gateway-design.md](gateway-design.md)
 
 ---
 
@@ -17,10 +22,12 @@
 
 | Term | Definition |
 |------|------------|
-| **Azure companion** | The new Rust process that runs in its own container and integrates with `sonde-gateway` through the local admin API for bootstrap and the local connector API for long-running runtime traffic. |
-| **State volume** | A mounted persistent directory reserved for Azure companion bootstrap output such as local credentials, managed-identity identifiers, and related provisioning artifacts once later slices implement them. |
-| **Bootstrap login** | The Azure device-code login flow performed by the current slice before the long-running runtime process starts. |
-| **Device code prompt** | The short operator-facing text shown on the modem display during bootstrap, consisting of a prompt plus the Azure device code. |
+| **Azure companion** | The Rust process that runs in its own container and integrates with `sonde-gateway` through the local admin API for bootstrap-only operator-visible actions and the local connector API for long-running runtime traffic. |
+| **State volume** | A mounted persistent directory reserved for Azure companion bootstrap output and other local provisioning artifacts. |
+| **Provisioning artifacts** | The local certificate PEM, private-key PEM, and related companion-owned state that indicate Azure bootstrap has already completed. |
+| **Queue configuration** | The Azure Service Bus namespace and the names of the upstream and downstream queues, supplied explicitly to the companion through configuration rather than hard-coded in the image. |
+| **Bootstrap-complete state** | The condition where the required provisioning artifacts exist and the required queue configuration is present, allowing the companion to skip bootstrap and start runtime directly. |
+| **Transparent connector payload** | A Service Bus message body that carries the raw Sonde connector payload bytes unchanged. |
 
 ---
 
@@ -42,21 +49,23 @@ Each requirement uses the following fields:
 ### AZC-0100  Dedicated companion container image
 
 **Priority:** Must
-**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771)
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), Azure Service Bus discovery review
 
 **Description:**
 The repository MUST build a dedicated Docker container image for the Azure
 companion. The image MUST be separate from the gateway image and MUST contain
-the Azure companion binary, the Rust-owned device-auth implementation required
-for device-code login, and the bootstrap scripts needed to initialize the
-mounted state volume.
+the Azure companion binary plus the bootstrap scripts needed to initialize the
+mounted state volume, decide whether bootstrap is required, and start the
+long-running runtime bridge. The image MUST remain suitable for Alpine Linux
+deployment.
 
 **Acceptance criteria:**
 
 1. Building the Azure companion Dockerfile produces an image that starts the Azure companion container without requiring the gateway image.
 2. The image contains the Azure companion binary.
-3. The image is based on Alpine Linux and does not require Azure CLI tooling to perform device-code login.
-4. The image contains the bootstrap scripts used by the initial login flow.
+3. The image is based on Alpine Linux.
+4. The image does not require Azure CLI for normal runtime connectivity to Service Bus.
+5. The image contains the bootstrap scripts used to decide between bootstrap and normal runtime startup.
 
 ---
 
@@ -66,16 +75,17 @@ mounted state volume.
 **Source:** Discovery review
 
 **Description:**
-The Azure companion container MUST use a mounted persistent state volume so
-later slices can store local provisioning output there. The image itself MUST
-remain stateless. The current slice MUST prepare and mount that directory but
-MUST NOT persist Azure access tokens there.
+The Azure companion container MUST use a mounted persistent state volume so the
+bootstrap workflow can leave behind the local provisioning artifacts needed by
+later runtime starts. The image itself MUST remain stateless. The companion MUST
+NOT treat short-lived Azure access tokens as persisted runtime state.
 
 **Acceptance criteria:**
 
 1. The bootstrap scripts create and use the mounted state directory rather than relying on image-local writable paths.
-2. The container image does not depend on a baked-in token cache or Azure CLI profile directory.
-3. The current slice does not write persisted Azure access tokens into the mounted state volume.
+2. The state volume is the companion-owned location used to detect whether bootstrap has already completed.
+3. The runtime can determine bootstrap-complete state from the presence of the required provisioning artifacts plus required queue configuration.
+4. The current design does not require persisted Azure access tokens in the state volume for normal runtime starts.
 
 ---
 
@@ -86,52 +96,59 @@ MUST NOT persist Azure access tokens there.
 
 **Description:**
 The repository MUST provide bootstrap scripts that prepare the mounted state
-volume, run the Rust-owned device-auth flow, and then start the long-running
-Azure companion process inside its dedicated container.
+volume, decide whether bootstrap is required, and then start either the
+bootstrap workflow or the long-running Azure companion runtime inside its
+dedicated container.
 
 **Acceptance criteria:**
 
 1. A provided bootstrap script can start the Azure companion container with the expected state volume plus the required local gateway socket bindings.
-2. The bootstrap path initializes the state volume before invoking the login logic.
-3. After bootstrap prerequisites are satisfied, the scripts start the Azure companion process without requiring manual in-container steps.
+2. The bootstrap path initializes the state volume before evaluating bootstrap-complete state.
+3. If bootstrap-complete state is absent, the scripts invoke the bootstrap workflow before starting the long-running runtime.
+4. If bootstrap-complete state is present, the scripts skip bootstrap and start the long-running runtime without requiring manual in-container steps.
+5. If bootstrap is invoked, the scripts do not start the long-running runtime until bootstrap-complete state has been established.
 
 ---
 
-## 4  Azure device-code login bootstrap
+## 4  Bootstrap-state detection and bootstrap trigger behavior
 
-### AZC-0200  Current-slice bootstrap always performs device auth
+### AZC-0200  Startup decision based on bootstrap-complete state
 
 **Priority:** Must
-**Source:** Discovery review
+**Source:** Azure Service Bus discovery review
 
 **Description:**
-Until later slices implement persistent provisioning output, the bootstrap flow
-MUST perform Azure device-code login on every start. The current slice MUST NOT
-treat any existing volume contents as reusable login state.
+At startup, the Azure companion MUST determine whether bootstrap has already
+completed. Bootstrap-complete state requires both the local provisioning
+artifacts and the required queue configuration. If either is missing, the
+companion MUST enter the bootstrap workflow instead of normal runtime mode.
 
 **Acceptance criteria:**
 
-1. Starting the container with an empty state volume enters the bootstrap login path.
-2. Starting the container with a previously used state volume still enters the bootstrap login path.
-3. The current slice does not inspect Azure CLI token caches or similar login-state artifacts to skip device auth.
+1. Starting the container without the required provisioning artifacts enters the bootstrap workflow.
+2. Starting the container without the required queue configuration enters the bootstrap workflow.
+3. Starting the container with both the required provisioning artifacts and required queue configuration skips bootstrap and starts runtime directly.
 
 ---
 
-### AZC-0201  Azure device-code login
+### AZC-0201  Device-code bootstrap entry
 
 **Priority:** Must
-**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771)
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
 
 **Description:**
-The bootstrap flow MUST obtain Azure authentication through Azure device-code
-login. The initial implementation MUST use an in-process Rust OAuth device-flow
-client rather than shelling out to Azure CLI.
+When bootstrap is required, the Azure companion MUST begin bootstrap by
+obtaining Azure authentication through Azure device-code login using an
+in-process Rust device-flow client rather than shelling out to Azure CLI. The
+Azure-side provisioning workflow that consumes that bootstrap authentication is
+outside this document's scope.
 
 **Acceptance criteria:**
 
-1. First-run bootstrap invokes Azure device-code login without requiring a local browser on the gateway host.
+1. Missing bootstrap-complete state causes the companion bootstrap path to invoke Azure device-code login without requiring a local browser on the gateway host.
 2. The login flow waits for successful operator completion before reporting bootstrap success.
 3. If Azure device-code login fails, bootstrap exits with a non-zero status and does not report success.
+4. Successful device-code login alone is not treated as bootstrap completion; the bootstrap path reports success only after bootstrap-complete state has been established.
 
 ---
 
@@ -149,7 +166,7 @@ ownership rules.
 
 **Acceptance criteria:**
 
-1. During first-run bootstrap, the Azure companion calls the admin `ShowModemDisplayMessage` RPC with text that includes both a short prompt and the exact device code.
+1. During bootstrap, the Azure companion calls the admin `ShowModemDisplayMessage` RPC with text that includes both a short prompt and the exact device code.
 2. The displayed device code matches the value produced by Azure device-code login without modification.
 3. The Azure companion uses the gateway admin socket, not the connector socket, for this display request.
 4. The bootstrap flow does not invoke raw modem serial commands or direct framebuffer upload.
@@ -163,8 +180,8 @@ ownership rules.
 
 **Description:**
 If the Azure companion cannot display the device code on the modem through the
-gateway admin API, bootstrap MUST fail closed. It MUST surface the failure
-to the operator and require a retry after the display becomes available.
+gateway admin API, bootstrap MUST fail closed. It MUST surface the failure to
+the operator and require a retry after the display becomes available.
 
 **Acceptance criteria:**
 
@@ -174,27 +191,25 @@ to the operator and require a retry after the display becomes available.
 
 ---
 
-### AZC-0204  Persisted login reuse deferred
+### AZC-0204  Bootstrapped state reuse
 
 **Priority:** Must
-**Source:** Discovery review
+**Source:** Azure Service Bus discovery review
 
 **Description:**
-Because this slice does not yet provision Azure resources or persist the
-managed-identity bootstrap artifacts that later slices will rely on, it MUST
-NOT treat the mounted state volume as reusable login state. Every start MUST
-repeat device-code login until the provisioning slice defines the persisted
-state format.
+If bootstrap-complete state is present at startup, the Azure companion MUST
+reuse that state and skip device-code bootstrap. It MUST NOT re-enter device
+login merely because the container restarted.
 
 **Acceptance criteria:**
 
-1. Restarting the container with the same state volume still performs device-code login.
-2. Each restart that performs device-code login issues a fresh modem display request for the new device code.
-3. No current-slice behavior depends on token caches or other persisted login state.
+1. Restarting the container with the required provisioning artifacts and queue configuration skips device-code login.
+2. Runtime startup after a restart does not require operator-visible bootstrap interaction when bootstrap-complete state is present.
+3. Removing either the required provisioning artifacts or queue configuration causes the next start to re-enter bootstrap.
 
 ---
 
-## 5  Gateway integration
+## 5  Gateway and Azure runtime integration
 
 ### AZC-0300  Bootstrap admin-socket integration
 
@@ -232,3 +247,159 @@ traffic MUST NOT depend on `GatewayAdmin`.
 2. Runtime startup does not require access to a legacy companion socket.
 3. The long-running runtime treats the connector API, not `GatewayAdmin`, as its normal control-plane integration path.
 
+---
+
+### AZC-0302  Explicit Azure queue configuration
+
+**Priority:** Must
+**Source:** Azure Service Bus discovery review
+
+**Description:**
+The Azure companion MUST require explicit configuration for the Azure Service
+Bus namespace plus the names of exactly two queues: one upstream queue for
+gateway-originated connector messages and one downstream queue for cloud-issued
+desired-state messages. These values MUST NOT be hard-coded in the container
+image.
+
+**Acceptance criteria:**
+
+1. Runtime startup requires explicit namespace configuration.
+2. Runtime startup requires explicit configuration for one upstream queue and one downstream queue.
+3. The upstream and downstream queues are independently configurable.
+4. The image does not hard-code environment-specific queue names or namespace values.
+
+---
+
+### AZC-0303  Pluggable broker transport boundary
+
+**Priority:** Must
+**Source:** Azure Service Bus discovery review, GW-0814
+
+**Description:**
+The Azure companion runtime MUST isolate its broker-specific integration behind
+a pluggable transport boundary so the gateway-facing connector logic does not
+depend on one specific Azure SDK crate. `azservicebus` is the first required
+transport implementation for this document, but the design MUST keep the Azure
+transport swappable.
+
+**Acceptance criteria:**
+
+1. The runtime design separates gateway-connector logic from broker-specific AMQP operations.
+2. Replacing the Azure Service Bus transport implementation does not require changing the gateway-facing connector protocol.
+3. `azservicebus` is supported as the initial concrete Azure transport implementation.
+
+---
+
+### AZC-0304  Azure Service Bus AMQP transport
+
+**Priority:** Must
+**Source:** Azure Service Bus discovery review
+
+**Description:**
+The Azure companion runtime MUST bridge the local connector session to Azure
+Service Bus over AMQP. The runtime MUST publish gateway-originated connector
+messages to the configured upstream queue and consume cloud-issued desired-state
+messages from the configured downstream queue.
+
+**Acceptance criteria:**
+
+1. Gateway-originated connector messages are forwarded to the configured upstream queue.
+2. Cloud-issued desired-state messages are received from the configured downstream queue and forwarded toward the local gateway connector socket.
+3. The runtime uses the same long-lived local connector session for both upstream and downstream connector traffic.
+
+---
+
+### AZC-0305  Certificate-authenticated Azure runtime
+
+**Priority:** Must
+**Source:** Azure Service Bus discovery review
+
+**Description:**
+The Azure companion runtime MUST authenticate to Azure using an Entra
+application/service principal with client-certificate authentication. The
+required RBAC roles are assumed to be preconfigured outside this document.
+
+**Acceptance criteria:**
+
+1. Normal runtime starts use the provisioned certificate and private-key material rather than device-code login.
+2. Runtime startup fails closed if the required certificate or private-key material is absent or unusable.
+3. The runtime design does not require interactive Azure authentication after bootstrap-complete state exists.
+
+---
+
+### AZC-0306  Transparent upstream connector payloads
+
+**Priority:** Must
+**Source:** Azure Service Bus discovery review, GW-0814
+
+**Description:**
+When forwarding gateway-originated connector traffic to the upstream queue, the
+Azure companion MUST carry the raw Sonde connector payload bytes unchanged in
+the Service Bus message body. The companion MAY attach minimal broker metadata
+in message properties, but it MUST NOT translate the connector payload into an
+Azure-specific schema.
+
+**Acceptance criteria:**
+
+1. The Service Bus message body for upstream traffic contains the raw Sonde connector payload bytes.
+2. The Azure companion does not rewrite connector payload fields into an Azure-specific typed schema before enqueueing them.
+3. Any broker properties used by the companion are supplementary metadata rather than a replacement for the raw connector payload body.
+
+---
+
+### AZC-0307  Transparent downstream desired-state payloads
+
+**Priority:** Must
+**Source:** Azure Service Bus discovery review, GW-0811
+
+**Description:**
+When consuming desired-state requests from the downstream queue, the Azure
+companion MUST interpret the Service Bus message body as a raw Sonde connector
+payload and forward those bytes unchanged to the local gateway connector socket.
+It MUST NOT require the Azure companion to decode and re-encode the desired
+state into a different transport schema.
+
+**Acceptance criteria:**
+
+1. The Azure companion forwards downstream desired-state message bodies to the local gateway connector socket as raw connector payload bytes.
+2. The Azure companion does not require Azure-specific payload translation to deliver desired state to the gateway.
+3. The downstream queue is reserved for desired-state requests rather than upstream state or app-data traffic.
+
+---
+
+### AZC-0308  Downstream settlement after local handoff
+
+**Priority:** Must
+**Source:** Azure Service Bus discovery review
+
+**Description:**
+The Azure companion MUST treat a downstream Service Bus message as successfully
+processed only after the raw connector payload has been written successfully to
+the local gateway connector socket. This success criterion covers local handoff
+to the gateway socket only; it does not imply a separate gateway reconciliation
+acknowledgement path.
+
+**Acceptance criteria:**
+
+1. The Azure companion does not settle a downstream desired-state message as successful before the raw payload has been written to the local connector socket.
+2. If the Azure companion cannot write the payload to the local connector socket, it does not report that Service Bus message as successfully processed.
+3. The requirement does not invent a new synchronous acknowledgement path inside the gateway connector protocol.
+
+---
+
+### AZC-0309  Detected transport loss observability
+
+**Priority:** Must
+**Source:** GW-0815, Azure Service Bus discovery review
+
+**Description:**
+The Azure companion MUST NOT silently mask detected failures at the broker or
+local connector boundary. If publish, receive, settlement, or local connector
+handoff fails, the runtime MUST surface the condition to operators through
+logging, process status, or both.
+
+**Acceptance criteria:**
+
+1. Detected upstream publish failures are surfaced through logging, process status, or both.
+2. Detected downstream receive, settlement, or local connector write failures are surfaced through logging, process status, or both.
+3. The runtime design does not silently claim success after a detected broker or local connector failure.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -8,10 +8,9 @@
 > **Scope:** This document covers the Azure companion container, bootstrap-state
 > detection, bootstrap-trigger behavior, and the long-running Azure Service Bus
 > runtime bridge between `sonde-gateway` and an external Azure control plane.
-> The internal Azure provisioning workflow that creates the runtime certificate,
-> private key,
-> Entra application/service principal, and Service Bus resources is out of scope
-> for this document.
+> The internal Azure provisioning workflow that creates the runtime certificate
+> and private key, Entra application/service principal, and Service Bus
+> resources is out of scope for this document.
 > **Related:** [gateway-companion-api.md](gateway-companion-api.md),
 > [gateway-requirements.md](gateway-requirements.md),
 > [gateway-design.md](gateway-design.md)

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -3,11 +3,15 @@
 # Azure Companion Validation Plan
 
 > **Document status:** Draft
-> **Scope:** Validation for the current Azure companion slice: container
-> packaging, bootstrap scripts, gateway admin/connector integration, and Azure
-> device-code login state handling.
-> **Audience:** Implementers and reviewers validating the Azure companion bootstrap flow.
-> **Related:** [azure-companion-requirements.md](azure-companion-requirements.md), [azure-companion-design.md](azure-companion-design.md), [gateway-validation.md](gateway-validation.md)
+> **Scope:** Validation for the Azure companion container, bootstrap-state
+> detection, gateway admin/connector integration, and Azure Service Bus bridge.
+> The internals of Azure provisioning that create the runtime certificate and
+> broker resources are outside this document's scope.
+> **Audience:** Implementers and reviewers validating the Azure companion
+> bootstrap and runtime bridge behavior.
+> **Related:** [azure-companion-requirements.md](azure-companion-requirements.md),
+> [azure-companion-design.md](azure-companion-design.md),
+> [gateway-validation.md](gateway-validation.md)
 
 ---
 
@@ -21,25 +25,51 @@
 1. Build the Azure companion Docker image from the repository Dockerfile.
 2. Run `docker run --rm <image> sonde-azure-companion --help`.
 3. Run `docker run --rm <image> sonde-azure-companion bootstrap-auth --help`.
-4. Assert: both commands succeed.
+4. Run `docker run --rm <image> sonde-azure-companion run --help`.
+5. Assert: all commands succeed.
 
 ---
 
-### T-AZC-0101  Bootstrap initializes the mounted state volume and enters device auth
+### T-AZC-0101  Startup enters bootstrap when provisioning artifacts are missing
 
 **Validates:** AZC-0101, AZC-0102, AZC-0200, AZC-0201
 
 **Procedure:**
 1. Create an empty temporary directory to use as the mounted state volume.
-2. Invoke the provided Azure companion bootstrap script with that directory mounted as the state volume and with the Rust device-flow HTTP endpoints stubbed or intercepted for test control.
-3. Assert: the bootstrap path runs before the long-running process starts.
-4. Assert: the bootstrap path invokes the Rust `bootstrap-auth` flow and requests a device code from the configured OAuth endpoint.
-5. Complete the stubbed login successfully.
-6. Assert: the bootstrap path starts the long-running Azure companion process without requiring manual in-container steps.
+2. Provide valid queue configuration to the bootstrap script.
+3. Invoke the Azure companion bootstrap entrypoint with that directory mounted as the state volume.
+4. Assert: the bootstrap path runs before the long-running runtime starts.
+5. Assert: the bootstrap path invokes the Rust `bootstrap-auth` flow and requests a device code from the configured OAuth endpoint.
 
 ---
 
-### T-AZC-0102  Device code is shown through the gateway admin display RPC
+### T-AZC-0102  Startup enters bootstrap when queue configuration is missing
+
+**Validates:** AZC-0102, AZC-0200, AZC-0302
+
+**Procedure:**
+1. Populate the mounted state volume with the expected provisioning artifacts.
+2. Start the Azure companion entrypoint without the required namespace and queue configuration.
+3. Assert: startup enters bootstrap instead of normal runtime mode.
+4. Assert: runtime bridge startup is not reported as successful.
+
+---
+
+### T-AZC-0103  Bootstrapped state skips device login
+
+**Validates:** AZC-0102, AZC-0200, AZC-0204, AZC-0302
+
+**Procedure:**
+1. Populate the mounted state volume with the expected provisioning artifacts.
+2. Provide the required namespace and queue configuration.
+3. Start the Azure companion entrypoint.
+4. Assert: startup skips the bootstrap path.
+5. Assert: the long-running runtime starts directly.
+6. Assert: no device-code login attempt is made.
+
+---
+
+### T-AZC-0104  Device code is shown through the gateway admin display RPC
 
 **Validates:** AZC-0202, AZC-0300
 
@@ -52,7 +82,7 @@
 
 ---
 
-### T-AZC-0103  Display failure aborts bootstrap
+### T-AZC-0105  Display failure aborts bootstrap
 
 **Validates:** AZC-0203
 
@@ -65,32 +95,6 @@
 
 ---
 
-### T-AZC-0104  Previously used state volume still enters device login
-
-**Validates:** AZC-0101, AZC-0200, AZC-0204
-
-**Procedure:**
-1. Populate the mounted state volume with unrelated placeholder files representing future provisioning output.
-2. Start the Azure companion container with that mounted directory.
-3. Assert: startup still performs Azure device-code login.
-4. Assert: startup issues a new modem display request for the new device code.
-5. Assert: the long-running Azure companion process starts normally after successful auth.
-6. Assert: startup succeeds without requiring access to a legacy companion socket.
-
----
-
-### T-AZC-0105  Repeated starts continue to perform device login until provisioning exists
-
-**Validates:** AZC-0204
-
-**Procedure:**
-1. Start the Azure companion bootstrap flow successfully with a mounted state volume.
-2. Start it again with the same mounted state volume.
-3. Assert: the second startup re-enters the bootstrap login path.
-4. Assert: a new Azure device-code login attempt is invoked.
-
----
-
 ### T-AZC-0106  Azure login failure aborts bootstrap
 
 **Validates:** AZC-0201
@@ -99,19 +103,118 @@
 1. Create an empty auth state volume.
 2. Invoke the Azure companion bootstrap path with the Rust device-flow token polling endpoint stubbed to fail.
 3. Assert: bootstrap exits with a non-zero status.
-4. Assert: the long-running Azure companion process is not started.
+4. Assert: the long-running runtime is not started.
 5. Assert: bootstrap does not report success.
 
 ---
 
-### T-AZC-0107  Long-running runtime connects through the gateway connector socket
+### T-AZC-0107  Bootstrap does not report success until bootstrap-complete state exists
+
+**Validates:** AZC-0102, AZC-0201
+
+**Procedure:**
+1. Start the Azure companion bootstrap path with the Rust device-flow endpoint stubbed to complete successfully.
+2. Prevent the out-of-scope provisioning handoff from creating bootstrap-complete state.
+3. Assert: bootstrap does not report success.
+4. Assert: the long-running runtime is not started.
+5. Assert: startup remains blocked or fails closed until bootstrap-complete state exists.
+
+---
+
+### T-AZC-0108  Long-running runtime connects through the gateway connector socket
 
 **Validates:** AZC-0301
 
 **Procedure:**
-1. Start a test gateway exposing both the admin socket and the connector socket.
-2. Complete a successful Azure bootstrap sequence.
+1. Start a test gateway exposing the connector socket.
+2. Provide bootstrap-complete state and valid queue configuration.
 3. Start the long-running Azure companion runtime.
 4. Assert: the runtime connects to the configured connector socket and keeps the connector session open.
 5. Assert: runtime startup does not require a legacy companion socket.
 
+---
+
+### T-AZC-0109  Runtime requires explicit Service Bus queue configuration
+
+**Validates:** AZC-0302
+
+**Procedure:**
+1. Prepare bootstrap-complete state in the mounted state volume.
+2. Start the runtime with the namespace missing, then with the upstream queue missing, then with the downstream queue missing.
+3. Assert: each sub-case fails closed before the runtime begins bridging traffic.
+4. Assert: the failure identifies missing configuration rather than silently selecting defaults.
+
+---
+
+### T-AZC-0110  Upstream connector payloads are published transparently
+
+**Validates:** AZC-0303, AZC-0304, AZC-0306
+
+**Procedure:**
+1. Start the runtime with a test double for the broker transport layer.
+2. Inject representative gateway-originated connector payloads through the local connector socket, covering at least one `ACTUAL_STATE`, one `APP_DATA`, and one `CONNECTOR_HEALTH` message.
+3. Assert: the transport layer receives the raw connector payload bytes unchanged.
+4. Assert: all upstream message types are routed to the configured upstream queue.
+5. Assert: any broker metadata used is supplementary and does not replace the raw payload body.
+
+---
+
+### T-AZC-0111  Downstream desired-state payloads are forwarded transparently
+
+**Validates:** AZC-0303, AZC-0304, AZC-0307
+
+**Procedure:**
+1. Start the runtime with a test double for the broker transport layer and a test gateway connector socket.
+2. Deliver a representative raw `DESIRED_STATE` connector payload from the configured downstream queue.
+3. Assert: the runtime writes the raw payload bytes unchanged to the local gateway connector socket.
+4. Assert: the downstream queue path is not used for upstream state or app-data traffic.
+
+---
+
+### T-AZC-0112  Downstream settlement waits for local connector handoff
+
+**Validates:** AZC-0308
+
+**Procedure:**
+1. Start the runtime with broker and local connector test doubles that let the test control when the local connector write succeeds or fails.
+2. Deliver one desired-state message from the downstream queue.
+3. In the success sub-case, allow the local connector write to complete and assert the broker message is then settled successfully.
+4. In the failure sub-case, force the local connector write to fail and assert the broker message is not reported as successfully processed.
+5. Assert: no extra synchronous acknowledgement path is required from the gateway.
+
+---
+
+### T-AZC-0113  Runtime uses certificate-based Azure authentication after bootstrap
+
+**Validates:** AZC-0305
+
+**Procedure:**
+1. Prepare bootstrap-complete state containing the required certificate PEM, private-key PEM, and service-principal metadata.
+2. Start the runtime with a broker test double that records the credential path used.
+3. Assert: runtime startup uses the provisioned certificate and private-key material rather than entering device-code login.
+4. Remove or corrupt the certificate or private-key material and assert: runtime startup fails closed.
+
+---
+
+### T-AZC-0114  Detected broker or local connector failures are surfaced
+
+**Validates:** AZC-0309
+
+**Procedure:**
+1. Start the runtime with test doubles that can inject an upstream publish failure, a downstream receive failure, a settlement failure, and a local connector write failure.
+2. Trigger each failure mode independently.
+3. Assert: each failure is surfaced through logging, process status, or both.
+4. Assert: the runtime does not silently claim success after a detected bridge failure.
+
+---
+
+### T-AZC-0115  Alpine image reaches the concrete `azservicebus` runtime path
+
+**Validates:** AZC-0100, AZC-0303, AZC-0304, AZC-0305
+
+**Procedure:**
+1. Build the Azure companion Alpine image.
+2. Prepare bootstrap-complete state and explicit queue configuration.
+3. Start the runtime in the container with the concrete `azservicebus` transport selected and with a deliberately unreachable or test-only Service Bus endpoint.
+4. Assert: the runtime reaches the concrete Azure transport initialization path and fails, if it fails, with an Azure transport/connectivity error rather than a missing binary, missing dynamic library, or unsupported-platform error.
+5. Assert: the runtime does not fall back to device-code login in this bootstrap-complete case.


### PR DESCRIPTION
## Summary
- add a pluggable Azure companion AMQP bridge that forwards raw connector payloads over Azure Service Bus
- add cert-based Entra client-assertion auth, runtime readiness checks, and bootstrap script gating for persisted runtime state
- update Alpine packaging, validation coverage, and Azure companion specs for the new bootstrap/runtime model

## Testing
- cargo test -p sonde-azure-companion
- cargo clippy -p sonde-azure-companion --all-targets -- -D warnings