### PR TITLE
deploy: move Azure companion bootstrap into the container

### DIFF
--- a/.github/docker/Dockerfile.azure-companion
+++ b/.github/docker/Dockerfile.azure-companion
@@ -25,6 +25,7 @@ RUN apk add --no-cache ca-certificates \
 COPY --from=builder /sonde/target/release/sonde-azure-companion /usr/local/bin/sonde-azure-companion
 COPY deploy/azure-companion/bootstrap.sh /opt/sonde/deploy/azure-companion/bootstrap.sh
 COPY deploy/azure-companion/entrypoint.sh /opt/sonde/deploy/azure-companion/entrypoint.sh
+COPY deploy/bicep/ /opt/sonde/deploy/bicep/
 
 RUN chmod +x /usr/local/bin/sonde-azure-companion \
     /opt/sonde/deploy/azure-companion/bootstrap.sh \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -154,6 +154,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -523,6 +562,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9676783265eadd6f11829982792c6f303f3854d014edfba384685dcf237dd062"
 dependencies = [
  "dbus",
+]
+
+[[package]]
+name = "bollard"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
 ]
 
 [[package]]
@@ -1442,6 +1524,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "der_derive"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,7 +1639,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1966,7 +2062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3140,6 +3236,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,7 +3264,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3209,6 +3319,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,7 +3345,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3817,12 +3942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4103,7 +4222,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4228,28 +4347,10 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "oauth-device-flows"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20dd669fa331a18d6d83a31bbea02ec9d0ab494cfee6a474935106997986964"
-dependencies = [
- "base64 0.22.1",
- "reqwest 0.12.28",
- "secrecy",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "time",
- "tokio",
- "url",
- "uuid",
 ]
 
 [[package]]
@@ -4421,6 +4522,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -5209,61 +5319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5403,6 +5458,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rcgen"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5525,7 +5594,6 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -5545,7 +5613,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5688,6 +5755,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5710,7 +5786,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5755,7 +5831,6 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -5868,16 +5943,6 @@ dependencies = [
  "generic-array",
  "pkcs8",
  "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "serde",
  "zeroize",
 ]
 
@@ -6388,7 +6453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6441,13 +6506,16 @@ dependencies = [
  "azservicebus",
  "azure_core",
  "base64 0.22.1",
+ "bollard",
  "clap",
  "ed25519-dalek",
  "futures",
+ "futures-util",
  "hyper-util",
  "jsonwebtoken",
- "oauth-device-flows",
  "p256",
+ "rcgen",
+ "regex",
  "reqwest 0.12.28",
  "rsa",
  "rustls-pemfile",
@@ -6456,6 +6524,7 @@ dependencies = [
  "sha2 0.10.9",
  "sonde-gateway",
  "spki",
+ "tar",
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
@@ -6464,7 +6533,6 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tower",
- "url",
  "wiremock",
  "x509-cert",
 ]
@@ -7192,10 +7260,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7329,21 +7397,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls_codec"
@@ -7947,7 +8000,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8368,16 +8421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8527,7 +8570,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9245,6 +9288,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9259,6 +9320,15 @@ name = "xml"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/sonde-azure-companion/Cargo.toml
+++ b/crates/sonde-azure-companion/Cargo.toml
@@ -8,12 +8,15 @@ license = "MIT"
 azservicebus = { version = "0.25.1", default-features = false, features = ["rustls"] }
 azure_core = { version = "0.25", default-features = false }
 base64 = "0.22"
+bollard = "0.20"
 clap = { version = "4", features = ["derive", "env"] }
+futures-util = "0.3"
 hyper-util = "0.1"
 jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
-oauth-device-flows = { version = "0.1", default-features = false }
+regex = "1"
 ed25519-dalek = { version = "2", features = ["pkcs8"] }
 p256 = { version = "0.13", features = ["pkcs8"] }
+rcgen = { version = "0.14", features = ["pem"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots-no-provider"] }
 rsa = "0.9"
 rustls-pemfile = "2"
@@ -26,8 +29,8 @@ time = "0.3"
 tokio = { version = "1", features = ["full"] }
 tonic = "0.14"
 tower = "0.5"
+tar = "0.4"
 thiserror = "2"
-url = "2"
 x509-cert = "0.2"
 
 [dev-dependencies]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -14,11 +14,18 @@ use azure_core::date::OffsetDateTime;
 use azure_core::error::ErrorKind;
 use azure_core::Uuid;
 use base64::Engine as _;
+use bollard::container::LogOutput;
+use bollard::models::ContainerCreateBody;
+use bollard::query_parameters::{
+    CreateContainerOptionsBuilder, CreateImageOptionsBuilder, LogsOptionsBuilder,
+    RemoveContainerOptionsBuilder, UploadToContainerOptionsBuilder,
+    WaitContainerOptionsBuilder,
+};
+use bollard::{body_full, Docker};
 use clap::{Args, Parser, Subcommand};
 use ed25519_dalek::pkcs8::DecodePrivateKey as Ed25519DecodePrivateKey;
+use futures_util::StreamExt;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
-use oauth_device_flows::provider::GenericProviderConfig;
-use oauth_device_flows::{DeviceFlow, DeviceFlowConfig, Provider};
 use rsa::pkcs1::DecodeRsaPrivateKey;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -28,7 +35,6 @@ use time::Duration as TimeDuration;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::Mutex;
 use tonic::transport::{Channel, Endpoint, Uri};
-use url::Url;
 use x509_cert::der::{Decode, Encode};
 use x509_cert::Certificate;
 
@@ -49,6 +55,15 @@ const DEFAULT_STATE_DIR: &str = "/var/lib/sonde-azure-companion";
 const DEFAULT_STATE_DIR: &str = r"C:\ProgramData\sonde-azure-companion";
 
 const SERVICE_PRINCIPAL_STATE_FILENAME: &str = "service-principal.json";
+/// Path to bundled Bicep files inside the companion container image.
+const BUNDLED_BICEP_PATH: &str = "/opt/sonde/deploy/bicep";
+/// Pinned Azure CLI container image digest for reproducible bootstrap.
+const AZURE_CLI_IMAGE: &str =
+    "mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7";
+const CERT_PEM_FILENAME: &str = "cert.pem";
+const KEY_PEM_FILENAME: &str = "key.pem";
+const SERVICE_BUS_CONFIG_FILENAME: &str = "service-bus.json";
+const STAGING_DIR_NAME: &str = ".staging";
 const DEFAULT_DOWNSTREAM_WAIT_SECS: u64 = 1;
 const CONNECTOR_MAX_FRAME_LENGTH: usize =
     sonde_gateway::connector::DEFAULT_CONNECTOR_MAX_MESSAGE_SIZE;
@@ -67,15 +82,11 @@ enum CompanionError {
     #[error(transparent)]
     Json(#[from] serde_json::Error),
     #[error(transparent)]
-    Url(#[from] url::ParseError),
-    #[error(transparent)]
     TonicTransport(#[from] tonic::transport::Error),
     #[error(transparent)]
     TonicStatus(#[from] tonic::Status),
     #[error(transparent)]
     AzureCore(#[from] azure_core::Error),
-    #[error(transparent)]
-    OAuth(#[from] oauth_device_flows::DeviceFlowError),
     #[error(transparent)]
     Jwt(#[from] jsonwebtoken::errors::Error),
     #[error(transparent)]
@@ -108,8 +119,8 @@ struct Cli {
 enum Command {
     /// Start the long-running Azure connector runtime.
     Run,
-    /// Perform Microsoft device auth and display the user code on the modem.
-    BootstrapAuth(BootstrapAuthArgs),
+    /// Perform bootstrap deployment and display the device code on the modem.
+    Bootstrap(BootstrapArgs),
     /// Ask the gateway admin API to render a transient modem display message.
     DisplayMessage {
         /// Between 1 and 4 text lines to render.
@@ -121,34 +132,18 @@ enum Command {
 }
 
 #[derive(Debug, Args)]
-struct BootstrapAuthArgs {
-    /// Microsoft Entra application client ID used for device auth.
-    #[arg(long, env = "SONDE_AZURE_DEVICE_CLIENT_ID")]
-    device_client_id: String,
+struct BootstrapArgs {
+    /// Azure region for Bicep deployment.
+    #[arg(long, env = "SONDE_AZURE_LOCATION", default_value = "eastus")]
+    azure_location: String,
 
-    /// Comma-delimited OAuth scopes to request during device auth.
-    #[arg(long, env = "SONDE_AZURE_DEVICE_SCOPES", value_delimiter = ',', num_args = 1..)]
-    device_scopes: Vec<String>,
+    /// Project name for Bicep deployment.
+    #[arg(long, env = "SONDE_AZURE_PROJECT_NAME", default_value = "sonde")]
+    azure_project_name: String,
 
-    /// Poll interval in seconds for the device auth token endpoint.
-    #[arg(
-        long,
-        env = "SONDE_AZURE_DEVICE_POLL_INTERVAL_SECS",
-        default_value_t = 5
-    )]
-    poll_interval_secs: u64,
-
-    /// Maximum number of token polling attempts before bootstrap fails.
-    #[arg(long, env = "SONDE_AZURE_DEVICE_MAX_ATTEMPTS", default_value_t = 60)]
-    max_attempts: u32,
-
-    /// Optional override for the device authorization endpoint, primarily for tests.
-    #[arg(long, env = "SONDE_AZURE_DEVICE_AUTH_URL")]
-    device_auth_url: Option<String>,
-
-    /// Optional override for the token endpoint, primarily for tests.
-    #[arg(long, env = "SONDE_AZURE_DEVICE_TOKEN_URL")]
-    device_token_url: Option<String>,
+    /// Optional Azure subscription ID override.
+    #[arg(long, env = "SONDE_AZURE_SUBSCRIPTION_ID")]
+    azure_subscription_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,6 +159,13 @@ struct ServicePrincipalStateFile {
     client_id: String,
     certificate_path: String,
     private_key_path: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+struct ServiceBusConfigFile {
+    namespace: String,
+    upstream_queue: String,
+    downstream_queue: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -189,6 +191,31 @@ struct ClientAssertionClaims {
 struct OAuthTokenResponse {
     access_token: String,
     expires_in: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct BicepBootstrapValues {
+    #[serde(rename = "tenantId")]
+    tenant_id: BicepOutputValue,
+    #[serde(rename = "clientId")]
+    client_id: BicepOutputValue,
+    #[serde(rename = "serviceBusNamespace")]
+    service_bus_namespace: BicepOutputValue,
+    #[serde(rename = "upstreamQueue")]
+    upstream_queue: BicepOutputValue,
+    #[serde(rename = "downstreamQueue")]
+    downstream_queue: BicepOutputValue,
+}
+
+#[derive(Debug, Deserialize)]
+struct BicepOutputValue {
+    value: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct BicepOutputs {
+    #[serde(rename = "companionBootstrapValues")]
+    companion_bootstrap_values: BicepOutputValue,
 }
 
 struct ClientAssertionCredential {
@@ -347,30 +374,6 @@ fn validate_display_lines(lines: &[String]) -> Result<(), CompanionError> {
     }
 }
 
-fn validate_device_scopes(scopes: &[String]) -> Result<(), CompanionError> {
-    if scopes.is_empty() {
-        Err(CompanionError::Config(
-            "bootstrap-auth requires at least one device scope".to_string(),
-        ))
-    } else if scopes.iter().any(|scope| scope.trim().is_empty()) {
-        Err(CompanionError::Config(
-            "bootstrap-auth device scopes must not be empty".to_string(),
-        ))
-    } else {
-        Ok(())
-    }
-}
-
-fn validate_device_client_id(client_id: &str) -> Result<(), CompanionError> {
-    if client_id.trim().is_empty() {
-        Err(CompanionError::Config(
-            "bootstrap-auth requires a non-empty device client ID".to_string(),
-        ))
-    } else {
-        Ok(())
-    }
-}
-
 fn require_non_empty(value: String, env_name: &str) -> Result<String, CompanionError> {
     if value.trim().is_empty() {
         Err(CompanionError::Config(format!(
@@ -381,21 +384,171 @@ fn require_non_empty(value: String, env_name: &str) -> Result<String, CompanionE
     }
 }
 
-fn load_runtime_config() -> Result<RuntimeConfig, CompanionError> {
+fn load_runtime_config(state_dir: &Path) -> Result<RuntimeConfig, CompanionError> {
+    let namespace_env = std::env::var("SONDE_AZURE_SERVICEBUS_NAMESPACE")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+    let upstream_env = std::env::var("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+    let downstream_env = std::env::var("SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+
+    let file_config = load_service_bus_config_file(state_dir).ok();
+
+    let namespace = namespace_env
+        .or_else(|| file_config.as_ref().map(|c| c.namespace.clone()))
+        .ok_or_else(|| {
+            CompanionError::Config(
+                "SONDE_AZURE_SERVICEBUS_NAMESPACE must be set and non-empty (or service-bus.json must exist in state dir)"
+                    .into(),
+            )
+        })?;
+    let upstream_queue = upstream_env
+        .or_else(|| file_config.as_ref().map(|c| c.upstream_queue.clone()))
+        .ok_or_else(|| {
+            CompanionError::Config(
+                "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE must be set and non-empty (or service-bus.json must exist in state dir)"
+                    .into(),
+            )
+        })?;
+    let downstream_queue = downstream_env
+        .or_else(|| file_config.as_ref().map(|c| c.downstream_queue.clone()))
+        .ok_or_else(|| {
+            CompanionError::Config(
+                "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE must be set and non-empty (or service-bus.json must exist in state dir)"
+                    .into(),
+            )
+        })?;
+
     Ok(RuntimeConfig {
-        namespace: require_non_empty(
-            std::env::var("SONDE_AZURE_SERVICEBUS_NAMESPACE").unwrap_or_default(),
-            "SONDE_AZURE_SERVICEBUS_NAMESPACE",
-        )?,
-        upstream_queue: require_non_empty(
-            std::env::var("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE").unwrap_or_default(),
-            "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE",
-        )?,
-        downstream_queue: require_non_empty(
-            std::env::var("SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE").unwrap_or_default(),
-            "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
-        )?,
+        namespace,
+        upstream_queue,
+        downstream_queue,
     })
+}
+
+fn load_service_bus_config_file(state_dir: &Path) -> Result<ServiceBusConfigFile, CompanionError> {
+    let config_path = state_dir.join(SERVICE_BUS_CONFIG_FILENAME);
+    let bytes = std::fs::read(&config_path)?;
+    let config: ServiceBusConfigFile = serde_json::from_slice(&bytes)?;
+    Ok(config)
+}
+
+fn prepare_staging_dir(state_dir: &Path) -> Result<PathBuf, CompanionError> {
+    let staging_dir = state_dir.join(STAGING_DIR_NAME);
+    if staging_dir.exists() {
+        std::fs::remove_dir_all(&staging_dir)?;
+    }
+    std::fs::create_dir_all(&staging_dir)?;
+    Ok(staging_dir)
+}
+
+fn commit_staging(staging_dir: &Path, state_dir: &Path) -> Result<(), CompanionError> {
+    let backup_dir = state_dir.join(format!("{STAGING_DIR_NAME}-backup"));
+    if backup_dir.exists() {
+        std::fs::remove_dir_all(&backup_dir)?;
+    }
+    std::fs::create_dir_all(&backup_dir)?;
+
+    let staged_files: Vec<(PathBuf, PathBuf)> = std::fs::read_dir(staging_dir)?
+        .map(|entry| {
+            let entry = entry?;
+            Ok((entry.path(), state_dir.join(entry.file_name())))
+        })
+        .collect::<Result<_, std::io::Error>>()?;
+
+    let mut backed_up: Vec<(PathBuf, PathBuf)> = Vec::new();
+    let mut committed: Vec<PathBuf> = Vec::new();
+
+    let commit_result: Result<(), CompanionError> = (|| {
+        for (_, dest) in &staged_files {
+            if dest.exists() {
+                let backup_path = backup_dir.join(
+                    dest.file_name()
+                        .ok_or_else(|| {
+                            CompanionError::Config(format!(
+                                "staged destination had no file name: {}",
+                                dest.display()
+                            ))
+                        })?,
+                );
+                std::fs::rename(dest, &backup_path)?;
+                backed_up.push((backup_path, dest.clone()));
+            }
+        }
+
+        for (src, dest) in &staged_files {
+            std::fs::rename(src, dest)?;
+            committed.push(dest.clone());
+        }
+        Ok(())
+    })();
+
+    if let Err(err) = commit_result {
+        for dest in &committed {
+            if dest.exists() {
+                let _ = std::fs::remove_file(dest);
+            }
+        }
+        for (backup_path, dest) in backed_up.iter().rev() {
+            if backup_path.exists() {
+                let _ = std::fs::rename(backup_path, dest);
+            }
+        }
+        let _ = std::fs::remove_dir_all(&backup_dir);
+        return Err(err);
+    }
+
+    let _ = std::fs::remove_dir_all(&backup_dir);
+    let _ = std::fs::remove_dir(staging_dir);
+    Ok(())
+}
+
+fn cleanup_staging(staging_dir: &Path) {
+    let _ = std::fs::remove_dir_all(staging_dir);
+}
+
+fn generate_certificate(staging_dir: &Path) -> Result<(PathBuf, PathBuf, String), CompanionError> {
+    use rcgen::{CertificateParams, KeyPair, PKCS_ECDSA_P256_SHA256};
+
+    let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).map_err(|e| {
+        CompanionError::Config(format!("failed to generate ECDSA P-256 key pair: {e}"))
+    })?;
+
+    let mut params = CertificateParams::new(Vec::<String>::new()).map_err(|e| {
+        CompanionError::Config(format!("failed to create certificate params: {e}"))
+    })?;
+    params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "sonde-azure-companion");
+    params.not_before = time::OffsetDateTime::now_utc();
+    params.not_after = time::OffsetDateTime::now_utc() + time::Duration::days(730);
+
+    let cert = params.self_signed(&key_pair).map_err(|e| {
+        CompanionError::Config(format!("failed to generate self-signed certificate: {e}"))
+    })?;
+
+    let cert_pem = cert.pem();
+    let key_pem = key_pair.serialize_pem();
+
+    let cert_path = staging_dir.join(CERT_PEM_FILENAME);
+    let key_path = staging_dir.join(KEY_PEM_FILENAME);
+
+    std::fs::write(&cert_path, cert_pem.as_bytes())?;
+    std::fs::write(&key_path, key_pem.as_bytes())?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    let cert_der = cert.der().to_vec();
+    let cert_base64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
+
+    Ok((cert_path, key_path, cert_base64))
 }
 
 fn service_principal_state_path(state_dir: &Path) -> PathBuf {
@@ -487,7 +640,7 @@ fn load_runtime_credential_state(
 fn check_runtime_ready(
     state_dir: &Path,
 ) -> Result<(RuntimeConfig, RuntimeCredentialState), CompanionError> {
-    let runtime_config = load_runtime_config()?;
+    let runtime_config = load_runtime_config(state_dir)?;
     let runtime_state = load_runtime_credential_state(state_dir)?;
     let _ = load_certificate_thumbprint(&runtime_state.certificate_path)?;
     let _ = load_signing_key(&runtime_state.private_key_path)?;
@@ -496,42 +649,6 @@ fn check_runtime_ready(
         &runtime_state.private_key_path,
     )?;
     Ok((runtime_config, runtime_state))
-}
-
-fn bootstrap_provider_and_config(
-    args: &BootstrapAuthArgs,
-) -> Result<(Provider, DeviceFlowConfig), CompanionError> {
-    validate_device_client_id(&args.device_client_id)?;
-    validate_device_scopes(&args.device_scopes)?;
-
-    let device_client_id = args.device_client_id.trim().to_string();
-    let device_scopes: Vec<String> = args
-        .device_scopes
-        .iter()
-        .map(|scope| scope.trim().to_string())
-        .collect();
-
-    let config = DeviceFlowConfig::new()
-        .client_id(device_client_id)
-        .scopes(device_scopes.clone())
-        .poll_interval(Duration::from_secs(args.poll_interval_secs))
-        .max_attempts(args.max_attempts);
-
-    match (&args.device_auth_url, &args.device_token_url) {
-        (Some(device_auth_url), Some(device_token_url)) => {
-            let provider = GenericProviderConfig::new(
-                Url::parse(device_auth_url)?,
-                Url::parse(device_token_url)?,
-                "Microsoft test override".to_string(),
-            )
-            .with_default_scopes(device_scopes);
-            Ok((Provider::Generic, config.generic_provider(provider)))
-        }
-        (None, None) => Ok((Provider::Microsoft, config)),
-        _ => Err(CompanionError::Config(
-            "device auth and token endpoint overrides must be provided together".to_string(),
-        )),
-    }
 }
 
 fn load_certificate_thumbprint(certificate_path: &Path) -> Result<String, CompanionError> {
@@ -730,6 +847,87 @@ fn validate_certificate_matches_private_key(
         )));
     }
     Ok(())
+}
+
+fn parse_bicep_outputs(
+    json: &str,
+) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
+    let outputs: BicepOutputs = serde_json::from_str(json).map_err(|e| {
+        CompanionError::Config(format!("failed to parse Bicep deployment outputs: {e}"))
+    })?;
+
+    let bootstrap_values: BicepBootstrapValues =
+        serde_json::from_value(outputs.companion_bootstrap_values.value).map_err(|e| {
+            CompanionError::Config(format!("failed to parse companionBootstrapValues: {e}"))
+        })?;
+
+    let sp = ServicePrincipalStateFile {
+        tenant_id: bootstrap_values
+            .tenant_id
+            .value
+            .as_str()
+            .ok_or_else(|| CompanionError::Config("tenantId must be a string".into()))?
+            .to_string(),
+        client_id: bootstrap_values
+            .client_id
+            .value
+            .as_str()
+            .ok_or_else(|| CompanionError::Config("clientId must be a string".into()))?
+            .to_string(),
+        certificate_path: CERT_PEM_FILENAME.to_string(),
+        private_key_path: KEY_PEM_FILENAME.to_string(),
+    };
+
+    let sb = ServiceBusConfigFile {
+        namespace: bootstrap_values
+            .service_bus_namespace
+            .value
+            .as_str()
+            .ok_or_else(|| CompanionError::Config("serviceBusNamespace must be a string".into()))?
+            .to_string(),
+        upstream_queue: bootstrap_values
+            .upstream_queue
+            .value
+            .as_str()
+            .ok_or_else(|| CompanionError::Config("upstreamQueue must be a string".into()))?
+            .to_string(),
+        downstream_queue: bootstrap_values
+            .downstream_queue
+            .value
+            .as_str()
+            .ok_or_else(|| CompanionError::Config("downstreamQueue must be a string".into()))?
+            .to_string(),
+    };
+
+    Ok((sp, sb))
+}
+
+fn build_az_bootstrap_script() -> String {
+    r#"set -eu
+az login --use-device-code --output none >&2
+if [ -n "${SONDE_AZURE_SUBSCRIPTION_ID:-}" ]; then
+    az account set --subscription "$SONDE_AZURE_SUBSCRIPTION_ID" >&2
+fi
+az deployment sub create \
+    --location "$SONDE_AZURE_LOCATION" \
+    --template-file /bicep/main.bicep \
+    --parameters companionCertificateBase64="$COMPANION_CERT_BASE64" \
+    --parameters project_name="$SONDE_AZURE_PROJECT_NAME" \
+    --query 'properties.outputs' \
+    --output json"#
+        .to_string()
+}
+
+fn build_container_env(cert_base64: &str, args: &BootstrapArgs) -> Vec<String> {
+    let mut env = vec![
+        format!("SONDE_AZURE_LOCATION={}", args.azure_location),
+        format!("SONDE_AZURE_PROJECT_NAME={}", args.azure_project_name),
+        format!("COMPANION_CERT_BASE64={cert_base64}"),
+    ];
+    if let Some(sub_id) = &args.azure_subscription_id {
+        env.push(format!("SONDE_AZURE_SUBSCRIPTION_ID={sub_id}"));
+    }
+    env
 }
 
 fn downstream_body_to_connector_payload(body: &[u8]) -> Result<Vec<u8>, CompanionError> {
@@ -1158,6 +1356,204 @@ async fn run(connector_socket: &str, state_dir: &Path) -> Result<(), CompanionEr
     run_with_factory(connector_socket, state_dir, &AzServiceBusTransportFactory).await
 }
 
+async fn copy_files_to_container(
+    docker: &Docker,
+    container_id: &str,
+    staging_dir: &Path,
+) -> Result<(), CompanionError> {
+    let mut archive = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut archive);
+        let bicep_path = Path::new(BUNDLED_BICEP_PATH);
+        if !bicep_path.is_dir() {
+            return Err(CompanionError::Config(format!(
+                "bundled Bicep path not found: {}",
+                bicep_path.display()
+            )));
+        }
+        builder.append_dir_all("bicep", bicep_path).map_err(|e| {
+            CompanionError::Config(format!("failed to add Bicep files to archive: {e}"))
+        })?;
+
+        let cert_path = staging_dir.join(CERT_PEM_FILENAME);
+        if !cert_path.is_file() {
+            return Err(CompanionError::Config(format!(
+                "generated certificate file not found: {}",
+                cert_path.display()
+            )));
+        }
+        builder
+            .append_path_with_name(&cert_path, format!("cert/{CERT_PEM_FILENAME}"))
+            .map_err(|e| {
+                CompanionError::Config(format!("failed to add certificate to archive: {e}"))
+            })?;
+        builder.finish().map_err(|e| {
+            CompanionError::Config(format!("failed to finalize tar archive: {e}"))
+        })?;
+    }
+
+    let upload_options = UploadToContainerOptionsBuilder::default()
+        .path("/")
+        .build();
+
+    docker
+        .upload_to_container(container_id, Some(upload_options), body_full(archive.into()))
+        .await
+        .map_err(|e| CompanionError::Config(format!("failed to copy files to container: {e}")))?;
+
+    Ok(())
+}
+
+async fn stream_container_output(
+    docker: &Docker,
+    container_id: &str,
+    admin_socket: &str,
+) -> Result<String, CompanionError> {
+    use regex::Regex;
+
+    let log_opts = LogsOptionsBuilder::default()
+        .follow(true)
+        .stdout(true)
+        .stderr(true)
+        .build();
+
+    let mut logs = docker.logs(container_id, Some(log_opts));
+    let mut stdout_buffer = String::new();
+    let device_code_re =
+        Regex::new(r"enter the code ([A-Z0-9-]+) to authenticate").expect("valid device code regex");
+    let mut device_code_displayed = false;
+
+    while let Some(result) = logs.next().await {
+        match result {
+            Ok(LogOutput::StdOut { message }) => {
+                let text = String::from_utf8_lossy(&message);
+                stdout_buffer.push_str(&text);
+            }
+            Ok(LogOutput::StdErr { message }) => {
+                let text = String::from_utf8_lossy(&message);
+                eprint!("{text}");
+
+                if !device_code_displayed {
+                    if let Some(captures) = device_code_re.captures(&text) {
+                        if let Some(code) = captures.get(1) {
+                            let device_code = code.as_str().to_string();
+                            eprintln!("Detected device code: {device_code}");
+                            if let Err(e) = display_message(
+                                admin_socket,
+                                vec!["Azure login".to_string(), device_code],
+                            )
+                            .await
+                            {
+                                return Err(CompanionError::Config(format!(
+                                    "failed to display device code on modem: {e}"
+                                )));
+                            }
+                            device_code_displayed = true;
+                        }
+                    }
+                }
+            }
+            Ok(LogOutput::Console { message }) => {
+                let text = String::from_utf8_lossy(&message);
+                stdout_buffer.push_str(&text);
+            }
+            Ok(LogOutput::StdIn { .. }) => {}
+            Err(e) => {
+                return Err(CompanionError::Config(format!(
+                    "failed to read container output: {e}"
+                )));
+            }
+        }
+    }
+
+    Ok(stdout_buffer)
+}
+
+async fn run_bootstrap_deployment(
+    admin_socket: &str,
+    staging_dir: &Path,
+    cert_base64: &str,
+    args: &BootstrapArgs,
+) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
+    let docker = Docker::connect_with_local_defaults()
+        .map_err(|e| CompanionError::Config(format!("failed to connect to Docker daemon: {e}")))?;
+
+    eprintln!("Pulling Azure CLI container image...");
+    let pull_opts = CreateImageOptionsBuilder::default()
+        .from_image(AZURE_CLI_IMAGE)
+        .build();
+    let mut pull_stream = docker.create_image(Some(pull_opts), None, None);
+    while let Some(result) = pull_stream.next().await {
+        result.map_err(|e| CompanionError::Config(format!("failed to pull Azure CLI image: {e}")))?;
+    }
+
+    let bootstrap_script = build_az_bootstrap_script();
+    let env_vars = build_container_env(cert_base64, args);
+    let container_name = format!("sonde-bootstrap-{}", Uuid::new_v4());
+    let container = docker
+        .create_container(
+            Some(
+                CreateContainerOptionsBuilder::default()
+                    .name(&container_name)
+                    .build(),
+            ),
+            ContainerCreateBody {
+                image: Some(AZURE_CLI_IMAGE.to_string()),
+                cmd: Some(vec!["sh".to_string(), "-c".to_string(), bootstrap_script]),
+                env: Some(env_vars),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|e| CompanionError::Config(format!("failed to create Azure CLI container: {e}")))?;
+    let container_id = container.id;
+
+    let bootstrap_result = async {
+        copy_files_to_container(&docker, &container_id, staging_dir).await?;
+        docker
+            .start_container(&container_id, None)
+            .await
+            .map_err(|e| CompanionError::Config(format!("failed to start Azure CLI container: {e}")))?;
+
+        let stdout_output = stream_container_output(&docker, &container_id, admin_socket).await?;
+        let wait_options = WaitContainerOptionsBuilder::default()
+            .condition("not-running")
+            .build();
+        let mut wait_stream = docker.wait_container(&container_id, Some(wait_options));
+        let exit_result = wait_stream.next().await;
+
+        match exit_result {
+            Some(Ok(result)) if result.status_code == 0 => {}
+            Some(Ok(result)) => {
+                return Err(CompanionError::Config(format!(
+                    "Azure CLI container exited with non-zero status: {}",
+                    result.status_code
+                )));
+            }
+            Some(Err(e)) => {
+                return Err(CompanionError::Config(format!(
+                    "failed to wait for Azure CLI container: {e}"
+                )));
+            }
+            None => {
+                return Err(CompanionError::Config(
+                    "Azure CLI container wait stream ended unexpectedly".into(),
+                ));
+            }
+        }
+
+        parse_bicep_outputs(&stdout_output)
+    }
+    .await;
+
+    let remove_options = RemoveContainerOptionsBuilder::default().force(true).build();
+    let _ = docker
+        .remove_container(&container_id, Some(remove_options))
+        .await;
+
+    bootstrap_result
+}
+
 async fn display_message(admin_socket: &str, lines: Vec<String>) -> Result<(), CompanionError> {
     validate_display_lines(&lines)?;
     let mut client = connect_admin(admin_socket).await?;
@@ -1167,44 +1563,63 @@ async fn display_message(admin_socket: &str, lines: Vec<String>) -> Result<(), C
     Ok(())
 }
 
-async fn bootstrap_auth(
+async fn display_progress(admin_socket: &str, msg: &str) {
+    if let Err(e) = display_message(admin_socket, vec![msg.to_string()]).await {
+        eprintln!("warning: failed to update modem display: {e}");
+    }
+}
+
+async fn bootstrap(
     admin_socket: &str,
     state_dir: &Path,
-    args: BootstrapAuthArgs,
+    args: BootstrapArgs,
 ) -> Result<(), CompanionError> {
     std::fs::create_dir_all(state_dir)?;
 
-    let (provider, config) = bootstrap_provider_and_config(&args)?;
-    let mut flow = DeviceFlow::new(provider, config)?;
-    let auth = flow.initialize().await?;
+    let staging_dir = prepare_staging_dir(state_dir)?;
 
-    eprintln!(
-        "Azure device auth required. Open {} and enter code {}",
-        auth.verification_uri(),
-        auth.user_code()
-    );
-    if let Some(verification_uri_complete) = auth.verification_uri_complete() {
-        eprintln!("Complete verification URL: {verification_uri_complete}");
+    display_progress(admin_socket, "Generating cert...").await;
+    eprintln!("Generating ECDSA P-256 self-signed certificate");
+    let (_cert_path, _key_path, cert_base64) = match generate_certificate(&staging_dir) {
+        Ok(result) => result,
+        Err(e) => {
+            cleanup_staging(&staging_dir);
+            display_progress(admin_socket, "Bootstrap failed").await;
+            return Err(e);
+        }
+    };
+
+    display_progress(admin_socket, "Authenticating...").await;
+    eprintln!("Starting Azure CLI container for device-code auth and Bicep deployment");
+    let (sp_state, sb_config) =
+        match run_bootstrap_deployment(admin_socket, &staging_dir, &cert_base64, &args).await {
+            Ok(result) => result,
+            Err(e) => {
+                cleanup_staging(&staging_dir);
+                display_progress(admin_socket, "Bootstrap failed").await;
+                return Err(e);
+            }
+        };
+
+    display_progress(admin_socket, "Writing config...").await;
+    eprintln!("Writing runtime artifacts to state volume");
+
+    let sp_path = staging_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME);
+    let sp_json = serde_json::to_string_pretty(&sp_state)?;
+    std::fs::write(&sp_path, sp_json.as_bytes())?;
+
+    let sb_path = staging_dir.join(SERVICE_BUS_CONFIG_FILENAME);
+    let sb_json = serde_json::to_string_pretty(&sb_config)?;
+    std::fs::write(&sb_path, sb_json.as_bytes())?;
+
+    if let Err(e) = commit_staging(&staging_dir, state_dir) {
+        cleanup_staging(&staging_dir);
+        display_progress(admin_socket, "Bootstrap failed").await;
+        return Err(e);
     }
 
-    display_message(
-        admin_socket,
-        vec!["Azure login".to_string(), auth.user_code().to_string()],
-    )
-    .await?;
-
-    let token = flow.poll_for_token().await?;
-    if let Some(expires_in) = token.expires_in {
-        eprintln!(
-            "Azure device auth succeeded; received temporary {} token valid for {} seconds",
-            token.token_type, expires_in
-        );
-    } else {
-        eprintln!(
-            "Azure device auth succeeded; received temporary {} token",
-            token.token_type
-        );
-    }
+    display_progress(admin_socket, "Bootstrap complete").await;
+    eprintln!("Bootstrap completed successfully");
 
     Ok(())
 }
@@ -1213,9 +1628,7 @@ async fn run_cli() -> Result<(), CompanionError> {
     let cli = Cli::parse();
     match cli.command.unwrap_or(Command::Run) {
         Command::Run => run(&cli.connector_socket, &cli.state_dir).await?,
-        Command::BootstrapAuth(args) => {
-            bootstrap_auth(&cli.admin_socket, &cli.state_dir, args).await?
-        }
+        Command::Bootstrap(args) => bootstrap(&cli.admin_socket, &cli.state_dir, args).await?,
         Command::DisplayMessage { lines } => display_message(&cli.admin_socket, lines).await?,
         Command::CheckRuntimeReady => {
             check_runtime_ready(&cli.state_dir)?;
@@ -1235,17 +1648,19 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        bootstrap_provider_and_config, check_runtime_ready, downstream_body_to_connector_payload,
-        load_runtime_config, load_signing_key, pump_downstream_once, pump_upstream_once,
-        read_framed, resolve_state_relative_path, validate_device_client_id,
-        validate_device_scopes, validate_display_lines, write_framed, BootstrapAuthArgs,
-        ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
-        RuntimeCredentialState, ServicePrincipalStateFile, UpstreamPublisher,
-        CONNECTOR_MAX_FRAME_LENGTH,
+        check_runtime_ready, cleanup_staging, commit_staging, downstream_body_to_connector_payload,
+        generate_certificate, load_runtime_config, load_signing_key, parse_bicep_outputs,
+        prepare_staging_dir, pump_downstream_once, pump_upstream_once, read_framed,
+        resolve_state_relative_path, validate_certificate_matches_private_key,
+        validate_display_lines, write_framed, ClientAssertionCredential, CompanionError,
+        DownstreamConsumer, RuntimeConfig, RuntimeCredentialState,
+        ServiceBusConfigFile, ServicePrincipalStateFile, UpstreamPublisher,
+        CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME,
+        SERVICE_BUS_CONFIG_FILENAME,
     };
     use azure_core::credentials::TokenCredential;
+    use base64::Engine as _;
     use jsonwebtoken::{Algorithm, EncodingKey};
-    use oauth_device_flows::Provider;
     use std::collections::VecDeque;
     use std::path::Path;
     use std::path::PathBuf;
@@ -1268,20 +1683,11 @@ mod tests {
     use tokio::sync::{Mutex, Notify};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+    use x509_cert::der::Decode;
+    use x509_cert::Certificate;
 
     fn lines(values: &[&str]) -> Vec<String> {
         values.iter().map(|s| (*s).to_string()).collect()
-    }
-
-    fn bootstrap_args() -> BootstrapAuthArgs {
-        BootstrapAuthArgs {
-            device_client_id: "client-id".to_string(),
-            device_scopes: vec!["scope-a".to_string()],
-            poll_interval_secs: 5,
-            max_attempts: 60,
-            device_auth_url: None,
-            device_token_url: None,
-        }
     }
 
     fn write_service_principal_state(temp: &TempDir) -> PathBuf {
@@ -1371,6 +1777,19 @@ mod tests {
             ],
             test,
         );
+    }
+
+    fn write_service_bus_config(temp: &TempDir, namespace: &str, upstream: &str, downstream: &str) {
+        let config = ServiceBusConfigFile {
+            namespace: namespace.to_string(),
+            upstream_queue: upstream.to_string(),
+            downstream_queue: downstream.to_string(),
+        };
+        std::fs::write(
+            temp.path().join(SERVICE_BUS_CONFIG_FILENAME),
+            serde_json::to_vec(&config).unwrap(),
+        )
+        .unwrap();
     }
 
     #[derive(Default)]
@@ -1749,46 +2168,151 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_auth_requires_at_least_one_scope() {
-        assert!(validate_device_scopes(&[]).is_err());
-        assert!(validate_device_scopes(&["scope".to_string()]).is_ok());
+    fn test_generate_certificate() {
+        let temp = TempDir::new().unwrap();
+        let (cert_path, key_path, cert_base64) = generate_certificate(temp.path()).unwrap();
+
+        assert_eq!(cert_path, temp.path().join(CERT_PEM_FILENAME));
+        assert_eq!(key_path, temp.path().join(KEY_PEM_FILENAME));
+        assert!(cert_path.is_file());
+        assert!(key_path.is_file());
+
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(cert_base64)
+            .unwrap();
+        let cert_file = std::fs::File::open(&cert_path).unwrap();
+        let mut reader = std::io::BufReader::new(cert_file);
+        let cert_der = rustls_pemfile::certs(&mut reader)
+            .next()
+            .transpose()
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded, cert_der.as_ref());
+
+        let certificate = Certificate::from_der(cert_der.as_ref()).unwrap();
+        assert_ne!(
+            certificate.tbs_certificate.validity.not_before,
+            certificate.tbs_certificate.validity.not_after
+        );
+        let (algorithm, _) = load_signing_key(&key_path).unwrap();
+        assert_eq!(algorithm, Algorithm::ES256);
+        validate_certificate_matches_private_key(&cert_path, &key_path).unwrap();
     }
 
     #[test]
-    fn bootstrap_auth_rejects_blank_scope_entries() {
-        assert!(validate_device_scopes(&[" ".to_string()]).is_err());
-        assert!(validate_device_scopes(&["scope".to_string(), "".to_string()]).is_err());
+    fn test_load_runtime_config_from_file() {
+        let temp = TempDir::new().unwrap();
+        write_service_bus_config(&temp, "file.servicebus.windows.net", "file-up", "file-down");
+
+        temp_env::with_vars_unset(
+            [
+                "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE",
+                "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+            ],
+            || {
+                let config = load_runtime_config(temp.path()).unwrap();
+                assert_eq!(
+                    config,
+                    RuntimeConfig {
+                        namespace: "file.servicebus.windows.net".to_string(),
+                        upstream_queue: "file-up".to_string(),
+                        downstream_queue: "file-down".to_string(),
+                    }
+                );
+            },
+        );
     }
 
     #[test]
-    fn bootstrap_auth_requires_non_empty_client_id() {
-        assert!(validate_device_client_id("").is_err());
-        assert!(validate_device_client_id("   ").is_err());
-        assert!(validate_device_client_id("client-id").is_ok());
+    fn test_load_runtime_config_env_overrides_file() {
+        let temp = TempDir::new().unwrap();
+        write_service_bus_config(&temp, "file.servicebus.windows.net", "file-up", "file-down");
+
+        temp_env::with_vars(
+            [
+                (
+                    "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                    Some("env.servicebus.windows.net"),
+                ),
+                ("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE", Some("env-up")),
+                (
+                    "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+                    Some("env-down"),
+                ),
+            ],
+            || {
+                let config = load_runtime_config(temp.path()).unwrap();
+                assert_eq!(
+                    config,
+                    RuntimeConfig {
+                        namespace: "env.servicebus.windows.net".to_string(),
+                        upstream_queue: "env-up".to_string(),
+                        downstream_queue: "env-down".to_string(),
+                    }
+                );
+            },
+        );
     }
 
     #[test]
-    fn bootstrap_auth_uses_microsoft_provider_by_default() {
-        let (provider, _config) = bootstrap_provider_and_config(&bootstrap_args()).unwrap();
-        assert_eq!(provider, Provider::Microsoft);
+    fn test_parse_bicep_outputs() {
+        let json = r#"{
+            "companionBootstrapValues": {
+                "value": {
+                    "tenantId": { "value": "11111111-1111-1111-1111-111111111111" },
+                    "clientId": { "value": "22222222-2222-2222-2222-222222222222" },
+                    "serviceBusNamespace": { "value": "example.servicebus.windows.net" },
+                    "upstreamQueue": { "value": "upstream" },
+                    "downstreamQueue": { "value": "downstream" }
+                }
+            }
+        }"#;
+
+        let (sp, sb) = parse_bicep_outputs(json).unwrap();
+        assert_eq!(
+            sp,
+            ServicePrincipalStateFile {
+                tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+                client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                certificate_path: CERT_PEM_FILENAME.to_string(),
+                private_key_path: KEY_PEM_FILENAME.to_string(),
+            }
+        );
+        assert_eq!(
+            sb,
+            ServiceBusConfigFile {
+                namespace: "example.servicebus.windows.net".to_string(),
+                upstream_queue: "upstream".to_string(),
+                downstream_queue: "downstream".to_string(),
+            }
+        );
     }
 
     #[test]
-    fn bootstrap_auth_accepts_explicit_endpoint_overrides() {
-        let mut args = bootstrap_args();
-        args.device_auth_url = Some("http://127.0.0.1/device".to_string());
-        args.device_token_url = Some("http://127.0.0.1/token".to_string());
+    fn test_staged_commit() {
+        let temp = TempDir::new().unwrap();
+        let staging_dir = prepare_staging_dir(temp.path()).unwrap();
+        std::fs::write(staging_dir.join(CERT_PEM_FILENAME), b"new-cert").unwrap();
+        std::fs::write(staging_dir.join(KEY_PEM_FILENAME), b"new-key").unwrap();
+        std::fs::write(temp.path().join(CERT_PEM_FILENAME), b"old-cert").unwrap();
 
-        let (provider, _config) = bootstrap_provider_and_config(&args).unwrap();
-        assert_eq!(provider, Provider::Generic);
+        commit_staging(&staging_dir, temp.path()).unwrap();
+
+        assert_eq!(std::fs::read(temp.path().join(CERT_PEM_FILENAME)).unwrap(), b"new-cert");
+        assert_eq!(std::fs::read(temp.path().join(KEY_PEM_FILENAME)).unwrap(), b"new-key");
+        assert!(!staging_dir.exists());
     }
 
     #[test]
-    fn bootstrap_auth_rejects_partial_endpoint_override() {
-        let mut args = bootstrap_args();
-        args.device_auth_url = Some("http://127.0.0.1/device".to_string());
+    fn test_staged_cleanup() {
+        let temp = TempDir::new().unwrap();
+        let staging_dir = prepare_staging_dir(temp.path()).unwrap();
+        std::fs::write(staging_dir.join(CERT_PEM_FILENAME), b"temp-cert").unwrap();
 
-        assert!(bootstrap_provider_and_config(&args).is_err());
+        cleanup_staging(&staging_dir);
+
+        assert!(!staging_dir.exists());
     }
 
     #[test]
@@ -1800,7 +2324,8 @@ mod tests {
                 "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
             ],
             || {
-                let err = load_runtime_config().unwrap_err();
+                let temp = TempDir::new().unwrap();
+                let err = load_runtime_config(temp.path()).unwrap_err();
                 assert!(matches!(err, CompanionError::Config(_)));
             },
         );

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -4,6 +4,7 @@
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use azservicebus::{
     ServiceBusClient, ServiceBusClientOptions, ServiceBusMessage, ServiceBusReceiver,
@@ -64,6 +65,8 @@ const CERT_PEM_FILENAME: &str = "cert.pem";
 const KEY_PEM_FILENAME: &str = "key.pem";
 const SERVICE_BUS_CONFIG_FILENAME: &str = "service-bus.json";
 const STAGING_DIR_NAME: &str = ".staging";
+const ACTIVE_STATE_FILENAME: &str = ".current-state";
+const STATE_GENERATION_PREFIX: &str = ".state-";
 const DEFAULT_DOWNSTREAM_WAIT_SECS: u64 = 1;
 const CONNECTOR_MAX_FRAME_LENGTH: usize =
     sonde_gateway::connector::DEFAULT_CONNECTOR_MAX_MESSAGE_SIZE;
@@ -446,7 +449,8 @@ fn load_runtime_config(state_dir: &Path) -> Result<RuntimeConfig, CompanionError
 }
 
 fn load_service_bus_config_file(state_dir: &Path) -> Result<ServiceBusConfigFile, CompanionError> {
-    let config_path = state_dir.join(SERVICE_BUS_CONFIG_FILENAME);
+    let effective_state_dir = resolve_effective_state_dir(state_dir)?;
+    let config_path = effective_state_dir.join(SERVICE_BUS_CONFIG_FILENAME);
     let bytes = std::fs::read(&config_path)?;
     let config: ServiceBusConfigFile = serde_json::from_slice(&bytes)?;
     Ok(config)
@@ -461,61 +465,65 @@ fn prepare_staging_dir(state_dir: &Path) -> Result<PathBuf, CompanionError> {
     Ok(staging_dir)
 }
 
+fn active_state_marker_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(ACTIVE_STATE_FILENAME)
+}
+
+fn active_state_generation_name(state_dir: &Path) -> Result<Option<String>, CompanionError> {
+    let marker_path = active_state_marker_path(state_dir);
+    let marker_text = match std::fs::read_to_string(&marker_path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let generation_name = marker_text.trim();
+    if generation_name.is_empty() {
+        return Err(CompanionError::Config(format!(
+            "active state marker `{}` must not be empty",
+            marker_path.display()
+        )));
+    }
+    let generation_path = resolve_state_relative_path(state_dir, generation_name)?;
+    if !generation_path.is_dir() {
+        return Err(CompanionError::Config(format!(
+            "active state generation directory not found: {}",
+            generation_path.display()
+        )));
+    }
+    Ok(Some(generation_name.to_string()))
+}
+
+fn resolve_effective_state_dir(state_dir: &Path) -> Result<PathBuf, CompanionError> {
+    match active_state_generation_name(state_dir)? {
+        Some(generation_name) => resolve_state_relative_path(state_dir, &generation_name),
+        None => Ok(state_dir.to_path_buf()),
+    }
+}
+
 fn commit_staging(staging_dir: &Path, state_dir: &Path) -> Result<(), CompanionError> {
-    let backup_dir = state_dir.join(format!("{STAGING_DIR_NAME}-backup"));
-    if backup_dir.exists() {
-        std::fs::remove_dir_all(&backup_dir)?;
-    }
-    std::fs::create_dir_all(&backup_dir)?;
+    let previous_generation = active_state_generation_name(state_dir)?;
+    let generation_suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| CompanionError::Config(format!("system clock before UNIX_EPOCH: {err}")))?
+        .as_nanos();
+    let generation_name = format!("{STATE_GENERATION_PREFIX}{generation_suffix}");
+    let generation_dir = state_dir.join(&generation_name);
+    std::fs::rename(staging_dir, &generation_dir)?;
 
-    let staged_files: Vec<(PathBuf, PathBuf)> = std::fs::read_dir(staging_dir)?
-        .map(|entry| {
-            let entry = entry?;
-            Ok((entry.path(), state_dir.join(entry.file_name())))
-        })
-        .collect::<Result<_, std::io::Error>>()?;
+    let marker_path = active_state_marker_path(state_dir);
+    let marker_tmp = state_dir.join(format!("{ACTIVE_STATE_FILENAME}.tmp"));
+    std::fs::write(&marker_tmp, format!("{generation_name}\n"))?;
+    std::fs::rename(&marker_tmp, &marker_path)?;
 
-    let mut backed_up: Vec<(PathBuf, PathBuf)> = Vec::new();
-    let mut committed: Vec<PathBuf> = Vec::new();
-
-    let commit_result: Result<(), CompanionError> = (|| {
-        for (_, dest) in &staged_files {
-            if dest.exists() {
-                let backup_path = backup_dir.join(dest.file_name().ok_or_else(|| {
-                    CompanionError::Config(format!(
-                        "staged destination had no file name: {}",
-                        dest.display()
-                    ))
-                })?);
-                std::fs::rename(dest, &backup_path)?;
-                backed_up.push((backup_path, dest.clone()));
-            }
+    if let Some(previous_generation) = previous_generation {
+        if previous_generation.starts_with(STATE_GENERATION_PREFIX)
+            && previous_generation != generation_name
+        {
+            let previous_dir = state_dir.join(previous_generation);
+            let _ = std::fs::remove_dir_all(previous_dir);
         }
-
-        for (src, dest) in &staged_files {
-            std::fs::rename(src, dest)?;
-            committed.push(dest.clone());
-        }
-        Ok(())
-    })();
-
-    if let Err(err) = commit_result {
-        for dest in &committed {
-            if dest.exists() {
-                let _ = std::fs::remove_file(dest);
-            }
-        }
-        for (backup_path, dest) in backed_up.iter().rev() {
-            if backup_path.exists() {
-                let _ = std::fs::rename(backup_path, dest);
-            }
-        }
-        let _ = std::fs::remove_dir_all(&backup_dir);
-        return Err(err);
     }
 
-    let _ = std::fs::remove_dir_all(&backup_dir);
-    let _ = std::fs::remove_dir(staging_dir);
     Ok(())
 }
 
@@ -582,10 +590,6 @@ fn write_private_key_pem(path: &Path, pem: &str) -> Result<(), CompanionError> {
     }
 }
 
-fn service_principal_state_path(state_dir: &Path) -> PathBuf {
-    state_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME)
-}
-
 fn resolve_state_relative_path(state_dir: &Path, value: &str) -> Result<PathBuf, CompanionError> {
     let path = PathBuf::from(value);
     if path.is_absolute() {
@@ -624,7 +628,8 @@ fn canonicalize_state_file_path(
 fn load_runtime_credential_state(
     state_dir: &Path,
 ) -> Result<RuntimeCredentialState, CompanionError> {
-    let state_path = service_principal_state_path(state_dir);
+    let effective_state_dir = resolve_effective_state_dir(state_dir)?;
+    let state_path = effective_state_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME);
     let state_bytes = match std::fs::read(&state_path) {
         Ok(state_bytes) => state_bytes,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -640,26 +645,34 @@ fn load_runtime_credential_state(
     let client_id = require_non_empty(state.client_id, "service principal client_id")?;
     let certificate_path_value =
         require_non_empty(state.certificate_path, "service principal certificate_path")?;
-    let certificate_path = resolve_state_relative_path(state_dir, &certificate_path_value)?;
+    let certificate_path =
+        resolve_state_relative_path(&effective_state_dir, &certificate_path_value)?;
     if !certificate_path.is_file() {
         return Err(CompanionError::Config(format!(
             "service principal certificate file not found: {}",
             certificate_path.display()
         )));
     }
-    let certificate_path =
-        canonicalize_state_file_path(state_dir, &certificate_path, &certificate_path_value)?;
+    let certificate_path = canonicalize_state_file_path(
+        &effective_state_dir,
+        &certificate_path,
+        &certificate_path_value,
+    )?;
     let private_key_path_value =
         require_non_empty(state.private_key_path, "service principal private_key_path")?;
-    let private_key_path = resolve_state_relative_path(state_dir, &private_key_path_value)?;
+    let private_key_path =
+        resolve_state_relative_path(&effective_state_dir, &private_key_path_value)?;
     if !private_key_path.is_file() {
         return Err(CompanionError::Config(format!(
             "service principal private key file not found: {}",
             private_key_path.display()
         )));
     }
-    let private_key_path =
-        canonicalize_state_file_path(state_dir, &private_key_path, &private_key_path_value)?;
+    let private_key_path = canonicalize_state_file_path(
+        &effective_state_dir,
+        &private_key_path,
+        &private_key_path_value,
+    )?;
     Ok(RuntimeCredentialState {
         tenant_id,
         client_id,
@@ -939,6 +952,7 @@ az login --use-device-code --output none >&2
 if [ -n "${SONDE_AZURE_SUBSCRIPTION_ID:-}" ]; then
     az account set --subscription "$SONDE_AZURE_SUBSCRIPTION_ID" >&2
 fi
+echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2
 az deployment sub create \
     --location "$SONDE_AZURE_LOCATION" \
     --template-file /bicep/main.bicep \
@@ -953,7 +967,16 @@ az deployment sub create \
 fn device_code_regex() -> &'static Regex {
     static DEVICE_CODE_RE: OnceLock<Regex> = OnceLock::new();
     DEVICE_CODE_RE.get_or_init(|| {
-        Regex::new(r"enter the code ([A-Z0-9-]+) to authenticate").expect("valid device code regex")
+        Regex::new(r"(?i)enter\s+the\s+code\s+([A-Z0-9-]+)\s+to\s+authenticate")
+            .expect("valid device code regex")
+    })
+}
+
+fn device_code_fallback_regex() -> &'static Regex {
+    static DEVICE_CODE_FALLBACK_RE: OnceLock<Regex> = OnceLock::new();
+    DEVICE_CODE_FALLBACK_RE.get_or_init(|| {
+        Regex::new(r"(?i)microsoft\.com/devicelogin[^\n]*\b([A-Z0-9]{4}(?:-[A-Z0-9]{4})+)\b")
+            .expect("valid fallback device code regex")
     })
 }
 
@@ -962,6 +985,12 @@ fn extract_device_code(stderr_buffer: &str) -> Option<String> {
         .captures(stderr_buffer)
         .and_then(|captures| captures.get(1))
         .map(|code| code.as_str().to_string())
+        .or_else(|| {
+            device_code_fallback_regex()
+                .captures(stderr_buffer)
+                .and_then(|captures| captures.get(1))
+                .map(|code| code.as_str().to_string())
+        })
 }
 
 fn build_container_env(cert_base64: &str, args: &BootstrapArgs) -> Vec<String> {
@@ -1467,6 +1496,7 @@ async fn stream_container_output(
     let mut stdout_buffer = String::new();
     let mut stderr_buffer = String::new();
     let mut device_code_displayed = false;
+    let mut deployment_displayed = false;
 
     while let Some(result) = logs.next().await {
         match result {
@@ -1482,6 +1512,13 @@ async fn stream_container_output(
                 if stderr_buffer.len() > MAX_STDERR_BUFFER_LEN {
                     let trim_start = stderr_buffer.len() - MAX_STDERR_BUFFER_LEN;
                     stderr_buffer.drain(..trim_start);
+                }
+
+                if !deployment_displayed
+                    && stderr_buffer.contains("__SONDE_AZURE_DEPLOYMENT_START__")
+                {
+                    display_progress(admin_socket, "Deploying Azure...").await?;
+                    deployment_displayed = true;
                 }
 
                 if !device_code_displayed {
@@ -1626,7 +1663,11 @@ async fn report_bootstrap_failure(
     err: CompanionError,
 ) -> Result<(), CompanionError> {
     cleanup_staging(staging_dir);
-    display_progress(admin_socket, "Bootstrap failed").await?;
+    if let Err(display_err) = display_progress(admin_socket, "Bootstrap failed").await {
+        return Err(CompanionError::Config(format!(
+            "bootstrap failed: {err}; additionally failed to display modem error: {display_err}"
+        )));
+    }
     Err(err)
 }
 
@@ -1704,13 +1745,14 @@ mod tests {
     use super::{
         build_az_bootstrap_script, check_runtime_ready, cleanup_staging, commit_staging,
         downstream_body_to_connector_payload, extract_device_code, generate_certificate,
-        load_runtime_config, load_signing_key, parse_bicep_outputs, prepare_staging_dir,
-        pump_downstream_once, pump_upstream_once, read_framed, resolve_state_relative_path,
+        load_runtime_config, load_runtime_credential_state, load_signing_key, parse_bicep_outputs,
+        prepare_staging_dir, pump_downstream_once, pump_upstream_once, read_framed,
+        resolve_effective_state_dir, resolve_state_relative_path,
         validate_certificate_matches_private_key, validate_display_lines, write_framed,
         ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
         RuntimeCredentialState, ServiceBusConfigFile, ServicePrincipalStateFile, UpstreamPublisher,
-        CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME,
-        SERVICE_BUS_CONFIG_FILENAME,
+        ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME,
+        SERVICE_BUS_CONFIG_FILENAME, SERVICE_PRINCIPAL_STATE_FILENAME,
     };
     use azure_core::credentials::TokenCredential;
     use base64::Engine as _;
@@ -2391,6 +2433,7 @@ mod tests {
         let script = build_az_bootstrap_script();
         assert!(script.contains(r#"--location "$SONDE_AZURE_LOCATION""#));
         assert!(script.contains(r#"--parameters location="$SONDE_AZURE_LOCATION""#));
+        assert!(script.contains(r#"echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2"#));
     }
 
     #[test]
@@ -2400,6 +2443,18 @@ mod tests {
             "enter the code ABCD-EFGH to authenticate.\n",
         );
         assert_eq!(extract_device_code(buffer).as_deref(), Some("ABCD-EFGH"));
+    }
+
+    #[test]
+    fn extract_device_code_is_case_insensitive() {
+        let buffer = "ENTER THE CODE WXYZ-1234 TO AUTHENTICATE";
+        assert_eq!(extract_device_code(buffer).as_deref(), Some("WXYZ-1234"));
+    }
+
+    #[test]
+    fn extract_device_code_supports_devicelogin_fallback_pattern() {
+        let buffer = "Open https://microsoft.com/devicelogin and use code QRST-UVWX when prompted.";
+        assert_eq!(extract_device_code(buffer).as_deref(), Some("QRST-UVWX"));
     }
 
     #[test]
@@ -2442,17 +2497,50 @@ mod tests {
         let staging_dir = prepare_staging_dir(temp.path()).unwrap();
         std::fs::write(staging_dir.join(CERT_PEM_FILENAME), b"new-cert").unwrap();
         std::fs::write(staging_dir.join(KEY_PEM_FILENAME), b"new-key").unwrap();
+        std::fs::write(
+            staging_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME),
+            serde_json::to_vec(&ServicePrincipalStateFile {
+                tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+                client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                certificate_path: CERT_PEM_FILENAME.to_string(),
+                private_key_path: KEY_PEM_FILENAME.to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            staging_dir.join(SERVICE_BUS_CONFIG_FILENAME),
+            serde_json::to_vec(&ServiceBusConfigFile {
+                namespace: "example.servicebus.windows.net".to_string(),
+                upstream_queue: "upstream".to_string(),
+                downstream_queue: "downstream".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
         std::fs::write(temp.path().join(CERT_PEM_FILENAME), b"old-cert").unwrap();
 
         commit_staging(&staging_dir, temp.path()).unwrap();
 
+        let active_marker = temp.path().join(ACTIVE_STATE_FILENAME);
+        assert!(active_marker.exists());
+        let effective_state_dir = resolve_effective_state_dir(temp.path()).unwrap();
+        assert_ne!(effective_state_dir, temp.path());
         assert_eq!(
-            std::fs::read(temp.path().join(CERT_PEM_FILENAME)).unwrap(),
+            std::fs::read(effective_state_dir.join(CERT_PEM_FILENAME)).unwrap(),
             b"new-cert"
         );
         assert_eq!(
-            std::fs::read(temp.path().join(KEY_PEM_FILENAME)).unwrap(),
+            std::fs::read(effective_state_dir.join(KEY_PEM_FILENAME)).unwrap(),
             b"new-key"
+        );
+        let runtime_state = load_runtime_credential_state(temp.path()).unwrap();
+        assert_eq!(
+            runtime_state.certificate_path,
+            effective_state_dir
+                .join(CERT_PEM_FILENAME)
+                .canonicalize()
+                .unwrap()
         );
         assert!(!staging_dir.exists());
     }

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -572,7 +572,7 @@ fn write_private_key_pem(path: &Path, pem: &str) -> Result<(), CompanionError> {
             .open(path)?;
         file.write_all(pem.as_bytes())?;
         file.flush()?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]
@@ -2776,7 +2776,7 @@ mod tests {
             .await
             .unwrap_err();
         assert!(!temp.path().join(".staging").exists());
-        assert!(err.to_string().contains("No such file or directory"));
+        assert!(matches!(err, CompanionError::TonicTransport(_)));
     }
 
     #[tokio::test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 sonde contributors
 
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use azservicebus::{
@@ -25,6 +25,7 @@ use clap::{Args, Parser, Subcommand};
 use ed25519_dalek::pkcs8::DecodePrivateKey as Ed25519DecodePrivateKey;
 use futures_util::StreamExt;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use regex::Regex;
 use rsa::pkcs1::DecodeRsaPrivateKey;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -400,30 +401,42 @@ fn load_runtime_config(state_dir: &Path) -> Result<RuntimeConfig, CompanionError
         Err(err) => return Err(err),
     };
 
-    let namespace = namespace_env
-        .or_else(|| file_config.as_ref().map(|c| c.namespace.clone()))
-        .ok_or_else(|| {
-            CompanionError::Config(
-                "SONDE_AZURE_SERVICEBUS_NAMESPACE must be set and non-empty (or service-bus.json must exist in state dir)"
-                    .into(),
-            )
-        })?;
-    let upstream_queue = upstream_env
-        .or_else(|| file_config.as_ref().map(|c| c.upstream_queue.clone()))
-        .ok_or_else(|| {
-            CompanionError::Config(
-                "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE must be set and non-empty (or service-bus.json must exist in state dir)"
-                    .into(),
-            )
-        })?;
-    let downstream_queue = downstream_env
-        .or_else(|| file_config.as_ref().map(|c| c.downstream_queue.clone()))
-        .ok_or_else(|| {
-            CompanionError::Config(
-                "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE must be set and non-empty (or service-bus.json must exist in state dir)"
-                    .into(),
-            )
-        })?;
+    let namespace = if let Some(value) = namespace_env {
+        require_non_empty(value, "SONDE_AZURE_SERVICEBUS_NAMESPACE")?
+    } else if let Some(config) = file_config.as_ref() {
+        require_non_empty(config.namespace.clone(), "service-bus.json namespace")?
+    } else {
+        return Err(CompanionError::Config(
+            "SONDE_AZURE_SERVICEBUS_NAMESPACE must be set and non-empty (or service-bus.json must exist in state dir)"
+                .into(),
+        ));
+    };
+    let upstream_queue = if let Some(value) = upstream_env {
+        require_non_empty(value, "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE")?
+    } else if let Some(config) = file_config.as_ref() {
+        require_non_empty(
+            config.upstream_queue.clone(),
+            "service-bus.json upstream_queue",
+        )?
+    } else {
+        return Err(CompanionError::Config(
+            "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE must be set and non-empty (or service-bus.json must exist in state dir)"
+                .into(),
+        ));
+    };
+    let downstream_queue = if let Some(value) = downstream_env {
+        require_non_empty(value, "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE")?
+    } else if let Some(config) = file_config.as_ref() {
+        require_non_empty(
+            config.downstream_queue.clone(),
+            "service-bus.json downstream_queue",
+        )?
+    } else {
+        return Err(CompanionError::Config(
+            "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE must be set and non-empty (or service-bus.json must exist in state dir)"
+                .into(),
+        ));
+    };
 
     Ok(RuntimeConfig {
         namespace,
@@ -536,18 +549,37 @@ fn generate_certificate(staging_dir: &Path) -> Result<(PathBuf, PathBuf, String)
     let key_path = staging_dir.join(KEY_PEM_FILENAME);
 
     std::fs::write(&cert_path, cert_pem.as_bytes())?;
-    std::fs::write(&key_path, key_pem.as_bytes())?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600))?;
-    }
+    write_private_key_pem(&key_path, &key_pem)?;
 
     let cert_der = cert.der().to_vec();
     let cert_base64 = base64::engine::general_purpose::STANDARD.encode(&cert_der);
 
     Ok((cert_path, key_path, cert_base64))
+}
+
+fn write_private_key_pem(path: &Path, pem: &str) -> Result<(), CompanionError> {
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(pem.as_bytes())?;
+        file.flush()?;
+        return Ok(());
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, pem.as_bytes())?;
+        Ok(())
+    }
 }
 
 fn service_principal_state_path(state_dir: &Path) -> PathBuf {
@@ -911,10 +943,25 @@ az deployment sub create \
     --location "$SONDE_AZURE_LOCATION" \
     --template-file /bicep/main.bicep \
     --parameters companionCertificateBase64="$COMPANION_CERT_BASE64" \
+    --parameters location="$SONDE_AZURE_LOCATION" \
     --parameters project_name="$SONDE_AZURE_PROJECT_NAME" \
     --query 'properties.outputs' \
     --output json"#
         .to_string()
+}
+
+fn device_code_regex() -> &'static Regex {
+    static DEVICE_CODE_RE: OnceLock<Regex> = OnceLock::new();
+    DEVICE_CODE_RE.get_or_init(|| {
+        Regex::new(r"enter the code ([A-Z0-9-]+) to authenticate").expect("valid device code regex")
+    })
+}
+
+fn extract_device_code(stderr_buffer: &str) -> Option<String> {
+    device_code_regex()
+        .captures(stderr_buffer)
+        .and_then(|captures| captures.get(1))
+        .map(|code| code.as_str().to_string())
 }
 
 fn build_container_env(cert_base64: &str, args: &BootstrapArgs) -> Vec<String> {
@@ -1410,8 +1457,6 @@ async fn stream_container_output(
     container_id: &str,
     admin_socket: &str,
 ) -> Result<String, CompanionError> {
-    use regex::Regex;
-
     let log_opts = LogsOptionsBuilder::default()
         .follow(true)
         .stdout(true)
@@ -1421,8 +1466,6 @@ async fn stream_container_output(
     let mut logs = docker.logs(container_id, Some(log_opts));
     let mut stdout_buffer = String::new();
     let mut stderr_buffer = String::new();
-    let device_code_re = Regex::new(r"enter the code ([A-Z0-9-]+) to authenticate")
-        .expect("valid device code regex");
     let mut device_code_displayed = false;
 
     while let Some(result) = logs.next().await {
@@ -1442,22 +1485,19 @@ async fn stream_container_output(
                 }
 
                 if !device_code_displayed {
-                    if let Some(captures) = device_code_re.captures(&stderr_buffer) {
-                        if let Some(code) = captures.get(1) {
-                            let device_code = code.as_str().to_string();
-                            eprintln!("Detected device code: {device_code}");
-                            if let Err(e) = display_message(
-                                admin_socket,
-                                vec!["Azure login".to_string(), device_code],
-                            )
-                            .await
-                            {
-                                return Err(CompanionError::Config(format!(
-                                    "failed to display device code on modem: {e}"
-                                )));
-                            }
-                            device_code_displayed = true;
+                    if let Some(device_code) = extract_device_code(&stderr_buffer) {
+                        eprintln!("Detected device code: {device_code}");
+                        if let Err(e) = display_message(
+                            admin_socket,
+                            vec!["Azure login".to_string(), device_code],
+                        )
+                        .await
+                        {
+                            return Err(CompanionError::Config(format!(
+                                "failed to display device code on modem: {e}"
+                            )));
                         }
+                        device_code_displayed = true;
                     }
                 }
             }
@@ -1576,10 +1616,18 @@ async fn display_message(admin_socket: &str, lines: Vec<String>) -> Result<(), C
     Ok(())
 }
 
-async fn display_progress(admin_socket: &str, msg: &str) {
-    if let Err(e) = display_message(admin_socket, vec![msg.to_string()]).await {
-        eprintln!("warning: failed to update modem display: {e}");
-    }
+async fn display_progress(admin_socket: &str, msg: &str) -> Result<(), CompanionError> {
+    display_message(admin_socket, vec![msg.to_string()]).await
+}
+
+async fn report_bootstrap_failure(
+    admin_socket: &str,
+    staging_dir: &Path,
+    err: CompanionError,
+) -> Result<(), CompanionError> {
+    cleanup_staging(staging_dir);
+    display_progress(admin_socket, "Bootstrap failed").await?;
+    Err(err)
 }
 
 async fn bootstrap(
@@ -1591,30 +1639,25 @@ async fn bootstrap(
 
     let staging_dir = prepare_staging_dir(state_dir)?;
 
-    display_progress(admin_socket, "Generating cert...").await;
+    if let Err(err) = display_progress(admin_socket, "Generating cert...").await {
+        cleanup_staging(&staging_dir);
+        return Err(err);
+    }
     eprintln!("Generating ECDSA P-256 self-signed certificate");
     let (_cert_path, _key_path, cert_base64) = match generate_certificate(&staging_dir) {
         Ok(result) => result,
-        Err(e) => {
-            cleanup_staging(&staging_dir);
-            display_progress(admin_socket, "Bootstrap failed").await;
-            return Err(e);
-        }
+        Err(e) => return report_bootstrap_failure(admin_socket, &staging_dir, e).await,
     };
 
-    display_progress(admin_socket, "Authenticating...").await;
+    display_progress(admin_socket, "Authenticating...").await?;
     eprintln!("Starting Azure CLI container for device-code auth and Bicep deployment");
     let (sp_state, sb_config) =
         match run_bootstrap_deployment(admin_socket, &staging_dir, &cert_base64, &args).await {
             Ok(result) => result,
-            Err(e) => {
-                cleanup_staging(&staging_dir);
-                display_progress(admin_socket, "Bootstrap failed").await;
-                return Err(e);
-            }
+            Err(e) => return report_bootstrap_failure(admin_socket, &staging_dir, e).await,
         };
 
-    display_progress(admin_socket, "Writing config...").await;
+    display_progress(admin_socket, "Writing config...").await?;
     eprintln!("Writing runtime artifacts to state volume");
 
     let sp_path = staging_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME);
@@ -1626,12 +1669,10 @@ async fn bootstrap(
     std::fs::write(&sb_path, sb_json.as_bytes())?;
 
     if let Err(e) = commit_staging(&staging_dir, state_dir) {
-        cleanup_staging(&staging_dir);
-        display_progress(admin_socket, "Bootstrap failed").await;
-        return Err(e);
+        return report_bootstrap_failure(admin_socket, &staging_dir, e).await;
     }
 
-    display_progress(admin_socket, "Bootstrap complete").await;
+    display_progress(admin_socket, "Bootstrap complete").await?;
     eprintln!("Bootstrap completed successfully");
 
     Ok(())
@@ -1661,14 +1702,15 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        check_runtime_ready, cleanup_staging, commit_staging, downstream_body_to_connector_payload,
-        generate_certificate, load_runtime_config, load_signing_key, parse_bicep_outputs,
-        prepare_staging_dir, pump_downstream_once, pump_upstream_once, read_framed,
-        resolve_state_relative_path, validate_certificate_matches_private_key,
-        validate_display_lines, write_framed, ClientAssertionCredential, CompanionError,
-        DownstreamConsumer, RuntimeConfig, RuntimeCredentialState, ServiceBusConfigFile,
-        ServicePrincipalStateFile, UpstreamPublisher, CERT_PEM_FILENAME,
-        CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME, SERVICE_BUS_CONFIG_FILENAME,
+        build_az_bootstrap_script, check_runtime_ready, cleanup_staging, commit_staging,
+        downstream_body_to_connector_payload, extract_device_code, generate_certificate,
+        load_runtime_config, load_signing_key, parse_bicep_outputs, prepare_staging_dir,
+        pump_downstream_once, pump_upstream_once, read_framed, resolve_state_relative_path,
+        validate_certificate_matches_private_key, validate_display_lines, write_framed,
+        ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
+        RuntimeCredentialState, ServiceBusConfigFile, ServicePrincipalStateFile, UpstreamPublisher,
+        CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME,
+        SERVICE_BUS_CONFIG_FILENAME,
     };
     use azure_core::credentials::TokenCredential;
     use base64::Engine as _;
@@ -2209,6 +2251,14 @@ mod tests {
         let (algorithm, _) = load_signing_key(&key_path).unwrap();
         assert_eq!(algorithm, Algorithm::ES256);
         validate_certificate_matches_private_key(&cert_path, &key_path).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let key_mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(key_mode, 0o600);
+        }
     }
 
     #[test]
@@ -2262,6 +2312,94 @@ mod tests {
                 );
             },
         );
+    }
+
+    #[test]
+    fn test_load_runtime_config_trims_selected_values() {
+        let temp = TempDir::new().unwrap();
+        write_service_bus_config(
+            &temp,
+            "  file.servicebus.windows.net  ",
+            "  file-up  ",
+            "  file-down  ",
+        );
+
+        temp_env::with_vars_unset(
+            [
+                "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE",
+                "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+            ],
+            || {
+                let config = load_runtime_config(temp.path()).unwrap();
+                assert_eq!(
+                    config,
+                    RuntimeConfig {
+                        namespace: "file.servicebus.windows.net".to_string(),
+                        upstream_queue: "file-up".to_string(),
+                        downstream_queue: "file-down".to_string(),
+                    }
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_load_runtime_config_rejects_blank_service_bus_file_values() {
+        let temp = TempDir::new().unwrap();
+        write_service_bus_config(&temp, "example.servicebus.windows.net", "  ", "downstream");
+
+        temp_env::with_vars_unset(
+            [
+                "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE",
+                "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+            ],
+            || {
+                let err = load_runtime_config(temp.path()).unwrap_err();
+                assert!(err
+                    .to_string()
+                    .contains("service-bus.json upstream_queue must be set and non-empty"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_load_runtime_config_surfaces_invalid_service_bus_json() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(
+            temp.path().join(SERVICE_BUS_CONFIG_FILENAME),
+            b"{not valid json",
+        )
+        .unwrap();
+
+        temp_env::with_vars_unset(
+            [
+                "SONDE_AZURE_SERVICEBUS_NAMESPACE",
+                "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE",
+                "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
+            ],
+            || {
+                let err = load_runtime_config(temp.path()).unwrap_err();
+                assert!(matches!(err, CompanionError::Json(_)));
+            },
+        );
+    }
+
+    #[test]
+    fn build_az_bootstrap_script_passes_location_parameter_to_template() {
+        let script = build_az_bootstrap_script();
+        assert!(script.contains(r#"--location "$SONDE_AZURE_LOCATION""#));
+        assert!(script.contains(r#"--parameters location="$SONDE_AZURE_LOCATION""#));
+    }
+
+    #[test]
+    fn extract_device_code_handles_split_prompt_buffer() {
+        let buffer = concat!(
+            "To sign in, use a web browser to open the page https://microsoft.com/devicelogin and ",
+            "enter the code ABCD-EFGH to authenticate.\n",
+        );
+        assert_eq!(extract_device_code(buffer).as_deref(), Some("ABCD-EFGH"));
     }
 
     #[test]
@@ -2622,6 +2760,23 @@ mod tests {
         assert!(err.to_string().contains("completion failure"));
         assert_eq!(consumer.completes, 0);
         assert_eq!(consumer.abandons, 1);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bootstrap_fails_closed_when_progress_display_fails() {
+        let temp = TempDir::new().unwrap();
+        let args = super::BootstrapArgs {
+            azure_location: "westus2".to_string(),
+            azure_project_name: "sonde".to_string(),
+            azure_subscription_id: None,
+        };
+
+        let err = super::bootstrap("/tmp/sonde-missing-admin.sock", temp.path(), args)
+            .await
+            .unwrap_err();
+        assert!(!temp.path().join(".staging").exists());
+        assert!(err.to_string().contains("No such file or directory"));
     }
 
     #[tokio::test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -1574,7 +1574,17 @@ async fn run_bootstrap_deployment(
 ) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
     let docker = Docker::connect_with_local_defaults()
         .map_err(|e| CompanionError::Config(format!("failed to connect to Docker daemon: {e}")))?;
+    run_bootstrap_deployment_with_docker(&docker, admin_socket, staging_dir, cert_base64, args)
+        .await
+}
 
+async fn run_bootstrap_deployment_with_docker(
+    docker: &Docker,
+    admin_socket: &str,
+    staging_dir: &Path,
+    cert_base64: &str,
+    args: &BootstrapArgs,
+) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
     eprintln!("Pulling Azure CLI container image...");
     let pull_opts = CreateImageOptionsBuilder::default()
         .from_image(AZURE_CLI_IMAGE)
@@ -1609,7 +1619,7 @@ async fn run_bootstrap_deployment(
     let container_id = container.id;
 
     let bootstrap_result = async {
-        copy_files_to_container(&docker, &container_id, staging_dir).await?;
+        copy_files_to_container(docker, &container_id, staging_dir).await?;
         docker
             .start_container(&container_id, None)
             .await
@@ -1617,7 +1627,7 @@ async fn run_bootstrap_deployment(
                 CompanionError::Config(format!("failed to start Azure CLI container: {e}"))
             })?;
 
-        let stdout_output = stream_container_output(&docker, &container_id, admin_socket).await?;
+        let stdout_output = stream_container_output(docker, &container_id, admin_socket).await?;
         let wait_options = WaitContainerOptionsBuilder::default()
             .condition("not-running")
             .build();
@@ -1702,7 +1712,10 @@ async fn bootstrap(
         Err(e) => return report_bootstrap_failure(admin_socket, &staging_dir, e).await,
     };
 
-    display_progress(admin_socket, "Authenticating...").await?;
+    if let Err(err) = display_progress(admin_socket, "Authenticating...").await {
+        cleanup_staging(&staging_dir);
+        return Err(err);
+    }
     eprintln!("Starting Azure CLI container for device-code auth and Bicep deployment");
     let (sp_state, sb_config) =
         match run_bootstrap_deployment(admin_socket, &staging_dir, &cert_base64, &args).await {
@@ -1710,7 +1723,10 @@ async fn bootstrap(
             Err(e) => return report_bootstrap_failure(admin_socket, &staging_dir, e).await,
         };
 
-    display_progress(admin_socket, "Writing config...").await?;
+    if let Err(err) = display_progress(admin_socket, "Writing config...").await {
+        cleanup_staging(&staging_dir);
+        return Err(err);
+    }
     eprintln!("Writing runtime artifacts to state volume");
 
     let sp_path = staging_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME);
@@ -1761,15 +1777,18 @@ mod tests {
         downstream_body_to_connector_payload, extract_device_code, generate_certificate,
         load_runtime_config, load_runtime_credential_state, load_signing_key, parse_bicep_outputs,
         prepare_staging_dir, pump_downstream_once, pump_upstream_once, read_framed,
-        resolve_effective_state_dir, resolve_state_relative_path, validate_display_lines,
-        write_framed, ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
+        resolve_effective_state_dir, resolve_state_relative_path,
+        run_bootstrap_deployment_with_docker, validate_display_lines, write_framed,
+        ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
         RuntimeCredentialState, ServiceBusConfigFile, ServicePrincipalStateFile, UpstreamPublisher,
-        ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME,
-        SERVICE_BUS_CONFIG_FILENAME, SERVICE_PRINCIPAL_STATE_FILENAME, STATE_GENERATION_PREFIX,
+        ACTIVE_STATE_FILENAME, BUNDLED_BICEP_PATH, CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH,
+        KEY_PEM_FILENAME, SERVICE_BUS_CONFIG_FILENAME, SERVICE_PRINCIPAL_STATE_FILENAME,
+        STATE_GENERATION_PREFIX,
     };
     use azure_core::credentials::TokenCredential;
     #[cfg(unix)]
     use base64::Engine as _;
+    use bollard::{Docker, API_DEFAULT_VERSION};
     use jsonwebtoken::{Algorithm, EncodingKey};
     use std::collections::VecDeque;
     use std::path::Path;
@@ -1791,7 +1810,7 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     #[cfg(unix)]
     use tokio::sync::{Mutex, Notify};
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{method, path, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
     #[cfg(unix)]
     use x509_cert::der::Decode;
@@ -2633,6 +2652,87 @@ mod tests {
             state_generations.is_empty(),
             "unexpected generations: {state_generations:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn bootstrap_deployment_removes_container_after_start_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/create"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/containers/create"))
+            .respond_with(
+                ResponseTemplate::new(201)
+                    .append_header("content-type", "application/json")
+                    .set_body_string(r#"{"Id":"test-container","Warnings":null}"#),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/containers/test-container/archive"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/containers/test-container/start"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("start failed"))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path_regex(r"^/containers/test-container$"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let docker = Docker::connect_with_http(&server.uri(), 120, API_DEFAULT_VERSION).unwrap();
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join(CERT_PEM_FILENAME), b"test-cert").unwrap();
+        let bundled_bicep_dir = Path::new(BUNDLED_BICEP_PATH);
+        std::fs::create_dir_all(bundled_bicep_dir).unwrap();
+        let bundled_bicep_file = bundled_bicep_dir.join("main.bicep");
+        let created_bicep_file = !bundled_bicep_file.exists();
+        if created_bicep_file {
+            std::fs::write(&bundled_bicep_file, b"targetScope = 'subscription'\n").unwrap();
+        }
+        let args = super::BootstrapArgs {
+            azure_location: "westus2".to_string(),
+            azure_project_name: "sonde".to_string(),
+            azure_subscription_id: None,
+        };
+
+        let err = run_bootstrap_deployment_with_docker(
+            &docker,
+            "/tmp/unused-admin.sock",
+            temp.path(),
+            "dummy-cert-base64",
+            &args,
+        )
+        .await
+        .unwrap_err();
+        if created_bicep_file {
+            let _ = std::fs::remove_file(&bundled_bicep_file);
+        }
+        assert!(matches!(err, CompanionError::Config(_)));
+
+        let requests = server.received_requests().await.unwrap();
+        let methods_and_paths = requests
+            .iter()
+            .map(|request| format!("{} {}", request.method, request.url.path()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            methods_and_paths,
+            vec![
+                "POST /images/create".to_string(),
+                "POST /containers/create".to_string(),
+                "PUT /containers/test-container/archive".to_string(),
+                "POST /containers/test-container/start".to_string(),
+                "DELETE /containers/test-container".to_string(),
+            ]
+        );
+        assert!(!requests[2].body.is_empty());
     }
 
     #[test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -394,7 +394,11 @@ fn load_runtime_config(state_dir: &Path) -> Result<RuntimeConfig, CompanionError
         .ok()
         .filter(|v| !v.trim().is_empty());
 
-    let file_config = load_service_bus_config_file(state_dir).ok();
+    let file_config = match load_service_bus_config_file(state_dir) {
+        Ok(config) => Some(config),
+        Err(CompanionError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => return Err(err),
+    };
 
     let namespace = namespace_env
         .or_else(|| file_config.as_ref().map(|c| c.namespace.clone()))
@@ -1416,6 +1420,7 @@ async fn stream_container_output(
 
     let mut logs = docker.logs(container_id, Some(log_opts));
     let mut stdout_buffer = String::new();
+    let mut stderr_buffer = String::new();
     let device_code_re = Regex::new(r"enter the code ([A-Z0-9-]+) to authenticate")
         .expect("valid device code regex");
     let mut device_code_displayed = false;
@@ -1429,9 +1434,15 @@ async fn stream_container_output(
             Ok(LogOutput::StdErr { message }) => {
                 let text = String::from_utf8_lossy(&message);
                 eprint!("{text}");
+                stderr_buffer.push_str(&text);
+                const MAX_STDERR_BUFFER_LEN: usize = 4096;
+                if stderr_buffer.len() > MAX_STDERR_BUFFER_LEN {
+                    let trim_start = stderr_buffer.len() - MAX_STDERR_BUFFER_LEN;
+                    stderr_buffer.drain(..trim_start);
+                }
 
                 if !device_code_displayed {
-                    if let Some(captures) = device_code_re.captures(&text) {
+                    if let Some(captures) = device_code_re.captures(&stderr_buffer) {
                         if let Some(code) = captures.get(1) {
                             let device_code = code.as_str().to_string();
                             eprintln!("Detected device code: {device_code}");

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -512,8 +512,17 @@ fn commit_staging(staging_dir: &Path, state_dir: &Path) -> Result<(), CompanionE
 
     let marker_path = active_state_marker_path(state_dir);
     let marker_tmp = state_dir.join(format!("{ACTIVE_STATE_FILENAME}.tmp"));
-    std::fs::write(&marker_tmp, format!("{generation_name}\n"))?;
-    std::fs::rename(&marker_tmp, &marker_path)?;
+    let marker_update_result: Result<(), CompanionError> = (|| {
+        std::fs::write(&marker_tmp, format!("{generation_name}\n"))?;
+        std::fs::rename(&marker_tmp, &marker_path)?;
+        Ok(())
+    })();
+
+    if let Err(err) = marker_update_result {
+        let _ = std::fs::remove_file(&marker_tmp);
+        let _ = std::fs::remove_dir_all(&generation_dir);
+        return Err(err);
+    }
 
     if let Some(previous_generation) = previous_generation {
         if previous_generation.starts_with(STATE_GENERATION_PREFIX)
@@ -585,8 +594,11 @@ fn write_private_key_pem(path: &Path, pem: &str) -> Result<(), CompanionError> {
 
     #[cfg(not(unix))]
     {
-        std::fs::write(path, pem.as_bytes())?;
-        Ok(())
+        let _ = (path, pem);
+        Err(CompanionError::Config(
+            "bootstrap private-key generation requires Unix so the key file can be created with owner-only permissions"
+                .to_string(),
+        ))
     }
 }
 
@@ -1742,19 +1754,21 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use super::validate_certificate_matches_private_key;
     use super::{
         build_az_bootstrap_script, check_runtime_ready, cleanup_staging, commit_staging,
         downstream_body_to_connector_payload, extract_device_code, generate_certificate,
         load_runtime_config, load_runtime_credential_state, load_signing_key, parse_bicep_outputs,
         prepare_staging_dir, pump_downstream_once, pump_upstream_once, read_framed,
-        resolve_effective_state_dir, resolve_state_relative_path,
-        validate_certificate_matches_private_key, validate_display_lines, write_framed,
-        ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
+        resolve_effective_state_dir, resolve_state_relative_path, validate_display_lines,
+        write_framed, ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
         RuntimeCredentialState, ServiceBusConfigFile, ServicePrincipalStateFile, UpstreamPublisher,
         ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME,
-        SERVICE_BUS_CONFIG_FILENAME, SERVICE_PRINCIPAL_STATE_FILENAME,
+        SERVICE_BUS_CONFIG_FILENAME, SERVICE_PRINCIPAL_STATE_FILENAME, STATE_GENERATION_PREFIX,
     };
     use azure_core::credentials::TokenCredential;
+    #[cfg(unix)]
     use base64::Engine as _;
     use jsonwebtoken::{Algorithm, EncodingKey};
     use std::collections::VecDeque;
@@ -1779,7 +1793,9 @@ mod tests {
     use tokio::sync::{Mutex, Notify};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+    #[cfg(unix)]
     use x509_cert::der::Decode;
+    #[cfg(unix)]
     use x509_cert::Certificate;
 
     fn lines(values: &[&str]) -> Vec<String> {
@@ -2266,36 +2282,45 @@ mod tests {
     #[test]
     fn test_generate_certificate() {
         let temp = TempDir::new().unwrap();
-        let (cert_path, key_path, cert_base64) = generate_certificate(temp.path()).unwrap();
 
-        assert_eq!(cert_path, temp.path().join(CERT_PEM_FILENAME));
-        assert_eq!(key_path, temp.path().join(KEY_PEM_FILENAME));
-        assert!(cert_path.is_file());
-        assert!(key_path.is_file());
-
-        let decoded = base64::engine::general_purpose::STANDARD
-            .decode(cert_base64)
-            .unwrap();
-        let cert_file = std::fs::File::open(&cert_path).unwrap();
-        let mut reader = std::io::BufReader::new(cert_file);
-        let cert_der = rustls_pemfile::certs(&mut reader)
-            .next()
-            .transpose()
-            .unwrap()
-            .unwrap();
-        assert_eq!(decoded, cert_der.as_ref());
-
-        let certificate = Certificate::from_der(cert_der.as_ref()).unwrap();
-        assert_ne!(
-            certificate.tbs_certificate.validity.not_before,
-            certificate.tbs_certificate.validity.not_after
-        );
-        let (algorithm, _) = load_signing_key(&key_path).unwrap();
-        assert_eq!(algorithm, Algorithm::ES256);
-        validate_certificate_matches_private_key(&cert_path, &key_path).unwrap();
+        #[cfg(not(unix))]
+        {
+            let err = generate_certificate(temp.path()).unwrap_err();
+            assert!(err
+                .to_string()
+                .contains("bootstrap private-key generation requires Unix"));
+        }
 
         #[cfg(unix)]
         {
+            let (cert_path, key_path, cert_base64) = generate_certificate(temp.path()).unwrap();
+
+            assert_eq!(cert_path, temp.path().join(CERT_PEM_FILENAME));
+            assert_eq!(key_path, temp.path().join(KEY_PEM_FILENAME));
+            assert!(cert_path.is_file());
+            assert!(key_path.is_file());
+
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(cert_base64)
+                .unwrap();
+            let cert_file = std::fs::File::open(&cert_path).unwrap();
+            let mut reader = std::io::BufReader::new(cert_file);
+            let cert_der = rustls_pemfile::certs(&mut reader)
+                .next()
+                .transpose()
+                .unwrap()
+                .unwrap();
+            assert_eq!(decoded, cert_der.as_ref());
+
+            let certificate = Certificate::from_der(cert_der.as_ref()).unwrap();
+            assert_ne!(
+                certificate.tbs_certificate.validity.not_before,
+                certificate.tbs_certificate.validity.not_after
+            );
+            let (algorithm, _) = load_signing_key(&key_path).unwrap();
+            assert_eq!(algorithm, Algorithm::ES256);
+            validate_certificate_matches_private_key(&cert_path, &key_path).unwrap();
+
             use std::os::unix::fs::PermissionsExt;
 
             let key_mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
@@ -2554,6 +2579,60 @@ mod tests {
         cleanup_staging(&staging_dir);
 
         assert!(!staging_dir.exists());
+    }
+
+    #[test]
+    fn test_staged_commit_rolls_back_generation_on_marker_update_failure() {
+        let temp = TempDir::new().unwrap();
+        let staging_dir = prepare_staging_dir(temp.path()).unwrap();
+        std::fs::write(staging_dir.join(CERT_PEM_FILENAME), b"new-cert").unwrap();
+        std::fs::write(staging_dir.join(KEY_PEM_FILENAME), b"new-key").unwrap();
+        std::fs::write(
+            staging_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME),
+            serde_json::to_vec(&ServicePrincipalStateFile {
+                tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+                client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                certificate_path: CERT_PEM_FILENAME.to_string(),
+                private_key_path: KEY_PEM_FILENAME.to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            staging_dir.join(SERVICE_BUS_CONFIG_FILENAME),
+            serde_json::to_vec(&ServiceBusConfigFile {
+                namespace: "example.servicebus.windows.net".to_string(),
+                upstream_queue: "upstream".to_string(),
+                downstream_queue: "downstream".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        std::fs::create_dir(temp.path().join(format!("{ACTIVE_STATE_FILENAME}.tmp"))).unwrap();
+
+        let err = commit_staging(&staging_dir, temp.path()).unwrap_err();
+        assert!(matches!(err, CompanionError::Io(_)));
+        assert!(!staging_dir.exists());
+        assert!(!temp.path().join(ACTIVE_STATE_FILENAME).exists());
+
+        let state_generations = std::fs::read_dir(temp.path())
+            .unwrap()
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let file_name = entry.file_name();
+                let file_name = file_name.to_str()?;
+                if file_name.starts_with(STATE_GENERATION_PREFIX) {
+                    Some(file_name.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            state_generations.is_empty(),
+            "unexpected generations: {state_generations:?}"
+        );
     }
 
     #[test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -18,8 +18,7 @@ use bollard::container::LogOutput;
 use bollard::models::ContainerCreateBody;
 use bollard::query_parameters::{
     CreateContainerOptionsBuilder, CreateImageOptionsBuilder, LogsOptionsBuilder,
-    RemoveContainerOptionsBuilder, UploadToContainerOptionsBuilder,
-    WaitContainerOptionsBuilder,
+    RemoveContainerOptionsBuilder, UploadToContainerOptionsBuilder, WaitContainerOptionsBuilder,
 };
 use bollard::{body_full, Docker};
 use clap::{Args, Parser, Subcommand};
@@ -465,15 +464,12 @@ fn commit_staging(staging_dir: &Path, state_dir: &Path) -> Result<(), CompanionE
     let commit_result: Result<(), CompanionError> = (|| {
         for (_, dest) in &staged_files {
             if dest.exists() {
-                let backup_path = backup_dir.join(
-                    dest.file_name()
-                        .ok_or_else(|| {
-                            CompanionError::Config(format!(
-                                "staged destination had no file name: {}",
-                                dest.display()
-                            ))
-                        })?,
-                );
+                let backup_path = backup_dir.join(dest.file_name().ok_or_else(|| {
+                    CompanionError::Config(format!(
+                        "staged destination had no file name: {}",
+                        dest.display()
+                    ))
+                })?);
                 std::fs::rename(dest, &backup_path)?;
                 backed_up.push((backup_path, dest.clone()));
             }
@@ -517,9 +513,8 @@ fn generate_certificate(staging_dir: &Path) -> Result<(PathBuf, PathBuf, String)
         CompanionError::Config(format!("failed to generate ECDSA P-256 key pair: {e}"))
     })?;
 
-    let mut params = CertificateParams::new(Vec::<String>::new()).map_err(|e| {
-        CompanionError::Config(format!("failed to create certificate params: {e}"))
-    })?;
+    let mut params = CertificateParams::new(Vec::<String>::new())
+        .map_err(|e| CompanionError::Config(format!("failed to create certificate params: {e}")))?;
     params
         .distinguished_name
         .push(rcgen::DnType::CommonName, "sonde-azure-companion");
@@ -1387,17 +1382,19 @@ async fn copy_files_to_container(
             .map_err(|e| {
                 CompanionError::Config(format!("failed to add certificate to archive: {e}"))
             })?;
-        builder.finish().map_err(|e| {
-            CompanionError::Config(format!("failed to finalize tar archive: {e}"))
-        })?;
+        builder
+            .finish()
+            .map_err(|e| CompanionError::Config(format!("failed to finalize tar archive: {e}")))?;
     }
 
-    let upload_options = UploadToContainerOptionsBuilder::default()
-        .path("/")
-        .build();
+    let upload_options = UploadToContainerOptionsBuilder::default().path("/").build();
 
     docker
-        .upload_to_container(container_id, Some(upload_options), body_full(archive.into()))
+        .upload_to_container(
+            container_id,
+            Some(upload_options),
+            body_full(archive.into()),
+        )
         .await
         .map_err(|e| CompanionError::Config(format!("failed to copy files to container: {e}")))?;
 
@@ -1419,8 +1416,8 @@ async fn stream_container_output(
 
     let mut logs = docker.logs(container_id, Some(log_opts));
     let mut stdout_buffer = String::new();
-    let device_code_re =
-        Regex::new(r"enter the code ([A-Z0-9-]+) to authenticate").expect("valid device code regex");
+    let device_code_re = Regex::new(r"enter the code ([A-Z0-9-]+) to authenticate")
+        .expect("valid device code regex");
     let mut device_code_displayed = false;
 
     while let Some(result) = logs.next().await {
@@ -1484,7 +1481,8 @@ async fn run_bootstrap_deployment(
         .build();
     let mut pull_stream = docker.create_image(Some(pull_opts), None, None);
     while let Some(result) = pull_stream.next().await {
-        result.map_err(|e| CompanionError::Config(format!("failed to pull Azure CLI image: {e}")))?;
+        result
+            .map_err(|e| CompanionError::Config(format!("failed to pull Azure CLI image: {e}")))?;
     }
 
     let bootstrap_script = build_az_bootstrap_script();
@@ -1505,7 +1503,9 @@ async fn run_bootstrap_deployment(
             },
         )
         .await
-        .map_err(|e| CompanionError::Config(format!("failed to create Azure CLI container: {e}")))?;
+        .map_err(|e| {
+            CompanionError::Config(format!("failed to create Azure CLI container: {e}"))
+        })?;
     let container_id = container.id;
 
     let bootstrap_result = async {
@@ -1513,7 +1513,9 @@ async fn run_bootstrap_deployment(
         docker
             .start_container(&container_id, None)
             .await
-            .map_err(|e| CompanionError::Config(format!("failed to start Azure CLI container: {e}")))?;
+            .map_err(|e| {
+                CompanionError::Config(format!("failed to start Azure CLI container: {e}"))
+            })?;
 
         let stdout_output = stream_container_output(&docker, &container_id, admin_socket).await?;
         let wait_options = WaitContainerOptionsBuilder::default()
@@ -1653,10 +1655,9 @@ mod tests {
         prepare_staging_dir, pump_downstream_once, pump_upstream_once, read_framed,
         resolve_state_relative_path, validate_certificate_matches_private_key,
         validate_display_lines, write_framed, ClientAssertionCredential, CompanionError,
-        DownstreamConsumer, RuntimeConfig, RuntimeCredentialState,
-        ServiceBusConfigFile, ServicePrincipalStateFile, UpstreamPublisher,
-        CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME,
-        SERVICE_BUS_CONFIG_FILENAME,
+        DownstreamConsumer, RuntimeConfig, RuntimeCredentialState, ServiceBusConfigFile,
+        ServicePrincipalStateFile, UpstreamPublisher, CERT_PEM_FILENAME,
+        CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME, SERVICE_BUS_CONFIG_FILENAME,
     };
     use azure_core::credentials::TokenCredential;
     use base64::Engine as _;
@@ -2236,10 +2237,7 @@ mod tests {
                     Some("env.servicebus.windows.net"),
                 ),
                 ("SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE", Some("env-up")),
-                (
-                    "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE",
-                    Some("env-down"),
-                ),
+                ("SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE", Some("env-down")),
             ],
             || {
                 let config = load_runtime_config(temp.path()).unwrap();
@@ -2299,8 +2297,14 @@ mod tests {
 
         commit_staging(&staging_dir, temp.path()).unwrap();
 
-        assert_eq!(std::fs::read(temp.path().join(CERT_PEM_FILENAME)).unwrap(), b"new-cert");
-        assert_eq!(std::fs::read(temp.path().join(KEY_PEM_FILENAME)).unwrap(), b"new-key");
+        assert_eq!(
+            std::fs::read(temp.path().join(CERT_PEM_FILENAME)).unwrap(),
+            b"new-cert"
+        );
+        assert_eq!(
+            std::fs::read(temp.path().join(KEY_PEM_FILENAME)).unwrap(),
+            b"new-key"
+        );
         assert!(!staging_dir.exists());
     }
 

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -1005,6 +1005,19 @@ fn extract_device_code(stderr_buffer: &str) -> Option<String> {
         })
 }
 
+fn trim_buffer_to_max_len(buffer: &mut String, max_len: usize) {
+    if buffer.len() <= max_len {
+        return;
+    }
+
+    let target_start = buffer.len() - max_len;
+    let trim_start = buffer
+        .char_indices()
+        .find_map(|(idx, _)| (idx >= target_start).then_some(idx))
+        .unwrap_or(buffer.len());
+    buffer.drain(..trim_start);
+}
+
 fn build_container_env(cert_base64: &str, args: &BootstrapArgs) -> Vec<String> {
     let mut env = vec![
         format!("SONDE_AZURE_LOCATION={}", args.azure_location),
@@ -1447,11 +1460,11 @@ async fn copy_files_to_container(
     docker: &Docker,
     container_id: &str,
     staging_dir: &Path,
+    bicep_path: &Path,
 ) -> Result<(), CompanionError> {
     let mut archive = Vec::new();
     {
         let mut builder = tar::Builder::new(&mut archive);
-        let bicep_path = Path::new(BUNDLED_BICEP_PATH);
         if !bicep_path.is_dir() {
             return Err(CompanionError::Config(format!(
                 "bundled Bicep path not found: {}",
@@ -1521,10 +1534,7 @@ async fn stream_container_output(
                 eprint!("{text}");
                 stderr_buffer.push_str(&text);
                 const MAX_STDERR_BUFFER_LEN: usize = 4096;
-                if stderr_buffer.len() > MAX_STDERR_BUFFER_LEN {
-                    let trim_start = stderr_buffer.len() - MAX_STDERR_BUFFER_LEN;
-                    stderr_buffer.drain(..trim_start);
-                }
+                trim_buffer_to_max_len(&mut stderr_buffer, MAX_STDERR_BUFFER_LEN);
 
                 if !deployment_displayed
                     && stderr_buffer.contains("__SONDE_AZURE_DEPLOYMENT_START__")
@@ -1585,6 +1595,25 @@ async fn run_bootstrap_deployment_with_docker(
     cert_base64: &str,
     args: &BootstrapArgs,
 ) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
+    run_bootstrap_deployment_with_docker_and_bicep_dir(
+        docker,
+        admin_socket,
+        staging_dir,
+        cert_base64,
+        args,
+        Path::new(BUNDLED_BICEP_PATH),
+    )
+    .await
+}
+
+async fn run_bootstrap_deployment_with_docker_and_bicep_dir(
+    docker: &Docker,
+    admin_socket: &str,
+    staging_dir: &Path,
+    cert_base64: &str,
+    args: &BootstrapArgs,
+    bicep_path: &Path,
+) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
     eprintln!("Pulling Azure CLI container image...");
     let pull_opts = CreateImageOptionsBuilder::default()
         .from_image(AZURE_CLI_IMAGE)
@@ -1619,7 +1648,7 @@ async fn run_bootstrap_deployment_with_docker(
     let container_id = container.id;
 
     let bootstrap_result = async {
-        copy_files_to_container(docker, &container_id, staging_dir).await?;
+        copy_files_to_container(docker, &container_id, staging_dir, bicep_path).await?;
         docker
             .start_container(&container_id, None)
             .await
@@ -1778,12 +1807,12 @@ mod tests {
         load_runtime_config, load_runtime_credential_state, load_signing_key, parse_bicep_outputs,
         prepare_staging_dir, pump_downstream_once, pump_upstream_once, read_framed,
         resolve_effective_state_dir, resolve_state_relative_path,
-        run_bootstrap_deployment_with_docker, validate_display_lines, write_framed,
-        ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
-        RuntimeCredentialState, ServiceBusConfigFile, ServicePrincipalStateFile, UpstreamPublisher,
-        ACTIVE_STATE_FILENAME, BUNDLED_BICEP_PATH, CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH,
-        KEY_PEM_FILENAME, SERVICE_BUS_CONFIG_FILENAME, SERVICE_PRINCIPAL_STATE_FILENAME,
-        STATE_GENERATION_PREFIX,
+        run_bootstrap_deployment_with_docker_and_bicep_dir, trim_buffer_to_max_len,
+        validate_display_lines, write_framed, ClientAssertionCredential, CompanionError,
+        DownstreamConsumer, RuntimeConfig, RuntimeCredentialState, ServiceBusConfigFile,
+        ServicePrincipalStateFile, UpstreamPublisher, ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME,
+        CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME, SERVICE_BUS_CONFIG_FILENAME,
+        SERVICE_PRINCIPAL_STATE_FILENAME, STATE_GENERATION_PREFIX,
     };
     use azure_core::credentials::TokenCredential;
     #[cfg(unix)]
@@ -2502,6 +2531,15 @@ mod tests {
     }
 
     #[test]
+    fn trim_buffer_to_max_len_preserves_utf8_boundaries() {
+        let mut buffer = "a🙂".repeat(2_000);
+        trim_buffer_to_max_len(&mut buffer, 4_096);
+        assert!(buffer.len() <= 4_096);
+        assert!(std::str::from_utf8(buffer.as_bytes()).is_ok());
+        assert!(buffer.ends_with("a🙂"));
+    }
+
+    #[test]
     fn test_parse_bicep_outputs() {
         let json = r#"{
             "companionBootstrapValues": {
@@ -2690,31 +2728,29 @@ mod tests {
         let docker = Docker::connect_with_http(&server.uri(), 120, API_DEFAULT_VERSION).unwrap();
         let temp = TempDir::new().unwrap();
         std::fs::write(temp.path().join(CERT_PEM_FILENAME), b"test-cert").unwrap();
-        let bundled_bicep_dir = Path::new(BUNDLED_BICEP_PATH);
-        std::fs::create_dir_all(bundled_bicep_dir).unwrap();
-        let bundled_bicep_file = bundled_bicep_dir.join("main.bicep");
-        let created_bicep_file = !bundled_bicep_file.exists();
-        if created_bicep_file {
-            std::fs::write(&bundled_bicep_file, b"targetScope = 'subscription'\n").unwrap();
-        }
+        let bicep_dir = temp.path().join("bicep");
+        std::fs::create_dir_all(&bicep_dir).unwrap();
+        std::fs::write(
+            bicep_dir.join("main.bicep"),
+            b"targetScope = 'subscription'\n",
+        )
+        .unwrap();
         let args = super::BootstrapArgs {
             azure_location: "westus2".to_string(),
             azure_project_name: "sonde".to_string(),
             azure_subscription_id: None,
         };
 
-        let err = run_bootstrap_deployment_with_docker(
+        let err = run_bootstrap_deployment_with_docker_and_bicep_dir(
             &docker,
             "/tmp/unused-admin.sock",
             temp.path(),
             "dummy-cert-base64",
             &args,
+            &bicep_dir,
         )
         .await
         .unwrap_err();
-        if created_bicep_file {
-            let _ = std::fs::remove_file(&bundled_bicep_file);
-        }
         assert!(matches!(err, CompanionError::Config(_)));
 
         let requests = server.received_requests().await.unwrap();

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -92,6 +92,13 @@ fn write_runtime_ready_state(state_dir: &Path) {
     .unwrap();
 }
 
+fn write_generated_runtime_ready_state(state_dir: &Path) {
+    let generation_dir = state_dir.join(".state-test");
+    fs::create_dir_all(&generation_dir).unwrap();
+    write_runtime_ready_state(&generation_dir);
+    fs::write(state_dir.join(".current-state"), b".state-test\n").unwrap();
+}
+
 fn wait_for_path(path: &Path) {
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {
@@ -117,6 +124,50 @@ fn container_ready_state_skips_bootstrap_and_runs() {
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
     write_runtime_ready_state(&state_dir);
+    let wrapper_log = temp.path().join("wrapper.log");
+    write_runtime_wrapper(&bin_dir, &wrapper_log);
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    cmd.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        ),
+    );
+    cmd.env("SONDE_AZURE_COMPANION_IN_CONTAINER", "1");
+    cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
+    cmd.env("SONDE_GATEWAY_ADMIN_SOCKET", temp.path().join("admin.sock"));
+    cmd.env(
+        "SONDE_GATEWAY_CONNECTOR_SOCKET",
+        temp.path().join("connector.sock"),
+    );
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success(), "runtime start failed: {output:?}");
+    assert_eq!(
+        fs::read_to_string(&wrapper_log)
+            .unwrap()
+            .lines()
+            .collect::<Vec<_>>(),
+        vec![format!(
+            "run {} {} {}",
+            temp.path().join("admin.sock").display(),
+            temp.path().join("connector.sock").display(),
+            state_dir.display()
+        )]
+    );
+}
+
+#[test]
+fn container_ready_state_uses_active_generation_directory() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let state_dir = temp.path().join("state");
+    fs::create_dir_all(&state_dir).unwrap();
+    write_generated_runtime_ready_state(&state_dir);
     let wrapper_log = temp.path().join("wrapper.log");
     write_runtime_wrapper(&bin_dir, &wrapper_log);
 

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -141,7 +141,10 @@ fn container_ready_state_skips_bootstrap_and_runs() {
     let output = cmd.output().unwrap();
     assert!(output.status.success(), "runtime start failed: {output:?}");
     assert_eq!(
-        fs::read_to_string(&wrapper_log).unwrap().lines().collect::<Vec<_>>(),
+        fs::read_to_string(&wrapper_log)
+            .unwrap()
+            .lines()
+            .collect::<Vec<_>>(),
         vec![format!(
             "run {} {} {}",
             temp.path().join("admin.sock").display(),
@@ -293,7 +296,10 @@ fn host_bootstrap_does_not_require_removed_device_env() {
 
     let output = cmd.output().unwrap();
     assert!(output.status.success(), "host bootstrap failed: {output:?}");
-    assert!(docker_log.exists(), "docker should still be invoked by the host wrapper");
+    assert!(
+        docker_log.exists(),
+        "docker should still be invoked by the host wrapper"
+    );
 }
 
 #[test]

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -6,27 +6,11 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::process::Command;
-use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use futures::stream;
 use tempfile::TempDir;
-use tokio::net::UnixListener;
-use tokio::process::Command as TokioCommand;
-use tokio::sync::Mutex;
-use tokio_stream::wrappers::UnixListenerStream;
-use tonic::{Request, Response, Status};
-use wiremock::matchers::{method, path};
-use wiremock::{Mock, MockServer, ResponseTemplate};
-
-use sonde_gateway::admin::pb::gateway_admin_server::{GatewayAdmin, GatewayAdminServer};
-use sonde_gateway::admin::pb::*;
-
-type BlePairingStream =
-    Pin<Box<dyn futures::Stream<Item = Result<BlePairingEvent, Status>> + Send>>;
 
 const TEST_CERT_PEM: &str = concat!(
     "-----BEGIN CERTIFICATE-----\n",
@@ -49,243 +33,20 @@ const TEST_KEY_PEM: &str = concat!(
     "-----END PRIVATE KEY-----\n"
 );
 
-#[derive(Clone)]
-struct TestAdminServer {
-    display_requests: Arc<Mutex<Vec<Vec<String>>>>,
-    display_error: Option<tonic::Code>,
-}
-
-#[tonic::async_trait]
-impl GatewayAdmin for TestAdminServer {
-    type OpenBlePairingStream = BlePairingStream;
-
-    async fn list_nodes(
-        &self,
-        _request: Request<Empty>,
-    ) -> Result<Response<ListNodesResponse>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn get_node(
-        &self,
-        _request: Request<GetNodeRequest>,
-    ) -> Result<Response<NodeInfo>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn register_node(
-        &self,
-        _request: Request<RegisterNodeRequest>,
-    ) -> Result<Response<RegisterNodeResponse>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn remove_node(
-        &self,
-        _request: Request<RemoveNodeRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn factory_reset(
-        &self,
-        _request: Request<FactoryResetRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn ingest_program(
-        &self,
-        _request: Request<IngestProgramRequest>,
-    ) -> Result<Response<IngestProgramResponse>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn list_programs(
-        &self,
-        _request: Request<Empty>,
-    ) -> Result<Response<ListProgramsResponse>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn assign_program(
-        &self,
-        _request: Request<AssignProgramRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn remove_program(
-        &self,
-        _request: Request<RemoveProgramRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn set_schedule(
-        &self,
-        _request: Request<SetScheduleRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn queue_reboot(
-        &self,
-        _request: Request<QueueRebootRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn queue_ephemeral(
-        &self,
-        _request: Request<QueueEphemeralRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn get_node_status(
-        &self,
-        _request: Request<GetNodeStatusRequest>,
-    ) -> Result<Response<NodeStatus>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn export_state(
-        &self,
-        _request: Request<ExportStateRequest>,
-    ) -> Result<Response<ExportStateResponse>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn import_state(
-        &self,
-        _request: Request<ImportStateRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn get_modem_status(
-        &self,
-        _request: Request<Empty>,
-    ) -> Result<Response<ModemStatus>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn set_modem_channel(
-        &self,
-        _request: Request<SetModemChannelRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn scan_modem_channels(
-        &self,
-        _request: Request<Empty>,
-    ) -> Result<Response<ScanModemChannelsResponse>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn show_modem_display_message(
-        &self,
-        request: Request<ShowModemDisplayMessageRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        self.display_requests
-            .lock()
-            .await
-            .push(request.into_inner().lines);
-        if let Some(code) = self.display_error {
-            return Err(Status::new(code, "injected display failure"));
-        }
-        Ok(Response::new(Empty {}))
-    }
-
-    async fn open_ble_pairing(
-        &self,
-        _request: Request<OpenBlePairingRequest>,
-    ) -> Result<Response<Self::OpenBlePairingStream>, Status> {
-        Ok(Response::new(Box::pin(stream::empty())))
-    }
-
-    async fn close_ble_pairing(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn confirm_ble_pairing(
-        &self,
-        _request: Request<ConfirmBlePairingRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn list_phones(
-        &self,
-        _request: Request<Empty>,
-    ) -> Result<Response<ListPhonesResponse>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn revoke_phone(
-        &self,
-        _request: Request<RevokePhoneRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn add_handler(
-        &self,
-        _request: Request<AddHandlerRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn remove_handler(
-        &self,
-        _request: Request<RemoveHandlerRequest>,
-    ) -> Result<Response<Empty>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-
-    async fn list_handlers(
-        &self,
-        _request: Request<Empty>,
-    ) -> Result<Response<ListHandlersResponse>, Status> {
-        Err(Status::unimplemented("not used in test"))
-    }
-}
-
 fn repo_root() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(2)
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
         .unwrap()
         .to_path_buf()
 }
 
-fn write_executable(path: &Path, body: &str) {
-    fs::write(path, body).unwrap();
-    let mut perms = fs::metadata(path).unwrap().permissions();
-    perms.set_mode(0o755);
-    fs::set_permissions(path, perms).unwrap();
-}
-
-async fn spawn_admin_server(
-    socket_path: &Path,
-    display_error: Option<tonic::Code>,
-) -> Arc<Mutex<Vec<Vec<String>>>> {
-    let display_requests = Arc::new(Mutex::new(Vec::new()));
-    let service = TestAdminServer {
-        display_requests: Arc::clone(&display_requests),
-        display_error,
-    };
-    let listener = UnixListener::bind(socket_path).unwrap();
-    tokio::spawn(async move {
-        tonic::transport::Server::builder()
-            .add_service(GatewayAdminServer::new(service))
-            .serve_with_incoming(UnixListenerStream::new(listener))
-            .await
-            .unwrap();
-    });
-    display_requests
+fn bootstrap_script_path() -> PathBuf {
+    repo_root()
+        .join("deploy")
+        .join("azure-companion")
+        .join("bootstrap.sh")
 }
 
 fn prepare_path_dir(temp: &TempDir) -> PathBuf {
@@ -294,8 +55,41 @@ fn prepare_path_dir(temp: &TempDir) -> PathBuf {
     bin_dir
 }
 
-fn bootstrap_script_path() -> PathBuf {
-    repo_root().join("deploy/azure-companion/bootstrap.sh")
+fn write_executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+fn write_runtime_wrapper(bin_dir: &Path, wrapper_log: &Path) {
+    write_executable(
+        &bin_dir.join("sonde-azure-companion"),
+        &format!(
+            "#!/bin/sh\nset -eu\nadmin_socket=\"\"\nconnector_socket=\"\"\nstate_dir=\"\"\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket)\n      admin_socket=\"$2\"\n      shift 2\n      ;;\n    --connector-socket)\n      connector_socket=\"$2\"\n      shift 2\n      ;;\n    --state-dir)\n      state_dir=\"$2\"\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\ncase \"$1\" in\n  run)\n    printf 'run %s %s %s\\n' \"$admin_socket\" \"$connector_socket\" \"$state_dir\" >> \"{}\"\n    exit 0\n    ;;\n  bootstrap)\n    printf 'bootstrap %s %s %s\\n' \"$admin_socket\" \"$connector_socket\" \"$state_dir\" >> \"{}\"\n    if [ \"${{SONDE_TEST_FAIL_BOOTSTRAP:-0}}\" = \"1\" ]; then\n      exit 17\n    fi\n    if [ \"${{SONDE_TEST_WRITE_RUNTIME_STATE:-0}}\" = \"1\" ]; then\n      mkdir -p \"$state_dir\"\n      cat > \"$state_dir/cert.pem\" <<'EOF'\n{}\nEOF\n      cat > \"$state_dir/key.pem\" <<'EOF'\n{}\nEOF\n      cat > \"$state_dir/service-principal.json\" <<'EOF'\n{{\"tenant_id\":\"11111111-1111-1111-1111-111111111111\",\"client_id\":\"22222222-2222-2222-2222-222222222222\",\"certificate_path\":\"cert.pem\",\"private_key_path\":\"key.pem\"}}\nEOF\n      cat > \"$state_dir/service-bus.json\" <<'EOF'\n{{\"namespace\":\"example.servicebus.windows.net\",\"upstream_queue\":\"upstream\",\"downstream_queue\":\"downstream\"}}\nEOF\n    fi\n    exit 0\n    ;;\n  *)\n    exec \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" --state-dir \"$state_dir\" \"$@\"\n    ;;\nesac\n",
+            wrapper_log.display(),
+            wrapper_log.display(),
+            TEST_CERT_PEM,
+            TEST_KEY_PEM,
+            env!("CARGO_BIN_EXE_sonde-azure-companion")
+        ),
+    );
+}
+
+fn write_runtime_ready_state(state_dir: &Path) {
+    fs::create_dir_all(state_dir).unwrap();
+    fs::write(state_dir.join("cert.pem"), TEST_CERT_PEM).unwrap();
+    fs::write(state_dir.join("key.pem"), TEST_KEY_PEM).unwrap();
+    fs::write(
+        state_dir.join("service-principal.json"),
+        br#"{"tenant_id":"11111111-1111-1111-1111-111111111111","client_id":"22222222-2222-2222-2222-222222222222","certificate_path":"cert.pem","private_key_path":"key.pem"}"#,
+    )
+    .unwrap();
+    fs::write(
+        state_dir.join("service-bus.json"),
+        br#"{"namespace":"example.servicebus.windows.net","upstream_queue":"upstream","downstream_queue":"downstream"}"#,
+    )
+    .unwrap();
 }
 
 fn wait_for_path(path: &Path) {
@@ -309,155 +103,6 @@ fn wait_for_path(path: &Path) {
     panic!("timed out waiting for {}", path.display());
 }
 
-fn write_runtime_wrapper(bin_dir: &Path, wrapper_log: &Path) {
-    write_executable(
-        &bin_dir.join("sonde-azure-companion"),
-        &format!(
-            "#!/bin/sh\nset -eu\nadmin_socket=\"\"\nconnector_socket=\"\"\nstate_dir=\"\"\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket)\n      admin_socket=\"$2\"\n      shift 2\n      ;;\n    --connector-socket)\n      connector_socket=\"$2\"\n      shift 2\n      ;;\n    --state-dir)\n      state_dir=\"$2\"\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\ncase \"$1\" in\n  run)\n    printf 'run %s %s %s\\n' \"$admin_socket\" \"$connector_socket\" \"$state_dir\" >> \"{}\"\n    exit 0\n    ;;\n  bootstrap-auth)\n    \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" --state-dir \"$state_dir\" \"$@\"\n    status=$?\n    if [ \"$status\" -eq 0 ] && [ \"${{SONDE_TEST_WRITE_RUNTIME_STATE:-0}}\" = \"1\" ]; then\n      mkdir -p \"$state_dir\"\n      cat > \"$state_dir/client-cert.pem\" <<'EOF'\n{}\nEOF\n      cat > \"$state_dir/client-key.pem\" <<'EOF'\n{}\nEOF\n      cat > \"$state_dir/service-principal.json\" <<'EOF'\n{{\"tenant_id\":\"11111111-1111-1111-1111-111111111111\",\"client_id\":\"22222222-2222-2222-2222-222222222222\",\"certificate_path\":\"client-cert.pem\",\"private_key_path\":\"client-key.pem\"}}\nEOF\n    fi\n    exit \"$status\"\n    ;;\n  *)\n    exec \"{}\" --admin-socket \"$admin_socket\" --connector-socket \"$connector_socket\" --state-dir \"$state_dir\" \"$@\"\n    ;;\nesac\n",
-            wrapper_log.display(),
-            env!("CARGO_BIN_EXE_sonde-azure-companion"),
-            TEST_CERT_PEM,
-            TEST_KEY_PEM,
-            env!("CARGO_BIN_EXE_sonde-azure-companion")
-        ),
-    );
-}
-
-fn write_runtime_ready_state(state_dir: &Path) {
-    fs::create_dir_all(state_dir).unwrap();
-    fs::write(state_dir.join("client-cert.pem"), TEST_CERT_PEM).unwrap();
-    fs::write(state_dir.join("client-key.pem"), TEST_KEY_PEM).unwrap();
-    fs::write(
-        state_dir.join("service-principal.json"),
-        br#"{"tenant_id":"11111111-1111-1111-1111-111111111111","client_id":"22222222-2222-2222-2222-222222222222","certificate_path":"client-cert.pem","private_key_path":"client-key.pem"}"#,
-    )
-    .unwrap();
-}
-
-fn bootstrap_env(
-    bin_dir: &Path,
-    state_dir: &Path,
-    admin_socket_path: &Path,
-    connector_socket_path: &Path,
-    oauth_server: &MockServer,
-) -> Vec<(String, String)> {
-    let mut path_value = std::env::var("PATH").unwrap_or_default();
-    path_value = format!("{}:{}", bin_dir.display(), path_value);
-    vec![
-        ("PATH".to_string(), path_value),
-        (
-            "SONDE_AZURE_COMPANION_IN_CONTAINER".to_string(),
-            "1".to_string(),
-        ),
-        (
-            "SONDE_AZURE_COMPANION_STATE_DIR".to_string(),
-            state_dir.display().to_string(),
-        ),
-        (
-            "SONDE_GATEWAY_ADMIN_SOCKET".to_string(),
-            admin_socket_path.display().to_string(),
-        ),
-        (
-            "SONDE_GATEWAY_CONNECTOR_SOCKET".to_string(),
-            connector_socket_path.display().to_string(),
-        ),
-        (
-            "SONDE_AZURE_DEVICE_CLIENT_ID".to_string(),
-            "test-client-id".to_string(),
-        ),
-        (
-            "SONDE_AZURE_DEVICE_SCOPES".to_string(),
-            "https://management.azure.com/.default".to_string(),
-        ),
-        (
-            "SONDE_AZURE_DEVICE_AUTH_URL".to_string(),
-            format!("{}/device", oauth_server.uri()),
-        ),
-        (
-            "SONDE_AZURE_DEVICE_TOKEN_URL".to_string(),
-            format!("{}/token", oauth_server.uri()),
-        ),
-        (
-            "SONDE_AZURE_SERVICEBUS_NAMESPACE".to_string(),
-            "example.servicebus.windows.net".to_string(),
-        ),
-        (
-            "SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE".to_string(),
-            "upstream".to_string(),
-        ),
-        (
-            "SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE".to_string(),
-            "downstream".to_string(),
-        ),
-    ]
-}
-
-async fn mount_successful_device_flow(
-    oauth_server: &MockServer,
-    user_code: &str,
-    expected_count: u64,
-) {
-    mount_device_code_request(oauth_server, user_code, expected_count).await;
-
-    Mock::given(method("POST"))
-        .and(path("/token"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .append_header("content-type", "application/json")
-                .set_body_string(
-                    "{\"access_token\":\"temporary-token\",\"token_type\":\"Bearer\",\"expires_in\":300}",
-                ),
-        )
-        .expect(expected_count)
-        .mount(oauth_server)
-        .await;
-}
-
-async fn mount_device_code_request(
-    oauth_server: &MockServer,
-    user_code: &str,
-    expected_count: u64,
-) {
-    Mock::given(method("POST"))
-        .and(path("/device"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .append_header("content-type", "application/json")
-                .set_body_string(format!(
-                    "{{\"device_code\":\"device-code-{user_code}\",\"user_code\":\"{user_code}\",\"verification_uri\":\"https://microsoft.com/devicelogin\",\"verification_uri_complete\":\"https://microsoft.com/devicelogin?code={user_code}\",\"expires_in\":900,\"interval\":1}}"
-                )),
-        )
-        .expect(expected_count)
-        .mount(oauth_server)
-        .await;
-}
-
-async fn mount_failed_token_poll(oauth_server: &MockServer, user_code: &str) {
-    mount_device_code_request(oauth_server, user_code, 1).await;
-
-    Mock::given(method("POST"))
-        .and(path("/token"))
-        .respond_with(
-            ResponseTemplate::new(400)
-                .append_header("content-type", "application/json")
-                .set_body_string(
-                    "{\"error\":\"expired_token\",\"error_description\":\"expired for test\"}",
-                ),
-        )
-        .expect(1)
-        .mount(oauth_server)
-        .await;
-}
-
-async fn run_bootstrap_with_env(env: &[(String, String)]) -> std::process::Output {
-    let mut cmd = TokioCommand::new("sh");
-    cmd.arg(bootstrap_script_path());
-    for (key, value) in env {
-        cmd.env(key, value);
-    }
-    cmd.output().await.unwrap()
-}
-
 fn docker_available() -> bool {
     Command::new("docker")
         .arg("version")
@@ -466,239 +111,84 @@ fn docker_available() -> bool {
         .unwrap_or(false)
 }
 
-#[tokio::test]
-async fn t_azc_0101_0102_0200_0201_0202_bootstrap_success_path() {
-    let temp = TempDir::new().unwrap();
-    let bin_dir = prepare_path_dir(&temp);
-    let state_dir = temp.path().join("state");
-    fs::create_dir_all(&state_dir).unwrap();
-    let admin_socket_path = temp.path().join("admin.sock");
-    let connector_socket_path = temp.path().join("connector.sock");
-    let display_requests = spawn_admin_server(&admin_socket_path, None).await;
-    let oauth_server = MockServer::start().await;
-    mount_successful_device_flow(&oauth_server, "ABCD-EFGH", 1).await;
-
-    let wrapper_log = temp.path().join("wrapper.log");
-    write_runtime_wrapper(&bin_dir, &wrapper_log);
-    let mut env = bootstrap_env(
-        &bin_dir,
-        &state_dir,
-        &admin_socket_path,
-        &connector_socket_path,
-        &oauth_server,
-    );
-    env.push((
-        "SONDE_TEST_WRITE_RUNTIME_STATE".to_string(),
-        "1".to_string(),
-    ));
-
-    let output = run_bootstrap_with_env(&env).await;
-    assert!(output.status.success(), "bootstrap failed: {output:?}");
-
-    let requests = display_requests.lock().await.clone();
-    assert_eq!(
-        requests,
-        vec![vec!["Azure login".to_string(), "ABCD-EFGH".to_string()]]
-    );
-    let wrapper_contents = fs::read_to_string(&wrapper_log).unwrap();
-    assert!(wrapper_contents.contains("run "));
-    assert!(wrapper_contents.contains(&admin_socket_path.display().to_string()));
-    assert!(wrapper_contents.contains(&connector_socket_path.display().to_string()));
-    assert!(wrapper_contents.contains(&state_dir.display().to_string()));
-}
-
-#[tokio::test]
-async fn t_azc_0203_display_failure_aborts_bootstrap() {
-    for code in [tonic::Code::FailedPrecondition, tonic::Code::Unavailable] {
-        let temp = TempDir::new().unwrap();
-        let bin_dir = prepare_path_dir(&temp);
-        let state_dir = temp.path().join("state");
-        fs::create_dir_all(&state_dir).unwrap();
-        let admin_socket_path = temp.path().join("admin.sock");
-        let connector_socket_path = temp.path().join("connector.sock");
-        let display_requests = spawn_admin_server(&admin_socket_path, Some(code)).await;
-        let oauth_server = MockServer::start().await;
-        mount_device_code_request(&oauth_server, "ZXCV-1234", 1).await;
-
-        let wrapper_log = temp.path().join("wrapper.log");
-        write_runtime_wrapper(&bin_dir, &wrapper_log);
-
-        let output = run_bootstrap_with_env(&bootstrap_env(
-            &bin_dir,
-            &state_dir,
-            &admin_socket_path,
-            &connector_socket_path,
-            &oauth_server,
-        ))
-        .await;
-        assert!(!output.status.success());
-        assert!(!wrapper_log.exists() || fs::read_to_string(&wrapper_log).unwrap().is_empty());
-        assert_eq!(
-            display_requests.lock().await.clone(),
-            vec![vec!["Azure login".to_string(), "ZXCV-1234".to_string()]]
-        );
-    }
-}
-
-#[tokio::test]
-async fn t_azc_0104_ready_state_skips_device_auth() {
+#[test]
+fn container_ready_state_skips_bootstrap_and_runs() {
     let temp = TempDir::new().unwrap();
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
     write_runtime_ready_state(&state_dir);
-    let admin_socket_path = temp.path().join("admin.sock");
-    let connector_socket_path = temp.path().join("connector.sock");
-    let display_requests = spawn_admin_server(&admin_socket_path, None).await;
-    let oauth_server = MockServer::start().await;
-
     let wrapper_log = temp.path().join("wrapper.log");
     write_runtime_wrapper(&bin_dir, &wrapper_log);
 
-    let output = run_bootstrap_with_env(&bootstrap_env(
-        &bin_dir,
-        &state_dir,
-        &admin_socket_path,
-        &connector_socket_path,
-        &oauth_server,
-    ))
-    .await;
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    cmd.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        ),
+    );
+    cmd.env("SONDE_AZURE_COMPANION_IN_CONTAINER", "1");
+    cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
+    cmd.env("SONDE_GATEWAY_ADMIN_SOCKET", temp.path().join("admin.sock"));
+    cmd.env(
+        "SONDE_GATEWAY_CONNECTOR_SOCKET",
+        temp.path().join("connector.sock"),
+    );
+
+    let output = cmd.output().unwrap();
     assert!(output.status.success(), "runtime start failed: {output:?}");
-    assert!(display_requests.lock().await.is_empty());
-    assert!(fs::read_to_string(&wrapper_log).unwrap().contains("run "));
-}
-
-#[tokio::test]
-async fn t_azc_0105_repeated_starts_reuse_ready_state() {
-    let temp = TempDir::new().unwrap();
-    let bin_dir = prepare_path_dir(&temp);
-    let state_dir = temp.path().join("state");
-    write_runtime_ready_state(&state_dir);
-    let admin_socket_path = temp.path().join("admin.sock");
-    let connector_socket_path = temp.path().join("connector.sock");
-    let display_requests = spawn_admin_server(&admin_socket_path, None).await;
-    let oauth_server = MockServer::start().await;
-
-    let wrapper_log = temp.path().join("wrapper.log");
-    write_runtime_wrapper(&bin_dir, &wrapper_log);
-    let env = bootstrap_env(
-        &bin_dir,
-        &state_dir,
-        &admin_socket_path,
-        &connector_socket_path,
-        &oauth_server,
-    );
-
-    let first = run_bootstrap_with_env(&env).await;
-    assert!(first.status.success(), "first bootstrap failed: {first:?}");
-
-    let second = run_bootstrap_with_env(&env).await;
-    assert!(
-        second.status.success(),
-        "second runtime start failed: {second:?}"
-    );
-
-    assert!(display_requests.lock().await.is_empty());
-    let wrapper_contents = fs::read_to_string(&wrapper_log).unwrap();
-    assert_eq!(wrapper_contents.lines().count(), 2);
-}
-
-#[tokio::test]
-async fn t_azc_0106_login_failure_aborts_bootstrap() {
-    let temp = TempDir::new().unwrap();
-    let bin_dir = prepare_path_dir(&temp);
-    let state_dir = temp.path().join("state");
-    fs::create_dir_all(&state_dir).unwrap();
-    let admin_socket_path = temp.path().join("admin.sock");
-    let connector_socket_path = temp.path().join("connector.sock");
-    let _display_requests = spawn_admin_server(&admin_socket_path, None).await;
-    let oauth_server = MockServer::start().await;
-    mount_failed_token_poll(&oauth_server, "FAIL-0001").await;
-
-    let wrapper_log = temp.path().join("wrapper.log");
-    write_runtime_wrapper(&bin_dir, &wrapper_log);
-
-    let output = run_bootstrap_with_env(&bootstrap_env(
-        &bin_dir,
-        &state_dir,
-        &admin_socket_path,
-        &connector_socket_path,
-        &oauth_server,
-    ))
-    .await;
-    assert!(!output.status.success());
-    assert!(!wrapper_log.exists());
-}
-
-#[tokio::test]
-async fn t_azc_0107_bootstrap_without_runtime_state_fails_closed() {
-    let temp = TempDir::new().unwrap();
-    let bin_dir = prepare_path_dir(&temp);
-    let state_dir = temp.path().join("state");
-    fs::create_dir_all(&state_dir).unwrap();
-    let admin_socket_path = temp.path().join("admin.sock");
-    let connector_socket_path = temp.path().join("connector.sock");
-    let display_requests = spawn_admin_server(&admin_socket_path, None).await;
-    let oauth_server = MockServer::start().await;
-    mount_successful_device_flow(&oauth_server, "POST-BOOT", 1).await;
-
-    let wrapper_log = temp.path().join("wrapper.log");
-    write_runtime_wrapper(&bin_dir, &wrapper_log);
-
-    let output = run_bootstrap_with_env(&bootstrap_env(
-        &bin_dir,
-        &state_dir,
-        &admin_socket_path,
-        &connector_socket_path,
-        &oauth_server,
-    ))
-    .await;
-    assert!(!output.status.success());
     assert_eq!(
-        display_requests.lock().await.clone(),
-        vec![vec!["Azure login".to_string(), "POST-BOOT".to_string()]]
+        fs::read_to_string(&wrapper_log).unwrap().lines().collect::<Vec<_>>(),
+        vec![format!(
+            "run {} {} {}",
+            temp.path().join("admin.sock").display(),
+            temp.path().join("connector.sock").display(),
+            state_dir.display()
+        )]
     );
-    assert!(!wrapper_log.exists() || fs::read_to_string(&wrapper_log).unwrap().is_empty());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("runtime state is still incomplete"));
-    assert!(fs::read_dir(&state_dir).unwrap().all(|entry| !entry
-        .unwrap()
-        .file_name()
-        .to_string_lossy()
-        .starts_with("check-runtime-ready.")));
 }
 
-#[tokio::test]
-async fn t_azc_0108_missing_runtime_config_beats_device_auth_env_error() {
+#[test]
+fn container_bootstrap_runs_and_then_starts_runtime() {
     let temp = TempDir::new().unwrap();
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
-    write_runtime_ready_state(&state_dir);
-    let admin_socket_path = temp.path().join("admin.sock");
-    let connector_socket_path = temp.path().join("connector.sock");
-    let _display_requests = spawn_admin_server(&admin_socket_path, None).await;
-    let oauth_server = MockServer::start().await;
-
+    fs::create_dir_all(&state_dir).unwrap();
     let wrapper_log = temp.path().join("wrapper.log");
     write_runtime_wrapper(&bin_dir, &wrapper_log);
-    let mut env = bootstrap_env(
-        &bin_dir,
-        &state_dir,
-        &admin_socket_path,
-        &connector_socket_path,
-        &oauth_server,
-    );
-    env.retain(|(key, _)| {
-        key != "SONDE_AZURE_SERVICEBUS_NAMESPACE"
-            && key != "SONDE_AZURE_DEVICE_CLIENT_ID"
-            && key != "SONDE_AZURE_DEVICE_SCOPES"
-    });
 
-    let output = run_bootstrap_with_env(&env).await;
-    assert!(!output.status.success());
-    assert!(!wrapper_log.exists() || fs::read_to_string(&wrapper_log).unwrap().is_empty());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("SONDE_AZURE_SERVICEBUS_NAMESPACE must be set and non-empty"));
-    assert!(stderr.contains("SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap"));
-    assert!(stderr.contains("SONDE_AZURE_DEVICE_SCOPES must be set for bootstrap"));
+    let mut cmd = Command::new("sh");
+    cmd.arg(bootstrap_script_path());
+    cmd.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        ),
+    );
+    cmd.env("SONDE_AZURE_COMPANION_IN_CONTAINER", "1");
+    cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
+    cmd.env("SONDE_GATEWAY_ADMIN_SOCKET", temp.path().join("admin.sock"));
+    cmd.env(
+        "SONDE_GATEWAY_CONNECTOR_SOCKET",
+        temp.path().join("connector.sock"),
+    );
+    cmd.env("SONDE_TEST_WRITE_RUNTIME_STATE", "1");
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success(), "bootstrap failed: {output:?}");
+    let lines: Vec<_> = fs::read_to_string(&wrapper_log)
+        .unwrap()
+        .lines()
+        .map(str::to_string)
+        .collect();
+    assert_eq!(lines.len(), 2);
+    assert!(lines[0].starts_with("bootstrap "));
+    assert!(lines[1].starts_with("run "));
 }
 
 #[test]
@@ -736,19 +226,21 @@ fn host_bootstrap_invokes_docker_with_expected_mounts() {
     cmd.env("SONDE_AZURE_COMPANION_IMAGE", "sonde-azure-companion:test");
     cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
     cmd.env("SONDE_GATEWAY_RUNTIME_DIR", &runtime_dir);
-    cmd.env("SONDE_AZURE_DEVICE_CLIENT_ID", "test-client-id");
-    cmd.env(
-        "SONDE_AZURE_DEVICE_SCOPES",
-        "https://management.azure.com/.default",
-    );
+    cmd.env("SONDE_AZURE_LOCATION", "westus2");
+    cmd.env("SONDE_AZURE_PROJECT_NAME", "sonde-test");
+    cmd.env("SONDE_AZURE_SUBSCRIPTION_ID", "sub-123");
 
     let output = cmd.output().unwrap();
     assert!(output.status.success(), "host bootstrap failed: {output:?}");
     let logged = fs::read_to_string(docker_log).unwrap();
     assert!(logged.contains("run --rm"));
     assert!(logged.contains("sonde-azure-companion:test"));
-    assert!(logged.contains("-e SONDE_AZURE_DEVICE_CLIENT_ID"));
-    assert!(logged.contains("-e SONDE_AZURE_DEVICE_SCOPES"));
+    assert!(logged.contains("-e SONDE_AZURE_LOCATION"));
+    assert!(logged.contains("-e SONDE_AZURE_PROJECT_NAME"));
+    assert!(logged.contains("-e SONDE_AZURE_SUBSCRIPTION_ID"));
+    assert!(!logged.contains("SONDE_AZURE_DEVICE_CLIENT_ID"));
+    assert!(!logged.contains("SONDE_AZURE_DEVICE_SCOPES"));
+    assert!(logged.contains("-v /var/run/docker.sock:/var/run/docker.sock"));
     assert!(logged.contains(&format!(
         "-v {}:/var/lib/sonde-azure-companion",
         state_dir.display()
@@ -761,11 +253,10 @@ fn host_bootstrap_invokes_docker_with_expected_mounts() {
         "-v {}:/var/run/sonde/connector.sock",
         connector_socket_path.display()
     )));
-    assert!(!logged.contains(&format!("-v {}:/var/run/sonde", runtime_dir.display())));
 }
 
 #[test]
-fn host_bootstrap_defers_bootstrap_env_validation_to_container() {
+fn host_bootstrap_does_not_require_removed_device_env() {
     let temp = TempDir::new().unwrap();
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
@@ -799,15 +290,10 @@ fn host_bootstrap_defers_bootstrap_env_validation_to_container() {
     cmd.env("SONDE_AZURE_COMPANION_IMAGE", "sonde-azure-companion:test");
     cmd.env("SONDE_AZURE_COMPANION_STATE_DIR", &state_dir);
     cmd.env("SONDE_GATEWAY_RUNTIME_DIR", &runtime_dir);
-    cmd.env("SONDE_AZURE_DEVICE_CLIENT_ID", "");
-    cmd.env("SONDE_AZURE_DEVICE_SCOPES", "");
 
     let output = cmd.output().unwrap();
     assert!(output.status.success(), "host bootstrap failed: {output:?}");
-    assert!(
-        docker_log.exists(),
-        "docker should still be invoked by the host wrapper"
-    );
+    assert!(docker_log.exists(), "docker should still be invoked by the host wrapper");
 }
 
 #[test]
@@ -850,16 +336,16 @@ fn t_azc_0100_container_image_smoke() {
             "--rm",
             "sonde-azure-companion:test",
             "sonde-azure-companion",
-            "bootstrap-auth",
+            "bootstrap",
             "--help",
         ])
         .status()
         .unwrap();
-    assert!(status.success(), "bootstrap-auth smoke test failed");
+    assert!(status.success(), "bootstrap smoke test failed");
 }
 
 #[test]
-fn container_bootstrap_forwards_sigterm_to_bootstrap_auth_child() {
+fn container_bootstrap_forwards_sigterm_to_bootstrap_child() {
     let temp = TempDir::new().unwrap();
     let bin_dir = prepare_path_dir(&temp);
     let state_dir = temp.path().join("state");
@@ -871,7 +357,7 @@ fn container_bootstrap_forwards_sigterm_to_bootstrap_auth_child() {
     write_executable(
         &bin_dir.join("sonde-azure-companion"),
         &format!(
-            "#!/bin/sh\nset -eu\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket|--connector-socket|--state-dir)\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\ncase \"$1\" in\n  bootstrap-auth)\n    printf '%s\\n' \"$$\" > \"{}\"\n    trap 'printf \"%s\\n\" TERM >> \"{}\"; exit 143' TERM\n    trap 'printf \"%s\\n\" INT >> \"{}\"; exit 130' INT\n    while :; do\n      sleep 1\n    done\n    ;;\n  run)\n    printf 'run\\n' >> \"{}\"\n    exit 0\n    ;;\n  *)\n    exit 64\n    ;;\nesac\n",
+            "#!/bin/sh\nset -eu\nwhile [ \"$#\" -gt 0 ]; do\n  case \"$1\" in\n    --admin-socket|--connector-socket|--state-dir)\n      shift 2\n      ;;\n    *)\n      break\n      ;;\n  esac\ndone\ncase \"$1\" in\n  bootstrap)\n    printf '%s\\n' \"$$\" > \"{}\"\n    trap 'printf \"%s\\n\" TERM >> \"{}\"; exit 143' TERM\n    trap 'printf \"%s\\n\" INT >> \"{}\"; exit 130' INT\n    while :; do\n      sleep 1\n    done\n    ;;\n  run)\n    printf 'run\\n' >> \"{}\"\n    exit 0\n    ;;\n  *)\n    exit 64\n    ;;\nesac\n",
             pid_file.display(),
             signal_log.display(),
             signal_log.display(),
@@ -895,11 +381,6 @@ fn container_bootstrap_forwards_sigterm_to_bootstrap_auth_child() {
     cmd.env(
         "SONDE_GATEWAY_CONNECTOR_SOCKET",
         temp.path().join("connector.sock"),
-    );
-    cmd.env("SONDE_AZURE_DEVICE_CLIENT_ID", "test-client-id");
-    cmd.env(
-        "SONDE_AZURE_DEVICE_SCOPES",
-        "https://management.azure.com/.default",
     );
 
     let mut child = cmd.spawn().unwrap();

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -25,6 +25,50 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         exit 1
     fi
 
+    host_json_string() {
+        key="$1"
+        file="$2"
+        sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$file" | head -n 1
+    }
+
+    host_runtime_ready() {
+        service_principal_path="$state_dir/service-principal.json"
+        if [ ! -f "$service_principal_path" ]; then
+            return 1
+        fi
+
+        cert_rel="$(host_json_string certificate_path "$service_principal_path")"
+        key_rel="$(host_json_string private_key_path "$service_principal_path")"
+        if [ -z "$cert_rel" ] || [ -z "$key_rel" ]; then
+            return 1
+        fi
+        if [ ! -f "$state_dir/$cert_rel" ] || [ ! -f "$state_dir/$key_rel" ]; then
+            return 1
+        fi
+
+        if [ -f "$state_dir/service-bus.json" ]; then
+            return 0
+        fi
+
+        [ -n "${SONDE_AZURE_SERVICEBUS_NAMESPACE:-}" ] &&
+            [ -n "${SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE:-}" ] &&
+            [ -n "${SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE:-}" ]
+    }
+
+    enable_docker_mount=0
+    if [ "$#" -gt 0 ] && [ "$1" = "bootstrap" ]; then
+        enable_docker_mount=1
+    elif [ "${SONDE_AZURE_COMPANION_ENABLE_DOCKER:-0}" = "1" ]; then
+        enable_docker_mount=1
+    elif ! host_runtime_ready; then
+        enable_docker_mount=1
+    fi
+
+    docker_mount_args=""
+    if [ "$enable_docker_mount" -eq 1 ]; then
+        docker_mount_args="-v /var/run/docker.sock:/var/run/docker.sock"
+    fi
+
     exec docker run --rm \
         --name "${SONDE_AZURE_COMPANION_CONTAINER_NAME:-sonde-azure-companion}" \
         -e SONDE_AZURE_COMPANION_IN_CONTAINER=1 \
@@ -40,7 +84,7 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         -v "$state_dir:$container_state_dir" \
         -v "$admin_socket_path:$container_admin_socket_path" \
         -v "$connector_socket_path:$container_connector_socket_path" \
-        -v /var/run/docker.sock:/var/run/docker.sock \
+        $docker_mount_args \
         "$image" "$@"
 fi
 

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -43,7 +43,12 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         fi
 
         generation_name="$(host_trim_string "$(cat "$active_state_file")")"
-        if [ -z "$generation_name" ] || [ ! -d "$state_dir/$generation_name" ]; then
+        case "$generation_name" in
+            ''|*/*|*\\*|*..*|-*)
+                return 1
+                ;;
+        esac
+        if [ ! -d "$state_dir/$generation_name" ]; then
             return 1
         fi
 

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -34,13 +34,13 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         -e SONDE_AZURE_SERVICEBUS_NAMESPACE \
         -e SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE \
         -e SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE \
-        -e SONDE_AZURE_DEVICE_CLIENT_ID \
-        -e SONDE_AZURE_DEVICE_SCOPES \
-        -e SONDE_AZURE_DEVICE_POLL_INTERVAL_SECS \
-        -e SONDE_AZURE_DEVICE_MAX_ATTEMPTS \
+        -e SONDE_AZURE_LOCATION \
+        -e SONDE_AZURE_PROJECT_NAME \
+        -e SONDE_AZURE_SUBSCRIPTION_ID \
         -v "$state_dir:$container_state_dir" \
         -v "$admin_socket_path:$container_admin_socket_path" \
         -v "$connector_socket_path:$container_connector_socket_path" \
+        -v /var/run/docker.sock:/var/run/docker.sock \
         "$image" "$@"
 fi
 
@@ -84,22 +84,6 @@ if sonde-azure-companion \
         run
 fi
 
-missing_bootstrap_env=0
-if [ -z "${SONDE_AZURE_DEVICE_CLIENT_ID:-}" ]; then
-    echo "SONDE_AZURE_DEVICE_CLIENT_ID must be set for bootstrap" >&2
-    missing_bootstrap_env=1
-fi
-if [ -z "${SONDE_AZURE_DEVICE_SCOPES:-}" ]; then
-    echo "SONDE_AZURE_DEVICE_SCOPES must be set for bootstrap" >&2
-    missing_bootstrap_env=1
-fi
-if [ "$missing_bootstrap_env" -ne 0 ]; then
-    if [ -f "$state_dir/service-principal.json" ]; then
-        check_runtime_ready_with_log || true
-    fi
-    exit 1
-fi
-
 bootstrap_pid=
 
 forward_signal() {
@@ -117,7 +101,7 @@ sonde-azure-companion \
     --admin-socket "$admin_socket_path" \
     --connector-socket "$connector_socket_path" \
     --state-dir "$state_dir" \
-    bootstrap-auth &
+    bootstrap &
 bootstrap_pid=$!
 
 if wait "$bootstrap_pid"; then
@@ -134,7 +118,7 @@ if [ "$bootstrap_status" -ne 0 ]; then
 fi
 
 if ! check_runtime_ready_with_log; then
-    echo "bootstrap completed device auth, but runtime state is still incomplete" >&2
+    echo "bootstrap completed, but runtime state is still incomplete" >&2
     exit 1
 fi
 

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -28,11 +28,31 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
     host_json_string() {
         key="$1"
         file="$2"
-        sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$file" | head -n 1
+        sed -n "s/.*\"$key\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p" "$file" | head -n 1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+    }
+
+    host_trim_string() {
+        printf '%s' "$1" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+    }
+
+    host_effective_state_dir() {
+        active_state_file="$state_dir/.current-state"
+        if [ ! -f "$active_state_file" ]; then
+            printf '%s\n' "$state_dir"
+            return 0
+        fi
+
+        generation_name="$(host_trim_string "$(cat "$active_state_file")")"
+        if [ -z "$generation_name" ] || [ ! -d "$state_dir/$generation_name" ]; then
+            return 1
+        fi
+
+        printf '%s\n' "$state_dir/$generation_name"
     }
 
     host_runtime_ready() {
-        service_principal_path="$state_dir/service-principal.json"
+        effective_state_dir="$(host_effective_state_dir)" || return 1
+        service_principal_path="$effective_state_dir/service-principal.json"
         if [ ! -f "$service_principal_path" ]; then
             return 1
         fi
@@ -42,17 +62,20 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         if [ -z "$cert_rel" ] || [ -z "$key_rel" ]; then
             return 1
         fi
-        if [ ! -f "$state_dir/$cert_rel" ] || [ ! -f "$state_dir/$key_rel" ]; then
+        if [ ! -f "$effective_state_dir/$cert_rel" ] || [ ! -f "$effective_state_dir/$key_rel" ]; then
             return 1
         fi
 
-        if [ -n "${SONDE_AZURE_SERVICEBUS_NAMESPACE:-}" ] &&
-            [ -n "${SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE:-}" ] &&
-            [ -n "${SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE:-}" ]; then
+        namespace_env="$(host_trim_string "${SONDE_AZURE_SERVICEBUS_NAMESPACE:-}")"
+        upstream_env="$(host_trim_string "${SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE:-}")"
+        downstream_env="$(host_trim_string "${SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE:-}")"
+        if [ -n "$namespace_env" ] &&
+            [ -n "$upstream_env" ] &&
+            [ -n "$downstream_env" ]; then
             return 0
         fi
 
-        service_bus_path="$state_dir/service-bus.json"
+        service_bus_path="$effective_state_dir/service-bus.json"
         if [ ! -f "$service_bus_path" ]; then
             return 1
         fi

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -46,13 +46,24 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
             return 1
         fi
 
-        if [ -f "$state_dir/service-bus.json" ]; then
+        if [ -n "${SONDE_AZURE_SERVICEBUS_NAMESPACE:-}" ] &&
+            [ -n "${SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE:-}" ] &&
+            [ -n "${SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE:-}" ]; then
             return 0
         fi
 
-        [ -n "${SONDE_AZURE_SERVICEBUS_NAMESPACE:-}" ] &&
-            [ -n "${SONDE_AZURE_SERVICEBUS_UPSTREAM_QUEUE:-}" ] &&
-            [ -n "${SONDE_AZURE_SERVICEBUS_DOWNSTREAM_QUEUE:-}" ]
+        service_bus_path="$state_dir/service-bus.json"
+        if [ ! -f "$service_bus_path" ]; then
+            return 1
+        fi
+
+        namespace="$(host_json_string namespace "$service_bus_path")"
+        upstream_queue="$(host_json_string upstream_queue "$service_bus_path")"
+        downstream_queue="$(host_json_string downstream_queue "$service_bus_path")"
+
+        [ -n "$namespace" ] &&
+            [ -n "$upstream_queue" ] &&
+            [ -n "$downstream_queue" ]
     }
 
     enable_docker_mount=0

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -99,7 +99,11 @@ The current runtime artifact shape is a companion-owned `service-principal.json`
 file containing the Entra tenant ID, client ID, PEM certificate path, and PEM
 private-key path, plus the referenced certificate and key files in the mounted
 state directory. After bootstrap, the state volume also contains
-`service-bus.json` with the Service Bus namespace and queue names.
+`service-bus.json` with the Service Bus namespace and queue names. New bootstrap
+commits are written into a generation directory under the state volume and made
+current by atomically updating a `.current-state` marker file. For backward
+compatibility, startup also accepts the legacy flat-file layout when the marker
+is absent.
 
 ### 3.3  Bootstrap-state decision
 
@@ -168,8 +172,10 @@ When bootstrap is required, the Azure companion performs this sequence:
 14. Write `service-principal.json` and `service-bus.json` to the staging
     directory with the extracted values and relative paths to the certificate
     and private-key PEM files.
-15. Atomically swap the staging directory contents into the state volume,
-    replacing any previous bootstrap artifacts only after all writes succeed.
+15. Rename the staging directory into a new generation directory under the state
+    volume, then atomically update the `.current-state` marker to point at that
+    generation, leaving the previous generation untouched until the new one is
+    fully committed.
 16. Remove the Azure CLI container.
 17. Display "Bootstrap complete" on the modem display.
 18. The bootstrap wrapper/entrypoint reports overall success only after

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -4,9 +4,11 @@
 
 > **Document status:** Draft
 > **Scope:** Internal design for the Azure companion container, bootstrap-state
-> detection, bootstrap trigger behavior, and the Service Bus AMQP runtime bridge.
-> The internal Azure provisioning workflow that creates the runtime certificate
-> and broker resources is outside this document's scope.
+> detection, bootstrap trigger behavior, integrated provisioning orchestration
+> (certificate generation, Bicep deployment via Docker API, runtime artifact
+> creation), and the Service Bus AMQP runtime bridge.
+> The Bicep module definitions themselves are specified in
+> [azure-provisioning-design.md](azure-provisioning-design.md).
 > **Audience:** Implementers building the Azure companion crate and its
 > deployment artifacts.
 > **Related:** [azure-provisioning-design.md](azure-provisioning-design.md),
@@ -28,8 +30,10 @@ The Azure companion now has two distinct responsibilities:
 
 1. detect whether bootstrap has already completed,
 2. invoke bootstrap when the required local provisioning artifacts are missing,
-3. use the gateway admin API to display the device code during bootstrap, and
-4. when bootstrap-complete state exists, bridge the gateway connector session to
+3. use the gateway admin API to display the device code during bootstrap,
+4. orchestrate the full provisioning lifecycle (certificate generation, Bicep
+   deployment via the Docker API, and runtime artifact creation), and
+5. when bootstrap-complete state exists, bridge the gateway connector session to
    Azure Service Bus over AMQP.
 
 The gateway-facing connector contract remains cloud-agnostic. Azure-specific
@@ -77,22 +81,25 @@ The container expects the following runtime inputs:
 
 | Input | Purpose |
 |-------|---------|
-| State volume | Persistent storage for local provisioning artifacts such as the runtime certificate PEM, private-key PEM, and service-principal metadata file. |
+| State volume | Persistent storage for local provisioning artifacts such as the runtime certificate PEM, private-key PEM, service-principal metadata file, and persisted Service Bus configuration. |
 | Gateway admin socket | Local IPC path used by bootstrap to call `GatewayAdmin` RPCs such as `ShowModemDisplayMessage`. |
 | Gateway connector socket | Local framed IPC path used by the long-running runtime after bootstrap succeeds. |
-| Service Bus namespace | Explicit runtime configuration for the Azure Service Bus namespace. |
-| Upstream queue name | Explicit runtime configuration for the queue that carries gateway-originated connector messages. |
-| Downstream queue name | Explicit runtime configuration for the queue that carries cloud-originated desired-state messages. |
+| Docker socket (bootstrap only) | Docker Engine API socket, bind-mounted from the host, used by bootstrap to run the Azure CLI container via Bollard. Not required for normal runtime operation. |
+| Service Bus namespace | Runtime configuration for the Azure Service Bus namespace, from environment variable or persisted `service-bus.json`. |
+| Upstream queue name | Runtime configuration for the queue that carries gateway-originated connector messages, from environment variable or persisted `service-bus.json`. |
+| Downstream queue name | Runtime configuration for the queue that carries cloud-originated desired-state messages, from environment variable or persisted `service-bus.json`. |
 
 Bootstrap-complete state is defined by the combination of:
 
 1. the required local provisioning artifacts in the state volume, and
-2. the required explicit queue configuration.
+2. the required queue configuration (from either environment variables or
+   persisted `service-bus.json` in the state volume).
 
 The current runtime artifact shape is a companion-owned `service-principal.json`
 file containing the Entra tenant ID, client ID, PEM certificate path, and PEM
 private-key path, plus the referenced certificate and key files in the mounted
-state directory.
+state directory. After bootstrap, the state volume also contains
+`service-bus.json` with the Service Bus namespace and queue names.
 
 ### 3.3  Bootstrap-state decision
 
@@ -102,43 +109,75 @@ Startup follows this decision:
 2. Check whether the required local provisioning artifacts exist.
 3. Check whether the required Service Bus namespace and queue configuration are present.
 4. If both are present, skip bootstrap and start `run`.
-5. Otherwise, start `bootstrap-auth`.
+5. Otherwise, start `bootstrap`.
 
-The internal Azure provisioning workflow that consumes the bootstrap token and
-produces the runtime artifacts is outside this document's scope. The Azure
-companion only defines the startup decision and the interfaces around it.
+When bootstrap is entered, the unified `bootstrap` subcommand orchestrates the
+full provisioning lifecycle as described in section 4.2.
 
 ---
 
 ## 4  Bootstrap flow
 
-> **Requirements:** AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204, AZC-0300
+> **Requirements:** AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204, AZC-0300,
+> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0407, AZC-0408
 
 ### 4.1  Bootstrap trigger
 
 Bootstrap is entered only when bootstrap-complete state is absent. This differs
 from the earlier draft, which always re-entered device-code login on restart.
 
-### 4.2  Device-code login sequence
+Re-running the `bootstrap` subcommand explicitly (e.g., for credential rotation)
+is safe: it regenerates the certificate, re-runs Bicep, and rewrites the runtime
+artifacts.
+
+### 4.2  Unified bootstrap sequence
 
 When bootstrap is required, the Azure companion performs this sequence:
 
-1. Invoke `sonde-azure-companion bootstrap-auth`.
-2. Inside Rust, construct a Microsoft device-flow client from explicit
-   environment-provided client ID and scopes.
-3. Request a device code from Microsoft's device authorization endpoint.
-4. Log the verification URI to stdout/stderr for operator visibility.
-5. Call the gateway admin `ShowModemDisplayMessage` RPC with a short prompt plus
-   the exact device code.
-6. Poll the token endpoint until the operator completes device auth or the flow
-   fails.
-7. Hand off to the out-of-scope provisioning workflow that creates the runtime
-   certificate and broker resources.
-8. The bootstrap wrapper/entrypoint reports overall success only after
-   bootstrap-complete state has been established.
+1. Invoke `sonde-azure-companion bootstrap`.
+2. Display "Generating cert…" on the modem display via the admin API.
+3. Generate a self-signed ECDSA P-256 X.509 certificate and private key using
+   Rust crypto libraries. The certificate has a 2-year default validity period.
+   Write the certificate PEM and private-key PEM to a staging directory within
+   the mounted state volume.
+4. Base64-encode the certificate's DER public material for the Bicep
+   `companionCertificateBase64` parameter.
+5. Display "Authenticating…" on the modem display.
+6. Use the Bollard crate to pull (if needed) the digest-pinned
+   `mcr.microsoft.com/azure-cli` image.
+7. Create an Azure CLI container with the bundled Bicep files and staged
+   certificate copied in via Bollard's `put_archive` API (not bind mounts,
+   since the companion's container-internal paths are not visible to the host
+   Docker daemon).
+8. The container runs a bootstrap script that executes
+   `az login --use-device-code` followed by `az deployment sub create`.
+9. Rust monitors the container's output stream, looking for the device-code
+   pattern produced by `az login --use-device-code`. Because the Azure CLI
+   image is pinned by digest, the output format is a known quantity for the
+   pinned version.
+10. When the device code is detected, call the gateway admin
+    `ShowModemDisplayMessage` RPC with a short prompt plus the exact device
+    code.
+11. Wait for the container to finish. On success, `az deployment sub create`
+    produces JSON deployment outputs on stdout.
+12. Display "Deploying Azure…" on the modem display (transitions from auth to
+    deployment phase may overlap in the single container session).
+13. Capture and parse the JSON outputs to extract `tenantId`, `clientId`,
+    Service Bus namespace, and queue names from the `companionBootstrapValues`
+    output object.
+14. Write `service-principal.json` and `service-bus.json` to the staging
+    directory with the extracted values and relative paths to the certificate
+    and private-key PEM files.
+15. Atomically swap the staging directory contents into the state volume,
+    replacing any previous bootstrap artifacts only after all writes succeed.
+16. Remove the Azure CLI container.
+17. Display "Bootstrap complete" on the modem display.
+18. The bootstrap wrapper/entrypoint reports overall success only after
+    bootstrap-complete state has been established.
 
-The modem display shows only the short prompt plus the device code; the full
-verification URL remains in stdout/stderr logs.
+If any step fails, the staging directory is cleaned up, the Azure CLI
+container is removed, and the existing state volume contents remain untouched,
+preserving the previous working state for the next retry or runtime start.
 
 ### 4.3  Display failure handling
 
@@ -150,15 +189,20 @@ non-zero status. It does not continue to a console-only fallback.
 
 ## 5  Rust binary interface
 
-> **Requirements:** AZC-0100, AZC-0102, AZC-0201, AZC-0202, AZC-0300, AZC-0301, AZC-0302, AZC-0304, AZC-0305
+> **Requirements:** AZC-0100, AZC-0102, AZC-0201, AZC-0202, AZC-0300, AZC-0301, AZC-0302, AZC-0304, AZC-0305,
+> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406
 
 The `sonde-azure-companion` binary exposes three modes:
 
 1. **`run`** — default long-running runtime mode. It connects to the gateway
    connector socket and bridges connector traffic to Azure Service Bus.
-2. **`bootstrap-auth`** — performs Microsoft OAuth device flow in Rust, logs the
-   verification URI, requests the modem display update, waits for operator
-   completion, and then returns control to the bootstrap workflow.
+2. **`bootstrap`** — performs the unified provisioning lifecycle: self-signed
+   ECDSA P-256 certificate generation, Azure device-code authentication and
+   Bicep deployment via the Bollard Docker API (inside a pinned Azure CLI
+   container), and runtime artifact creation (`service-principal.json`,
+   `service-bus.json`, certificate PEM, private-key PEM). The Rust code
+   monitors the Azure CLI container's output to extract the device code and
+   display it on the modem via the gateway admin API.
 3. **`display-message`** — helper mode used by bootstrap logic to call the
    gateway admin `ShowModemDisplayMessage` RPC with 1 to 4 lines of text.
 
@@ -258,3 +302,155 @@ Detected failures on either side of the bridge are surfaced rather than masked:
 
 The runtime may reconnect or exit, but it must not silently claim success after
 a detected bridge failure.
+
+---
+
+## 8  Provisioning orchestration internals
+
+> **Requirements:** AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405,
+> AZC-0406, AZC-0407, AZC-0408
+
+### 8.1  Certificate generation
+
+The `bootstrap` subcommand generates a self-signed ECDSA P-256 X.509
+certificate using Rust crypto libraries already present in the workspace
+(`p256`, `x509-cert`, or `rcgen`). The certificate is generated with:
+
+- Subject CN: `sonde-azure-companion`
+- Key algorithm: ECDSA P-256
+- Signature algorithm: ECDSA with SHA-256
+- Validity: 2 years from generation time
+- Output: `cert.pem` and `key.pem` written to a staging directory within the
+  state volume
+
+The DER-encoded certificate public material is base64-encoded for the Bicep
+`companionCertificateBase64` parameter. This reuses the same parameter
+interface already defined in `deploy/bicep/main.bicep`.
+
+### 8.2  Bollard Docker API integration
+
+The `bootstrap` subcommand uses the Bollard crate to interact with the Docker
+Engine API. It does not shell out to the `docker` CLI. The integration flow:
+
+1. Connect to the Docker daemon via Bollard's auto-detection (typically
+   `/var/run/docker.sock` inside the container).
+2. Pull the `mcr.microsoft.com/azure-cli` image if not already present. The
+   image reference is pinned by digest in the source code for reproducibility.
+   If the pull fails (e.g., network is unavailable), bootstrap fails with a
+   clear error message.
+3. Create a container with environment variables for deployment parameters
+   (`SONDE_AZURE_LOCATION`, `COMPANION_CERT_BASE64`, etc.).
+4. Copy the bundled Bicep files and staged certificate into the container
+   using Bollard's `put_archive` API. This avoids bind mounts, which would
+   fail because the companion's container-internal paths are not visible to the
+   host Docker daemon when running as a sibling container.
+5. Start the container and stream its output (stdout/stderr).
+6. Monitor the output for the device-code pattern from `az login --use-device-code`.
+   When detected, extract the code and display it on the modem via the admin API.
+7. Wait for the container to exit and capture the JSON deployment outputs.
+8. Remove the container after completion (regardless of success or failure).
+
+If the container fails to start or the Docker daemon is unreachable, bootstrap
+fails with a descriptive error and cleans up any created-but-unstarted
+container resources.
+
+### 8.3  Azure CLI container execution
+
+Inside the Azure CLI container, the bootstrap runs a shell script that:
+
+1. Authenticates using `az login --use-device-code`. The device code and
+   verification URL appear on stderr, which Rust monitors and relays to the
+   modem display. Because the Azure CLI image is pinned by digest, the output
+   format is a known quantity that can be parsed reliably for that version.
+2. Optionally sets the target subscription if `SONDE_AZURE_SUBSCRIPTION_ID` is
+   provided via `az account set --subscription`.
+3. Runs `az deployment sub create` with:
+   - `--location` from `SONDE_AZURE_LOCATION` (default: `eastus`)
+   - `--template-file` pointing to the copied `main.bicep`
+   - `--parameters companionCertificateBase64=<base64>` plus any additional
+     parameter overrides from environment variables
+   - `--query properties.outputs` to extract only the deployment outputs
+   - `--output json` for machine-parseable output
+
+The deployment outputs JSON is emitted on stdout. All other `az` output
+(device-code prompt, login confirmation, deployment progress) goes to stderr,
+keeping stdout clean for JSON parsing.
+
+### 8.4  Staged artifact creation
+
+All new artifacts are written to a staging directory (`$state_dir/.staging/`)
+before being committed to the state volume. This ensures that a failed
+re-bootstrap does not corrupt the previous working state.
+
+After parsing the Bicep deployment outputs, the bootstrap creates in the
+staging directory:
+
+1. **`cert.pem`** and **`key.pem`** — already written during certificate
+   generation (step 3 of §4.2).
+2. **`service-principal.json`** containing:
+   ```json
+   {
+     "tenant_id": "<from companionBootstrapValues.tenantId>",
+     "client_id": "<from companionBootstrapValues.clientId>",
+     "certificate_path": "cert.pem",
+     "private_key_path": "key.pem"
+   }
+   ```
+3. **`service-bus.json`** containing:
+   ```json
+   {
+     "namespace": "<from companionBootstrapValues.serviceBusNamespace>",
+     "upstream_queue": "<from companionBootstrapValues.upstreamQueue>",
+     "downstream_queue": "<from companionBootstrapValues.downstreamQueue>"
+   }
+   ```
+
+Only after all staging writes succeed does the bootstrap atomically move the
+staged files into the state volume root, replacing any previous artifacts.
+If any write fails (e.g., disk full), the staging directory is removed and the
+previous state remains intact.
+
+The `key.pem` file MUST be written with owner-only read permissions (mode 0600)
+to protect the private key material.
+
+The runtime's `check-runtime-ready` path is updated to also check for the
+persisted Service Bus configuration file (`service-bus.json`) as an alternative
+to environment variables, enabling a fully automated startup after bootstrap.
+Environment variables, if set, override the persisted file values.
+
+### 8.5  Bundled Bicep files
+
+The Azure companion Dockerfile includes:
+
+```dockerfile
+COPY deploy/bicep/ /opt/sonde/deploy/bicep/
+```
+
+This bundles the complete Bicep deployment surface into the companion image.
+The bootstrap mounts this path into the Azure CLI container at runtime.
+
+### 8.6  Docker socket requirements
+
+The `bootstrap.sh` entrypoint script is updated to bind-mount the Docker
+socket from the host:
+
+```sh
+-v /var/run/docker.sock:/var/run/docker.sock
+```
+
+This is required only during bootstrap. Normal runtime operation after
+bootstrap does not need Docker socket access.
+
+### 8.7  Progress display phases
+
+The bootstrap displays these messages on the modem via the admin API:
+
+| Phase | Modem display | stderr log |
+|-------|--------------|------------|
+| Certificate generation | "Generating cert..." | "Generating ECDSA P-256 self-signed certificate" |
+| Azure CLI container start | "Authenticating..." | "Starting Azure CLI container for device-code auth" |
+| Device code received | "Azure login" + device code | "Device auth: open {uri} and enter code {code}" |
+| Bicep deployment | "Deploying Azure..." | "Running Bicep deployment" |
+| Config writing | "Writing config..." | "Writing runtime artifacts to state volume" |
+| Bootstrap complete | "Bootstrap complete" | "Bootstrap completed successfully" |
+| Bootstrap failure | "Bootstrap failed" | Error details |

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -6,11 +6,12 @@
 > **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771),
 > connector redesign discovery review, and Azure Service Bus discovery review.
 > **Scope:** This document covers the Azure companion container, bootstrap-state
-> detection, bootstrap-trigger behavior, and the long-running Azure Service Bus
-> runtime bridge between `sonde-gateway` and an external Azure control plane.
-> The internal Azure provisioning workflow that creates the runtime certificate
-> and private key, Entra application/service principal, and Service Bus
-> resources is out of scope for this document.
+> detection, bootstrap-trigger behavior, the integrated Azure provisioning
+> orchestration (certificate generation, Bicep deployment via Docker API, and
+> runtime artifact creation), and the long-running Azure Service Bus runtime
+> bridge between `sonde-gateway` and an external Azure control plane.
+> The Bicep module definitions themselves are specified in
+> [azure-provisioning-requirements.md](azure-provisioning-requirements.md).
 > **Related:** [azure-provisioning-requirements.md](azure-provisioning-requirements.md),
 > [gateway-companion-api.md](gateway-companion-api.md),
 > [gateway-requirements.md](gateway-requirements.md),
@@ -25,8 +26,8 @@
 | **Azure companion** | The Rust process that runs in its own container and integrates with `sonde-gateway` through the local admin API for bootstrap-only operator-visible actions and the local connector API for long-running runtime traffic. |
 | **State volume** | A mounted persistent directory reserved for Azure companion bootstrap output and other local provisioning artifacts. |
 | **Provisioning artifacts** | The local certificate PEM, private-key PEM, and related companion-owned state that indicate Azure bootstrap has already completed. |
-| **Queue configuration** | The Azure Service Bus namespace and the names of the upstream and downstream queues, supplied explicitly to the companion through configuration rather than hard-coded in the image. |
-| **Bootstrap-complete state** | The condition where the required provisioning artifacts exist and the required queue configuration is present, allowing the companion to skip bootstrap and start runtime directly. |
+| **Queue configuration** | The Azure Service Bus namespace and the names of the upstream and downstream queues, supplied to the companion through either environment variables or a persisted configuration file (`service-bus.json`) written by bootstrap. Both sources are valid; persisted configuration is the primary source after bootstrap, and environment variables may override it. |
+| **Bootstrap-complete state** | The condition where the required provisioning artifacts exist and the required queue configuration is present (from either source), allowing the companion to skip bootstrap and start runtime directly. |
 | **Transparent connector payload** | A Service Bus message body that carries the raw Sonde connector payload bytes unchanged. |
 
 ---
@@ -131,24 +132,29 @@ companion MUST enter the bootstrap workflow instead of normal runtime mode.
 
 ---
 
-### AZC-0201  Device-code bootstrap entry
+### AZC-0201  Unified bootstrap subcommand
 
 **Priority:** Must
 **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
 
 **Description:**
-When bootstrap is required, the Azure companion MUST begin bootstrap by
-obtaining Azure authentication through Azure device-code login using an
-in-process Rust device-flow client rather than shelling out to Azure CLI. The
-Azure-side provisioning workflow that consumes that bootstrap authentication is
-outside this document's scope.
+When bootstrap is required, the Azure companion MUST provide a single unified
+`bootstrap` subcommand that performs the entire provisioning lifecycle:
+certificate generation, device-code authentication (inside the Azure CLI
+container), Bicep deployment via the Docker API, and local runtime artifact
+creation. The earlier `bootstrap-auth` subcommand is retired and replaced by
+this unified command. Device-code authentication occurs inside the
+digest-pinned Azure CLI container via `az login --use-device-code`; the Rust
+companion monitors the container output to extract the device code and display
+it on the modem.
 
 **Acceptance criteria:**
 
-1. Missing bootstrap-complete state causes the companion bootstrap path to invoke Azure device-code login without requiring a local browser on the gateway host.
-2. The login flow waits for successful operator completion before reporting bootstrap success.
-3. If Azure device-code login fails, bootstrap exits with a non-zero status and does not report success.
+1. Missing bootstrap-complete state causes the companion bootstrap path to invoke the unified `bootstrap` subcommand.
+2. The `bootstrap` subcommand performs device-code login, certificate generation, Bicep deployment, and runtime artifact creation in sequence.
+3. If any phase of the unified bootstrap fails, the subcommand exits with a non-zero status and does not report success.
 4. Successful device-code login alone is not treated as bootstrap completion; the bootstrap path reports success only after bootstrap-complete state has been established.
+5. The earlier `bootstrap-auth` subcommand name is no longer accepted.
 
 ---
 
@@ -158,11 +164,13 @@ outside this document's scope.
 **Source:** Discovery review, GW-0809
 
 **Description:**
-When Azure device-code login produces a device code, the Rust bootstrap flow MUST
-request a modem display update through the gateway admin API. The displayed
-message MUST include a short prompt and the exact device code. The Azure
-companion MUST NOT attempt raw modem control or bypass the gateway's display
-ownership rules.
+When the Azure CLI container's `az login --use-device-code` produces a device
+code in its output, the Rust bootstrap flow MUST extract the code and request
+a modem display update through the gateway admin API. The displayed message
+MUST include a short prompt and the exact device code. The Azure companion
+MUST NOT attempt raw modem control or bypass the gateway's display ownership
+rules. Because the Azure CLI container image is pinned by digest, the output
+format is a known quantity for the pinned version.
 
 **Acceptance criteria:**
 
@@ -259,14 +267,17 @@ The Azure companion MUST require explicit configuration for the Azure Service
 Bus namespace plus the names of exactly two queues: one upstream queue for
 gateway-originated connector messages and one downstream queue for cloud-issued
 desired-state messages. These values MUST NOT be hard-coded in the container
-image.
+image. Configuration MAY be supplied through environment variables or through a
+persisted configuration file (`service-bus.json`) written by the bootstrap
+workflow. Environment variables, if set, override persisted file values.
 
 **Acceptance criteria:**
 
-1. Runtime startup requires explicit namespace configuration.
-2. Runtime startup requires explicit configuration for one upstream queue and one downstream queue.
+1. Runtime startup requires namespace configuration from either environment variables or a persisted configuration file.
+2. Runtime startup requires configuration for one upstream queue and one downstream queue from either source.
 3. The upstream and downstream queues are independently configurable.
 4. The image does not hard-code environment-specific queue names or namespace values.
+5. Environment variables override values from the persisted configuration file when both are present.
 
 ---
 
@@ -403,3 +414,193 @@ logging, process status, or both.
 1. Detected upstream publish failures are surfaced through logging, process status, or both.
 2. Detected downstream receive, settlement, or local connector write failures are surfaced through logging, process status, or both.
 3. The runtime design does not silently claim success after a detected broker or local connector failure.
+
+---
+
+## 6  Bootstrap provisioning orchestration
+
+### AZC-0400  Self-signed certificate generation
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
+
+**Description:**
+The unified `bootstrap` subcommand MUST generate a self-signed ECDSA P-256
+X.509 certificate and corresponding private key in Rust for use as the Entra
+application credential. The certificate and private key MUST be written to the
+mounted state volume as PEM files.
+
+**Acceptance criteria:**
+
+1. Bootstrap generates an ECDSA P-256 key pair and self-signed X.509 certificate without requiring external tooling.
+2. The generated certificate has a default validity period of 2 years from the time of generation.
+3. The certificate PEM and private-key PEM are written to the mounted state volume.
+4. The certificate's DER-encoded public material can be base64-encoded and passed to the Bicep deployment's `companionCertificateBase64` parameter.
+5. Re-running bootstrap regenerates the certificate and private key.
+6. The private-key PEM file MUST be written with owner-only read permissions (mode 0600).
+
+---
+
+### AZC-0401  Bicep deployment via Docker API
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
+
+**Description:**
+The unified `bootstrap` subcommand MUST execute the Bicep deployment by using
+the Bollard Rust Docker SDK to run the Azure CLI container image. The bootstrap
+MUST NOT shell out to the Docker CLI binary; it MUST use the Docker Engine API
+directly through the Bollard crate.
+
+**Acceptance criteria:**
+
+1. Bootstrap uses the Bollard crate to create and run an Azure CLI container for Bicep deployment.
+2. Bootstrap does not invoke the `docker` CLI binary or shell out to any Docker command.
+3. The Azure CLI container image is pinned by digest for reproducible provisioning.
+4. Bootstrap mounts the bundled Bicep files and generated certificate into the Azure CLI container.
+5. Bootstrap passes the device-login access token to the Azure CLI container for `az` authentication via a non-interactive mechanism.
+6. Bootstrap captures the Bicep deployment JSON outputs from the container's stdout.
+7. The access token MUST NOT be logged to stdout/stderr or persisted to any file.
+8. Bootstrap cleans up the Azure CLI container after completion, regardless of success or failure.
+
+---
+
+### AZC-0402  Bundled Bicep files in companion image
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
+
+**Description:**
+The Azure companion container image MUST bundle the Bicep deployment files from
+`deploy/bicep/` at build time so the bootstrap subcommand can mount them into
+the Azure CLI container without relying on host-side file access.
+
+**Acceptance criteria:**
+
+1. The Azure companion Dockerfile copies `deploy/bicep/` into the image at a fixed path.
+2. The bundled Bicep files include the top-level `main.bicep`, all module files, and `bicepconfig.json`.
+3. Bootstrap references the bundled path when mounting Bicep files into the Azure CLI container.
+
+---
+
+### AZC-0403  Runtime artifact creation from Bicep outputs
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), AZP-0203
+
+**Description:**
+After successful Bicep deployment, the unified `bootstrap` subcommand MUST
+create the local runtime artifacts expected by `sonde-azure-companion run`:
+`service-principal.json` containing the Entra tenant ID, client ID, and
+relative paths to the certificate and private-key PEM files already written to
+the state volume.
+
+**Acceptance criteria:**
+
+1. Bootstrap writes `service-principal.json` to the mounted state volume after successful Bicep deployment.
+2. The `service-principal.json` contains `tenant_id`, `client_id`, `certificate_path`, and `private_key_path` fields.
+3. The `tenant_id` and `client_id` values are extracted from the Bicep deployment outputs.
+4. The `certificate_path` and `private_key_path` values are relative paths within the state volume pointing to the generated PEM files.
+5. The resulting state satisfies the `check-runtime-ready` validation without manual intervention.
+
+---
+
+### AZC-0404  Service Bus configuration from Bicep outputs
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), AZC-0302
+
+**Description:**
+After successful Bicep deployment, the unified `bootstrap` subcommand MUST
+persist or surface the Service Bus namespace and queue names so the companion
+runtime can use them without requiring the operator to manually extract and
+supply them.
+
+**Acceptance criteria:**
+
+1. Bootstrap extracts the Service Bus namespace, upstream queue name, and downstream queue name from the Bicep deployment outputs.
+2. Bootstrap writes or persists these values so they are available at the next container startup.
+3. The runtime can read the persisted queue configuration without requiring the operator to re-enter it manually.
+
+---
+
+### AZC-0405  Bootstrap progress display
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), AZC-0202
+
+**Description:**
+The unified `bootstrap` subcommand MUST report progress for each major phase
+on both the modem display (via the gateway admin API) and stderr. The phases
+include authentication, certificate generation, Azure deployment, and
+completion.
+
+**Acceptance criteria:**
+
+1. Each major bootstrap phase updates the modem display with a short status message via the admin `ShowModemDisplayMessage` RPC.
+2. Each major bootstrap phase logs a status message to stderr.
+3. The authentication phase displays the device code as defined by AZC-0202.
+4. Bootstrap completion displays a success message on the modem display.
+5. Bootstrap failure displays an error indication on the modem display before exiting.
+
+---
+
+### AZC-0406  Docker socket access
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
+
+**Description:**
+The Azure companion container MUST have access to the Docker Engine API so the
+Bollard crate can create and manage the Azure CLI container during bootstrap.
+The Docker socket MUST be bind-mounted from the host into the companion
+container.
+
+**Acceptance criteria:**
+
+1. The bootstrap entrypoint script bind-mounts the Docker socket from the host into the companion container.
+2. Bollard auto-detects the Docker socket path inside the container.
+3. If the Docker socket is not accessible, bootstrap fails with a clear error message identifying the missing socket.
+
+---
+
+### AZC-0407  Idempotent re-bootstrap
+
+**Priority:** Must
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771) AC-2, AZP-0300
+
+**Description:**
+Re-running the unified `bootstrap` subcommand on an already-provisioned system
+MUST be safe. Bootstrap MUST re-generate the certificate, re-run the Bicep
+deployment, and re-write the runtime artifacts. The Bicep deployment is
+inherently idempotent; certificate regeneration updates the Entra application
+credential. Bootstrap MUST use a staging approach so that a failed re-bootstrap
+does not corrupt the existing working state.
+
+**Acceptance criteria:**
+
+1. Re-running bootstrap on a system with existing provisioning artifacts succeeds without errors.
+2. Re-bootstrap regenerates the certificate and private key.
+3. Re-bootstrap re-runs the Bicep deployment with the new certificate.
+4. Re-bootstrap updates `service-principal.json` with any changed values.
+5. The runtime can start successfully after re-bootstrap.
+6. If re-bootstrap fails at any phase after authentication, the previous working state remains intact.
+7. No staging artifacts remain in the state volume after a failed re-bootstrap.
+
+---
+
+### AZC-0408  Azure subscription selection
+
+**Priority:** Should
+**Source:** Discovery review
+
+**Description:**
+The unified `bootstrap` subcommand SHOULD allow the operator to specify which
+Azure subscription to target for the Bicep deployment. If not specified, the
+deployment SHOULD use the default subscription from the device-login session.
+
+**Acceptance criteria:**
+
+1. Bootstrap accepts an optional Azure subscription ID via environment variable.
+2. If specified, the Bicep deployment targets that subscription.
+3. If not specified, the Bicep deployment uses the device-login session's default subscription.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -457,11 +457,10 @@ directly through the Bollard crate.
 1. Bootstrap uses the Bollard crate to create and run an Azure CLI container for Bicep deployment.
 2. Bootstrap does not invoke the `docker` CLI binary or shell out to any Docker command.
 3. The Azure CLI container image is pinned by digest for reproducible provisioning.
-4. Bootstrap mounts the bundled Bicep files and generated certificate into the Azure CLI container.
-5. Bootstrap passes the device-login access token to the Azure CLI container for `az` authentication via a non-interactive mechanism.
+4. Bootstrap uploads the bundled Bicep files and generated certificate into the Azure CLI container before running `az deployment`.
+5. Bootstrap authenticates by running `az login --use-device-code` inside the Azure CLI container and parsing the emitted device code for modem display.
 6. Bootstrap captures the Bicep deployment JSON outputs from the container's stdout.
-7. The access token MUST NOT be logged to stdout/stderr or persisted to any file.
-8. Bootstrap cleans up the Azure CLI container after completion, regardless of success or failure.
+7. Bootstrap cleans up the Azure CLI container after completion, regardless of success or failure.
 
 ---
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -4,9 +4,9 @@
 
 > **Document status:** Draft
 > **Scope:** Validation for the Azure companion container, bootstrap-state
-> detection, gateway admin/connector integration, and Azure Service Bus bridge.
-> The internals of Azure provisioning that create the runtime certificate and
-> broker resources are outside this document's scope.
+> detection, gateway admin/connector integration, provisioning orchestration
+> (certificate generation, Bicep deployment via Docker API, runtime artifact
+> creation), and Azure Service Bus bridge.
 > **Audience:** Implementers and reviewers validating the Azure companion
 > bootstrap and runtime bridge behavior.
 > **Related:** [azure-provisioning-validation.md](azure-provisioning-validation.md),
@@ -25,7 +25,7 @@
 **Procedure:**
 1. Build the Azure companion Docker image from the repository Dockerfile.
 2. Run `docker run --rm <image> sonde-azure-companion --help`.
-3. Run `docker run --rm <image> sonde-azure-companion bootstrap-auth --help`.
+3. Run `docker run --rm <image> sonde-azure-companion bootstrap --help`.
 4. Run `docker run --rm <image> sonde-azure-companion run --help`.
 5. Assert: all commands succeed.
 
@@ -40,7 +40,7 @@
 2. Provide valid queue configuration to the bootstrap script.
 3. Invoke the Azure companion bootstrap entrypoint with that directory mounted as the state volume.
 4. Assert: the bootstrap path runs before the long-running runtime starts.
-5. Assert: the bootstrap path invokes the Rust `bootstrap-auth` flow and requests a device code from the configured OAuth endpoint.
+5. Assert: the bootstrap path invokes the Rust `bootstrap` flow and requests a device code from the configured OAuth endpoint.
 
 ---
 
@@ -219,3 +219,199 @@
 3. Start the runtime in the container with the concrete `azservicebus` transport selected and with a deliberately unreachable or test-only Service Bus endpoint.
 4. Assert: the runtime reaches the concrete Azure transport initialization path and fails, if it fails, with an Azure transport/connectivity error rather than a missing binary, missing dynamic library, or unsupported-platform error.
 5. Assert: the runtime does not fall back to device-code login in this bootstrap-complete case.
+
+---
+
+### T-AZC-0400  Bootstrap generates ECDSA P-256 self-signed certificate
+
+**Validates:** AZC-0400
+
+**Procedure:**
+1. Start the bootstrap subcommand with device-flow and Bicep deployment stubbed.
+2. Assert: bootstrap creates `cert.pem` and `key.pem` in the mounted state volume.
+3. Parse the generated `cert.pem` and assert: the certificate uses ECDSA P-256 key algorithm.
+4. Assert: the certificate's validity period is approximately 2 years from the generation time.
+5. Assert: the certificate is self-signed (issuer equals subject).
+6. Assert: the DER-encoded public material can be base64-encoded without error.
+
+---
+
+### T-AZC-0401  Bootstrap uses Bollard to run Azure CLI container
+
+**Validates:** AZC-0401, AZC-0402
+
+**Procedure:**
+1. Start the bootstrap subcommand with a mock Docker API server (Bollard supports custom connection).
+2. Assert: bootstrap sends Docker API requests to create and start a container using the pinned Azure CLI image digest.
+3. Assert: bootstrap does not invoke the `docker` CLI binary.
+4. Assert: the container creation request includes bind mounts for the bundled Bicep files and generated certificate.
+5. Assert: bootstrap captures the container's stdout output containing Bicep deployment JSON.
+6. Assert: bootstrap removes the container after completion.
+
+---
+
+### T-AZC-0402  Companion image bundles Bicep files
+
+**Validates:** AZC-0402
+
+**Procedure:**
+1. Build the Azure companion Docker image.
+2. Run `docker run --rm <image> ls /opt/sonde/deploy/bicep/`.
+3. Assert: the listing includes `main.bicep`, `bicepconfig.json`, and the `modules/` directory.
+4. Assert: the `modules/` directory contains the expected Bicep module files.
+
+---
+
+### T-AZC-0403  Bootstrap writes service-principal.json from Bicep outputs
+
+**Validates:** AZC-0403
+
+**Procedure:**
+1. Run the bootstrap subcommand with device-flow stubbed to succeed and Bicep deployment stubbed to return known output values (tenantId, clientId, namespace, queue names).
+2. Assert: `service-principal.json` exists in the state volume after bootstrap completes.
+3. Parse `service-principal.json` and assert: it contains `tenant_id`, `client_id`, `certificate_path`, and `private_key_path`.
+4. Assert: `tenant_id` and `client_id` match the stubbed Bicep output values.
+5. Assert: `certificate_path` and `private_key_path` are relative paths that resolve to existing PEM files in the state volume.
+6. Assert: `check-runtime-ready` succeeds after bootstrap completes.
+
+---
+
+### T-AZC-0404  Bootstrap persists Service Bus configuration
+
+**Validates:** AZC-0404
+
+**Procedure:**
+1. Run the bootstrap subcommand with stubbed Bicep outputs containing known namespace and queue names.
+2. Assert: the Service Bus namespace, upstream queue, and downstream queue values are persisted in the state volume.
+3. Restart the container without the Service Bus environment variables.
+4. Assert: the runtime can read the persisted configuration and startup succeeds (or reaches the Azure transport path).
+
+---
+
+### T-AZC-0405  Bootstrap displays progress on modem
+
+**Validates:** AZC-0405
+
+**Procedure:**
+1. Start a test gateway exposing the admin socket and instrument the admin `ShowModemDisplayMessage` RPC.
+2. Run the bootstrap subcommand with device-flow and Bicep deployment stubbed.
+3. Assert: at least four distinct modem display updates are received during bootstrap.
+4. Assert: the updates include messages for authentication, certificate generation, deployment, and completion phases.
+5. Assert: each phase also emits a corresponding stderr log message.
+6. Run the bootstrap subcommand with a forced failure in the Bicep deployment phase.
+7. Assert: the modem displays an error indication before bootstrap exits.
+
+---
+
+### T-AZC-0406  Bootstrap fails if Docker socket is inaccessible
+
+**Validates:** AZC-0406
+
+**Procedure:**
+1. Start the bootstrap subcommand without the Docker socket mounted.
+2. Assert: bootstrap fails with a non-zero exit status.
+3. Assert: the error message identifies the inaccessible Docker socket as the cause.
+4. Assert: bootstrap does not hang indefinitely waiting for Docker connectivity.
+
+---
+
+### T-AZC-0407  Re-bootstrap on already-provisioned system succeeds
+
+**Validates:** AZC-0407
+
+**Procedure:**
+1. Run bootstrap to completion with stubbed services, creating all runtime artifacts.
+2. Record the certificate fingerprint and `service-principal.json` content.
+3. Re-run bootstrap with the same stubbed services.
+4. Assert: bootstrap completes successfully.
+5. Assert: the certificate PEM file has been regenerated (different fingerprint).
+6. Assert: `service-principal.json` has been rewritten.
+7. Assert: `check-runtime-ready` succeeds after re-bootstrap.
+
+---
+
+### T-AZC-0408  Bootstrap accepts optional subscription ID
+
+**Validates:** AZC-0408
+
+**Procedure:**
+1. Run bootstrap with `SONDE_AZURE_SUBSCRIPTION_ID` set to a known value.
+2. Assert: the Bicep deployment command within the Azure CLI container targets the specified subscription.
+3. Run bootstrap without `SONDE_AZURE_SUBSCRIPTION_ID`.
+4. Assert: the Bicep deployment uses the default subscription from the device-login session.
+
+---
+
+### T-AZC-0409  Failed re-bootstrap preserves previous working state
+
+**Validates:** AZC-0407, AZC-0403
+
+**Procedure:**
+1. Run bootstrap to completion with stubbed services, creating all runtime artifacts.
+2. Record the content of `service-principal.json`, `cert.pem`, and `key.pem`.
+3. Re-run bootstrap with the Bicep deployment phase stubbed to fail.
+4. Assert: bootstrap exits with a non-zero status.
+5. Assert: the previous `service-principal.json`, `cert.pem`, and `key.pem` are unchanged.
+6. Assert: `check-runtime-ready` still succeeds with the previous artifacts.
+7. Assert: no `.staging/` directory remains in the state volume.
+
+---
+
+### T-AZC-0410  Bootstrap fails cleanly on image pull failure
+
+**Validates:** AZC-0401, AZC-0405
+
+**Procedure:**
+1. Start bootstrap with Bollard configured to reject the image pull (simulated network failure).
+2. Assert: bootstrap fails with a non-zero exit status.
+3. Assert: the error message identifies the image pull failure.
+4. Assert: the modem displays an error indication.
+5. Assert: no Azure CLI container is left running.
+
+---
+
+### T-AZC-0411  Bootstrap fails cleanly on container start failure
+
+**Validates:** AZC-0401, AZC-0406
+
+**Procedure:**
+1. Start bootstrap with a mock Docker API that accepts container creation but rejects the start request.
+2. Assert: bootstrap fails with a non-zero exit status.
+3. Assert: bootstrap cleans up the created-but-unstarted container.
+4. Assert: previous state volume contents are preserved.
+
+---
+
+### T-AZC-0412  Bootstrap fails cleanly on state volume write failure
+
+**Validates:** AZC-0403, AZC-0407
+
+**Procedure:**
+1. Start bootstrap with a state volume configured to reject writes (read-only mount or simulated disk-full).
+2. Assert: bootstrap fails with a non-zero exit status.
+3. Assert: the error message identifies the write failure.
+4. Assert: no partial artifacts are left in the state volume.
+
+---
+
+### T-AZC-0413  Private key file permissions
+
+**Validates:** AZC-0400
+
+**Procedure:**
+1. Run bootstrap to completion.
+2. Inspect the file permissions of `key.pem` in the state volume.
+3. Assert: the private key file has owner-only read permissions (mode 0600 or equivalent).
+4. Assert: the certificate file (`cert.pem`) is world-readable.
+
+---
+
+### T-AZC-0414  Access token is not logged
+
+**Validates:** AZC-0401
+
+**Procedure:**
+1. Run bootstrap with a stubbed device-flow that returns a known token value.
+2. Capture all stderr and stdout output from the bootstrap process.
+3. Assert: the access token value does not appear in any log output.
+4. Assert: the access token is not persisted to any file in the state volume.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -40,7 +40,7 @@
 2. Provide valid queue configuration to the bootstrap script.
 3. Invoke the Azure companion bootstrap entrypoint with that directory mounted as the state volume.
 4. Assert: the bootstrap path runs before the long-running runtime starts.
-5. Assert: the bootstrap path invokes the Rust `bootstrap` flow and requests a device code from the configured OAuth endpoint.
+5. Assert: the bootstrap path invokes the Rust `bootstrap` flow, parses the device code from Azure CLI stderr, and forwards it to the modem display.
 
 ---
 
@@ -244,7 +244,7 @@
 1. Start the bootstrap subcommand with a mock Docker API server (Bollard supports custom connection).
 2. Assert: bootstrap sends Docker API requests to create and start a container using the pinned Azure CLI image digest.
 3. Assert: bootstrap does not invoke the `docker` CLI binary.
-4. Assert: the container creation request includes bind mounts for the bundled Bicep files and generated certificate.
+4. Assert: bootstrap uploads the bundled Bicep files and generated certificate into the Azure CLI container with Docker archive upload APIs before running the deployment.
 5. Assert: bootstrap captures the container's stdout output containing Bicep deployment JSON.
 6. Assert: bootstrap removes the container after completion.
 


### PR DESCRIPTION
## Summary

Closes #771 by moving Azure bootstrap orchestration into the Azure companion container.

This change updates the Sonde Azure companion so the container itself now:
- generates the runtime ECDSA P-256 certificate/key
- runs a pinned zure-cli container through Bollard
- performs Azure device login and Bicep deployment
- writes service-principal.json and persisted service-bus.json
- starts runtime only after bootstrap-complete state exists

It also removes the obsolete Rust oauth-device-flows bootstrap path and its dead tests/dependencies.

## Specification traceability

### Requirements
- Updated docs/azure-companion-requirements.md
- Added bootstrap orchestration requirements AZC-0400 through AZC-0408

### Design
- Updated docs/azure-companion-design.md
- Documented the unified bootstrap flow, Bollard container copy/upload strategy, staged artifact commit, and persisted queue config

### Validation
- Updated docs/azure-companion-validation.md
- Added coverage for cert generation, Bicep output handling, staged commits, cleanup, and bootstrap failure cases

## Implementation

### Rust
- Replaced ootstrap-auth with unified ootstrap
- Added cert generation and persisted service-bus.json loading
- Added Bollard-based Azure CLI bootstrap deployment
- Added rollback-safe staged writes
- Removed stale Rust device-flow code and oauth-device-flows dependency

### Container/runtime
- Bundled deploy/bicep/ into the Azure companion image
- Updated deploy/azure-companion/bootstrap.sh to launch the new bootstrap path and forward Docker socket / Azure deployment env vars

## Validation run

- cargo check -p sonde-azure-companion
- cargo clippy -p sonde-azure-companion -- -D warnings
- cargo test -p sonde-azure-companion

## Notes

- Azure CLI image is pinned by digest so the parsed device-login output remains stable until the pin is intentionally updated.
- Persisted service-bus.json now allows runtime startup without re-supplying queue env vars after bootstrap.