### PR TITLE
ci: publish nightly sensor assets

### DIFF
--- a/.github/docker/Dockerfile.gateway
+++ b/.github/docker/Dockerfile.gateway
@@ -3,8 +3,9 @@
 #
 # Multi-stage Dockerfile for the sonde-gateway container image.
 # Produces a minimal Alpine-based image containing sonde-gateway,
-# sonde-admin, the sensor handler binaries, espflash, and the
-# bundled modem firmware images prepared by gateway-container.yml.
+# sonde-admin, the sensor handler binaries, espflash, the bundled
+# BPF test-program artifacts, and the modem firmware images prepared
+# by gateway-container.yml.
 #
 # Published to ghcr.io/alan-jowett/sonde-gateway by the
 # gateway-container.yml CI workflow (GW-1800).
@@ -14,6 +15,8 @@
 #   # Requires modem artifacts at:
 #   #   .artifacts/modem-firmware/flash_image.bin
 #   #   .artifacts/modem-firmware-verbose/flash_image.bin
+#   # and BPF test-program artifacts at:
+#   #   .artifacts/test-programs/*.o
 #
 # Run:
 #   docker run -d \
@@ -48,6 +51,7 @@ FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d650
 # Non-root user for the gateway process (GW-1802 AC3).
 RUN addgroup -S sonde && adduser -S sonde -G sonde \
     && mkdir -p /var/lib/sonde \
+       /usr/local/share/sonde/test-programs \
        /usr/local/share/sonde/firmware/modem/default \
        /usr/local/share/sonde/firmware/modem/verbose \
     && chown sonde:sonde /var/lib/sonde
@@ -57,6 +61,7 @@ COPY --from=builder /src/target/release/sonde-gateway      /usr/local/bin/
 COPY --from=builder /src/target/release/sonde-admin         /usr/local/bin/
 COPY --from=builder /src/target/release/sonde-sht40-handler /usr/local/bin/
 COPY --from=builder /src/target/release/sonde-tmp102-handler /usr/local/bin/
+COPY .artifacts/test-programs/*.o /usr/local/share/sonde/test-programs/
 COPY .artifacts/modem-firmware/flash_image.bin /usr/local/share/sonde/firmware/modem/default/flash_image.bin
 COPY .artifacts/modem-firmware-verbose/flash_image.bin /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin
 

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -209,7 +209,7 @@ jobs:
             expected="$(sha256sum ".artifacts/test-programs/${file}" | awk '{print $1}')"
             actual="$(
               docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
-                "sha256sum /usr/local/share/sonde/test-programs/${file} | awk '{print \\\$1}'"
+                "sha256sum /usr/local/share/sonde/test-programs/${file} | awk \"{print \\\$1}\""
             )"
             test "$actual" = "$expected"
           done < expected-files.txt

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -199,20 +199,22 @@ jobs:
       - name: Smoke test — BPF artifact hashes match same-run downloads
         run: |
           set -euo pipefail
-          find .artifacts/test-programs -maxdepth 1 -name '*.o' -printf '%f\n' | sort > expected-files.txt
+          (
+            cd .artifacts/test-programs
+            set -- *.o
+            test -e "$1"
+            sha256sum "$@" | while read -r sum file; do
+              printf '%s %s\n' "$file" "$sum"
+            done | sort
+          ) > expected-hashes.txt
           docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
-            'set -- /usr/local/share/sonde/test-programs/*.o
+            'cd /usr/local/share/sonde/test-programs
+             set -- *.o
              test -e "$1"
-             for f in "$@"; do basename "$f"; done | sort' > actual-files.txt
-          diff -u expected-files.txt actual-files.txt
-          while IFS= read -r file; do
-            expected="$(sha256sum ".artifacts/test-programs/${file}" | awk '{print $1}')"
-            actual="$(
-              docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
-                "sha256sum /usr/local/share/sonde/test-programs/${file} | awk \"{print \\\$1}\""
-            )"
-            test "$actual" = "$expected"
-          done < expected-files.txt
+             sha256sum "$@" | while read -r sum file; do
+               printf "%s %s\n" "$file" "$sum"
+             done | sort' > actual-hashes.txt
+          diff -u expected-hashes.txt actual-hashes.txt
 
       # Push the per-arch image with a temporary tag (consumed by the
       # manifest job). Include the workflow run ID so overlapping runs

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -31,10 +31,41 @@ jobs:
     name: Build modem firmware (same run)
     uses: ./.github/workflows/esp32-modem.yml
 
+  # Standalone dispatches also need same-run compiled BPF test-program artifacts.
+  # workflow_call executions expect the caller to upload a bpf-test-programs artifact.
+  bpf-test-programs:
+    if: github.event_name == 'workflow_dispatch'
+    name: Build BPF test programs (same run)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang make
+
+      - name: Build BPF test programs
+        run: make -C test-programs
+
+      - name: Stage BPF test programs
+        run: |
+          mkdir -p artifact-staging
+          cp test-programs/*.o artifact-staging/
+
+      - name: Upload BPF test programs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bpf-test-programs
+          path: artifact-staging/*
+          if-no-files-found: error
+          retention-days: 7
+
   # ── Per-architecture native builds ────────────────────────────────
   build:
-    needs: [modem-firmware]
-    if: ${{ always() && (needs.modem-firmware.result == 'success' || needs.modem-firmware.result == 'skipped') }}
+    needs: [modem-firmware, bpf-test-programs]
+    if: ${{ always() && (needs.modem-firmware.result == 'success' || needs.modem-firmware.result == 'skipped') && (needs.bpf-test-programs.result == 'success' || needs.bpf-test-programs.result == 'skipped') }}
     strategy:
       matrix:
         include:
@@ -62,6 +93,12 @@ jobs:
         with:
           name: modem-firmware-verbose
           path: .artifacts/modem-firmware-verbose
+
+      - name: Download BPF test-program artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bpf-test-programs
+          path: .artifacts/test-programs
 
       - name: Log in to GitHub Container Registry
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
@@ -94,6 +131,8 @@ jobs:
           docker run --rm --entrypoint sonde-sht40-handler ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
           docker run --rm --entrypoint sonde-tmp102-handler ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
           docker run --rm --entrypoint espflash ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --help
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'find /usr/local/share/sonde/test-programs -maxdepth 1 -name "*.o" | grep -q .'
 
       - name: Smoke test — runtime defaults
         run: |
@@ -126,7 +165,15 @@ jobs:
         run: |
           docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
             'test -r /usr/local/share/sonde/firmware/modem/default/flash_image.bin \
-             && test -r /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin'
+              && test -r /usr/local/share/sonde/firmware/modem/verbose/flash_image.bin'
+
+      - name: Smoke test — bundled BPF test programs
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'test -d /usr/local/share/sonde/test-programs \
+             && set -- /usr/local/share/sonde/test-programs/*.o \
+             && test -e "$1" \
+             && for f in "$@"; do test -r "$f"; done'
 
       - name: Smoke test — runtime image excludes Rust toolchain and source tree
         run: |
@@ -148,6 +195,24 @@ jobs:
           )
           test "$default_actual" = "$default_expected"
           test "$verbose_actual" = "$verbose_expected"
+
+      - name: Smoke test — BPF artifact hashes match same-run downloads
+        run: |
+          set -euo pipefail
+          find .artifacts/test-programs -maxdepth 1 -name '*.o' -printf '%f\n' | sort > expected-files.txt
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'set -- /usr/local/share/sonde/test-programs/*.o
+             test -e "$1"
+             for f in "$@"; do basename "$f"; done | sort' > actual-files.txt
+          diff -u expected-files.txt actual-files.txt
+          while IFS= read -r file; do
+            expected="$(sha256sum ".artifacts/test-programs/${file}" | awk '{print $1}')"
+            actual="$(
+              docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+                "sha256sum /usr/local/share/sonde/test-programs/${file} | awk '{print \\\$1}'"
+            )"
+            test "$actual" = "$expected"
+          done < expected-files.txt
 
       # Push the per-arch image with a temporary tag (consumed by the
       # manifest job). Include the workflow run ID so overlapping runs

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -80,9 +80,84 @@ jobs:
     if: needs.should_run.outputs.run_builds == 'true'
     uses: ./.github/workflows/ci.yml
 
+  bpf-test-programs:
+    name: BPF test programs
+    needs: [should_run]
+    if: needs.should_run.outputs.run_builds == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang make
+
+      - name: Build BPF test programs
+        run: make -C test-programs
+
+      - name: Stage BPF test programs
+        run: |
+          mkdir -p artifact-staging
+          cp test-programs/*.o artifact-staging/
+
+      - name: Upload BPF test programs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bpf-test-programs
+          path: artifact-staging/*
+          if-no-files-found: error
+          retention-days: 7
+
+  sensor-handlers:
+    name: Sensor handlers (${{ matrix.arch }})
+    needs: [should_run]
+    if: needs.should_run.outputs.run_builds == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            artifact: sensor-handlers-linux-amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            artifact: sensor-handlers-linux-arm64
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          key: ${{ matrix.arch }}-sensor-handlers
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libudev-dev
+
+      - name: Build sensor handlers
+        run: cargo build --release -p sonde-sht40-handler -p sonde-tmp102-handler
+
+      - name: Stage sensor handlers
+        run: |
+          mkdir -p artifact-staging
+          cp target/release/sonde-sht40-handler artifact-staging/
+          cp target/release/sonde-tmp102-handler artifact-staging/
+
+      - name: Upload sensor handlers
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: artifact-staging/*
+          if-no-files-found: error
+          retention-days: 7
+
   gateway-container:
     name: Gateway container
-    needs: [should_run, modem-firmware]
+    needs: [should_run, modem-firmware, bpf-test-programs]
     if: needs.should_run.outputs.run_builds == 'true'
     uses: ./.github/workflows/gateway-container.yml
     permissions:
@@ -259,7 +334,7 @@ jobs:
   # ── Publish release ────────────────────────────────────────────────
   release:
     name: Publish nightly
-    needs: [should_run, gateway, gateway-container, node-firmware, modem-firmware, desktop, android, installer-linux, installer-linux-arm64, installer-windows]
+    needs: [should_run, gateway, bpf-test-programs, sensor-handlers, gateway-container, node-firmware, modem-firmware, desktop, android, installer-linux, installer-linux-arm64, installer-windows]
     if: needs.should_run.outputs.run_builds == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -299,10 +374,15 @@ jobs:
           cp artifacts/gateway-linux-x86_64/sonde-admin     release-assets/sonde-admin
           cp artifacts/gateway-linux-arm64/sonde-gateway    release-assets/sonde-gateway-arm64
           cp artifacts/gateway-linux-arm64/sonde-admin      release-assets/sonde-admin-arm64
+          cp artifacts/sensor-handlers-linux-amd64/sonde-sht40-handler  release-assets/sonde-sht40-handler
+          cp artifacts/sensor-handlers-linux-amd64/sonde-tmp102-handler release-assets/sonde-tmp102-handler
+          cp artifacts/sensor-handlers-linux-arm64/sonde-sht40-handler  release-assets/sonde-sht40-handler-arm64
+          cp artifacts/sensor-handlers-linux-arm64/sonde-tmp102-handler release-assets/sonde-tmp102-handler-arm64
           cp artifacts/gateway-windows-x86_64/sonde-gateway.exe release-assets/sonde-gateway.exe
           cp artifacts/gateway-windows-x86_64/sonde-admin.exe   release-assets/sonde-admin.exe
           cp artifacts/node-firmware/flash_image.bin        release-assets/node-flash_image.bin
           cp artifacts/modem-firmware/flash_image.bin       release-assets/modem-flash_image.bin
+          tar -C artifacts/bpf-test-programs -czf release-assets/sonde-bpf-test-programs.tar.gz .
           for f in artifacts/sonde-pair-windows/*; do cp -r "$f" release-assets/; done
           for f in artifacts/sonde-pair-linux/*;   do cp -r "$f" release-assets/; done
           for f in artifacts/sonde-pair-android-debug/*; do cp -r "$f" release-assets/; done
@@ -323,10 +403,15 @@ jobs:
           | Admin CLI (Linux x86_64) | `sonde-admin` |
           | Gateway (Linux arm64) | `sonde-gateway-arm64` |
           | Admin CLI (Linux arm64) | `sonde-admin-arm64` |
+          | SHT40 handler (Linux x86_64) | `sonde-sht40-handler` |
+          | TMP102 handler (Linux x86_64) | `sonde-tmp102-handler` |
+          | SHT40 handler (Linux arm64) | `sonde-sht40-handler-arm64` |
+          | TMP102 handler (Linux arm64) | `sonde-tmp102-handler-arm64` |
           | Gateway (Windows x86_64) | `sonde-gateway.exe` |
           | Admin CLI (Windows) | `sonde-admin.exe` |
           | ESP32-C3 Node firmware | `node-flash_image.bin` |
           | ESP32-S3 Modem firmware | `modem-flash_image.bin` |
+          | BPF test programs | `sonde-bpf-test-programs.tar.gz` |
           | Desktop — Windows | `*.exe` |
           | Desktop — Linux | `*.deb` |
           | Android APK (debug) | `*-debug.apk` |

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1961,11 +1961,11 @@ All diagnostic events are logged at `INFO` level **(GW-1706)**:
 
 ## 22  Container image
 
-> **Requirements:** GW-1800 (multi-arch image), GW-1801 (tagging), GW-1802 (runtime configuration), GW-1803 (optional secret-service), GW-1804 (bundled modem flashing assets).
+> **Requirements:** GW-1800 (multi-arch image), GW-1801 (tagging), GW-1802 (runtime configuration), GW-1803 (optional secret-service), GW-1804 (bundled modem flashing assets), GW-1805 (bundled BPF test-program assets), GW-1806 (nightly release sensor assets).
 
 ### 22.1  Overview
 
-The gateway is distributed as a multi-architecture Docker container image alongside the traditional bare-metal binaries and `.deb` packages. The image targets Alpine Linux (musl libc) for minimal size and contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, `sonde-tmp102-handler`, `espflash`, and two bundled modem merged flash images (default and verbose).
+The gateway is distributed as a multi-architecture Docker container image alongside the traditional bare-metal binaries and `.deb` packages. The image targets Alpine Linux (musl libc) for minimal size and contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, `sonde-tmp102-handler`, `espflash`, the compiled BPF test-program artifacts from `test-programs/`, and two bundled modem merged flash images (default and verbose).
 
 ### 22.2  Build strategy
 
@@ -1974,7 +1974,7 @@ Each architecture (`linux/amd64`, `linux/arm64`) is built natively on a per-arch
 **Multi-stage Dockerfile** (`.github/docker/Dockerfile.gateway`):
 
 1. **Builder stage** (`rust:alpine`): installs `musl-dev`, `protobuf`, and the additional native dependencies required to build `espflash`; installs the pinned `espflash` CLI; builds all four Sonde binaries; and uses `--no-default-features` for `sonde-gateway` to exclude the `keyring` feature and its `secret-service`/`zbus` dependency tree.
-2. **Runtime stage** (`alpine:3.21`): copies only the compiled runtime binaries, the `espflash` executable from the builder stage, and the two merged modem flash images (`modem-firmware` and `modem-firmware-verbose`) supplied in the Docker build context by the same workflow run. It then creates a non-root `sonde` user and declares `VOLUME /var/lib/sonde`.
+2. **Runtime stage** (`alpine:3.21`): copies only the compiled runtime binaries, the `espflash` executable from the builder stage, the compiled BPF test-program artifacts, and the two merged modem flash images (`modem-firmware` and `modem-firmware-verbose`) supplied in the Docker build context by the same workflow run. It then creates a non-root `sonde` user and declares `VOLUME /var/lib/sonde`.
 
 ### 22.3  Bundled flashing assets (GW-1804)
 
@@ -1989,6 +1989,16 @@ The runtime image exposes the bundled modem flashing assets at fixed paths:
 The container continues to start with `sonde-gateway` as its default entrypoint. Operators who need to reflash a modem run the container with an entrypoint override (for example `--entrypoint espflash` or `--entrypoint sh`) and invoke `espflash write-bin -p PORT 0x0 <image-path>` manually. The gateway process does not invoke `espflash` on startup or during routine operation.
 
 To keep "latest" unambiguous, the bundled modem images are defined as the modem artifacts produced from the same git revision and workflow run as the container image build. The container workflow therefore consumes the `modem-firmware` and `modem-firmware-verbose` artifacts from the same CI execution rather than downloading an arbitrary previously published release.
+
+### 22.3a  Bundled BPF test-program assets (GW-1805)
+
+The runtime image also exposes the compiled BPF test-program artifacts at a stable in-image directory:
+
+| Asset set | Path |
+|-----------|------|
+| Compiled BPF test programs | `/usr/local/share/sonde/test-programs/` |
+
+The bundled files are the `.o` outputs built from the repository's `test-programs/*.c` sources using the same workflow run and git revision as the image build. They are provided as operator/test assets so an engineer can extract or ingest them from the container without rebuilding them locally.
 
 ### 22.4  Feature flag: `keyring` (GW-1803)
 
@@ -2012,10 +2022,20 @@ Public tags are created only after both architectures pass smoke tests.
 | `VOLUME` | `/var/lib/sonde` |
 | `USER` | `sonde` (non-root) |
 
-Serial device access requires the operator to pass `--device=/dev/ttyACM0` and `--group-add <host-dialout-gid>` at `docker run` time. The container defaults assume `/dev/ttyACM0`; operators using a different modem path must override `--port`. The bundled modem images remain readable by the non-root `sonde` user so operators can invoke manual flashing commands without switching users inside the container.
+Serial device access requires the operator to pass `--device=/dev/ttyACM0` and `--group-add <host-dialout-gid>` at `docker run` time. The container defaults assume `/dev/ttyACM0`; operators using a different modem path must override `--port`. The bundled modem images and bundled BPF test-program artifacts remain readable by the non-root `sonde` user so operators can invoke manual flashing commands or copy out the test programs without switching users inside the container.
 
 ### 22.7  CI integration
 
 The `gateway-container.yml` workflow is called by `nightly-release.yml` as a parallel job. The nightly release job waits for the container build to complete before publishing the GitHub release. Release-tag container builds are therefore driven indirectly via `nightly-release.yml`, while `gateway-container.yml` itself is also available via `workflow_dispatch`.
 
-To satisfy GW-1804's provenance rule, every execution path that publishes or smoke-tests the gateway container must make the modem artifacts available in the same workflow run before the image-build step. In the nightly/release path, those artifacts come from the sibling modem-firmware job in the caller workflow. In the standalone `workflow_dispatch` path, the workflow must first run the modem build (or an equivalent reusable workflow) so the image still consumes same-run `modem-firmware` and `modem-firmware-verbose` artifacts rather than downloading files from a previous run.
+To satisfy GW-1804's provenance rule, every execution path that publishes or smoke-tests the gateway container must make the modem artifacts available in the same workflow run before the image-build step. To satisfy GW-1805 and GW-1806, that same execution path must also make the compiled BPF test-program artifact set available before the image-build step. In the nightly/release path, those artifacts come from sibling jobs in the caller workflow: `modem-firmware` for the merged modem images and a dedicated sensor-assets stage for the compiled `test-programs/*.o` outputs and standalone handler binaries. In the standalone `workflow_dispatch` path, the workflow must first run the modem build and the BPF test-program build (or equivalent reusable workflows) so the image still consumes same-run artifacts rather than downloading files from a previous run.
+
+### 22.8  Nightly release sensor assets (GW-1806)
+
+The nightly/release orchestrator publishes three sensor-support asset groups in addition to the existing binaries, firmware, apps, installers, and container image:
+
+1. `sonde-sht40-handler` for `linux/amd64` and `linux/arm64`
+2. `sonde-tmp102-handler` for `linux/amd64` and `linux/arm64`
+3. the compiled arch-independent BPF test-program `.o` artifacts from `test-programs/`
+
+These assets are staged into the nightly/release GitHub pre-release with collision-free names so operators can download them directly without extracting them from the container image.

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2312,14 +2312,14 @@ The gateway MUST log `DIAG_REQUEST` reception and `DIAG_REPLY` transmission at `
 **Source:** Issue #780
 
 **Description:**  
-The CI MUST produce a multi-architecture Docker container image (`linux/amd64` + `linux/arm64`) published to `ghcr.io/alan-jowett/sonde-gateway`. The image MUST be based on Alpine Linux (musl libc) for minimal size. A multi-stage build ensures the final image contains no Rust toolchain or source code, and no build artifacts other than the intentionally bundled runtime assets described by GW-1804. Each architecture MUST be built natively on a per-arch GitHub runner (no QEMU cross-compilation).
+The CI MUST produce a multi-architecture Docker container image (`linux/amd64` + `linux/arm64`) published to `ghcr.io/alan-jowett/sonde-gateway`. The image MUST be based on Alpine Linux (musl libc) for minimal size. A multi-stage build ensures the final image contains no Rust toolchain or source code, and no build artifacts other than the intentionally bundled runtime assets described by GW-1804 and GW-1805. Each architecture MUST be built natively on a per-arch GitHub runner (no QEMU cross-compilation).
 
 **Acceptance criteria:**
 
 1. The image is based on Alpine Linux (musl libc).
-2. The image contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, `sonde-tmp102-handler`, and `espflash`.
+2. The image contains `sonde-gateway`, `sonde-admin`, `sonde-sht40-handler`, `sonde-tmp102-handler`, `espflash`, and the bundled BPF test-program artifacts required by GW-1805.
 3. `docker manifest inspect` shows both `linux/amd64` and `linux/arm64` platforms.
-4. The final image contains no Rust toolchain or source code, and no build artifacts other than the intentionally bundled modem flash images required by GW-1804.
+4. The final image contains no Rust toolchain or source code, and no build artifacts other than the intentionally bundled modem flash images required by GW-1804 and the compiled BPF test-program artifacts required by GW-1805.
 5. Each architecture is built on a native runner (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`).
 6. Per-arch images pass smoke tests (binary execution, linkage verification) before any public tag is created.
 
@@ -2349,7 +2349,7 @@ Container images MUST follow a consistent tagging strategy. Release builds (git 
 **Source:** Issue #780
 
 **Description:**  
-The container image MUST be configured for production use. The `ENTRYPOINT` is `sonde-gateway` with a default `CMD` that points the database to the declared volume, selects `/dev/ttyACM0` as the default modem path, and uses the `env` key provider that is suitable for container deployments. A `VOLUME` at `/var/lib/sonde` is declared for database persistence. The gateway runs as a non-root `sonde` user inside the container. The `--key-provider file` and `--key-provider env` backends work without D-Bus. The image MUST also expose the bundled modem flash images at stable in-image paths so an operator can invoke `espflash` manually from the container when needed.
+The container image MUST be configured for production use. The `ENTRYPOINT` is `sonde-gateway` with a default `CMD` that points the database to the declared volume, selects `/dev/ttyACM0` as the default modem path, and uses the `env` key provider that is suitable for container deployments. A `VOLUME` at `/var/lib/sonde` is declared for database persistence. The gateway runs as a non-root `sonde` user inside the container. The `--key-provider file` and `--key-provider env` backends work without D-Bus. The image MUST also expose the bundled modem flash images and bundled BPF test-program artifacts at stable in-image paths so an operator can invoke `espflash` manually from the container when needed and ingest/inspect the test programs without rebuilding them locally.
 
 **Acceptance criteria:**
 
@@ -2361,6 +2361,7 @@ The container image MUST be configured for production use. The `ENTRYPOINT` is `
 6. Serial device access requires the operator to pass `--device` and `--group-add` at `docker run` time.
 7. The default modem flash image is available at `/usr/local/share/sonde/firmware/modem/default/flash_image.bin`.
 8. The verbose modem flash image is available at `/usr/local/share/sonde/firmware/modem/verbose/flash_image.bin`.
+9. The bundled compiled BPF test programs are available under `/usr/local/share/sonde/test-programs/`.
 
 ---
 
@@ -2397,6 +2398,42 @@ The gateway container image MUST bundle the modem flashing assets needed for man
 3. The image contains the verbose merged modem flash image.
 4. The default and verbose files bundled into the image are byte-identical to the `modem-firmware` and `modem-firmware-verbose` artifacts produced for the same workflow run as the container image build.
 5. The container's default startup path remains `sonde-gateway`; using the bundled flashing assets requires an operator to invoke `espflash` manually.
+
+---
+
+### GW-1805  Bundled BPF test-program assets
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+The gateway container image MUST bundle the compiled BPF test-program artifacts from `test-programs/` at stable in-image paths. These bundled `.o` files are operator/test assets rather than runtime dependencies of `sonde-gateway`; the default container startup path remains unchanged. The bundled BPF artifacts MUST come from the same git revision and workflow run as the nightly/release build that produced the container image.
+
+**Acceptance criteria:**
+
+1. The container image contains the compiled `.o` outputs for the supported BPF test programs from `test-programs/`.
+2. The bundled BPF artifacts are readable by the container's default non-root `sonde` user.
+3. The bundled BPF artifacts are available under a stable in-image directory rooted at `/usr/local/share/sonde/test-programs/`.
+4. The bundled BPF artifacts come from the same git revision and workflow run as the container image build.
+5. Bundling the BPF artifacts does not change the container's default startup path; operators access them via explicit entrypoint override or by copying them out of the image.
+
+---
+
+### GW-1806  Nightly release sensor assets
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+The nightly/release orchestrator workflow MUST build and publish standalone sensor-support assets in addition to the existing gateway/admin binaries, firmware, apps, installers, and container image. These assets include the Rust handler binaries `sonde-tmp102-handler` and `sonde-sht40-handler` for both `linux/amd64` and `linux/arm64`, plus the compiled BPF test-program artifacts from `test-programs/` built once as arch-independent outputs. The published release assets and intermediate workflow artifacts MUST use distinct names that avoid architecture collisions.
+
+**Acceptance criteria:**
+
+1. The nightly/release workflow publishes `sonde-tmp102-handler` and `sonde-sht40-handler` for both `linux/amd64` and `linux/arm64`.
+2. The nightly/release workflow publishes the compiled BPF test-program `.o` artifacts from `test-programs/` once as arch-independent outputs.
+3. Release asset names distinguish amd64 and arm64 handler binaries without collisions.
+4. The release notes / asset manifest enumerate the handler binaries and bundled BPF test-program assets.
+5. The gateway container build can consume the same-run BPF test-program artifacts when producing the container image for that workflow execution.
 
 ---
 
@@ -2532,3 +2569,5 @@ The gateway container image MUST bundle the modem flashing assets needed for man
 | GW-1802 | Container runtime configuration | Must |
 | GW-1803 | Optional secret-service dependency | Must |
 | GW-1804 | Bundled modem flashing assets | Must |
+| GW-1805 | Bundled BPF test-program assets | Must |
+| GW-1806 | Nightly release sensor assets | Must |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -3616,9 +3616,9 @@ A configurable stub handler process (or in-process mock) that:
 
 ## 17  Container image tests
 
-### T-1800  Container image contains expected binaries and flashing tool
+### T-1800  Container image contains expected binaries, flashing tool, and bundled BPF assets
 
-**Traces to:** GW-1800 (AC-2, AC-4), GW-1804 (AC-1)
+**Traces to:** GW-1800 (AC-2, AC-4), GW-1804 (AC-1), GW-1805 (AC-1)
 
 **Preconditions:** Container image built from `Dockerfile.gateway` for the native architecture.
 
@@ -3628,10 +3628,11 @@ A configurable stub handler process (or in-process mock) that:
 3. Run `docker run --rm --entrypoint sonde-sht40-handler <image> --version`.
 4. Run `docker run --rm --entrypoint sonde-tmp102-handler <image> --version`.
 5. Run `docker run --rm --entrypoint espflash <image> --help`.
+6. Run `docker run --rm --entrypoint sh <image> -c 'find /usr/local/share/sonde/test-programs -maxdepth 1 -name "*.o" | grep -q .'`.
 
 **Expected:**
-1. All five commands exit 0; the four Sonde binaries print version strings and `espflash` prints help text.
-2. No Rust toolchain or source code is present in the image; the only non-binary build outputs present are the intentionally bundled modem flash images.
+1. All six commands exit 0; the four Sonde binaries print version strings, `espflash` prints help text, and at least one bundled BPF test-program object is present.
+2. No Rust toolchain or source code is present in the image; the only non-binary build outputs present are the intentionally bundled modem flash images and compiled BPF test-program objects.
 
 ---
 
@@ -3702,6 +3703,24 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1802b  Container exposes bundled BPF test-program paths
+
+**Traces to:** GW-1802 (AC-9), GW-1805 (AC-1, AC-2, AC-3)
+
+**Preconditions:** Container image built.
+
+**Steps:**
+1. Run `docker run --rm --entrypoint sh <image> -c 'test -d /usr/local/share/sonde/test-programs'`.
+2. Run `docker run --rm --entrypoint sh <image> -c 'find /usr/local/share/sonde/test-programs -maxdepth 1 -name "*.o" | grep -q .'`.
+3. Run `docker run --rm --entrypoint sh <image> -c 'find /usr/local/share/sonde/test-programs -maxdepth 1 -name "*.o" -readable | grep -q .'`.
+
+**Expected:**
+1. The stable bundled BPF directory exists at `/usr/local/share/sonde/test-programs`.
+2. The directory contains compiled `.o` test-program artifacts.
+3. The bundled `.o` files are readable by the container's default non-root user.
+
+---
+
 ### T-1803  Build without keyring feature
 
 **Traces to:** GW-1803 (AC-1, AC-2, AC-4, AC-5)
@@ -3767,6 +3786,44 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1806a  Bundled BPF test programs match same-run CI artifacts
+
+**Traces to:** GW-1805 (AC-4), GW-1806 (AC-5)
+
+**Preconditions:** A workflow run has produced the compiled BPF test-program artifact set and the container image for the same commit/tag.
+
+**Steps:**
+1. Download the compiled BPF test-program artifact set from the same workflow run that produced the container image.
+2. Extract `/usr/local/share/sonde/test-programs/` from the container image.
+3. Compare the file list and SHA-256 hashes of the downloaded `.o` files against the in-image copies.
+
+**Expected:**
+1. The same set of `.o` filenames exists in both locations.
+2. Each in-image `.o` file is byte-identical to the same-run workflow artifact.
+3. The compared artifacts and image were all produced by the same workflow run.
+
+---
+
+### T-1807  Nightly release publishes sensor handlers and BPF test programs
+
+**Traces to:** GW-1806 (AC-1, AC-2, AC-3, AC-4)
+
+**Preconditions:** `nightly-release.yml` run completed successfully.
+
+**Steps:**
+1. Inspect the workflow artifacts and/or GitHub release assets produced by the run.
+2. Verify separate Linux handler assets exist for amd64 and arm64 for both `sonde-sht40-handler` and `sonde-tmp102-handler`.
+3. Verify the compiled arch-independent BPF test-program artifact set is present.
+4. Inspect the generated release notes / asset manifest.
+
+**Expected:**
+1. Distinct amd64 and arm64 assets exist for both Rust handler binaries.
+2. A compiled BPF `.o` artifact set from `test-programs/` is present exactly once as an arch-independent asset group.
+3. Asset names distinguish architectures without collisions.
+4. The release notes / asset manifest enumerate the handler binaries and BPF test-program assets.
+
+---
+
 | GW-1306 | T-1306a, T-1306b, T-1306c, T-1306d |
 | GW-1307 | T-1307a, T-1307b, T-1307c, T-1307d, T-1307e, T-1307f, T-1307g, T-1307h, T-1307i |
 | GW-1308 | T-1308 |
@@ -3795,6 +3852,8 @@ A configurable stub handler process (or in-process mock) that:
 | GW-1706 | T-1711 |
 | GW-1800 | T-1800, T-1804, T-1805 |
 | GW-1801 | T-1801, T-1801a, T-1804 |
-| GW-1802 | T-1802, T-1802a |
+| GW-1802 | T-1802, T-1802a, T-1802b |
 | GW-1803 | T-1803 |
 | GW-1804 | T-1800, T-1802a, T-1806 |
+| GW-1805 | T-1800, T-1802b, T-1806a |
+| GW-1806 | T-1806a, T-1807 |


### PR DESCRIPTION
## Summary
- build and publish `sonde-sht40-handler` and `sonde-tmp102-handler` for `linux/amd64` and `linux/arm64`
- build and publish the `test-programs/*.o` set once as an arch-independent nightly/release artifact
- copy the compiled BPF objects into the gateway container and verify same-run provenance in the container workflow
- update the gateway requirements, design, and validation docs for GW-1805/GW-1806

## Validation
- built `sonde-sht40-handler` and `sonde-tmp102-handler` locally in release mode
- compiled the BPF test programs locally
- reviewed workflow/Dockerfile wiring and fixed artifact-layout issues found during audit
- local Docker-based container smoke validation was blocked because the Docker daemon was unavailable in the environment