### PR TITLE
modem: set D2 (GPIO3) to output, low at boot

### DIFF
--- a/crates/sonde-modem/src/bin/modem.rs
+++ b/crates/sonde-modem/src/bin/modem.rs
@@ -116,6 +116,22 @@ fn main() {
     }
     info!("GPIO2 configured as button input (active-low, pull-up — MD-0600)");
 
+    // Configure GPIO3 (XIAO D2) as output, driven low at boot.
+    unsafe {
+        esp_idf_sys::gpio_reset_pin(esp_idf_sys::gpio_num_t_GPIO_NUM_3);
+        esp_idf_sys::esp!(esp_idf_sys::gpio_set_direction(
+            esp_idf_sys::gpio_num_t_GPIO_NUM_3,
+            esp_idf_sys::gpio_mode_t_GPIO_MODE_OUTPUT,
+        ))
+        .expect("failed to configure GPIO3 direction");
+        esp_idf_sys::esp!(esp_idf_sys::gpio_set_level(
+            esp_idf_sys::gpio_num_t_GPIO_NUM_3,
+            0,
+        ))
+        .expect("failed to set GPIO3 low");
+    }
+    info!("GPIO3 (XIAO D2) configured as output, low");
+
     let button_scanner = ButtonScanner::new(|| {
         // Active-low: GPIO reads 0 when pressed, 1 when idle.
         // Return true when pressed.

--- a/crates/sonde-modem/src/bin/modem.rs
+++ b/crates/sonde-modem/src/bin/modem.rs
@@ -116,19 +116,20 @@ fn main() {
     }
     info!("GPIO2 configured as button input (active-low, pull-up — MD-0600)");
 
-    // Configure GPIO3 (XIAO D2) as output, driven low at boot.
+    // Configure GPIO3 (XIAO D2) to latch low before enabling output, so it is
+    // driven low at boot without a transient high pulse.
     unsafe {
         esp_idf_sys::gpio_reset_pin(esp_idf_sys::gpio_num_t_GPIO_NUM_3);
-        esp_idf_sys::esp!(esp_idf_sys::gpio_set_direction(
-            esp_idf_sys::gpio_num_t_GPIO_NUM_3,
-            esp_idf_sys::gpio_mode_t_GPIO_MODE_OUTPUT,
-        ))
-        .expect("failed to configure GPIO3 direction");
         esp_idf_sys::esp!(esp_idf_sys::gpio_set_level(
             esp_idf_sys::gpio_num_t_GPIO_NUM_3,
             0,
         ))
         .expect("failed to set GPIO3 low");
+        esp_idf_sys::esp!(esp_idf_sys::gpio_set_direction(
+            esp_idf_sys::gpio_num_t_GPIO_NUM_3,
+            esp_idf_sys::gpio_mode_t_GPIO_MODE_OUTPUT,
+        ))
+        .expect("failed to configure GPIO3 direction");
     }
     info!("GPIO3 (XIAO D2) configured as output, low");
 


### PR DESCRIPTION
Configure GPIO3 (XIAO D2) as output driven low during modem boot, immediately after the GPIO2 button setup.

Latches the output level low before switching direction to OUTPUT to avoid a transient high pulse on the pin. Uses `gpio_reset_pin` → `gpio_set_level(0)` → `gpio_set_direction(OUTPUT)`.