### PR TITLE
Add Azure provisioning Bicep stack

### DIFF
--- a/deploy/bicep/.gitignore
+++ b/deploy/bicep/.gitignore
@@ -1,0 +1,1 @@
+main.json

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -13,7 +13,7 @@ Azure companion architecture.
   - `connector-upstream`
   - `desired-state`
 - An Azure Storage Account and Table resource for later decoded-data storage
-- A placeholder Azure Function App on a consumption plan
+- A placeholder Azure Function App on a Flex Consumption plan
 - A system-assigned managed identity on the Function App with:
   - receive permissions on the upstream queue
   - send permissions on the downstream queue

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -29,8 +29,8 @@ Azure companion architecture.
 | Parameter | Default | Purpose |
 |-----------|---------|---------|
 | `location` | `eastus` | Azure region for the stack |
-| `projectName` | `sonde` | Prefix for resource names and tags |
-| `resourceGroupName` | empty | Optional override for the resource group name |
+| `project_name` | `sonde` | Prefix for resource names and tags |
+| `resource_group_name` | empty | Optional override for the resource group name |
 | `companionCertificateBase64` | none | Base64-encoded DER certificate public material registered on the Azure companion app |
 | `serviceBusNamespaceName` | derived | Optional Service Bus namespace override |
 | `upstreamQueueName` | `connector-upstream` | Gateway-originated connector traffic queue |
@@ -41,7 +41,7 @@ Azure companion architecture.
 | `functionPlanName` | derived | Optional Function hosting plan override |
 
 When resource names are derived automatically, the deployment normalizes
-`projectName` to satisfy Azure naming rules for the target resource types.
+`project_name` to satisfy Azure naming rules for the target resource types.
 
 ## Companion certificate input
 

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -1,0 +1,106 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Azure provisioning workflow for issue #772
+
+This directory contains the Bicep-based provisioning surface for the current
+Azure companion architecture.
+
+## What it provisions
+
+- A dedicated resource group (or a caller-specified existing group target)
+- A Standard-tier Azure Service Bus namespace
+- Two Service Bus queues:
+  - `connector-upstream`
+  - `desired-state`
+- An Azure Storage Account and Table resource for later decoded-data storage
+- A placeholder Azure Function App on a consumption plan
+- A system-assigned managed identity on the Function App with:
+  - receive permissions on the upstream queue
+  - send permissions on the downstream queue
+  - write permissions on the Storage Table
+- An Entra application / service principal for `sonde-azure-companion` using a
+  caller-supplied certificate public credential
+- Azure companion Service Bus RBAC:
+  - send on the upstream queue
+  - receive on the downstream queue
+
+## Inputs
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `location` | `eastus` | Azure region for the stack |
+| `projectName` | `sonde` | Prefix for resource names and tags |
+| `resourceGroupName` | empty | Optional override for the resource group name |
+| `companionCertificateBase64` | none | Base64-encoded DER certificate public material registered on the Azure companion app |
+| `serviceBusNamespaceName` | derived | Optional Service Bus namespace override |
+| `upstreamQueueName` | `connector-upstream` | Gateway-originated connector traffic queue |
+| `downstreamQueueName` | `desired-state` | Desired-state ingress queue |
+| `storageAccountName` | derived | Optional Storage Account override |
+| `tableName` | `decodeddata` | Placeholder decoded-data table resource |
+| `functionAppName` | derived | Optional Function App override |
+| `functionPlanName` | derived | Optional Function hosting plan override |
+
+When resource names are derived automatically, the deployment normalizes
+`projectName` to satisfy Azure naming rules for the target resource types.
+
+## Companion certificate input
+
+The deployment registers only the **public certificate** on the Entra app. The
+matching certificate PEM and private-key PEM remain caller-managed local
+artifacts for `sonde-azure-companion` bootstrap.
+
+One way to derive `companionCertificateBase64` from a PEM certificate is:
+
+```powershell
+openssl x509 -in companion-cert.pem -outform der | openssl base64 -A
+```
+
+## Plan / apply
+
+Plan the deployment:
+
+```powershell
+$cert = openssl x509 -in companion-cert.pem -outform der | openssl base64 -A
+az deployment sub what-if `
+  --location eastus `
+  --template-file .\deploy\bicep\main.bicep `
+  --parameters companionCertificateBase64=$cert
+```
+
+Create or update the stack:
+
+```powershell
+$cert = openssl x509 -in companion-cert.pem -outform der | openssl base64 -A
+az deployment sub create `
+  --location eastus `
+  --template-file .\deploy\bicep\main.bicep `
+  --parameters companionCertificateBase64=$cert
+```
+
+## Bootstrap handoff
+
+The deployment outputs the values needed to create the Azure companion runtime
+state:
+
+- tenant ID
+- client ID
+- Service Bus namespace
+- upstream queue name
+- downstream queue name
+
+You still need to place the matching PEM certificate and private key into the
+Azure companion state directory and write `service-principal.json` that points
+at those local files.
+
+## Teardown
+
+Delete the resource group that was created for the stack, or target the
+documented resource group explicitly:
+
+```powershell
+az group delete --name <resource-group-name> --yes --no-wait
+```
+
+This removes the Azure resource-plane stack. If you also want to remove the
+Entra application and service principal, delete those identity objects
+explicitly after teardown.

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -32,6 +32,7 @@ Azure companion architecture.
 | `project_name` | `sonde` | Prefix for resource names and tags |
 | `resource_group_name` | empty | Optional override for the resource group name |
 | `companionCertificateBase64` | none | Base64-encoded DER certificate public material registered on the Azure companion app |
+| `companionCertificateDisplayName` | `sonde-azure-companion` | Optional display name for the registered certificate credential |
 | `serviceBusNamespaceName` | derived | Optional Service Bus namespace override |
 | `upstreamQueueName` | `connector-upstream` | Gateway-originated connector traffic queue |
 | `downstreamQueueName` | `desired-state` | Desired-state ingress queue |

--- a/deploy/bicep/bicepconfig.json
+++ b/deploy/bicep/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "microsoftGraphV1": "br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:1.0.0"
+  }
+}

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -41,7 +41,7 @@ param functionPlanName string = ''
 
 var projectSlug = toLower(replace(replace(replace(replace(replace(project_name, '-', ''), '_', ''), ' ', ''), '.', ''), '/', ''))
 var effectiveProjectSlug = empty(projectSlug) ? 'sonde' : projectSlug
-var effectiveResourceGroupName = empty(resource_group_name) ? '${project_name}-azure' : resource_group_name
+var effectiveResourceGroupName = empty(resource_group_name) ? '${take(effectiveProjectSlug, 84)}-azure' : resource_group_name
 var effectiveServiceBusNamespaceName = empty(serviceBusNamespaceName)
   ? take('${take(effectiveProjectSlug, 20)}-sb-${take(uniqueString(subscription().subscriptionId, effectiveResourceGroupName), 8)}', 50)
   : serviceBusNamespaceName

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -7,10 +7,10 @@ targetScope = 'subscription'
 param location string = 'eastus'
 
 @description('Prefix used for resource names and default tags.')
-param projectName string = 'sonde'
+param project_name string = 'sonde'
 
-@description('Optional override for the resource group name. Leave empty to derive one from projectName.')
-param resourceGroupName string = ''
+@description('Optional override for the resource group name. Leave empty to derive one from project_name.')
+param resource_group_name string = ''
 
 @description('Base64-encoded DER certificate public data to register on the Azure companion app registration.')
 param companionCertificateBase64 string
@@ -39,14 +39,14 @@ param functionAppName string = ''
 @description('Optional override for the placeholder Function hosting plan name.')
 param functionPlanName string = ''
 
-var projectSlug = toLower(replace(replace(replace(replace(replace(projectName, '-', ''), '_', ''), ' ', ''), '.', ''), '/', ''))
+var projectSlug = toLower(replace(replace(replace(replace(replace(project_name, '-', ''), '_', ''), ' ', ''), '.', ''), '/', ''))
 var effectiveProjectSlug = empty(projectSlug) ? 'sonde' : projectSlug
-var effectiveResourceGroupName = empty(resourceGroupName) ? '${projectName}-azure' : resourceGroupName
+var effectiveResourceGroupName = empty(resource_group_name) ? '${project_name}-azure' : resource_group_name
 var effectiveServiceBusNamespaceName = empty(serviceBusNamespaceName)
   ? take('${take(effectiveProjectSlug, 20)}-sb-${take(uniqueString(subscription().subscriptionId, effectiveResourceGroupName), 8)}', 50)
   : serviceBusNamespaceName
 var effectiveStorageAccountName = empty(storageAccountName)
-  ? take('st${take(uniqueString(subscription().subscriptionId, projectName, effectiveResourceGroupName, 'storage'), 22)}', 24)
+  ? take('st${take(uniqueString(subscription().subscriptionId, project_name, effectiveResourceGroupName, 'storage'), 22)}', 24)
   : storageAccountName
 var effectiveFunctionAppName = empty(functionAppName)
   ? take('${take(effectiveProjectSlug, 24)}-decoder-${take(uniqueString(subscription().subscriptionId, effectiveResourceGroupName, 'func'), 8)}', 60)
@@ -55,7 +55,7 @@ var effectiveFunctionPlanName = empty(functionPlanName)
   ? take('${take(effectiveProjectSlug, 24)}-func-plan', 40)
   : functionPlanName
 var tags = {
-  project: projectName
+  project: project_name
 }
 
 resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
@@ -67,7 +67,7 @@ resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
 module companionIdentity './modules/companion-identity.bicep' = {
   name: 'companionIdentity'
   params: {
-    projectName: projectName
+    projectName: project_name
     identitySuffix: take(uniqueString(subscription().subscriptionId, effectiveResourceGroupName, 'companion-identity'), 8)
     certificateBase64: companionCertificateBase64
     certificateDisplayName: companionCertificateDisplayName

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+targetScope = 'subscription'
+
+@description('Azure region for all deployed resources.')
+param location string = 'eastus'
+
+@description('Prefix used for resource names and default tags.')
+param projectName string = 'sonde'
+
+@description('Optional override for the resource group name. Leave empty to derive one from projectName.')
+param resourceGroupName string = ''
+
+@description('Base64-encoded DER certificate public data to register on the Azure companion app registration.')
+param companionCertificateBase64 string
+
+@description('Display name for the registered companion certificate credential.')
+param companionCertificateDisplayName string = 'sonde-azure-companion'
+
+@description('Optional override for the Service Bus namespace name.')
+param serviceBusNamespaceName string = ''
+
+@description('Queue name for gateway-originated connector traffic.')
+param upstreamQueueName string = 'connector-upstream'
+
+@description('Queue name for cloud-originated desired-state traffic.')
+param downstreamQueueName string = 'desired-state'
+
+@description('Optional override for the Storage Account name.')
+param storageAccountName string = ''
+
+@description('Table name reserved for later decoded-data persistence.')
+param tableName string = 'decodeddata'
+
+@description('Optional override for the placeholder Azure Function App name.')
+param functionAppName string = ''
+
+@description('Optional override for the placeholder Function hosting plan name.')
+param functionPlanName string = ''
+
+var projectSlug = toLower(replace(replace(replace(replace(replace(projectName, '-', ''), '_', ''), ' ', ''), '.', ''), '/', ''))
+var effectiveProjectSlug = empty(projectSlug) ? 'sonde' : projectSlug
+var effectiveResourceGroupName = empty(resourceGroupName) ? '${projectName}-azure' : resourceGroupName
+var effectiveServiceBusNamespaceName = empty(serviceBusNamespaceName)
+  ? take('${take(effectiveProjectSlug, 20)}-sb-${take(uniqueString(subscription().subscriptionId, effectiveResourceGroupName), 8)}', 50)
+  : serviceBusNamespaceName
+var effectiveStorageAccountName = empty(storageAccountName)
+  ? take('st${take(uniqueString(subscription().subscriptionId, projectName, effectiveResourceGroupName, 'storage'), 22)}', 24)
+  : storageAccountName
+var effectiveFunctionAppName = empty(functionAppName)
+  ? take('${take(effectiveProjectSlug, 24)}-decoder-${take(uniqueString(subscription().subscriptionId, effectiveResourceGroupName, 'func'), 8)}', 60)
+  : functionAppName
+var effectiveFunctionPlanName = empty(functionPlanName)
+  ? take('${take(effectiveProjectSlug, 24)}-func-plan', 40)
+  : functionPlanName
+var tags = {
+  project: projectName
+}
+
+resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
+  name: effectiveResourceGroupName
+  location: location
+  tags: tags
+}
+
+module companionIdentity './modules/companion-identity.bicep' = {
+  name: 'companionIdentity'
+  params: {
+    projectName: projectName
+    certificateBase64: companionCertificateBase64
+    certificateDisplayName: companionCertificateDisplayName
+  }
+}
+
+module stack './modules/stack.bicep' = {
+  name: 'azureCompanionStack'
+  scope: stackResourceGroup
+  params: {
+    location: location
+    tags: tags
+    serviceBusNamespaceName: effectiveServiceBusNamespaceName
+    upstreamQueueName: upstreamQueueName
+    downstreamQueueName: downstreamQueueName
+    storageAccountName: effectiveStorageAccountName
+    tableName: tableName
+    functionAppName: effectiveFunctionAppName
+    functionPlanName: effectiveFunctionPlanName
+    companionServicePrincipalObjectId: companionIdentity.outputs.servicePrincipalObjectId
+  }
+}
+
+output resourceGroupName string = stackResourceGroup.name
+output serviceBusNamespaceName string = stack.outputs.serviceBusNamespaceName
+output upstreamQueueName string = stack.outputs.upstreamQueueName
+output downstreamQueueName string = stack.outputs.downstreamQueueName
+output storageAccountName string = stack.outputs.storageAccountName
+output storageTableName string = stack.outputs.tableName
+output functionAppName string = stack.outputs.functionAppName
+output functionPrincipalId string = stack.outputs.functionPrincipalId
+output companionClientId string = companionIdentity.outputs.clientId
+output companionTenantId string = companionIdentity.outputs.tenantId
+output companionServicePrincipalObjectId string = companionIdentity.outputs.servicePrincipalObjectId
+output companionBootstrapValues object = {
+  tenantId: companionIdentity.outputs.tenantId
+  clientId: companionIdentity.outputs.clientId
+  serviceBusNamespace: stack.outputs.serviceBusNamespaceName
+  upstreamQueue: stack.outputs.upstreamQueueName
+  downstreamQueue: stack.outputs.downstreamQueueName
+  note: 'The deployment registers the supplied certificate public material on the Entra app. The matching PEM certificate and private key remain caller-managed local artifacts for sonde-azure-companion bootstrap.'
+}

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -68,6 +68,7 @@ module companionIdentity './modules/companion-identity.bicep' = {
   name: 'companionIdentity'
   params: {
     projectName: projectName
+    identitySuffix: take(uniqueString(subscription().subscriptionId, effectiveResourceGroupName, 'companion-identity'), 8)
     certificateBase64: companionCertificateBase64
     certificateDisplayName: companionCertificateDisplayName
   }

--- a/deploy/bicep/modules/companion-identity.bicep
+++ b/deploy/bicep/modules/companion-identity.bicep
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+targetScope = 'subscription'
+
+extension microsoftGraphV1
+
+@description('Project prefix used for the companion app registration display name.')
+param projectName string
+
+@description('Base64-encoded DER certificate public data to register on the Azure companion app registration.')
+param certificateBase64 string
+
+@description('Display name for the registered companion certificate credential.')
+param certificateDisplayName string = 'sonde-azure-companion'
+
+var projectSlug = toLower(replace(projectName, '-', ''))
+var appDisplayName = '${projectName}-azure-companion'
+var appUniqueName = '${projectSlug}-azure-companion'
+
+resource companionApp 'Microsoft.Graph/applications@v1.0' = {
+  uniqueName: appUniqueName
+  displayName: appDisplayName
+  signInAudience: 'AzureADMyOrg'
+  keyCredentials: [
+    {
+      displayName: certificateDisplayName
+      usage: 'Verify'
+      type: 'AsymmetricX509Cert'
+      key: certificateBase64
+    }
+  ]
+}
+
+resource companionServicePrincipal 'Microsoft.Graph/servicePrincipals@v1.0' = {
+  appId: companionApp.appId
+}
+
+output clientId string = companionApp.appId
+output tenantId string = tenant().tenantId
+output servicePrincipalObjectId string = companionServicePrincipal.id

--- a/deploy/bicep/modules/companion-identity.bicep
+++ b/deploy/bicep/modules/companion-identity.bicep
@@ -17,9 +17,10 @@ param certificateBase64 string
 @description('Display name for the registered companion certificate credential.')
 param certificateDisplayName string = 'sonde-azure-companion'
 
-var projectSlug = toLower(replace(projectName, '-', ''))
+var projectSlug = toLower(replace(replace(replace(replace(replace(projectName, '-', ''), '_', ''), ' ', ''), '.', ''), '/', ''))
+var effectiveProjectSlug = empty(projectSlug) ? 'sonde' : projectSlug
 var appDisplayName = '${projectName}-azure-companion'
-var appUniqueName = '${projectSlug}-azure-companion-${identitySuffix}'
+var appUniqueName = '${effectiveProjectSlug}-azure-companion-${identitySuffix}'
 
 resource companionApp 'Microsoft.Graph/applications@v1.0' = {
   uniqueName: appUniqueName

--- a/deploy/bicep/modules/companion-identity.bicep
+++ b/deploy/bicep/modules/companion-identity.bicep
@@ -8,6 +8,9 @@ extension microsoftGraphV1
 @description('Project prefix used for the companion app registration display name.')
 param projectName string
 
+@description('Stable per-stack suffix used to keep the companion identity unique across deployments.')
+param identitySuffix string
+
 @description('Base64-encoded DER certificate public data to register on the Azure companion app registration.')
 param certificateBase64 string
 
@@ -16,7 +19,7 @@ param certificateDisplayName string = 'sonde-azure-companion'
 
 var projectSlug = toLower(replace(projectName, '-', ''))
 var appDisplayName = '${projectName}-azure-companion'
-var appUniqueName = '${projectSlug}-azure-companion'
+var appUniqueName = '${projectSlug}-azure-companion-${identitySuffix}'
 
 resource companionApp 'Microsoft.Graph/applications@v1.0' = {
   uniqueName: appUniqueName

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -15,12 +15,17 @@ param functionPlanName string
 @description('Blob container URL used by the Function placeholder deployment configuration.')
 param deploymentContainerUrl string
 
-@secure()
-@description('Connection string used by the Function placeholder deployment storage configuration.')
-param storageConnectionString string
+@description('Storage Account name used by the Function placeholder deployment configuration.')
+param storageAccountName string
 
 @description('Tags applied to provisioned resources.')
 param tags object
+
+resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${existingStorageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${existingStorageAccount.listKeys().keys[0].value}'
 
 resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: functionPlanName

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -12,31 +12,31 @@ param functionAppName string
 @description('Function hosting plan name.')
 param functionPlanName string
 
+@description('Blob container URL used by the Function placeholder deployment configuration.')
+param deploymentContainerUrl string
+
 @secure()
-@description('Connection string for the Function host storage account.')
+@description('Connection string used by the Function placeholder deployment storage configuration.')
 param storageConnectionString string
 
 @description('Tags applied to provisioned resources.')
 param tags object
 
-var contentShareName = toLower(take(replace(functionAppName, '-', ''), 63))
-
-resource hostingPlan 'Microsoft.Web/serverfarms@2022-03-01' = {
+resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: functionPlanName
   location: location
+  kind: 'functionapp'
   tags: tags
   sku: {
-    name: 'Y1'
-    tier: 'Dynamic'
-    size: 'Y1'
-    family: 'Y'
+    name: 'FC1'
+    tier: 'FlexConsumption'
   }
   properties: {
     reserved: true
   }
 }
 
-resource functionApp 'Microsoft.Web/sites@2022-03-01' = {
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
   name: functionAppName
   location: location
   kind: 'functionapp,linux'
@@ -45,43 +45,39 @@ resource functionApp 'Microsoft.Web/sites@2022-03-01' = {
     type: 'SystemAssigned'
   }
   properties: {
-    reserved: true
     httpsOnly: true
     serverFarmId: hostingPlan.id
     siteConfig: {
-      linuxFxVersion: 'Custom'
-      appSettings: [
-        {
-          name: 'AzureWebJobsStorage'
-          value: storageConnectionString
+      minTlsVersion: '1.2'
+    }
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: deploymentContainerUrl
+          authentication: {
+            type: 'StorageAccountConnectionString'
+            storageAccountConnectionStringName: 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
+          }
         }
-        {
-          name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
-          value: storageConnectionString
-        }
-        {
-          name: 'WEBSITE_CONTENTSHARE'
-          value: contentShareName
-        }
-        {
-          name: 'FUNCTIONS_EXTENSION_VERSION'
-          value: '~4'
-        }
-        {
-          name: 'FUNCTIONS_WORKER_RUNTIME'
-          value: 'custom'
-        }
-      ]
+      }
+      runtime: {
+        name: 'custom'
+        version: '1.0'
+      }
+      scaleAndConcurrency: {
+        maximumInstanceCount: 100
+        instanceMemoryMB: 512
+      }
     }
   }
 }
 
-resource webConfig 'Microsoft.Web/sites/config@2022-03-01' = {
+resource appSettings 'Microsoft.Web/sites/config@2024-04-01' = {
   parent: functionApp
-  name: 'web'
+  name: 'appsettings'
   properties: {
-    ftpsState: 'Disabled'
-    minTlsVersion: '1.2'
+    DEPLOYMENT_STORAGE_CONNECTION_STRING: storageConnectionString
   }
 }
 

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+targetScope = 'resourceGroup'
+
+@description('Azure region for the Function placeholder resources.')
+param location string
+
+@description('Function App name.')
+param functionAppName string
+
+@description('Function hosting plan name.')
+param functionPlanName string
+
+@secure()
+@description('Connection string for the Function host storage account.')
+param storageConnectionString string
+
+@description('Tags applied to provisioned resources.')
+param tags object
+
+var contentShareName = toLower(take(replace(functionAppName, '-', ''), 63))
+
+resource hostingPlan 'Microsoft.Web/serverfarms@2022-03-01' = {
+  name: functionPlanName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+    size: 'Y1'
+    family: 'Y'
+  }
+  properties: {
+    reserved: true
+  }
+}
+
+resource functionApp 'Microsoft.Web/sites@2022-03-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp,linux'
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    reserved: true
+    httpsOnly: true
+    serverFarmId: hostingPlan.id
+    siteConfig: {
+      linuxFxVersion: 'Custom'
+      appSettings: [
+        {
+          name: 'AzureWebJobsStorage'
+          value: storageConnectionString
+        }
+        {
+          name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
+          value: storageConnectionString
+        }
+        {
+          name: 'WEBSITE_CONTENTSHARE'
+          value: contentShareName
+        }
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'custom'
+        }
+      ]
+    }
+  }
+}
+
+resource webConfig 'Microsoft.Web/sites/config@2022-03-01' = {
+  parent: functionApp
+  name: 'web'
+  properties: {
+    ftpsState: 'Disabled'
+    minTlsVersion: '1.2'
+  }
+}
+
+output functionAppName string = functionApp.name
+output functionAppResourceId string = functionApp.id
+output principalId string = functionApp.identity.principalId

--- a/deploy/bicep/modules/function-rbac.bicep
+++ b/deploy/bicep/modules/function-rbac.bicep
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+targetScope = 'resourceGroup'
+
+@description('System-assigned managed identity principal ID for the placeholder Function App.')
+param functionPrincipalId string
+
+@description('Service Bus namespace name.')
+param serviceBusNamespaceName string
+
+@description('Queue name for gateway-originated connector traffic.')
+param upstreamQueueName string
+
+@description('Queue name for cloud-originated desired-state traffic.')
+param downstreamQueueName string
+
+@description('Storage Account name.')
+param storageAccountName string
+
+@description('Storage Table name.')
+param tableName string
+
+var serviceBusDataSenderRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39')
+var serviceBusDataReceiverRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0')
+var storageTableDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3')
+
+resource existingServiceBusNamespace 'Microsoft.ServiceBus/namespaces@2024-01-01' existing = {
+  name: serviceBusNamespaceName
+}
+
+resource existingUpstreamQueue 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' existing = {
+  parent: existingServiceBusNamespace
+  name: upstreamQueueName
+}
+
+resource existingDownstreamQueue 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' existing = {
+  parent: existingServiceBusNamespace
+  name: downstreamQueueName
+}
+
+resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource existingTableService 'Microsoft.Storage/storageAccounts/tableServices@2023-05-01' existing = {
+  parent: existingStorageAccount
+  name: 'default'
+}
+
+resource existingStorageTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' existing = {
+  parent: existingTableService
+  name: tableName
+}
+
+resource functionUpstreamReceiver 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('function-upstream-receiver', functionPrincipalId, serviceBusDataReceiverRoleId, serviceBusNamespaceName, upstreamQueueName)
+  scope: existingUpstreamQueue
+  properties: {
+    principalId: functionPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: serviceBusDataReceiverRoleId
+  }
+}
+
+resource functionDownstreamSender 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('function-downstream-sender', functionPrincipalId, serviceBusDataSenderRoleId, serviceBusNamespaceName, downstreamQueueName)
+  scope: existingDownstreamQueue
+  properties: {
+    principalId: functionPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: serviceBusDataSenderRoleId
+  }
+}
+
+resource functionTableContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('function-table-contributor', functionPrincipalId, storageTableDataContributorRoleId, existingStorageTable.id)
+  scope: existingStorageTable
+  properties: {
+    principalId: functionPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageTableDataContributorRoleId
+  }
+}

--- a/deploy/bicep/modules/service-bus.bicep
+++ b/deploy/bicep/modules/service-bus.bicep
@@ -28,7 +28,7 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
     capacity: 0
   }
   properties: {
-    disableLocalAuth: false
+    disableLocalAuth: true
     publicNetworkAccess: 'Enabled'
     zoneRedundant: false
   }

--- a/deploy/bicep/modules/service-bus.bicep
+++ b/deploy/bicep/modules/service-bus.bicep
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+targetScope = 'resourceGroup'
+
+@description('Azure region for the Service Bus resources.')
+param location string
+
+@description('Service Bus namespace name.')
+param namespaceName string
+
+@description('Queue name for gateway-originated connector traffic.')
+param upstreamQueueName string
+
+@description('Queue name for cloud-originated desired-state traffic.')
+param downstreamQueueName string
+
+@description('Tags applied to provisioned resources.')
+param tags object
+
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
+  name: namespaceName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+    tier: 'Standard'
+    capacity: 0
+  }
+  properties: {
+    disableLocalAuth: false
+    publicNetworkAccess: 'Enabled'
+    zoneRedundant: false
+  }
+}
+
+resource upstreamQueue 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' = {
+  parent: serviceBusNamespace
+  name: upstreamQueueName
+  properties: {
+    deadLetteringOnMessageExpiration: true
+    enableBatchedOperations: true
+    enableExpress: false
+    enablePartitioning: false
+    maxDeliveryCount: 10
+    maxSizeInMegabytes: 1024
+    requiresDuplicateDetection: false
+    requiresSession: false
+    status: 'Active'
+  }
+}
+
+resource downstreamQueue 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' = {
+  parent: serviceBusNamespace
+  name: downstreamQueueName
+  properties: {
+    deadLetteringOnMessageExpiration: true
+    enableBatchedOperations: true
+    enableExpress: false
+    enablePartitioning: false
+    maxDeliveryCount: 10
+    maxSizeInMegabytes: 1024
+    requiresDuplicateDetection: false
+    requiresSession: false
+    status: 'Active'
+  }
+}
+
+output namespaceName string = serviceBusNamespace.name
+output namespaceFqdn string = '${serviceBusNamespace.name}.servicebus.windows.net'
+output namespaceResourceId string = serviceBusNamespace.id
+output upstreamQueueName string = upstreamQueue.name
+output upstreamQueueResourceId string = upstreamQueue.id
+output downstreamQueueName string = downstreamQueue.name
+output downstreamQueueResourceId string = downstreamQueue.id

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+targetScope = 'resourceGroup'
+
+@description('Azure region for all deployed resources.')
+param location string
+
+@description('Tags applied to provisioned resources.')
+param tags object
+
+@description('Service Bus namespace name.')
+param serviceBusNamespaceName string
+
+@description('Queue name for gateway-originated connector traffic.')
+param upstreamQueueName string
+
+@description('Queue name for cloud-originated desired-state traffic.')
+param downstreamQueueName string
+
+@description('Storage Account name.')
+param storageAccountName string
+
+@description('Storage Table name.')
+param tableName string
+
+@description('Placeholder Function App name.')
+param functionAppName string
+
+@description('Placeholder Function hosting plan name.')
+param functionPlanName string
+
+@description('Object ID of the Azure companion runtime service principal.')
+param companionServicePrincipalObjectId string
+
+var serviceBusDataSenderRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e1ecfa86-44a4-4fa6-9e13-a6f4d06e2913')
+var serviceBusDataReceiverRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')
+var storageTableDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b00c-4d22-95b9-937d2d07ed72')
+var companionUpstreamSenderAssignmentName = guid('companion-upstream-sender', companionServicePrincipalObjectId, serviceBusDataSenderRoleId, serviceBusNamespaceName, upstreamQueueName)
+var companionDownstreamReceiverAssignmentName = guid('companion-downstream-receiver', companionServicePrincipalObjectId, serviceBusDataReceiverRoleId, serviceBusNamespaceName, downstreamQueueName)
+var functionUpstreamReceiverAssignmentName = guid('function-upstream-receiver', functionAppName, serviceBusDataReceiverRoleId, serviceBusNamespaceName, upstreamQueueName)
+var functionDownstreamSenderAssignmentName = guid('function-downstream-sender', functionAppName, serviceBusDataSenderRoleId, serviceBusNamespaceName, downstreamQueueName)
+var functionTableContributorAssignmentName = guid('function-table-contributor', functionAppName, storageTableDataContributorRoleId, storageAccountName, tableName)
+
+module serviceBus './service-bus.bicep' = {
+  name: 'serviceBus'
+  params: {
+    location: location
+    namespaceName: serviceBusNamespaceName
+    upstreamQueueName: upstreamQueueName
+    downstreamQueueName: downstreamQueueName
+    tags: tags
+  }
+}
+
+module storage './storage.bicep' = {
+  name: 'storage'
+  params: {
+    location: location
+    storageAccountName: storageAccountName
+    tableName: tableName
+    tags: tags
+  }
+}
+
+var functionStorageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storage.outputs.storageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storage.outputs.primaryKey}'
+
+module functionPlaceholder './function-placeholder.bicep' = {
+  name: 'functionPlaceholder'
+  params: {
+    location: location
+    functionAppName: functionAppName
+    functionPlanName: functionPlanName
+    storageConnectionString: functionStorageConnectionString
+    tags: tags
+  }
+}
+
+resource existingServiceBusNamespace 'Microsoft.ServiceBus/namespaces@2024-01-01' existing = {
+  name: serviceBusNamespaceName
+}
+
+resource existingUpstreamQueue 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' existing = {
+  parent: existingServiceBusNamespace
+  name: upstreamQueueName
+}
+
+resource existingDownstreamQueue 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' existing = {
+  parent: existingServiceBusNamespace
+  name: downstreamQueueName
+}
+
+resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource existingTableService 'Microsoft.Storage/storageAccounts/tableServices@2023-05-01' existing = {
+  parent: existingStorageAccount
+  name: 'default'
+}
+
+resource existingStorageTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' existing = {
+  parent: existingTableService
+  name: tableName
+}
+
+resource companionUpstreamSender 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: companionUpstreamSenderAssignmentName
+  scope: existingUpstreamQueue
+  properties: {
+    principalId: companionServicePrincipalObjectId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: serviceBusDataSenderRoleId
+  }
+}
+
+resource companionDownstreamReceiver 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: companionDownstreamReceiverAssignmentName
+  scope: existingDownstreamQueue
+  properties: {
+    principalId: companionServicePrincipalObjectId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: serviceBusDataReceiverRoleId
+  }
+}
+
+resource functionUpstreamReceiver 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: functionUpstreamReceiverAssignmentName
+  scope: existingUpstreamQueue
+  properties: {
+    principalId: functionPlaceholder.outputs.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: serviceBusDataReceiverRoleId
+  }
+}
+
+resource functionDownstreamSender 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: functionDownstreamSenderAssignmentName
+  scope: existingDownstreamQueue
+  properties: {
+    principalId: functionPlaceholder.outputs.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: serviceBusDataSenderRoleId
+  }
+}
+
+resource functionTableContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: functionTableContributorAssignmentName
+  scope: existingStorageTable
+  properties: {
+    principalId: functionPlaceholder.outputs.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageTableDataContributorRoleId
+  }
+}
+
+output serviceBusNamespaceName string = serviceBus.outputs.namespaceName
+output upstreamQueueName string = serviceBus.outputs.upstreamQueueName
+output downstreamQueueName string = serviceBus.outputs.downstreamQueueName
+output storageAccountName string = storage.outputs.storageAccountName
+output tableName string = storage.outputs.tableName
+output functionAppName string = functionPlaceholder.outputs.functionAppName
+output functionPrincipalId string = functionPlaceholder.outputs.principalId

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -35,12 +35,8 @@ param companionServicePrincipalObjectId string
 
 var serviceBusDataSenderRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39')
 var serviceBusDataReceiverRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0')
-var storageTableDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3')
 var companionUpstreamSenderAssignmentName = guid('companion-upstream-sender', companionServicePrincipalObjectId, serviceBusDataSenderRoleId, serviceBusNamespaceName, upstreamQueueName)
 var companionDownstreamReceiverAssignmentName = guid('companion-downstream-receiver', companionServicePrincipalObjectId, serviceBusDataReceiverRoleId, serviceBusNamespaceName, downstreamQueueName)
-var functionUpstreamReceiverAssignmentName = guid('function-upstream-receiver', functionAppName, serviceBusDataReceiverRoleId, serviceBusNamespaceName, upstreamQueueName)
-var functionDownstreamSenderAssignmentName = guid('function-downstream-sender', functionAppName, serviceBusDataSenderRoleId, serviceBusNamespaceName, downstreamQueueName)
-var functionTableContributorAssignmentName = guid('function-table-contributor', functionAppName, storageTableDataContributorRoleId, storageAccountName, tableName)
 var deploymentStorageContainerName = toLower(take('app-package-${take(functionAppName, 32)}-${take(uniqueString(resourceGroup().id, functionAppName), 7)}', 63))
 
 module serviceBus './service-bus.bicep' = {
@@ -94,20 +90,6 @@ resource existingDownstreamQueue 'Microsoft.ServiceBus/namespaces/queues@2024-01
   name: downstreamQueueName
 }
 
-resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
-  name: storageAccountName
-}
-
-resource existingTableService 'Microsoft.Storage/storageAccounts/tableServices@2023-05-01' existing = {
-  parent: existingStorageAccount
-  name: 'default'
-}
-
-resource existingStorageTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' existing = {
-  parent: existingTableService
-  name: tableName
-}
-
 resource companionUpstreamSender 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: companionUpstreamSenderAssignmentName
   scope: existingUpstreamQueue
@@ -134,40 +116,21 @@ resource companionDownstreamReceiver 'Microsoft.Authorization/roleAssignments@20
   }
 }
 
-resource functionUpstreamReceiver 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: functionUpstreamReceiverAssignmentName
-  scope: existingUpstreamQueue
+module functionRbac './function-rbac.bicep' = {
+  name: 'functionRbac'
+  params: {
+    functionPrincipalId: functionPlaceholder.outputs.principalId
+    serviceBusNamespaceName: serviceBusNamespaceName
+    upstreamQueueName: upstreamQueueName
+    downstreamQueueName: downstreamQueueName
+    storageAccountName: storageAccountName
+    tableName: tableName
+  }
   dependsOn: [
     serviceBus
+    storage
+    functionPlaceholder
   ]
-  properties: {
-    principalId: functionPlaceholder.outputs.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: serviceBusDataReceiverRoleId
-  }
-}
-
-resource functionDownstreamSender 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: functionDownstreamSenderAssignmentName
-  scope: existingDownstreamQueue
-  dependsOn: [
-    serviceBus
-  ]
-  properties: {
-    principalId: functionPlaceholder.outputs.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: serviceBusDataSenderRoleId
-  }
-}
-
-resource functionTableContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: functionTableContributorAssignmentName
-  scope: existingStorageTable
-  properties: {
-    principalId: functionPlaceholder.outputs.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: storageTableDataContributorRoleId
-  }
 }
 
 output serviceBusNamespaceName string = serviceBus.outputs.namespaceName

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -33,14 +33,15 @@ param functionPlanName string
 @description('Object ID of the Azure companion runtime service principal.')
 param companionServicePrincipalObjectId string
 
-var serviceBusDataSenderRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e1ecfa86-44a4-4fa6-9e13-a6f4d06e2913')
-var serviceBusDataReceiverRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde')
-var storageTableDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b00c-4d22-95b9-937d2d07ed72')
+var serviceBusDataSenderRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39')
+var serviceBusDataReceiverRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0')
+var storageTableDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3')
 var companionUpstreamSenderAssignmentName = guid('companion-upstream-sender', companionServicePrincipalObjectId, serviceBusDataSenderRoleId, serviceBusNamespaceName, upstreamQueueName)
 var companionDownstreamReceiverAssignmentName = guid('companion-downstream-receiver', companionServicePrincipalObjectId, serviceBusDataReceiverRoleId, serviceBusNamespaceName, downstreamQueueName)
 var functionUpstreamReceiverAssignmentName = guid('function-upstream-receiver', functionAppName, serviceBusDataReceiverRoleId, serviceBusNamespaceName, upstreamQueueName)
 var functionDownstreamSenderAssignmentName = guid('function-downstream-sender', functionAppName, serviceBusDataSenderRoleId, serviceBusNamespaceName, downstreamQueueName)
 var functionTableContributorAssignmentName = guid('function-table-contributor', functionAppName, storageTableDataContributorRoleId, storageAccountName, tableName)
+var deploymentStorageContainerName = toLower(take('app-package-${take(functionAppName, 32)}-${take(uniqueString(resourceGroup().id, functionAppName), 7)}', 63))
 
 module serviceBus './service-bus.bicep' = {
   name: 'serviceBus'
@@ -59,11 +60,13 @@ module storage './storage.bicep' = {
     location: location
     storageAccountName: storageAccountName
     tableName: tableName
+    deploymentContainerName: deploymentStorageContainerName
     tags: tags
   }
 }
 
 var functionStorageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storage.outputs.storageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storage.outputs.primaryKey}'
+var functionDeploymentContainerUrl = '${storage.outputs.blobEndpoint}${storage.outputs.deploymentContainerName}'
 
 module functionPlaceholder './function-placeholder.bicep' = {
   name: 'functionPlaceholder'
@@ -71,6 +74,7 @@ module functionPlaceholder './function-placeholder.bicep' = {
     location: location
     functionAppName: functionAppName
     functionPlanName: functionPlanName
+    deploymentContainerUrl: functionDeploymentContainerUrl
     storageConnectionString: functionStorageConnectionString
     tags: tags
   }
@@ -107,6 +111,9 @@ resource existingStorageTable 'Microsoft.Storage/storageAccounts/tableServices/t
 resource companionUpstreamSender 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: companionUpstreamSenderAssignmentName
   scope: existingUpstreamQueue
+  dependsOn: [
+    serviceBus
+  ]
   properties: {
     principalId: companionServicePrincipalObjectId
     principalType: 'ServicePrincipal'
@@ -117,6 +124,9 @@ resource companionUpstreamSender 'Microsoft.Authorization/roleAssignments@2022-0
 resource companionDownstreamReceiver 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: companionDownstreamReceiverAssignmentName
   scope: existingDownstreamQueue
+  dependsOn: [
+    serviceBus
+  ]
   properties: {
     principalId: companionServicePrincipalObjectId
     principalType: 'ServicePrincipal'
@@ -127,6 +137,9 @@ resource companionDownstreamReceiver 'Microsoft.Authorization/roleAssignments@20
 resource functionUpstreamReceiver 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: functionUpstreamReceiverAssignmentName
   scope: existingUpstreamQueue
+  dependsOn: [
+    serviceBus
+  ]
   properties: {
     principalId: functionPlaceholder.outputs.principalId
     principalType: 'ServicePrincipal'
@@ -137,6 +150,9 @@ resource functionUpstreamReceiver 'Microsoft.Authorization/roleAssignments@2022-
 resource functionDownstreamSender 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: functionDownstreamSenderAssignmentName
   scope: existingDownstreamQueue
+  dependsOn: [
+    serviceBus
+  ]
   properties: {
     principalId: functionPlaceholder.outputs.principalId
     principalType: 'ServicePrincipal'

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -37,7 +37,7 @@ var serviceBusDataSenderRoleId = subscriptionResourceId('Microsoft.Authorization
 var serviceBusDataReceiverRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0')
 var companionUpstreamSenderAssignmentName = guid('companion-upstream-sender', companionServicePrincipalObjectId, serviceBusDataSenderRoleId, serviceBusNamespaceName, upstreamQueueName)
 var companionDownstreamReceiverAssignmentName = guid('companion-downstream-receiver', companionServicePrincipalObjectId, serviceBusDataReceiverRoleId, serviceBusNamespaceName, downstreamQueueName)
-var deploymentStorageContainerName = toLower(take('app-package-${take(functionAppName, 32)}-${take(uniqueString(resourceGroup().id, functionAppName), 7)}', 63))
+var deploymentStorageContainerName = 'app-package-${take(uniqueString(resourceGroup().id, functionAppName, 'deployment-package'), 20)}'
 
 module serviceBus './service-bus.bicep' = {
   name: 'serviceBus'

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -61,7 +61,6 @@ module storage './storage.bicep' = {
   }
 }
 
-var functionStorageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storage.outputs.storageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storage.outputs.primaryKey}'
 var functionDeploymentContainerUrl = '${storage.outputs.blobEndpoint}${storage.outputs.deploymentContainerName}'
 
 module functionPlaceholder './function-placeholder.bicep' = {
@@ -71,7 +70,7 @@ module functionPlaceholder './function-placeholder.bicep' = {
     functionAppName: functionAppName
     functionPlanName: functionPlanName
     deploymentContainerUrl: functionDeploymentContainerUrl
-    storageConnectionString: functionStorageConnectionString
+    storageAccountName: storage.outputs.storageAccountName
     tags: tags
   }
 }

--- a/deploy/bicep/modules/storage.bicep
+++ b/deploy/bicep/modules/storage.bicep
@@ -12,6 +12,9 @@ param storageAccountName string
 @description('Table name reserved for decoded data.')
 param tableName string
 
+@description('Blob container name used by the placeholder Function App deployment slot.')
+param deploymentContainerName string
+
 @description('Tags applied to provisioned resources.')
 param tags object
 
@@ -36,6 +39,19 @@ resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2023-05-0
   name: 'default'
 }
 
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: deploymentContainerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
 resource storageTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
   parent: tableService
   name: tableName
@@ -48,5 +64,8 @@ resource storageTable 'Microsoft.Storage/storageAccounts/tableServices/tables@20
 output primaryKey string = storageAccount.listKeys().keys[0].value
 output storageAccountName string = storageAccount.name
 output storageAccountResourceId string = storageAccount.id
+output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob
+output deploymentContainerName string = deploymentContainer.name
+output deploymentContainerResourceId string = deploymentContainer.id
 output tableName string = storageTable.name
 output tableResourceId string = storageTable.id

--- a/deploy/bicep/modules/storage.bicep
+++ b/deploy/bicep/modules/storage.bicep
@@ -60,8 +60,6 @@ resource storageTable 'Microsoft.Storage/storageAccounts/tableServices/tables@20
   }
 }
 
-@secure()
-output primaryKey string = storageAccount.listKeys().keys[0].value
 output storageAccountName string = storageAccount.name
 output storageAccountResourceId string = storageAccount.id
 output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob

--- a/deploy/bicep/modules/storage.bicep
+++ b/deploy/bicep/modules/storage.bicep
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+targetScope = 'resourceGroup'
+
+@description('Azure region for the Storage resources.')
+param location string
+
+@description('Storage Account name.')
+param storageAccountName string
+
+@description('Table name reserved for decoded data.')
+param tableName string
+
+@description('Tags applied to provisioned resources.')
+param tags object
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource storageTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
+  parent: tableService
+  name: tableName
+  properties: {
+    signedIdentifiers: []
+  }
+}
+
+@secure()
+output primaryKey string = storageAccount.listKeys().keys[0].value
+output storageAccountName string = storageAccount.name
+output storageAccountResourceId string = storageAccount.id
+output tableName string = storageTable.name
+output tableResourceId string = storageTable.id

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -9,7 +9,8 @@
 > and broker resources is outside this document's scope.
 > **Audience:** Implementers building the Azure companion crate and its
 > deployment artifacts.
-> **Related:** [azure-companion-requirements.md](azure-companion-requirements.md),
+> **Related:** [azure-provisioning-design.md](azure-provisioning-design.md),
+> [azure-companion-requirements.md](azure-companion-requirements.md),
 > [gateway-companion-api.md](gateway-companion-api.md),
 > [gateway-design.md](gateway-design.md)
 

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -11,7 +11,8 @@
 > The internal Azure provisioning workflow that creates the runtime certificate
 > and private key, Entra application/service principal, and Service Bus
 > resources is out of scope for this document.
-> **Related:** [gateway-companion-api.md](gateway-companion-api.md),
+> **Related:** [azure-provisioning-requirements.md](azure-provisioning-requirements.md),
+> [gateway-companion-api.md](gateway-companion-api.md),
 > [gateway-requirements.md](gateway-requirements.md),
 > [gateway-design.md](gateway-design.md)
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -9,7 +9,8 @@
 > broker resources are outside this document's scope.
 > **Audience:** Implementers and reviewers validating the Azure companion
 > bootstrap and runtime bridge behavior.
-> **Related:** [azure-companion-requirements.md](azure-companion-requirements.md),
+> **Related:** [azure-provisioning-validation.md](azure-provisioning-validation.md),
+> [azure-companion-requirements.md](azure-companion-requirements.md),
 > [azure-companion-design.md](azure-companion-design.md),
 > [gateway-validation.md](gateway-validation.md)
 

--- a/docs/azure-provisioning-design.md
+++ b/docs/azure-provisioning-design.md
@@ -96,6 +96,9 @@ The design keeps the queue names explicit deployment outputs so bootstrap and
 runtime configuration can consume them directly rather than relying on embedded
 defaults inside `sonde-azure-companion`. The default namespace tier is
 Standard.
+The namespace disables local/SAS authentication by default so steady-state
+access is mediated through Entra identities and the scoped RBAC grants defined
+elsewhere in this design.
 
 ### 3.4  Storage resources
 
@@ -107,6 +110,9 @@ The storage module provisions:
 This module intentionally stops at resource creation. It does not define the
 table's logical schema, retention semantics, or decoded-column contract; those
 belong to the later Azure Function work that will own decode/storage behavior.
+When the Function placeholder needs storage credentials for deployment wiring,
+the design keeps that secret handling inside the consuming module rather than
+surfacing raw account keys as deployment outputs.
 
 ### 3.5  Function placeholder resources
 

--- a/docs/azure-provisioning-design.md
+++ b/docs/azure-provisioning-design.md
@@ -1,0 +1,253 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Azure Provisioning Design Specification
+
+> **Document status:** Draft
+> **Scope:** Design for the Azure provisioning workflow that supports the Azure
+> companion deployment model: Bicep-managed resource provisioning, runtime
+> identity setup, and bootstrap handoff artifacts.
+> **Audience:** Implementers building the provisioning workflow under
+> `deploy/bicep/`.
+> **Related:** [azure-provisioning-requirements.md](azure-provisioning-requirements.md),
+> [azure-provisioning-validation.md](azure-provisioning-validation.md),
+> [azure-companion-requirements.md](azure-companion-requirements.md),
+> [azure-companion-design.md](azure-companion-design.md)
+
+---
+
+## 1  Overview
+
+The Azure provisioning workflow exists to supply the Azure-side prerequisites
+for the current Azure companion architecture. It is not the runtime bridge
+itself; instead, it provisions the resources and identity material that let the
+bootstrap and runtime paths described in `azure-companion-design.md` operate.
+
+This document therefore separates the problem into three layers:
+
+1. **Resource-plane provisioning** via Bicep for Service Bus, Storage, and
+   Function placeholder resources.
+2. **Runtime identity provisioning** for the certificate-authenticated Entra
+   application/service principal used by `sonde-azure-companion`.
+3. **Bootstrap handoff** that turns Azure deployment outputs into the local
+   runtime artifacts consumed by the Azure companion container.
+
+---
+
+## 2  Repository layout
+
+> **Requirements:** AZP-0100
+
+The provisioning work is rooted under `deploy/bicep/`.
+
+The design assumes this layout:
+
+| Artifact | Purpose |
+|----------|---------|
+| `deploy/bicep/main.bicep` | Top-level deployment entrypoint. |
+| `deploy/bicep/modules/service-bus.bicep` | Service Bus namespace and queue provisioning. |
+| `deploy/bicep/modules/storage.bicep` | Storage Account and Table resource provisioning. |
+| `deploy/bicep/modules/function-placeholder.bicep` | Placeholder Function hosting resources for the later decoder issue. |
+| `deploy/bicep/modules/identity.*` | Runtime identity provisioning artifacts or wrappers used by the Bicep-driven workflow. |
+| `deploy/bicep/README.md` or equivalent inline deployment documentation | Operator-facing description of inputs, outputs, and post-deploy handoff. |
+
+The exact file count is not normative. The important design constraint is that
+the repository exposes one Bicep-rooted deployment surface rather than a mix of
+unrelated ad hoc provisioning entrypoints.
+
+---
+
+## 3  Deployment model
+
+> **Requirements:** AZP-0100, AZP-0101, AZP-0102, AZP-0103, AZP-0104, AZP-0300, AZP-0301
+
+### 3.1  Inputs
+
+The top-level deployment accepts these caller-provided inputs:
+
+| Input | Purpose |
+|-------|---------|
+| `location` | Azure region for the stack. Default: `eastus`. |
+| `project_name` | Resource-name prefix and default project tag value. Default: `sonde`. |
+| `resource_group_name` | Optional override for the target resource group name. |
+
+The deployment may accept additional inputs as implementation details, but
+those three are the required stable interface inherited from issue #772.
+Derived resource names may normalize `project_name` as needed to satisfy Azure
+provider naming constraints while preserving the caller-visible deployment
+interface.
+
+### 3.2  Resource group and tagging
+
+The deployment targets one resource group for the Azure companion stack. If the
+caller does not supply `resource_group_name`, the workflow derives one from
+`project_name`. All resource-plane resources managed by this workflow inherit a
+common tag set whose required baseline entry is `project = sonde` unless the
+caller intentionally overrides the project value.
+
+### 3.3  Service Bus resources
+
+The Service Bus module provisions:
+
+1. one namespace,
+2. one upstream queue for gateway-originated connector traffic, and
+3. one downstream queue for desired-state ingress.
+
+The design keeps the queue names explicit deployment outputs so bootstrap and
+runtime configuration can consume them directly rather than relying on embedded
+defaults inside `sonde-azure-companion`. The default namespace tier is
+Standard.
+
+### 3.4  Storage resources
+
+The storage module provisions:
+
+1. one Storage Account, and
+2. the Table resource reserved for later decoded-data persistence.
+
+This module intentionally stops at resource creation. It does not define the
+table's logical schema, retention semantics, or decoded-column contract; those
+belong to the later Azure Function work that will own decode/storage behavior.
+
+### 3.5  Function placeholder resources
+
+The function-placeholder module provisions the hosting resources that reserve
+space for the later decoder Function App. This module may create the Function
+App shell, a consumption hosting plan, storage linkage, and placeholder app
+settings, but it must not depend on the later function code package being
+present in this issue.
+
+---
+
+## 4  Runtime identity provisioning
+
+> **Requirements:** AZP-0200, AZP-0201, AZP-0202
+
+The current Azure companion runtime design uses a certificate-authenticated
+Entra application/service principal rather than managed identity. The
+provisioning workflow therefore needs an identity phase in addition to the
+resource-plane Bicep modules.
+
+### 4.1  Identity model
+
+The runtime identity consists of:
+
+1. an Entra application registration,
+2. its corresponding service principal,
+3. a certificate credential bound to that application identity, and
+4. Service Bus permissions aligned with the bridge's upstream send and
+   downstream receive/settle behavior.
+
+### 4.2  Bicep boundary
+
+The Bicep workflow is the canonical deployment surface, but the design does not
+assume that every Entra and certificate operation can or should be expressed as
+pure resource-plane declarations. Instead, the workflow may include an adjunct
+identity step as long as:
+
+1. the overall operator entrypoint remains Bicep-rooted,
+2. the identity step is repository-owned and documented, and
+3. the resulting artifacts and outputs satisfy the bootstrap handoff contract.
+
+This keeps the requirements honest about the difference between Azure
+resource-plane provisioning and Entra/certificate lifecycle work, while still
+treating both as part of the same issue.
+
+### 4.3  Role assignments
+
+The identity step must assign only the Service Bus permissions required by the
+Azure companion bridge:
+
+1. send to the upstream queue, and
+2. receive and settle on the downstream queue.
+
+The design intentionally avoids broader "owner" or "administrator" roles for
+normal runtime operation.
+
+### 4.4  Function placeholder identity
+
+The placeholder Function App uses its own system-assigned managed identity. It
+is not reused as the Azure companion runtime identity, because the two
+processes have different trust boundaries and different steady-state
+permissions.
+
+The Function App identity receives the narrow data-plane permissions needed by
+the later decoder/control-plane path:
+
+1. receive from the upstream queue,
+2. send on the downstream queue, and
+3. write decoded records to the reserved Table Storage resource.
+
+The design keeps these grants scoped to the resources actually used by the
+Function App rather than assigning broader namespace-wide or account-wide
+administrator privileges.
+
+---
+
+## 5  Bootstrap handoff contract
+
+> **Requirements:** AZP-0203, AZP-0300
+
+The Azure provisioning workflow must end with a documented handoff that
+bootstrap can use to create the runtime-state files expected by
+`sonde-azure-companion`.
+
+### 5.1  Required handoff values
+
+The handoff contract includes:
+
+| Value | Consumer |
+|-------|----------|
+| Entra tenant ID | `service-principal.json` |
+| Entra client ID | `service-principal.json` |
+| Certificate reference or exported PEM | certificate PEM material used by the runtime |
+| Private-key reference or exported PEM | private-key PEM material used by the runtime |
+| Service Bus namespace | Azure companion runtime configuration |
+| Upstream queue name | Azure companion runtime configuration |
+| Downstream queue name | Azure companion runtime configuration |
+
+### 5.2  Local artifact compatibility
+
+The handoff is complete only when the provisioning workflow's outputs can be
+translated into the local runtime artifact shape already defined by the Azure
+companion specs:
+
+1. `service-principal.json`,
+2. certificate PEM, and
+3. private-key PEM.
+
+This document does not require the Bicep deployment itself to write those files
+onto the gateway host. It does require the design to define how the deployment
+workflow makes the necessary values available to the bootstrap path that does.
+
+---
+
+## 6  Outputs and lifecycle
+
+> **Requirements:** AZP-0100, AZP-0102, AZP-0103, AZP-0104, AZP-0300, AZP-0301
+
+### 6.1  Outputs
+
+The top-level workflow exposes or documents the following outputs:
+
+1. resource group name,
+2. Service Bus namespace name,
+3. upstream queue name,
+4. downstream queue name,
+5. Storage Account name,
+6. Table resource name,
+7. Function placeholder resource identity, and
+8. the runtime identity / bootstrap handoff values described in section 5.
+
+### 6.2  Idempotency
+
+Repeated deployment runs converge the stack instead of duplicating foundational
+resources. Any intentionally one-time or manually managed identity/certificate
+operations must be called out explicitly in the deployment documentation.
+
+### 6.3  Teardown
+
+Teardown removes the resource-plane stack or clearly documents any intentionally
+retained artifacts. If some identity artifacts cannot be safely removed by the
+same workflow, the teardown documentation must say so plainly rather than
+pretending full cleanup occurred.
+

--- a/docs/azure-provisioning-requirements.md
+++ b/docs/azure-provisioning-requirements.md
@@ -1,0 +1,262 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Azure Provisioning Requirements Specification
+
+> **Document status:** Draft
+> **Source:** [issue #772](https://github.com/Alan-Jowett/sonde/issues/772),
+> discovery review for the Azure companion architecture, and
+> [azure-companion-requirements.md](azure-companion-requirements.md).
+> **Scope:** This document covers the Azure-side provisioning workflow for the
+> Azure companion deployment model: Bicep-managed resource provisioning,
+> companion runtime identity provisioning, and the bootstrap handoff contract
+> needed by `sonde-azure-companion`. It does not define Azure Function decoder
+> logic, table schema semantics, or dashboarding.
+> **Related:** [azure-provisioning-design.md](azure-provisioning-design.md),
+> [azure-provisioning-validation.md](azure-provisioning-validation.md),
+> [azure-companion-requirements.md](azure-companion-requirements.md),
+> [azure-companion-design.md](azure-companion-design.md)
+
+---
+
+## 1  Definitions
+
+| Term | Definition |
+|------|------------|
+| **Azure provisioning workflow** | The repository-owned deployment workflow that creates the Azure resources and identity material required by the Azure companion architecture. |
+| **Bicep root deployment** | The top-level Bicep entrypoint under `deploy/bicep/` that composes the provisioning modules for this workflow. |
+| **Runtime identity bundle** | The Entra tenant/client identity plus certificate-authenticated service-principal material required for the Azure companion runtime after bootstrap completes. |
+| **Bootstrap handoff contract** | The defined set of outputs and artifact locations that lets bootstrap materialize `service-principal.json`, certificate PEM, and private-key PEM for `sonde-azure-companion`. |
+| **Function placeholder** | Azure Function hosting resources reserved for a later decoder implementation, without requiring the decoder code to exist in this issue. |
+| **Storage resources** | The Azure Storage Account and Table resources reserved for later decoded-data persistence. This document covers only their provisioning, not the logical table schema. |
+
+---
+
+## 2  Requirement format
+
+Each requirement uses the following fields:
+
+- **ID** — Unique identifier (`AZP-XXXX`).
+- **Title** — Short name.
+- **Description** — What the provisioning workflow must do.
+- **Acceptance criteria** — Observable, testable conditions that confirm the requirement is met.
+- **Priority** — MoSCoW: **Must**, **Should**, **May**.
+- **Source** — Issue, companion specification, or reviewed discovery output that motivates the requirement.
+
+---
+
+## 3  Bicep deployment structure
+
+### AZP-0100  Bicep-based provisioning entrypoint
+
+**Priority:** Must
+**Source:** [issue #772](https://github.com/Alan-Jowett/sonde/issues/772), reviewed discovery output
+
+**Description:**
+The repository MUST provide a Bicep-based provisioning entrypoint under
+`deploy/bicep/` for the Azure companion deployment model. The Bicep workflow
+MUST be the canonical infrastructure-as-code surface for this issue.
+
+**Acceptance criteria:**
+
+1. The repository contains a top-level Bicep deployment entrypoint under `deploy/bicep/`.
+2. The deployment exposes `location`, `project_name`, and `resource_group_name` inputs.
+3. The default `location` is `eastus` unless the caller overrides it.
+4. The default `project_name` is `sonde` unless the caller overrides it.
+5. `resource_group_name` remains an optional override rather than a required input.
+6. The deployment can render a plan/what-if view of the resources it intends to create.
+7. When the workflow derives resource names from `project_name`, it documents or applies any normalization needed to satisfy Azure provider naming rules.
+8. The deployment documentation identifies the parameters and outputs required for Azure companion provisioning.
+
+---
+
+### AZP-0101  Resource group and tagging
+
+**Priority:** Must
+**Source:** [issue #772](https://github.com/Alan-Jowett/sonde/issues/772)
+
+**Description:**
+The provisioning workflow MUST create or target a dedicated Azure resource group
+for the Sonde Azure companion stack and MUST tag the managed Azure resources
+with `project = sonde` by default.
+
+**Acceptance criteria:**
+
+1. The workflow can create a dedicated resource group when one does not already exist.
+2. The workflow can target a caller-specified resource-group override instead of inventing a second group.
+3. Service Bus, Storage, and Function placeholder resources deployed by this workflow carry the `project = sonde` tag unless the caller overrides the value explicitly.
+
+---
+
+### AZP-0102  Service Bus namespace and queues
+
+**Priority:** Must
+**Source:** [issue #772](https://github.com/Alan-Jowett/sonde/issues/772), AZC-0302, AZC-0304
+
+**Description:**
+The provisioning workflow MUST create the Azure Service Bus resources required
+by the Azure companion runtime: one namespace plus one upstream queue and one
+downstream queue. The namespace uses the Standard tier unless the caller
+explicitly opts into a different supported tier.
+
+**Acceptance criteria:**
+
+1. The workflow provisions one Service Bus namespace.
+2. The workflow provisions one upstream queue for gateway-originated connector traffic.
+3. The workflow provisions one downstream queue for cloud-originated desired-state traffic.
+4. The default namespace tier is Standard.
+5. The workflow exposes the namespace and queue names as deployment outputs or documented post-deploy values consumable by Azure companion bootstrap/runtime configuration.
+
+---
+
+### AZP-0103  Storage account and table resources
+
+**Priority:** Must
+**Source:** [issue #772](https://github.com/Alan-Jowett/sonde/issues/772), reviewed discovery output
+
+**Description:**
+The provisioning workflow MUST create the Azure Storage resources reserved for
+later decoded-data persistence: a Storage Account and the required Table
+resource. This issue does not define the table's logical schema.
+
+**Acceptance criteria:**
+
+1. The workflow provisions one Azure Storage Account for this stack.
+2. The workflow provisions the Table resource needed by the later decoder path.
+3. The workflow documents that table schema ownership is deferred to the later Azure Function issue and is not defined by this provisioning specification.
+
+---
+
+### AZP-0104  Function placeholder infrastructure
+
+**Priority:** Must
+**Source:** [issue #772](https://github.com/Alan-Jowett/sonde/issues/772), reviewed discovery output
+
+**Description:**
+The provisioning workflow MUST create placeholder Azure Function hosting
+resources for the later decoder implementation without requiring the decoder
+code to exist in this issue. The placeholder Function App uses a consumption
+plan unless a later issue explicitly changes that hosting model.
+
+**Acceptance criteria:**
+
+1. The workflow provisions the Azure resources needed to host the later decoder Function App.
+2. The workflow does not require the decoder function code package to exist in order to deploy the placeholder resources.
+3. The placeholder Function App resources use a consumption-plan hosting model.
+4. The deployment outputs or documentation identify the placeholder Function App resources reserved for the later issue.
+
+---
+
+## 4  Runtime identity and bootstrap handoff
+
+### AZP-0200  Certificate-authenticated runtime identity
+
+**Priority:** Must
+**Source:** reviewed discovery output, AZC-0305
+
+**Description:**
+The provisioning workflow MUST define and provision the Azure runtime identity
+model required by `sonde-azure-companion`: an Entra application/service
+principal that authenticates with a certificate rather than managed identity or
+interactive login during normal runtime operation.
+
+**Acceptance criteria:**
+
+1. The workflow creates or configures an Entra application/service principal for the Azure companion runtime.
+2. The workflow defines certificate-based authentication material for that identity.
+3. The workflow does not require Azure managed identity, Azure Arc, or interactive device login for steady-state runtime authentication.
+
+---
+
+### AZP-0201  Service Bus role assignments for bridge directions
+
+**Priority:** Must
+**Source:** reviewed discovery output, AZC-0304, AZC-0308
+
+**Description:**
+The provisioning workflow MUST assign Service Bus permissions that match the
+Azure companion bridge's bidirectional behavior: upstream publish plus
+downstream consume and settlement.
+
+**Acceptance criteria:**
+
+1. The runtime identity can send messages to the configured upstream queue.
+2. The runtime identity can receive and settle messages from the configured downstream queue.
+3. The documented permissions align with the Azure companion bridge responsibilities and do not rely on unrelated administrator privileges.
+
+---
+
+### AZP-0202  Function placeholder managed identity and data-plane RBAC
+
+**Priority:** Must
+**Source:** reviewed discovery output
+
+**Description:**
+The provisioning workflow MUST attach a system-assigned managed identity to the
+placeholder Azure Function App and grant only the data-plane permissions needed
+for the later decoder/control-plane function path: receive from the upstream
+queue, send on the downstream queue, and write decoded records to Table
+Storage.
+
+**Acceptance criteria:**
+
+1. The placeholder Function App has a system-assigned managed identity.
+2. That identity can receive messages from the configured upstream queue.
+3. That identity can send messages to the configured downstream queue.
+4. That identity can write to the Storage Table reserved for decoded data.
+5. The Function App identity is distinct from the Azure companion runtime identity unless a later specification explicitly merges them.
+
+---
+
+### AZP-0203  Bootstrap handoff contract
+
+**Priority:** Must
+**Source:** reviewed discovery output, AZC-0200, AZC-0305
+
+**Description:**
+The provisioning workflow MUST define a handoff contract that lets Azure
+companion bootstrap produce the local runtime artifacts expected by
+`sonde-azure-companion`, including `service-principal.json`, certificate PEM,
+and private-key PEM.
+
+**Acceptance criteria:**
+
+1. The workflow documents which values and artifacts must be handed off to bootstrap for runtime starts.
+2. The handoff contract includes the tenant ID, client ID, certificate reference or material, private-key reference or material, and Service Bus namespace/queue configuration.
+3. The handoff contract is compatible with the current Azure companion runtime expectations in `azure-companion-requirements.md`.
+
+---
+
+## 5  Lifecycle behavior
+
+### AZP-0300  Idempotent deployment workflow
+
+**Priority:** Must
+**Source:** [issue #772](https://github.com/Alan-Jowett/sonde/issues/772), [issue #771](https://github.com/Alan-Jowett/sonde/issues/771)
+
+**Description:**
+The Bicep-based provisioning workflow MUST support repeatable deployment of the
+Azure companion infrastructure without requiring manual cleanup between runs.
+
+**Acceptance criteria:**
+
+1. Re-running the deployment against an already-provisioned stack succeeds without creating duplicate foundational resources.
+2. The deployment documentation identifies any resources whose updates are intentionally constrained or one-time.
+3. The workflow surfaces deployment failures rather than silently masking them.
+
+---
+
+### AZP-0301  Removable stack
+
+**Priority:** Must
+**Source:** [issue #772](https://github.com/Alan-Jowett/sonde/issues/772)
+
+**Description:**
+The provisioning workflow SHOULD support removal of the Azure resources it
+created for this stack or document any intentionally retained artifacts that
+require explicit manual handling.
+
+**Acceptance criteria:**
+
+1. The documented teardown path removes the resource-plane infrastructure created for this stack, or clearly enumerates any retained artifacts.
+2. Teardown behavior is documented for Service Bus, Storage, and Function placeholder resources.
+

--- a/docs/azure-provisioning-requirements.md
+++ b/docs/azure-provisioning-requirements.md
@@ -105,6 +105,7 @@ explicitly opts into a different supported tier.
 3. The workflow provisions one downstream queue for cloud-originated desired-state traffic.
 4. The default namespace tier is Standard.
 5. The workflow exposes the namespace and queue names as deployment outputs or documented post-deploy values consumable by Azure companion bootstrap/runtime configuration.
+6. The default namespace configuration disables local/SAS authentication so Entra-based RBAC is the only steady-state access path unless a later specification explicitly broadens it.
 
 ---
 
@@ -123,6 +124,7 @@ resource. This issue does not define the table's logical schema.
 1. The workflow provisions one Azure Storage Account for this stack.
 2. The workflow provisions the Table resource needed by the later decoder path.
 3. The workflow documents that table schema ownership is deferred to the later Azure Function issue and is not defined by this provisioning specification.
+4. The workflow does not expose raw Storage Account keys in deployment outputs or bootstrap handoff values.
 
 ---
 

--- a/docs/azure-provisioning-validation.md
+++ b/docs/azure-provisioning-validation.md
@@ -1,0 +1,159 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Azure Provisioning Validation Specification
+
+> **Document status:** Draft
+> **Scope:** Validation for the Azure provisioning workflow that supports the
+> Azure companion deployment model.
+> **Audience:** Implementers and reviewers validating the Bicep workflow,
+> runtime identity provisioning, and bootstrap handoff behavior.
+> **Related:** [azure-provisioning-requirements.md](azure-provisioning-requirements.md),
+> [azure-provisioning-design.md](azure-provisioning-design.md),
+> [azure-companion-validation.md](azure-companion-validation.md)
+
+---
+
+## 1  Test cases
+
+### T-AZP-0100  Bicep entrypoint renders the planned stack
+
+**Validates:** AZP-0100
+
+**Procedure:**
+1. Invoke the top-level deployment entrypoint under `deploy/bicep/` with test values for `location`, `project_name`, and `resource_group_name`.
+2. Run the Bicep validation or what-if path supported by the workflow.
+3. Assert: the plan includes the foundational resources defined by this specification.
+4. Assert: the documented defaults for `location` and `project_name` are `eastus` and `sonde`.
+5. Assert: the deployment inputs and outputs are documented.
+
+---
+
+### T-AZP-0101  Resource group and tags are applied
+
+**Validates:** AZP-0101
+
+**Procedure:**
+1. Deploy the workflow into a test subscription or resource group.
+2. Inspect the resulting resource group and managed resources.
+3. Assert: the deployment targets the expected resource group.
+4. Assert: Service Bus, Storage, and Function placeholder resources carry the required `project = sonde` tag unless a deliberate override was supplied.
+
+---
+
+### T-AZP-0102  Service Bus namespace and queues are provisioned
+
+**Validates:** AZP-0102
+
+**Procedure:**
+1. Deploy the workflow.
+2. Inspect the resulting Service Bus resources.
+3. Assert: one namespace exists for the stack.
+4. Assert: one upstream queue and one downstream queue exist.
+5. Assert: the namespace uses the Standard tier by default.
+6. Assert: the queue names are available through deployment outputs or documented post-deploy values.
+
+---
+
+### T-AZP-0103  Storage resources are provisioned without schema coupling
+
+**Validates:** AZP-0103
+
+**Procedure:**
+1. Deploy the workflow.
+2. Inspect the resulting Storage Account and Table resources.
+3. Assert: the Storage Account exists.
+4. Assert: the Table resource exists.
+5. Assert: the provisioning documentation explicitly defers logical table schema ownership to the later Azure Function work.
+
+---
+
+### T-AZP-0104  Function placeholder resources deploy without decoder code
+
+**Validates:** AZP-0104
+
+**Procedure:**
+1. Run the deployment without supplying any decoder function package.
+2. Inspect the resulting Function hosting resources.
+3. Assert: the placeholder Function App resources exist.
+4. Assert: the placeholder Function App uses a consumption hosting plan.
+5. Assert: the deployment did not require the later decoder implementation to be present.
+
+---
+
+### T-AZP-0200  Runtime identity uses certificate-authenticated service principal
+
+**Validates:** AZP-0200
+
+**Procedure:**
+1. Run the provisioning workflow, including the runtime identity phase.
+2. Inspect the resulting Azure identity configuration and deployment outputs.
+3. Assert: the runtime identity is an Entra application/service principal.
+4. Assert: the identity uses certificate-based authentication material.
+5. Assert: the workflow does not require managed identity or interactive runtime login for steady-state operation.
+
+---
+
+### T-AZP-0201  Service Bus permissions match bridge behavior
+
+**Validates:** AZP-0201
+
+**Procedure:**
+1. Run the provisioning workflow.
+2. Inspect the assigned Service Bus roles or permissions for the runtime identity.
+3. Assert: the identity can send to the upstream queue.
+4. Assert: the identity can receive and settle messages on the downstream queue.
+5. Assert: the assigned permissions do not exceed the documented runtime need without an explicit justification.
+
+---
+
+### T-AZP-0202  Bootstrap handoff contract satisfies Azure companion runtime inputs
+
+**Validates:** AZP-0203
+
+**Procedure:**
+1. Run the provisioning workflow.
+2. Collect the documented outputs and artifacts from the handoff contract.
+3. Compare them against the runtime-state inputs expected by `sonde-azure-companion`.
+4. Assert: the handoff includes tenant ID, client ID, certificate material or reference, private-key material or reference, and Service Bus namespace/queue values.
+5. Assert: the handoff can be translated into `service-principal.json`, certificate PEM, and private-key PEM without inventing extra undocumented values.
+
+---
+
+### T-AZP-0203  Function placeholder identity has the required RBAC
+
+**Validates:** AZP-0202
+
+**Procedure:**
+1. Run the provisioning workflow.
+2. Inspect the placeholder Function App identity configuration.
+3. Assert: the Function App has a system-assigned managed identity.
+4. Inspect the permissions granted to that identity.
+5. Assert: the identity can receive from the upstream queue.
+6. Assert: the identity can send on the downstream queue.
+7. Assert: the identity can write to the reserved Table Storage resource.
+8. Assert: the Function App identity is distinct from the Azure companion runtime identity.
+
+---
+
+### T-AZP-0300  Re-running deployment converges cleanly
+
+**Validates:** AZP-0300
+
+**Procedure:**
+1. Run the provisioning workflow against an empty test environment.
+2. Run the same deployment again with the same inputs.
+3. Assert: the second run converges without creating duplicate foundational resources.
+4. Assert: any intentionally constrained one-time behavior is documented.
+
+---
+
+### T-AZP-0301  Teardown behavior is documented and executable
+
+**Validates:** AZP-0301
+
+**Procedure:**
+1. Provision the stack in a disposable test environment.
+2. Execute the documented teardown path.
+3. Assert: the resource-plane stack is removed, or any retained artifacts are explicitly identified by the documentation.
+4. Assert: teardown expectations for Service Bus, Storage, and Function placeholder resources are clear.
+

--- a/docs/azure-provisioning-validation.md
+++ b/docs/azure-provisioning-validation.md
@@ -50,7 +50,8 @@
 3. Assert: one namespace exists for the stack.
 4. Assert: one upstream queue and one downstream queue exist.
 5. Assert: the namespace uses the Standard tier by default.
-6. Assert: the queue names are available through deployment outputs or documented post-deploy values.
+6. Assert: the namespace has local/SAS authentication disabled by default.
+7. Assert: the queue names are available through deployment outputs or documented post-deploy values.
 
 ---
 
@@ -63,7 +64,8 @@
 2. Inspect the resulting Storage Account and Table resources.
 3. Assert: the Storage Account exists.
 4. Assert: the Table resource exists.
-5. Assert: the provisioning documentation explicitly defers logical table schema ownership to the later Azure Function work.
+5. Assert: deployment outputs and bootstrap handoff values do not expose raw Storage Account keys.
+6. Assert: the provisioning documentation explicitly defers logical table schema ownership to the later Azure Function work.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a Bicep-based Azure provisioning surface under `deploy/bicep/` for the current Azure companion architecture
- add Azure provisioning requirements, design, and validation specs and cross-link them from the existing Azure companion docs
- provision the companion runtime identity, Service Bus resources, storage/table resources, and a placeholder Function App with managed identity and scoped RBAC

## Traceability
### Requirements discovery
- realign #772 to the current Azure companion architecture
- keep Bicep as the canonical IaC surface
- include Service Bus, storage/table resources, and a placeholder Function App
- provision the Azure companion runtime as a certificate-authenticated Entra app/service principal
- provision a separate system-assigned Function App identity with upstream receive, downstream send, and Storage Table write permissions
- exclude Managed Grafana and leave table schema / decoder logic to later work

### Specification changes
- add `docs/azure-provisioning-requirements.md`
- add `docs/azure-provisioning-design.md`
- add `docs/azure-provisioning-validation.md`
- cross-link the provisioning spec set from the existing Azure companion specs

### Implementation changes
- add subscription-scope `deploy/bicep/main.bicep`
- add Bicep modules for Service Bus, storage/table, companion identity, Function placeholder, and RBAC wiring
- add `deploy/bicep/README.md` and `deploy/bicep/bicepconfig.json`
- ignore generated `deploy/bicep/main.json` and add SPDX headers to `.bicep` sources

## Audits
- Specification audit: PASS
- Implementation audit: PASS
- Fixed during audit: normalized derived resource names to satisfy Azure naming constraints

## Validation
- `az bicep build --file deploy/bicep/main.bicep --stdout`

Closes #772