### PR TITLE
Add pairing-time signal-check flow

### DIFF
--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -273,53 +273,63 @@ pub fn handle_node_provision<S: PlatformStorage>(
 // Diagnostic relay (ble-pairing-protocol.md §6a, ND-1100 through ND-1106)
 // ---------------------------------------------------------------------------
 
-/// Parsed DIAG_RELAY_REQUEST parameters.
+/// Parsed START_DIAG_RELAY parameters.
 pub struct DiagRelayParams {
     pub rf_channel: u8,
     pub payload: Vec<u8>,
 }
 
-/// Parse and validate a DIAG_RELAY_REQUEST BLE envelope body.
-///
-/// Returns `Ok(params)` on success, or `Err(encoded_error_response)` if
-/// the request is invalid (bad channel or payload size).
-pub fn handle_diag_relay_request(body: &[u8]) -> Result<DiagRelayParams, Vec<u8>> {
-    use sonde_protocol::{
-        decode_diag_relay_request, BLE_DIAG_RELAY_RESPONSE, DIAG_RELAY_STATUS_CHANNEL_ERROR,
-        MAX_FRAME_SIZE,
-    };
+#[derive(Debug, Clone, PartialEq)]
+pub enum DiagRelayResult {
+    Success(Vec<u8>),
+    Timeout,
+    ChannelError,
+}
 
-    let (rf_channel, payload) = decode_diag_relay_request(body).map_err(|_| {
-        encode_ble_envelope(
-            BLE_DIAG_RELAY_RESPONSE,
-            &encode_diag_relay_status(DIAG_RELAY_STATUS_CHANNEL_ERROR),
-        )
-        .expect("error response fits")
-    })?;
-
-    if !(1..=13).contains(&rf_channel) || payload.is_empty() || payload.len() > MAX_FRAME_SIZE {
-        return Err(encode_ble_envelope(
-            BLE_DIAG_RELAY_RESPONSE,
-            &encode_diag_relay_status(DIAG_RELAY_STATUS_CHANNEL_ERROR),
-        )
-        .expect("error response fits"));
+impl DiagRelayResult {
+    fn status(&self) -> u8 {
+        match self {
+            Self::Success(_) => sonde_protocol::DIAG_RELAY_RESULT_OK,
+            Self::Timeout => sonde_protocol::DIAG_RELAY_RESULT_TIMEOUT,
+            Self::ChannelError => sonde_protocol::DIAG_RELAY_RESULT_CHANNEL_ERROR,
+        }
     }
+}
 
+/// Parse and validate a START_DIAG_RELAY BLE envelope body.
+pub fn handle_start_diag_relay(body: &[u8]) -> Result<DiagRelayParams, u8> {
+    use sonde_protocol::{decode_start_diag_relay, MAX_FRAME_SIZE};
+
+    let (rf_channel, payload) =
+        decode_start_diag_relay(body).map_err(|_| sonde_protocol::DIAG_RELAY_ACK_INVALID)?;
+    if !(1..=13).contains(&rf_channel) || payload.is_empty() || payload.len() > MAX_FRAME_SIZE {
+        return Err(sonde_protocol::DIAG_RELAY_ACK_INVALID);
+    }
     Ok(DiagRelayParams {
         rf_channel,
         payload: payload.to_vec(),
     })
 }
 
-fn encode_diag_relay_status(status: u8) -> Vec<u8> {
-    sonde_protocol::encode_diag_relay_response(status, &[]).unwrap_or_default()
+/// Encode a DIAG_RELAY_ACK BLE envelope.
+pub fn encode_diag_relay_ack(status: u8) -> Vec<u8> {
+    let body = sonde_protocol::encode_diag_relay_ack(status).unwrap_or_default();
+    encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_ACK, &body).unwrap_or_default()
 }
 
-/// Encode a DIAG_RELAY_RESPONSE BLE envelope.
-pub fn encode_diag_relay_response(status: u8, payload: &[u8]) -> Vec<u8> {
-    let body = sonde_protocol::encode_diag_relay_response(status, payload)
-        .unwrap_or_else(|_| encode_diag_relay_status(status));
-    encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_RESPONSE, &body).unwrap_or_default()
+/// Encode a DIAG_RELAY_RESULT BLE envelope.
+pub fn encode_diag_relay_result(result: Option<&DiagRelayResult>) -> Vec<u8> {
+    let (status, payload) = match result {
+        Some(DiagRelayResult::Success(payload)) => {
+            (sonde_protocol::DIAG_RELAY_RESULT_OK, payload.as_slice())
+        }
+        Some(other) => (other.status(), &[][..]),
+        None => (sonde_protocol::DIAG_RELAY_RESULT_NO_RESULT, &[][..]),
+    };
+    let body = sonde_protocol::encode_diag_relay_result(status, payload).unwrap_or_else(|_| {
+        sonde_protocol::encode_diag_relay_result(status, &[]).unwrap_or_default()
+    });
+    encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_RESULT, &body).unwrap_or_default()
 }
 
 /// Execute the diagnostic relay: broadcast on ESP-NOW, listen for DIAG_REPLY.
@@ -336,7 +346,7 @@ pub fn encode_diag_relay_response(status: u8, payload: &[u8]) -> Vec<u8> {
 pub fn do_diag_relay<T: crate::traits::Transport>(
     transport: &mut T,
     params: &DiagRelayParams,
-) -> Vec<u8> {
+) -> DiagRelayResult {
     const DIAG_MAX_RETRIES: u32 = 3;
     const DIAG_RETRY_DELAY_MS: u64 = 200;
     const DIAG_LISTEN_TIMEOUT_MS: u32 = 2000;
@@ -392,10 +402,7 @@ pub fn do_diag_relay<T: crate::traits::Transport>(
                                     raw.len(),
                                     msg_type
                                 );
-                                return encode_diag_relay_response(
-                                    sonde_protocol::DIAG_RELAY_STATUS_OK,
-                                    &raw,
-                                );
+                                return DiagRelayResult::Success(raw);
                             }
                             log::info!(
                                 "BLE: diagnostic relay ignoring frame attempt={} len={} msg_type=0x{:02x}",
@@ -445,10 +452,7 @@ pub fn do_diag_relay<T: crate::traits::Transport>(
                             raw.len(),
                             msg_type
                         );
-                        return encode_diag_relay_response(
-                            sonde_protocol::DIAG_RELAY_STATUS_OK,
-                            &raw,
-                        );
+                        return DiagRelayResult::Success(raw);
                     }
                     log::info!(
                         "BLE: diagnostic relay ignoring frame attempt={} len={} msg_type=0x{:02x}",
@@ -482,7 +486,7 @@ pub fn do_diag_relay<T: crate::traits::Transport>(
         }
     }
 
-    encode_diag_relay_response(sonde_protocol::DIAG_RELAY_STATUS_TIMEOUT, &[])
+    DiagRelayResult::Timeout
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -351,6 +351,16 @@ pub fn do_diag_relay<T: crate::traits::Transport>(
             }
         }
 
+        log::info!(
+            "BLE: DIAG relay attempt={} send_len={} send_msg_type=0x{:02x}",
+            attempt + 1,
+            params.payload.len(),
+            params
+                .payload
+                .get(sonde_protocol::OFFSET_MSG_TYPE)
+                .copied()
+                .unwrap_or(0)
+        );
         if let Err(err) = transport.send(&params.payload) {
             log::warn!(
                 "BLE: DIAG relay send failed attempt={} error={}",
@@ -359,6 +369,7 @@ pub fn do_diag_relay<T: crate::traits::Transport>(
             );
             continue;
         }
+        log::info!("BLE: DIAG relay send queued attempt={}", attempt + 1);
 
         // Listen for DIAG_REPLY (msg_type 0x85 at header byte offset 2),
         // ignoring other msg_types until the per-attempt listen window expires.

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -351,7 +351,12 @@ pub fn do_diag_relay<T: crate::traits::Transport>(
             }
         }
 
-        if transport.send(&params.payload).is_err() {
+        if let Err(err) = transport.send(&params.payload) {
+            log::warn!(
+                "BLE: DIAG relay send failed attempt={} error={}",
+                attempt + 1,
+                err
+            );
             continue;
         }
 
@@ -367,30 +372,100 @@ pub fn do_diag_relay<T: crate::traits::Transport>(
                 let before = std::time::Instant::now();
                 match transport.recv(remaining_ms) {
                     Ok(Some(raw)) => {
-                        if raw.len() >= 3
-                            && raw[sonde_protocol::OFFSET_MSG_TYPE]
-                                == sonde_protocol::MSG_DIAG_REPLY
-                        {
-                            return encode_diag_relay_response(
-                                sonde_protocol::DIAG_RELAY_STATUS_OK,
-                                &raw,
+                        if raw.len() >= 3 {
+                            let msg_type = raw[sonde_protocol::OFFSET_MSG_TYPE];
+                            if msg_type == sonde_protocol::MSG_DIAG_REPLY {
+                                log::info!(
+                                    "BLE: DIAG_REPLY received attempt={} len={} msg_type=0x{:02x}",
+                                    attempt + 1,
+                                    raw.len(),
+                                    msg_type
+                                );
+                                return encode_diag_relay_response(
+                                    sonde_protocol::DIAG_RELAY_STATUS_OK,
+                                    &raw,
+                                );
+                            }
+                            log::info!(
+                                "BLE: diagnostic relay ignoring frame attempt={} len={} msg_type=0x{:02x}",
+                                attempt + 1,
+                                raw.len(),
+                                msg_type
+                            );
+                        } else {
+                            log::info!(
+                                "BLE: diagnostic relay ignoring short frame attempt={} len={}",
+                                attempt + 1,
+                                raw.len()
                             );
                         }
                         let elapsed = before.elapsed().as_millis() as u32;
                         remaining_ms = remaining_ms.saturating_sub(elapsed.max(1));
                     }
-                    _ => break,
+                    Ok(None) => {
+                        log::info!(
+                            "BLE: diagnostic relay listen timeout attempt={} window_ms={}",
+                            attempt + 1,
+                            remaining_ms
+                        );
+                        break;
+                    }
+                    Err(err) => {
+                        log::warn!(
+                            "BLE: diagnostic relay recv failed attempt={} error={}",
+                            attempt + 1,
+                            err
+                        );
+                        break;
+                    }
                 }
             }
         }
         #[cfg(not(feature = "esp"))]
         {
             // In test builds, recv returns immediately; single attempt per retry.
-            if let Ok(Some(raw)) = transport.recv(DIAG_LISTEN_TIMEOUT_MS) {
-                if raw.len() >= 3
-                    && raw[sonde_protocol::OFFSET_MSG_TYPE] == sonde_protocol::MSG_DIAG_REPLY
-                {
-                    return encode_diag_relay_response(sonde_protocol::DIAG_RELAY_STATUS_OK, &raw);
+            match transport.recv(DIAG_LISTEN_TIMEOUT_MS) {
+                Ok(Some(raw)) if raw.len() >= 3 => {
+                    let msg_type = raw[sonde_protocol::OFFSET_MSG_TYPE];
+                    if msg_type == sonde_protocol::MSG_DIAG_REPLY {
+                        log::info!(
+                            "BLE: DIAG_REPLY received attempt={} len={} msg_type=0x{:02x}",
+                            attempt + 1,
+                            raw.len(),
+                            msg_type
+                        );
+                        return encode_diag_relay_response(
+                            sonde_protocol::DIAG_RELAY_STATUS_OK,
+                            &raw,
+                        );
+                    }
+                    log::info!(
+                        "BLE: diagnostic relay ignoring frame attempt={} len={} msg_type=0x{:02x}",
+                        attempt + 1,
+                        raw.len(),
+                        msg_type
+                    );
+                }
+                Ok(Some(raw)) => {
+                    log::info!(
+                        "BLE: diagnostic relay ignoring short frame attempt={} len={}",
+                        attempt + 1,
+                        raw.len()
+                    );
+                }
+                Ok(None) => {
+                    log::info!(
+                        "BLE: diagnostic relay listen timeout attempt={} window_ms={}",
+                        attempt + 1,
+                        DIAG_LISTEN_TIMEOUT_MS
+                    );
+                }
+                Err(err) => {
+                    log::warn!(
+                        "BLE: diagnostic relay recv failed attempt={} error={}",
+                        attempt + 1,
+                        err
+                    );
                 }
             }
         }

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -274,6 +274,7 @@ pub fn handle_node_provision<S: PlatformStorage>(
 // ---------------------------------------------------------------------------
 
 /// Parsed START_DIAG_RELAY parameters.
+#[derive(Debug)]
 pub struct DiagRelayParams {
     pub rf_channel: u8,
     pub payload: Vec<u8>,

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -28,20 +28,21 @@ use esp32_nimble::utilities::BleUuid;
 use esp32_nimble::{
     enums::{AuthReq, SecurityIOCap},
     utilities::mutex::Mutex as NimbleMutex,
-    BLEAdvertisementData, BLECharacteristic, BLEDevice, NimbleProperties,
+    BLEAdvertisementData, BLECharacteristic, BLEDevice, NimbleProperties, NotifyTxStatus,
 };
 use log::{info, warn};
 
 use crate::ble_pairing::{
-    do_diag_relay, encode_diag_relay_response, encode_node_ack, handle_diag_relay_request,
-    handle_node_provision, is_mtu_acceptable, parse_ble_envelope, parse_node_provision,
-    BLE_MIN_ATT_MTU, BLE_MSG_NODE_PROVISION,
+    do_diag_relay, encode_diag_relay_ack, encode_diag_relay_result, encode_node_ack,
+    handle_node_provision, handle_start_diag_relay, is_mtu_acceptable, parse_ble_envelope,
+    parse_node_provision, DiagRelayParams, DiagRelayResult, BLE_MIN_ATT_MTU,
+    BLE_MSG_NODE_PROVISION,
 };
 use crate::error::NodeResult;
 use crate::esp_transport::EspNowTransport;
 use crate::map_storage::MapStorage;
 use crate::traits::PlatformStorage;
-use sonde_protocol::BLE_DIAG_RELAY_REQUEST;
+use sonde_protocol::{BLE_FETCH_DIAG_RESULT, BLE_START_DIAG_RELAY};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -55,6 +56,20 @@ const NODE_COMMAND_UUID: BleUuid = BleUuid::Uuid16(0xFE51);
 
 /// Polling interval for the main loop waiting for disconnect.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PendingIndication {
+    NodeAck,
+    DiagAckAccepted,
+    DiagAckRejected,
+    DiagResult { clear_on_success: bool },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SessionExit {
+    Disconnect,
+    StartDiagnostic(DiagRelayParams),
+}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -70,10 +85,10 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// NODE_PROVISION triggers a factory reset before writing new credentials
 /// (ND-0917).
 ///
-/// `transport`: optional ESP-NOW transport for DIAG_RELAY_REQUEST support
-/// (ND-1100). When `Some`, diagnostic relay requests are forwarded over
-/// the radio with channel switching (ND-1101, ND-1106). When `None`,
-/// relay requests return `DIAG_RELAY_STATUS_CHANNEL_ERROR`.
+/// `transport`: optional ESP-NOW transport for async diagnostic relay support
+/// (ND-1100). When `Some`, accepted diagnostics are executed over the radio
+/// with channel switching (ND-1102, ND-1106). When `None`, the node still
+/// accepts the request, suspends BLE, and later returns a channel-error result.
 ///
 /// Returns `Ok(())` when the BLE connection is terminated (the caller should
 /// reboot per ND-0907), or `Err` if BLE initialisation fails.
@@ -84,22 +99,47 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
     mut transport: Option<&mut EspNowTransport>,
 ) -> NodeResult<()> {
     let paired_on_entry = storage.read_key().is_some();
+    let mut stored_diag_result: Option<DiagRelayResult> = None;
 
-    // The GATT write callback cannot hold &mut storage (not Send, lifetime
-    // issues). Instead, the callback stores raw write bytes in a shared
-    // Option, and the main loop polls it with direct &mut storage access.
+    loop {
+        match run_ble_pairing_session(
+            storage,
+            map_storage,
+            button_held,
+            paired_on_entry,
+            &mut stored_diag_result,
+        )? {
+            SessionExit::Disconnect => {
+                info!("BLE: disconnect detected -- exiting pairing mode");
+                return Ok(());
+            }
+            SessionExit::StartDiagnostic(params) => {
+                stored_diag_result = Some(execute_diag_relay(
+                    storage,
+                    transport.as_deref_mut(),
+                    &params,
+                ));
+            }
+        }
+    }
+}
+
+fn run_ble_pairing_session<S: PlatformStorage>(
+    storage: &mut S,
+    map_storage: &mut MapStorage,
+    button_held: bool,
+    paired_on_entry: bool,
+    stored_diag_result: &mut Option<DiagRelayResult>,
+) -> NodeResult<SessionExit> {
     let pending_write: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
     let disconnected = Arc::new(Mutex::new(false));
     let authenticated = Arc::new(Mutex::new(false));
     let conn_handle: Arc<Mutex<Option<u16>>> = Arc::new(Mutex::new(None));
+    let notify_pending: Arc<Mutex<Option<PendingIndication>>> = Arc::new(Mutex::new(None));
+    let notify_complete: Arc<Mutex<Option<(PendingIndication, bool)>>> = Arc::new(Mutex::new(None));
+    let mut pending_diag_start: Option<DiagRelayParams> = None;
 
-    // --- NimBLE initialisation ---
     let ble_device = BLEDevice::take();
-
-    // Configure LESC Just Works security (ND-0904).
-    // AuthReq::all() includes SC (Secure Connections) + Bond + MITM,
-    // matching the modem's configuration. With NoInputNoOutput IO cap,
-    // MITM is downgraded to Just Works but LESC is still enforced.
     ble_device
         .security()
         .set_auth(AuthReq::all())
@@ -107,31 +147,23 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
 
     let ble_server = ble_device.get_server();
 
-    // --- Connection event ---
     let disc_connect = Arc::clone(&disconnected);
     let handle_connect = Arc::clone(&conn_handle);
     ble_server.on_connect(move |server, desc| {
         let peer_addr = desc.address();
         let mtu = desc.mtu();
         info!("BLE: client connected addr={:?} mtu={}", peer_addr, mtu);
-
-        // Only one connection at a time.
         if server.connected_count() > 1 {
             warn!("BLE: second connection rejected");
             let _ = server.disconnect_with_reason(desc.conn_handle(), 0x13);
             return;
         }
-
         if let Ok(mut d) = disc_connect.lock() {
             *d = false;
         }
         if let Ok(mut h) = handle_connect.lock() {
             *h = Some(desc.conn_handle());
         }
-
-        // Proactively initiate LESC pairing from the server side so that
-        // clients that don't trigger pairing on their own (e.g. btleplug
-        // on WinRT) still go through LESC Just Works (ND-0904 criterion 3).
         let conn_handle = desc.conn_handle();
         unsafe {
             esp_idf_sys::ble_gap_security_initiate(conn_handle);
@@ -142,7 +174,6 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         );
     });
 
-    // --- Disconnect event ---
     let disc_disconnect = Arc::clone(&disconnected);
     let auth_disconnect = Arc::clone(&authenticated);
     let handle_disconnect = Arc::clone(&conn_handle);
@@ -159,7 +190,6 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         }
     });
 
-    // --- Authentication complete ---
     let auth_complete = Arc::clone(&authenticated);
     ble_server.on_authentication_complete(move |server, desc, result| {
         if result.is_ok() {
@@ -181,21 +211,15 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         }
     });
 
-    // Passkey request (no-op for Just Works).
     ble_server.on_passkey_request(move || 0u32);
 
-    // --- GATT service + Node Command characteristic ---
     let ble_service = ble_server.create_service(NODE_SERVICE_UUID);
-
     let node_cmd_char: Arc<NimbleMutex<BLECharacteristic>> =
         ble_service.lock().create_characteristic(
             NODE_COMMAND_UUID,
             NimbleProperties::WRITE | NimbleProperties::INDICATE,
         );
 
-    // GATT write handler: all writes are stored into `pending_write`.
-    // Writes received before LESC pairing completes (ND-0904 criterion 4)
-    // are accepted but only processed by the main loop on a later poll.
     let write_pending = Arc::clone(&pending_write);
     let write_auth = Arc::clone(&authenticated);
     node_cmd_char.lock().on_write(move |args| {
@@ -217,7 +241,19 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         }
     });
 
-    // --- Advertising ---
+    let notify_pending_cb = Arc::clone(&notify_pending);
+    let notify_complete_cb = Arc::clone(&notify_complete);
+    node_cmd_char.lock().on_notify_tx(move |notify| {
+        let success = matches!(notify.status(), NotifyTxStatus::SuccessIndicate);
+        if let Ok(mut pending) = notify_pending_cb.lock() {
+            if let Some(kind) = pending.take() {
+                if let Ok(mut complete) = notify_complete_cb.lock() {
+                    *complete = Some((kind, success));
+                }
+            }
+        }
+    });
+
     let mac = ble_device
         .get_addr()
         .map_err(|e| {
@@ -227,9 +263,6 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         .as_le_bytes();
     let device_name = format!("sonde-{:02x}{:02x}", mac[1], mac[0]);
     info!("BLE: advertising as '{}' (ND-0903)", device_name);
-
-    // Set the GAP device name so connected clients (e.g. Windows) see
-    // the correct name instead of the NimBLE default ("nimble") (ND-0903).
     if let Err(e) = BLEDevice::set_device_name(&device_name) {
         warn!("BLE: failed to set GAP device name: {:?}", e);
     }
@@ -238,7 +271,6 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
     let mut adv_data = BLEAdvertisementData::new();
     adv_data.name(&device_name);
     adv_data.add_service_uuid(NODE_SERVICE_UUID);
-
     ble_advertising
         .lock()
         .set_data(&mut adv_data)
@@ -253,39 +285,64 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
 
     info!("BLE Node Provisioning Service registered (UUID 0xFE50, ND-0902)");
 
-    // --- Main loop: poll for writes and disconnects ---
     loop {
-        // Check for disconnect.
-        if let Ok(d) = disconnected.lock() {
-            if *d {
-                info!("BLE: disconnect detected -- exiting pairing mode");
-                break;
+        if let Some((kind, success)) = notify_complete.lock().ok().and_then(|mut c| c.take()) {
+            match kind {
+                PendingIndication::DiagAckAccepted if success => {
+                    info!("BLE: START_DIAG_RELAY acknowledged -- suspending BLE");
+                    if let Some(handle) = conn_handle.lock().ok().and_then(|h| *h) {
+                        let _ = ble_server.disconnect(handle);
+                    }
+                    if let Err(e) = ble_advertising.lock().stop() {
+                        warn!("BLE: failed to stop advertising before diagnostic: {:?}", e);
+                    }
+                    if let Err(e) = BLEDevice::deinit_full() {
+                        warn!(
+                            "BLE: failed to deinitialize BLE stack before diagnostic: {:?}",
+                            e
+                        );
+                    }
+                    return Ok(SessionExit::StartDiagnostic(
+                        pending_diag_start
+                            .take()
+                            .expect("accepted diagnostic ack should retain request"),
+                    ));
+                }
+                PendingIndication::DiagAckAccepted => {
+                    warn!("BLE: START_DIAG_RELAY indication failed");
+                    pending_diag_start = None;
+                }
+                PendingIndication::DiagResult {
+                    clear_on_success: true,
+                } if success => {
+                    info!("BLE: DIAG_RELAY_RESULT delivered -- clearing stored result");
+                    *stored_diag_result = None;
+                }
+                PendingIndication::DiagResult { .. } if !success => {
+                    warn!("BLE: DIAG_RELAY_RESULT indication failed");
+                }
+                _ => {}
             }
         }
 
-        // Check for a pending GATT write (only process after auth).
-        // Primary path: on_authentication_complete sets `authenticated`.
-        // Fallback: if on_authentication_complete didn't fire (e.g.,
-        // esp32-nimble doesn't dispatch BLE_GAP_EVENT_ENC_CHANGE on this
-        // build), check the connection's encryption status directly.
+        if let Ok(d) = disconnected.lock() {
+            if *d {
+                let _ = BLEDevice::deinit_full();
+                return Ok(SessionExit::Disconnect);
+            }
+        }
+
         let is_auth = authenticated.lock().map(|a| *a).unwrap_or(false);
         let is_auth = is_auth || check_encryption_fallback(&conn_handle, &authenticated);
         let write_data = if is_auth {
-            if let Ok(mut p) = pending_write.lock() {
-                p.take()
-            } else {
-                None
-            }
+            pending_write.lock().ok().and_then(|mut p| p.take())
         } else {
             None
         };
 
         if let Some(data) = write_data {
             info!("BLE: GATT write received ({} bytes)", data.len());
-
-            // Parse BLE envelope. Silently discard malformed/unknown
-            // messages -- the phone will time out waiting for NODE_ACK.
-            let ack_data = match parse_ble_envelope(&data) {
+            let response = match parse_ble_envelope(&data) {
                 Some((msg_type, body)) if msg_type == BLE_MSG_NODE_PROVISION => {
                     match parse_node_provision(body) {
                         Ok(provision) => {
@@ -297,155 +354,88 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
                                 paired_on_entry,
                             );
                             info!("BLE: NODE_PROVISION handled, status=0x{:02x}", status);
-                            Some(encode_node_ack(status))
+                            Some((PendingIndication::NodeAck, encode_node_ack(status)))
                         }
                         Err(e) => {
                             warn!("BLE: NODE_PROVISION parse error: {}", e);
-                            None // silently discard
+                            None
                         }
                     }
                 }
-                Some((msg_type, body)) if msg_type == BLE_DIAG_RELAY_REQUEST => {
-                    match (handle_diag_relay_request(body), transport.as_deref_mut()) {
-                        (Ok(params), Some(t)) => {
-                            info!(
-                                "BLE: DIAG_RELAY_REQUEST rf_channel={} payload_len={} (ND-1100)",
-                                params.rf_channel,
-                                params.payload.len()
-                            );
-                            // Save current channel, switch, relay, restore (ND-1101, ND-1106).
-                            let mut orig_primary: u8 = 0;
-                            let mut orig_secondary: esp_idf_sys::wifi_second_chan_t = 0;
-                            let got_channel = unsafe {
-                                esp_idf_sys::esp_wifi_get_channel(
-                                    &mut orig_primary,
-                                    &mut orig_secondary,
-                                ) == esp_idf_sys::ESP_OK
-                            };
-                            if !got_channel {
-                                // Fall back to stored channel so we can still restore (ND-1106).
-                                orig_primary = storage.read_channel().unwrap_or(1);
-                                orig_secondary =
-                                    esp_idf_sys::wifi_second_chan_t_WIFI_SECOND_CHAN_NONE;
-                                warn!(
-                                    "BLE: esp_wifi_get_channel failed, will restore to channel {}",
-                                    orig_primary
-                                );
-                            } else {
+                Some((msg_type, body)) if msg_type == BLE_START_DIAG_RELAY => {
+                    let (kind, payload) = if pending_diag_start.is_some()
+                        || stored_diag_result.is_some()
+                    {
+                        (
+                            PendingIndication::DiagAckRejected,
+                            encode_diag_relay_ack(sonde_protocol::DIAG_RELAY_ACK_BUSY),
+                        )
+                    } else {
+                        match handle_start_diag_relay(body) {
+                            Ok(params) => {
                                 info!(
-                                    "BLE: current Wi-Fi channel before DIAG relay primary={} secondary={}",
-                                    orig_primary,
-                                    orig_secondary
-                                );
-                            }
-                            let set_ok = unsafe {
-                                let rc = esp_idf_sys::esp_wifi_set_channel(
+                                    "BLE: START_DIAG_RELAY rf_channel={} payload_len={} (ND-1100)",
                                     params.rf_channel,
-                                    esp_idf_sys::wifi_second_chan_t_WIFI_SECOND_CHAN_NONE,
+                                    params.payload.len()
                                 );
-                                if rc != esp_idf_sys::ESP_OK {
-                                    warn!("BLE: failed to set Wi-Fi channel {} for DIAG relay: err={}", params.rf_channel, rc);
-                                }
-                                rc == esp_idf_sys::ESP_OK
-                            };
-                            if !set_ok {
-                                Some(encode_diag_relay_response(
-                                    sonde_protocol::DIAG_RELAY_STATUS_CHANNEL_ERROR,
-                                    &[],
-                                ))
-                            } else {
-                                let mut relay_primary: u8 = 0;
-                                let mut relay_secondary: esp_idf_sys::wifi_second_chan_t = 0;
-                                let relay_channel_ok = unsafe {
-                                    esp_idf_sys::esp_wifi_get_channel(
-                                        &mut relay_primary,
-                                        &mut relay_secondary,
-                                    ) == esp_idf_sys::ESP_OK
-                                };
-                                if relay_channel_ok {
-                                    info!(
-                                        "BLE: DIAG relay armed requested_channel={} current_primary={} current_secondary={}",
-                                        params.rf_channel,
-                                        relay_primary,
-                                        relay_secondary
-                                    );
-                                } else {
-                                    warn!(
-                                        "BLE: failed to read Wi-Fi channel after DIAG relay retune"
-                                    );
-                                }
-                                t.log_recv_debug_snapshot("before do_diag_relay");
-                                let response = do_diag_relay(t, &params);
-                                t.log_recv_debug_snapshot("after do_diag_relay");
-                                // Always restore channel (ND-1106).
-                                unsafe {
-                                    let rc = esp_idf_sys::esp_wifi_set_channel(
-                                        orig_primary,
-                                        orig_secondary,
-                                    );
-                                    if rc != esp_idf_sys::ESP_OK {
-                                        warn!("BLE: failed to restore Wi-Fi channel after DIAG relay: err={}", rc);
-                                    }
-                                }
-                                let mut restored_primary: u8 = 0;
-                                let mut restored_secondary: esp_idf_sys::wifi_second_chan_t = 0;
-                                let restore_channel_ok = unsafe {
-                                    esp_idf_sys::esp_wifi_get_channel(
-                                        &mut restored_primary,
-                                        &mut restored_secondary,
-                                    ) == esp_idf_sys::ESP_OK
-                                };
-                                if restore_channel_ok {
-                                    info!(
-                                        "BLE: Wi-Fi channel restored primary={} secondary={}",
-                                        restored_primary, restored_secondary
-                                    );
-                                } else {
-                                    warn!("BLE: failed to read Wi-Fi channel after DIAG relay restore");
-                                }
-                                Some(response)
+                                pending_diag_start = Some(params);
+                                (
+                                    PendingIndication::DiagAckAccepted,
+                                    encode_diag_relay_ack(sonde_protocol::DIAG_RELAY_ACK_ACCEPTED),
+                                )
                             }
+                            Err(status) => (
+                                PendingIndication::DiagAckRejected,
+                                encode_diag_relay_ack(status),
+                            ),
                         }
-                        (Ok(_), None) => {
-                            warn!("BLE: DIAG_RELAY_REQUEST but no transport available");
-                            Some(encode_diag_relay_response(
-                                sonde_protocol::DIAG_RELAY_STATUS_CHANNEL_ERROR,
-                                &[],
-                            ))
-                        }
-                        (Err(error_response), _) => Some(error_response),
-                    }
+                    };
+                    Some((kind, payload))
+                }
+                Some((msg_type, _)) if msg_type == BLE_FETCH_DIAG_RESULT => {
+                    let clear_on_success = stored_diag_result.is_some();
+                    Some((
+                        PendingIndication::DiagResult { clear_on_success },
+                        encode_diag_relay_result(stored_diag_result.as_ref()),
+                    ))
                 }
                 Some((msg_type, _)) => {
                     warn!(
                         "BLE: unexpected message type 0x{:02x}, discarding",
                         msg_type
                     );
-                    None // silently discard
+                    None
                 }
                 None => {
                     warn!("BLE: envelope parse error, discarding");
-                    None // silently discard
+                    None
                 }
             };
 
-            // Send NODE_ACK indication if we have a valid response.
-            if let Some(ack) = ack_data {
-                let current_handle = conn_handle.lock().ok().and_then(|h| *h);
-                if let Some(handle) = current_handle {
+            if let Some((kind, payload)) = response {
+                if let Some(handle) = conn_handle.lock().ok().and_then(|h| *h) {
+                    if let Ok(mut pending) = notify_pending.lock() {
+                        *pending = Some(kind);
+                    }
                     let chr = node_cmd_char.lock();
-                    if let Err(e) = chr.notify_with(&ack, handle) {
-                        warn!("BLE: NODE_ACK indication failed: {:?}", e);
+                    if let Err(e) = chr.notify_with(&payload, handle) {
+                        warn!("BLE: indication failed: {:?}", e);
+                        if let Ok(mut pending) = notify_pending.lock() {
+                            *pending = None;
+                        }
+                        if kind == PendingIndication::DiagAckAccepted {
+                            pending_diag_start = None;
+                        }
                     }
                 } else {
-                    warn!("BLE: no active connection for NODE_ACK indication");
+                    warn!("BLE: no active connection for indication");
+                    if kind == PendingIndication::DiagAckAccepted {
+                        pending_diag_start = None;
+                    }
                 }
             }
         }
 
-        // Busy-wait with a short sleep to avoid spinning.
-        // Feed the task watchdog on each iteration so the indefinite-duration
-        // BLE pairing session does not trigger the 20 s watchdog (ND-0919 AC 7).
         unsafe {
             esp_idf_svc::sys::esp_task_wdt_reset();
             esp_idf_svc::sys::vTaskDelay(
@@ -453,8 +443,69 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
             );
         }
     }
+}
 
-    Ok(())
+fn execute_diag_relay<S: PlatformStorage>(
+    storage: &mut S,
+    transport: Option<&mut EspNowTransport>,
+    params: &DiagRelayParams,
+) -> DiagRelayResult {
+    let Some(transport) = transport else {
+        warn!("BLE: START_DIAG_RELAY accepted but no transport available");
+        return DiagRelayResult::ChannelError;
+    };
+
+    let mut orig_primary: u8 = 0;
+    let mut orig_secondary: esp_idf_sys::wifi_second_chan_t = 0;
+    let got_channel = unsafe {
+        esp_idf_sys::esp_wifi_get_channel(&mut orig_primary, &mut orig_secondary)
+            == esp_idf_sys::ESP_OK
+    };
+    if !got_channel {
+        orig_primary = storage.read_channel().unwrap_or(1);
+        orig_secondary = esp_idf_sys::wifi_second_chan_t_WIFI_SECOND_CHAN_NONE;
+        warn!(
+            "BLE: esp_wifi_get_channel failed, will restore to channel {}",
+            orig_primary
+        );
+    } else {
+        info!(
+            "BLE: current Wi-Fi channel before DIAG relay primary={} secondary={}",
+            orig_primary, orig_secondary
+        );
+    }
+
+    let set_ok = unsafe {
+        let rc = esp_idf_sys::esp_wifi_set_channel(
+            params.rf_channel,
+            esp_idf_sys::wifi_second_chan_t_WIFI_SECOND_CHAN_NONE,
+        );
+        if rc != esp_idf_sys::ESP_OK {
+            warn!(
+                "BLE: failed to set Wi-Fi channel {} for DIAG relay: err={}",
+                params.rf_channel, rc
+            );
+        }
+        rc == esp_idf_sys::ESP_OK
+    };
+    if !set_ok {
+        return DiagRelayResult::ChannelError;
+    }
+
+    transport.log_recv_debug_snapshot("before do_diag_relay");
+    let result = do_diag_relay(transport, params);
+    transport.log_recv_debug_snapshot("after do_diag_relay");
+
+    unsafe {
+        let rc = esp_idf_sys::esp_wifi_set_channel(orig_primary, orig_secondary);
+        if rc != esp_idf_sys::ESP_OK {
+            warn!(
+                "BLE: failed to restore Wi-Fi channel after DIAG relay: err={}",
+                rc
+            );
+        }
+    }
+    result
 }
 
 #[cfg(test)]

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -65,7 +65,7 @@ enum PendingIndication {
     DiagResult { clear_on_success: bool },
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 enum SessionExit {
     Disconnect,
     StartDiagnostic(DiagRelayParams),

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -309,8 +309,9 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
                     match (handle_diag_relay_request(body), transport.as_deref_mut()) {
                         (Ok(params), Some(t)) => {
                             info!(
-                                "BLE: DIAG_RELAY_REQUEST rf_channel={} (ND-1100)",
-                                params.rf_channel
+                                "BLE: DIAG_RELAY_REQUEST rf_channel={} payload_len={} (ND-1100)",
+                                params.rf_channel,
+                                params.payload.len()
                             );
                             // Save current channel, switch, relay, restore (ND-1101, ND-1106).
                             let mut orig_primary: u8 = 0;
@@ -330,6 +331,12 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
                                     "BLE: esp_wifi_get_channel failed, will restore to channel {}",
                                     orig_primary
                                 );
+                            } else {
+                                info!(
+                                    "BLE: current Wi-Fi channel before DIAG relay primary={} secondary={}",
+                                    orig_primary,
+                                    orig_secondary
+                                );
                             }
                             let set_ok = unsafe {
                                 let rc = esp_idf_sys::esp_wifi_set_channel(
@@ -347,7 +354,29 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
                                     &[],
                                 ))
                             } else {
+                                let mut relay_primary: u8 = 0;
+                                let mut relay_secondary: esp_idf_sys::wifi_second_chan_t = 0;
+                                let relay_channel_ok = unsafe {
+                                    esp_idf_sys::esp_wifi_get_channel(
+                                        &mut relay_primary,
+                                        &mut relay_secondary,
+                                    ) == esp_idf_sys::ESP_OK
+                                };
+                                if relay_channel_ok {
+                                    info!(
+                                        "BLE: DIAG relay armed requested_channel={} current_primary={} current_secondary={}",
+                                        params.rf_channel,
+                                        relay_primary,
+                                        relay_secondary
+                                    );
+                                } else {
+                                    warn!(
+                                        "BLE: failed to read Wi-Fi channel after DIAG relay retune"
+                                    );
+                                }
+                                t.log_recv_debug_snapshot("before do_diag_relay");
                                 let response = do_diag_relay(t, &params);
+                                t.log_recv_debug_snapshot("after do_diag_relay");
                                 // Always restore channel (ND-1106).
                                 unsafe {
                                     let rc = esp_idf_sys::esp_wifi_set_channel(
@@ -357,6 +386,22 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
                                     if rc != esp_idf_sys::ESP_OK {
                                         warn!("BLE: failed to restore Wi-Fi channel after DIAG relay: err={}", rc);
                                     }
+                                }
+                                let mut restored_primary: u8 = 0;
+                                let mut restored_secondary: esp_idf_sys::wifi_second_chan_t = 0;
+                                let restore_channel_ok = unsafe {
+                                    esp_idf_sys::esp_wifi_get_channel(
+                                        &mut restored_primary,
+                                        &mut restored_secondary,
+                                    ) == esp_idf_sys::ESP_OK
+                                };
+                                if restore_channel_ok {
+                                    info!(
+                                        "BLE: Wi-Fi channel restored primary={} secondary={}",
+                                        restored_primary, restored_secondary
+                                    );
+                                } else {
+                                    warn!("BLE: failed to read Wi-Fi channel after DIAG relay restore");
                                 }
                                 Some(response)
                             }

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -392,12 +392,19 @@ fn run_ble_pairing_session<S: PlatformStorage>(
                     };
                     Some((kind, payload))
                 }
-                Some((msg_type, _)) if msg_type == BLE_FETCH_DIAG_RESULT => {
-                    let clear_on_success = stored_diag_result.is_some();
-                    Some((
-                        PendingIndication::DiagResult { clear_on_success },
-                        encode_diag_relay_result(stored_diag_result.as_ref()),
-                    ))
+                Some((msg_type, body)) if msg_type == BLE_FETCH_DIAG_RESULT => {
+                    if !body.is_empty() {
+                        Some((
+                            PendingIndication::DiagAckRejected,
+                            encode_diag_relay_ack(sonde_protocol::DIAG_RELAY_ACK_INVALID),
+                        ))
+                    } else {
+                        let clear_on_success = stored_diag_result.is_some();
+                        Some((
+                            PendingIndication::DiagResult { clear_on_success },
+                            encode_diag_relay_result(stored_diag_result.as_ref()),
+                        ))
+                    }
                 }
                 Some((msg_type, _)) => {
                     warn!(

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -134,6 +134,7 @@ fn run_ble_pairing_session<S: PlatformStorage>(
     let pending_write: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
     let disconnected = Arc::new(Mutex::new(false));
     let authenticated = Arc::new(Mutex::new(false));
+    let session_authenticated = Arc::new(Mutex::new(false));
     let conn_handle: Arc<Mutex<Option<u16>>> = Arc::new(Mutex::new(None));
     let notify_pending: Arc<Mutex<Option<PendingIndication>>> = Arc::new(Mutex::new(None));
     let notify_complete: Arc<Mutex<Option<(PendingIndication, bool)>>> = Arc::new(Mutex::new(None));
@@ -142,7 +143,9 @@ fn run_ble_pairing_session<S: PlatformStorage>(
     let ble_device = BLEDevice::take();
     ble_device
         .security()
-        .set_auth(AuthReq::all())
+        // Headless nodes use LESC Just Works: require bonding + secure
+        // connections, but not MITM / Numeric Comparison.
+        .set_auth(AuthReq::Bond | AuthReq::Sc)
         .set_io_cap(SecurityIOCap::NoInputNoOutput);
 
     let ble_server = ble_device.get_server();
@@ -165,17 +168,23 @@ fn run_ble_pairing_session<S: PlatformStorage>(
             *h = Some(desc.conn_handle());
         }
         let conn_handle = desc.conn_handle();
-        unsafe {
-            esp_idf_sys::ble_gap_security_initiate(conn_handle);
+        let rc = unsafe { esp_idf_sys::ble_gap_security_initiate(conn_handle) };
+        if rc == 0 {
+            info!(
+                "BLE: server-initiated security for conn_handle={}",
+                conn_handle
+            );
+        } else {
+            warn!(
+                "BLE: server-initiated security failed for conn_handle={} rc={}",
+                conn_handle, rc
+            );
         }
-        info!(
-            "BLE: server-initiated security for conn_handle={}",
-            conn_handle
-        );
     });
 
     let disc_disconnect = Arc::clone(&disconnected);
     let auth_disconnect = Arc::clone(&authenticated);
+    let session_auth_disconnect = Arc::clone(&session_authenticated);
     let handle_disconnect = Arc::clone(&conn_handle);
     ble_server.on_disconnect(move |desc, _reason| {
         info!("BLE: client disconnected addr={:?}", desc.address());
@@ -188,9 +197,13 @@ fn run_ble_pairing_session<S: PlatformStorage>(
         if let Ok(mut h) = handle_disconnect.lock() {
             *h = None;
         }
+        if !session_auth_disconnect.lock().map(|a| *a).unwrap_or(false) {
+            info!("BLE: unauthenticated disconnect -- remaining in pairing mode");
+        }
     });
 
     let auth_complete = Arc::clone(&authenticated);
+    let session_auth_complete = Arc::clone(&session_authenticated);
     ble_server.on_authentication_complete(move |server, desc, result| {
         if result.is_ok() {
             let mtu = desc.mtu();
@@ -203,6 +216,9 @@ fn run_ble_pairing_session<S: PlatformStorage>(
             } else {
                 info!("BLE: LESC pairing complete, MTU={}", mtu);
                 if let Ok(mut a) = auth_complete.lock() {
+                    *a = true;
+                }
+                if let Ok(mut a) = session_auth_complete.lock() {
                     *a = true;
                 }
             }
@@ -325,10 +341,14 @@ fn run_ble_pairing_session<S: PlatformStorage>(
             }
         }
 
-        if let Ok(d) = disconnected.lock() {
+        if let Ok(mut d) = disconnected.lock() {
             if *d {
-                let _ = BLEDevice::deinit_full();
-                return Ok(SessionExit::Disconnect);
+                let saw_authenticated = session_authenticated.lock().map(|a| *a).unwrap_or(false);
+                if saw_authenticated {
+                    let _ = BLEDevice::deinit_full();
+                    return Ok(SessionExit::Disconnect);
+                }
+                *d = false;
             }
         }
 

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -167,19 +167,6 @@ fn run_ble_pairing_session<S: PlatformStorage>(
         if let Ok(mut h) = handle_connect.lock() {
             *h = Some(desc.conn_handle());
         }
-        let conn_handle = desc.conn_handle();
-        let rc = unsafe { esp_idf_sys::ble_gap_security_initiate(conn_handle) };
-        if rc == 0 {
-            info!(
-                "BLE: server-initiated security for conn_handle={}",
-                conn_handle
-            );
-        } else {
-            warn!(
-                "BLE: server-initiated security failed for conn_handle={} rc={}",
-                conn_handle, rc
-            );
-        }
     });
 
     let disc_disconnect = Arc::clone(&disconnected);
@@ -539,7 +526,7 @@ fn execute_diag_relay<S: PlatformStorage>(
 mod tests {}
 
 /// Fallback encryption check for when `on_authentication_complete` doesn't
-/// fire (e.g., esp32-nimble build that doesn't dispatch ENC_CHANGE event 38).
+/// fire (e.g., an `esp32-nimble` build that misses some newer GAP events).
 /// Returns `true` only if the link is encrypted AND MTU is acceptable,
 /// promoting `authenticated` to `true`.  Returns `false` if not encrypted,
 /// not connected, or MTU is too low (disconnects in that case).

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -409,7 +409,7 @@ impl crate::traits::Transport for EspNowTransport {
                     .copied()
                     .map(u32::from)
                     .unwrap_or(u32::MAX);
-                log::info!(
+                log::debug!(
                     "ESP-NOW recv pop len={} msg_type={} timeout_ms={}",
                     len,
                     format_msg_type(msg_type),
@@ -425,7 +425,7 @@ impl crate::traits::Transport for EspNowTransport {
                 if full_drops > 0 {
                     log::warn!("ESP-NOW recv ring: {} full drop(s)", full_drops);
                 }
-                log::info!("ESP-NOW recv timeout timeout_ms={}", timeout_ms);
+                log::debug!("ESP-NOW recv timeout timeout_ms={}", timeout_ms);
                 return Ok(None);
             }
             let remaining = deadline - now;

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -9,7 +9,7 @@
 //! callback, eliminating per-frame heap allocation from the WiFi task
 //! context.
 
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Instant;
 
@@ -111,30 +111,31 @@ struct RecvState {
     enqueued_count: AtomicU32,
     last_len: AtomicU32,
     last_msg_type: AtomicU32,
-    last_src_mac: AtomicU64,
+    last_src_mac_hi: AtomicU32,
+    last_src_mac_lo: AtomicU32,
     last_rssi_dbm: AtomicI32,
 }
 
 /// Global callback state — set once during [`EspNowTransport::new`].
 static RECV_STATE: std::sync::OnceLock<RecvState> = std::sync::OnceLock::new();
 
-fn pack_mac(mac: [u8; 6]) -> u64 {
-    ((mac[0] as u64) << 40)
-        | ((mac[1] as u64) << 32)
-        | ((mac[2] as u64) << 24)
-        | ((mac[3] as u64) << 16)
-        | ((mac[4] as u64) << 8)
-        | (mac[5] as u64)
+fn pack_mac_words(mac: [u8; 6]) -> (u32, u32) {
+    let hi = ((mac[0] as u32) << 24)
+        | ((mac[1] as u32) << 16)
+        | ((mac[2] as u32) << 8)
+        | (mac[3] as u32);
+    let lo = ((mac[4] as u32) << 8) | (mac[5] as u32);
+    (hi, lo)
 }
 
-fn unpack_mac(packed: u64) -> [u8; 6] {
+fn unpack_mac_words(hi: u32, lo: u32) -> [u8; 6] {
     [
-        ((packed >> 40) & 0xFF) as u8,
-        ((packed >> 32) & 0xFF) as u8,
-        ((packed >> 24) & 0xFF) as u8,
-        ((packed >> 16) & 0xFF) as u8,
-        ((packed >> 8) & 0xFF) as u8,
-        (packed & 0xFF) as u8,
+        ((hi >> 24) & 0xFF) as u8,
+        ((hi >> 16) & 0xFF) as u8,
+        ((hi >> 8) & 0xFF) as u8,
+        (hi & 0xFF) as u8,
+        ((lo >> 8) & 0xFF) as u8,
+        (lo & 0xFF) as u8,
     ]
 }
 
@@ -174,9 +175,9 @@ unsafe extern "C" fn raw_recv_cb(
         state.callback_count.fetch_add(1, Ordering::Relaxed);
         state.last_len.store(len as u32, Ordering::Relaxed);
         state.last_msg_type.store(msg_type, Ordering::Relaxed);
-        state
-            .last_src_mac
-            .store(pack_mac(src_addr), Ordering::Relaxed);
+        let (last_src_mac_hi, last_src_mac_lo) = pack_mac_words(src_addr);
+        state.last_src_mac_hi.store(last_src_mac_hi, Ordering::Relaxed);
+        state.last_src_mac_lo.store(last_src_mac_lo, Ordering::Relaxed);
         state.last_rssi_dbm.store(rssi_dbm, Ordering::Relaxed);
         let enqueued = {
             // Match try_lock errors explicitly: recover on Poisoned so
@@ -289,7 +290,8 @@ impl EspNowTransport {
                 enqueued_count: AtomicU32::new(0),
                 last_len: AtomicU32::new(0),
                 last_msg_type: AtomicU32::new(u32::MAX),
-                last_src_mac: AtomicU64::new(0),
+                last_src_mac_hi: AtomicU32::new(0),
+                last_src_mac_lo: AtomicU32::new(0),
                 last_rssi_dbm: AtomicI32::new(i32::MIN),
             })
             .map_err(|_| NodeError::Transport("recv callback already registered"))?;
@@ -322,7 +324,10 @@ impl EspNowTransport {
             let contention_drops = state.contention_drops.load(Ordering::Relaxed);
             let last_len = state.last_len.load(Ordering::Relaxed);
             let last_msg_type = state.last_msg_type.load(Ordering::Relaxed);
-            let last_src_mac = unpack_mac(state.last_src_mac.load(Ordering::Relaxed));
+            let last_src_mac = unpack_mac_words(
+                state.last_src_mac_hi.load(Ordering::Relaxed),
+                state.last_src_mac_lo.load(Ordering::Relaxed),
+            );
             let last_rssi_dbm = state.last_rssi_dbm.load(Ordering::Relaxed);
             log::info!(
                 "ESP-NOW diag snapshot label=\"{}\" callback_count={} enqueued_count={} ring_count={} contention_drops={} full_drops={} last_len={} last_msg_type={} last_src={:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} last_rssi_dbm={}",

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -176,8 +176,12 @@ unsafe extern "C" fn raw_recv_cb(
         state.last_len.store(len as u32, Ordering::Relaxed);
         state.last_msg_type.store(msg_type, Ordering::Relaxed);
         let (last_src_mac_hi, last_src_mac_lo) = pack_mac_words(src_addr);
-        state.last_src_mac_hi.store(last_src_mac_hi, Ordering::Relaxed);
-        state.last_src_mac_lo.store(last_src_mac_lo, Ordering::Relaxed);
+        state
+            .last_src_mac_hi
+            .store(last_src_mac_hi, Ordering::Relaxed);
+        state
+            .last_src_mac_lo
+            .store(last_src_mac_lo, Ordering::Relaxed);
         state.last_rssi_dbm.store(rssi_dbm, Ordering::Relaxed);
         let enqueued = {
             // Match try_lock errors explicitly: recover on Poisoned so

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -9,7 +9,7 @@
 //! callback, eliminating per-frame heap allocation from the WiFi task
 //! context.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Instant;
 
@@ -107,10 +107,36 @@ struct RecvState {
     rx_ring: Arc<Mutex<RxRing>>,
     condvar: Arc<Condvar>,
     contention_drops: AtomicU32,
+    callback_count: AtomicU32,
+    enqueued_count: AtomicU32,
+    last_len: AtomicU32,
+    last_msg_type: AtomicU32,
+    last_src_mac: AtomicU64,
+    last_rssi_dbm: AtomicI32,
 }
 
 /// Global callback state — set once during [`EspNowTransport::new`].
 static RECV_STATE: std::sync::OnceLock<RecvState> = std::sync::OnceLock::new();
+
+fn pack_mac(mac: [u8; 6]) -> u64 {
+    ((mac[0] as u64) << 40)
+        | ((mac[1] as u64) << 32)
+        | ((mac[2] as u64) << 24)
+        | ((mac[3] as u64) << 16)
+        | ((mac[4] as u64) << 8)
+        | (mac[5] as u64)
+}
+
+fn unpack_mac(packed: u64) -> [u8; 6] {
+    [
+        ((packed >> 40) & 0xFF) as u8,
+        ((packed >> 32) & 0xFF) as u8,
+        ((packed >> 24) & 0xFF) as u8,
+        ((packed >> 16) & 0xFF) as u8,
+        ((packed >> 8) & 0xFF) as u8,
+        (packed & 0xFF) as u8,
+    ]
+}
 
 /// Raw ESP-NOW receive callback — copies frame data into the ring buffer.
 ///
@@ -124,12 +150,34 @@ unsafe extern "C" fn raw_recv_cb(
     if recv_info.is_null() || data.is_null() || data_len <= 0 {
         return;
     }
+    let info = unsafe { &*recv_info };
+    if info.src_addr.is_null() {
+        return;
+    }
+    let src_addr = unsafe { *(info.src_addr as *const [u8; 6]) };
     let len = data_len as usize;
     if len > ESPNOW_MAX_DATA_SIZE {
         return;
     }
     let payload = unsafe { core::slice::from_raw_parts(data, len) };
+    let msg_type = payload
+        .get(sonde_protocol::OFFSET_MSG_TYPE)
+        .copied()
+        .map(u32::from)
+        .unwrap_or(u32::MAX);
+    let rssi_dbm = if info.rx_ctrl.is_null() {
+        i32::MIN
+    } else {
+        unsafe { (*info.rx_ctrl).rssi() as i32 }
+    };
     if let Some(state) = RECV_STATE.get() {
+        state.callback_count.fetch_add(1, Ordering::Relaxed);
+        state.last_len.store(len as u32, Ordering::Relaxed);
+        state.last_msg_type.store(msg_type, Ordering::Relaxed);
+        state
+            .last_src_mac
+            .store(pack_mac(src_addr), Ordering::Relaxed);
+        state.last_rssi_dbm.store(rssi_dbm, Ordering::Relaxed);
         let enqueued = {
             // Match try_lock errors explicitly: recover on Poisoned so
             // RX doesn't go permanently silent, only count WouldBlock
@@ -143,6 +191,7 @@ unsafe extern "C" fn raw_recv_cb(
                 Err(std::sync::TryLockError::Poisoned(p)) => p.into_inner(),
             };
             if guard.push(payload) {
+                state.enqueued_count.fetch_add(1, Ordering::Relaxed);
                 true
             } else {
                 guard.drop_count = guard.drop_count.saturating_add(1);
@@ -154,6 +203,14 @@ unsafe extern "C" fn raw_recv_cb(
         if enqueued {
             state.condvar.notify_one();
         }
+    }
+}
+
+fn format_msg_type(msg_type: u32) -> String {
+    if msg_type == u32::MAX {
+        "none".to_string()
+    } else {
+        format!("0x{:02x}", msg_type as u8)
     }
 }
 
@@ -228,6 +285,12 @@ impl EspNowTransport {
                 rx_ring: Arc::clone(&rx_ring),
                 condvar: Arc::clone(&rx_condvar),
                 contention_drops: AtomicU32::new(0),
+                callback_count: AtomicU32::new(0),
+                enqueued_count: AtomicU32::new(0),
+                last_len: AtomicU32::new(0),
+                last_msg_type: AtomicU32::new(u32::MAX),
+                last_src_mac: AtomicU64::new(0),
+                last_rssi_dbm: AtomicI32::new(i32::MIN),
             })
             .map_err(|_| NodeError::Transport("recv callback already registered"))?;
         unsafe {
@@ -242,6 +305,51 @@ impl EspNowTransport {
             rx_condvar,
             poison_warned: AtomicBool::new(false),
         })
+    }
+
+    pub fn log_recv_debug_snapshot(&self, label: &str) {
+        let ring = match self.rx_ring.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let ring_count = ring.count;
+        let full_drops = ring.drop_count;
+        drop(ring);
+
+        if let Some(state) = RECV_STATE.get() {
+            let callback_count = state.callback_count.load(Ordering::Relaxed);
+            let enqueued_count = state.enqueued_count.load(Ordering::Relaxed);
+            let contention_drops = state.contention_drops.load(Ordering::Relaxed);
+            let last_len = state.last_len.load(Ordering::Relaxed);
+            let last_msg_type = state.last_msg_type.load(Ordering::Relaxed);
+            let last_src_mac = unpack_mac(state.last_src_mac.load(Ordering::Relaxed));
+            let last_rssi_dbm = state.last_rssi_dbm.load(Ordering::Relaxed);
+            log::info!(
+                "ESP-NOW diag snapshot label=\"{}\" callback_count={} enqueued_count={} ring_count={} contention_drops={} full_drops={} last_len={} last_msg_type={} last_src={:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} last_rssi_dbm={}",
+                label,
+                callback_count,
+                enqueued_count,
+                ring_count,
+                contention_drops,
+                full_drops,
+                last_len,
+                format_msg_type(last_msg_type),
+                last_src_mac[0],
+                last_src_mac[1],
+                last_src_mac[2],
+                last_src_mac[3],
+                last_src_mac[4],
+                last_src_mac[5],
+                last_rssi_dbm
+            );
+        } else {
+            log::info!(
+                "ESP-NOW diag snapshot label=\"{}\" recv_state=uninitialized ring_count={} full_drops={}",
+                label,
+                ring_count,
+                full_drops
+            );
+        }
     }
 }
 
@@ -287,6 +395,17 @@ impl crate::traits::Transport for EspNowTransport {
                 if full_drops > 0 {
                     log::warn!("ESP-NOW recv ring: {} full drop(s)", full_drops);
                 }
+                let msg_type = buf
+                    .get(sonde_protocol::OFFSET_MSG_TYPE)
+                    .copied()
+                    .map(u32::from)
+                    .unwrap_or(u32::MAX);
+                log::info!(
+                    "ESP-NOW recv pop len={} msg_type={} timeout_ms={}",
+                    len,
+                    format_msg_type(msg_type),
+                    timeout_ms
+                );
                 return Ok(Some(buf[..len].to_vec()));
             }
             let now = Instant::now();
@@ -297,6 +416,7 @@ impl crate::traits::Transport for EspNowTransport {
                 if full_drops > 0 {
                     log::warn!("ESP-NOW recv ring: {} full drop(s)", full_drops);
                 }
+                log::info!("ESP-NOW recv timeout timeout_ms={}", timeout_ms);
                 return Ok(None);
             }
             let remaining = deadline - now;

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -552,7 +552,7 @@ async fn connect_node(
     let result: Result<ConnectedNodeSession<BtleplugTransport>, PairingError> =
         tokio::task::spawn_blocking(move || {
             tokio::runtime::Handle::current().block_on(async move {
-                reuse_or_connect_session(existing, addr, || BtleplugTransport::new()).await
+                reuse_or_connect_session(existing, addr, BtleplugTransport::new).await
             })
         })
         .await
@@ -591,8 +591,7 @@ async fn check_rssi(
 
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async move {
-            let session =
-                reuse_or_connect_session(session, addr, || BtleplugTransport::new()).await?;
+            let session = reuse_or_connect_session(session, addr, BtleplugTransport::new).await?;
             let mut session = session;
             let outcome =
                 phase2::check_rssi(&mut session.transport, &artifacts, &addr, cancel.as_ref())

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -198,10 +198,20 @@ where
 async fn finalize_signal_check<T: BleTransport>(
     mut session: ConnectedNodeSession<T>,
     outcome: Result<phase2::DiagnosticResult, PairingError>,
+    cancelled: &AtomicBool,
 ) -> (
     Option<ConnectedNodeSession<T>>,
     Result<DiagnosticInfo, PairingError>,
 ) {
+    if cancelled.load(Ordering::Relaxed) {
+        let _ = session.transport.disconnect().await;
+        return (
+            None,
+            Err(PairingError::Cancelled {
+                operation: "signal check",
+            }),
+        );
+    }
     match outcome {
         Ok(diag) => (
             Some(session),
@@ -209,6 +219,13 @@ async fn finalize_signal_check<T: BleTransport>(
                 rssi_dbm: diag.rssi_dbm,
                 signal_quality: diag.signal_quality,
             }),
+        ),
+        Err(PairingError::DiagnosticFailed(message)) => {
+            (Some(session), Err(PairingError::DiagnosticFailed(message)))
+        }
+        Err(PairingError::InvalidResponse { msg_type, reason }) => (
+            Some(session),
+            Err(PairingError::InvalidResponse { msg_type, reason }),
         ),
         Err(e) => {
             let _ = session.transport.disconnect().await;
@@ -596,7 +613,7 @@ async fn check_rssi(
             let outcome =
                 phase2::check_rssi(&mut session.transport, &artifacts, &addr, cancel.as_ref())
                     .await;
-            Ok::<_, PairingError>(finalize_signal_check(session, outcome).await)
+            Ok::<_, PairingError>(finalize_signal_check(session, outcome, cancel.as_ref()).await)
         })
     })
     .await
@@ -987,7 +1004,7 @@ async fn check_rssi(
             let outcome =
                 phase2::check_rssi(&mut session.transport, &artifacts, &addr, cancel.as_ref())
                     .await;
-            Ok::<_, PairingError>(finalize_signal_check(session, outcome).await)
+            Ok::<_, PairingError>(finalize_signal_check(session, outcome, cancel.as_ref()).await)
         })
     })
     .await
@@ -1521,10 +1538,11 @@ mod tests {
     }
 
     #[test]
-    fn finalize_signal_check_drops_failed_session() {
+    fn finalize_signal_check_retains_session_for_diagnostic_failure() {
         run_async_test(async {
             let disconnects = Arc::new(AtomicUsize::new(0));
             let stop_scans = Arc::new(AtomicUsize::new(0));
+            let cancelled = AtomicBool::new(false);
             let session = ConnectedNodeSession {
                 address: [0xAA; 6],
                 transport: CountingTransport::new(247, disconnects.clone(), stop_scans),
@@ -1532,12 +1550,40 @@ mod tests {
 
             let (session, outcome) = finalize_signal_check(
                 session,
-                Err(PairingError::DiagnosticFailed("reconnect failed".into())),
+                Err(PairingError::DiagnosticFailed("timed out".into())),
+                &cancelled,
+            )
+            .await;
+
+            assert!(session.is_some());
+            assert!(matches!(outcome, Err(PairingError::DiagnosticFailed(_))));
+            assert_eq!(disconnects.load(AtomicOrdering::Relaxed), 0);
+        });
+    }
+
+    #[test]
+    fn finalize_signal_check_drops_session_when_cancelled_late() {
+        run_async_test(async {
+            let disconnects = Arc::new(AtomicUsize::new(0));
+            let stop_scans = Arc::new(AtomicUsize::new(0));
+            let cancelled = AtomicBool::new(true);
+            let session = ConnectedNodeSession {
+                address: [0xAA; 6],
+                transport: CountingTransport::new(247, disconnects.clone(), stop_scans),
+            };
+
+            let (session, outcome) = finalize_signal_check(
+                session,
+                Ok(phase2::DiagnosticResult {
+                    rssi_dbm: -55,
+                    signal_quality: 0,
+                }),
+                &cancelled,
             )
             .await;
 
             assert!(session.is_none());
-            assert!(matches!(outcome, Err(PairingError::DiagnosticFailed(_))));
+            assert!(matches!(outcome, Err(PairingError::Cancelled { .. })));
             assert_eq!(disconnects.load(AtomicOrdering::Relaxed), 1);
         });
     }

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@
 //! non-Send futures from [`sonde_pair::transport::BleTransport`] work on
 //! the tokio multi-threaded runtime.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
@@ -50,6 +51,7 @@ struct AppState {
     connected_node: Mutex<Option<ConnectedNodeSession<BtleplugTransport>>>,
     #[cfg(target_os = "android")]
     connected_node: Mutex<Option<ConnectedNodeSession<AndroidBleTransport>>>,
+    signal_check_cancel: Mutex<Option<Arc<AtomicBool>>>,
     phase: Arc<Mutex<String>>,
     logs: Arc<Mutex<Vec<String>>>,
     /// Phase 1 AEAD artifacts, held in memory for Phase 2 provisioning.
@@ -503,6 +505,7 @@ async fn connect_node(
     match result {
         Ok(session) => {
             *state.connected_node.lock().unwrap() = Some(session);
+            *state.signal_check_cancel.lock().unwrap() = None;
             *state.phase.lock().unwrap() = "Connected".into();
             Ok(ConnectedNodeInfo { address })
         }
@@ -524,12 +527,20 @@ async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo,
         .unwrap()
         .take()
         .ok_or_else(|| "No connected node session".to_string())?;
+    let cancel = Arc::new(AtomicBool::new(false));
+    *state.signal_check_cancel.lock().unwrap() = Some(cancel.clone());
     *state.phase.lock().unwrap() = "Signal Check".into();
 
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async move {
             let mut session = session;
-            let outcome = phase2::check_rssi(&mut session.transport, &artifacts).await;
+            let outcome = phase2::check_rssi(
+                &mut session.transport,
+                &artifacts,
+                &session.address,
+                cancel.as_ref(),
+            )
+            .await;
             (session, outcome)
         })
     })
@@ -537,16 +548,30 @@ async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo,
     .map_err(|e| format!("task panicked: {e}"))?;
 
     let (session, outcome) = result;
-    *state.connected_node.lock().unwrap() = Some(session);
+    *state.signal_check_cancel.lock().unwrap() = None;
     match outcome {
         Ok(diag) => {
+            *state.connected_node.lock().unwrap() = Some(session);
             *state.phase.lock().unwrap() = "Connected".into();
             Ok(DiagnosticInfo {
                 rssi_dbm: diag.rssi_dbm,
                 signal_quality: diag.signal_quality,
             })
         }
+        Err(PairingError::Cancelled { .. }) => {
+            tokio::task::spawn_blocking(move || {
+                tokio::runtime::Handle::current().block_on(async move {
+                    let mut session = session;
+                    let _ = session.transport.disconnect().await;
+                })
+            })
+            .await
+            .map_err(|e| format!("task panicked: {e}"))?;
+            *state.phase.lock().unwrap() = "Idle".into();
+            Err("signal check cancelled".into())
+        }
         Err(e) => {
+            *state.connected_node.lock().unwrap() = Some(session);
             let msg = e.to_string();
             *state.phase.lock().unwrap() = format!("Error: {msg}");
             Err(msg)
@@ -557,6 +582,9 @@ async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo,
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
 async fn disconnect_node(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    if let Some(cancel) = state.signal_check_cancel.lock().unwrap().as_ref() {
+        cancel.store(true, Ordering::Relaxed);
+    }
     let session = state.connected_node.lock().unwrap().take();
     if let Some(session) = session {
         tokio::task::spawn_blocking(move || {
@@ -569,6 +597,7 @@ async fn disconnect_node(state: tauri::State<'_, AppState>) -> Result<(), String
         .map_err(|e| format!("task panicked: {e}"))?
         .map_err(|e| e.to_string())?;
     }
+    *state.signal_check_cancel.lock().unwrap() = None;
     *state.phase.lock().unwrap() = "Idle".into();
     Ok(())
 }
@@ -594,6 +623,9 @@ fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
 async fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    if let Some(cancel) = state.signal_check_cancel.lock().unwrap().as_ref() {
+        cancel.store(true, Ordering::Relaxed);
+    }
     let session = state.connected_node.lock().unwrap().take();
     if let Some(session) = session {
         tokio::task::spawn_blocking(move || {
@@ -606,6 +638,7 @@ async fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> 
         .map_err(|e| format!("task panicked: {e}"))?
         .map_err(|e| e.to_string())?;
     }
+    *state.signal_check_cancel.lock().unwrap() = None;
     *state.pairing_artifacts.lock().unwrap() = None;
     let store = FilePairingStore::new().map_err(|e| e.to_string())?;
     store.clear().map_err(|e| e.to_string())?;
@@ -893,6 +926,7 @@ async fn connect_node(
     match result {
         Ok(session) => {
             *state.connected_node.lock().unwrap() = Some(session);
+            *state.signal_check_cancel.lock().unwrap() = None;
             *state.phase.lock().unwrap() = "Connected".into();
             Ok(ConnectedNodeInfo { address })
         }
@@ -914,12 +948,20 @@ async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo,
         .unwrap()
         .take()
         .ok_or_else(|| "No connected node session".to_string())?;
+    let cancel = Arc::new(AtomicBool::new(false));
+    *state.signal_check_cancel.lock().unwrap() = Some(cancel.clone());
     *state.phase.lock().unwrap() = "Signal Check".into();
 
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async move {
             let mut session = session;
-            let outcome = phase2::check_rssi(&mut session.transport, &artifacts).await;
+            let outcome = phase2::check_rssi(
+                &mut session.transport,
+                &artifacts,
+                &session.address,
+                cancel.as_ref(),
+            )
+            .await;
             (session, outcome)
         })
     })
@@ -927,16 +969,30 @@ async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo,
     .map_err(|e| format!("task panicked: {e}"))?;
 
     let (session, outcome) = result;
-    *state.connected_node.lock().unwrap() = Some(session);
+    *state.signal_check_cancel.lock().unwrap() = None;
     match outcome {
         Ok(diag) => {
+            *state.connected_node.lock().unwrap() = Some(session);
             *state.phase.lock().unwrap() = "Connected".into();
             Ok(DiagnosticInfo {
                 rssi_dbm: diag.rssi_dbm,
                 signal_quality: diag.signal_quality,
             })
         }
+        Err(PairingError::Cancelled { .. }) => {
+            tokio::task::spawn_blocking(move || {
+                tokio::runtime::Handle::current().block_on(async move {
+                    let mut session = session;
+                    let _ = session.transport.disconnect().await;
+                })
+            })
+            .await
+            .map_err(|e| format!("task panicked: {e}"))?;
+            *state.phase.lock().unwrap() = "Idle".into();
+            Err("signal check cancelled".into())
+        }
         Err(e) => {
+            *state.connected_node.lock().unwrap() = Some(session);
             let msg = e.to_string();
             *state.phase.lock().unwrap() = format!("Error: {msg}");
             Err(msg)
@@ -947,6 +1003,9 @@ async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo,
 #[cfg(target_os = "android")]
 #[tauri::command]
 async fn disconnect_node(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    if let Some(cancel) = state.signal_check_cancel.lock().unwrap().as_ref() {
+        cancel.store(true, Ordering::Relaxed);
+    }
     let session = state.connected_node.lock().unwrap().take();
     if let Some(session) = session {
         tokio::task::spawn_blocking(move || {
@@ -959,6 +1018,7 @@ async fn disconnect_node(state: tauri::State<'_, AppState>) -> Result<(), String
         .map_err(|e| format!("task panicked: {e}"))?
         .map_err(|e| e.to_string())?;
     }
+    *state.signal_check_cancel.lock().unwrap() = None;
     *state.phase.lock().unwrap() = "Idle".into();
     Ok(())
 }
@@ -984,6 +1044,9 @@ fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus
 #[cfg(target_os = "android")]
 #[tauri::command]
 async fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    if let Some(cancel) = state.signal_check_cancel.lock().unwrap().as_ref() {
+        cancel.store(true, Ordering::Relaxed);
+    }
     let session = state.connected_node.lock().unwrap().take();
     if let Some(session) = session {
         tokio::task::spawn_blocking(move || {
@@ -998,6 +1061,7 @@ async fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> 
     }
     let mut store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
     store.clear().map_err(|e| e.to_string())?;
+    *state.signal_check_cancel.lock().unwrap() = None;
     *state.pairing_artifacts.lock().unwrap() = None;
     *state.phase.lock().unwrap() = "Idle".into();
     Ok(())
@@ -1015,6 +1079,13 @@ fn get_phase(state: tauri::State<'_, AppState>) -> String {
 #[tauri::command]
 fn get_logs(state: tauri::State<'_, AppState>) -> Vec<String> {
     std::mem::take(&mut *state.logs.lock().unwrap())
+}
+
+#[tauri::command]
+fn cancel_signal_check(state: tauri::State<'_, AppState>) {
+    if let Some(cancel) = state.signal_check_cancel.lock().unwrap().as_ref() {
+        cancel.store(true, Ordering::Relaxed);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1155,6 +1226,7 @@ pub fn run() {
     let state = AppState {
         scanner: Mutex::new(None),
         connected_node: Mutex::new(None),
+        signal_check_cancel: Mutex::new(None),
         phase: Arc::new(Mutex::new("Idle".into())),
         logs,
         pairing_artifacts: Mutex::new(None),
@@ -1175,6 +1247,7 @@ pub fn run() {
             get_pairing_status,
             clear_pairing,
             get_logs,
+            cancel_signal_check,
         ])
         .run(tauri::generate_context!())
         .expect("error running Sonde Pairing Tool");

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use sonde_pair::discovery::{service_type, DeviceScanner, ServiceType};
 use sonde_pair::phase1::PairingProgress;
 use sonde_pair::rng::OsRng;
+use sonde_pair::transport::BleTransport;
 use sonde_pair::types::{BoardLayout, ScannedDevice};
 use sonde_pair::{phase1, phase2};
 
@@ -44,10 +45,19 @@ struct AppState {
     scanner: Mutex<Option<DeviceScanner<BtleplugTransport>>>,
     #[cfg(target_os = "android")]
     scanner: Mutex<Option<DeviceScanner<AndroidBleTransport>>>,
+    #[cfg(not(target_os = "android"))]
+    connected_node: Mutex<Option<ConnectedNodeSession<BtleplugTransport>>>,
+    #[cfg(target_os = "android")]
+    connected_node: Mutex<Option<ConnectedNodeSession<AndroidBleTransport>>>,
     phase: Arc<Mutex<String>>,
     logs: Arc<Mutex<Vec<String>>>,
     /// Phase 1 AEAD artifacts, held in memory for Phase 2 provisioning.
     pairing_artifacts: Mutex<Option<Arc<phase1::PairingArtifacts>>>,
+}
+
+struct ConnectedNodeSession<T> {
+    address: [u8; 6],
+    transport: T,
 }
 
 /// Reports Phase 1 sub-phase transitions to the UI via the shared `phase` mutex.
@@ -77,6 +87,18 @@ struct DeviceInfo {
 struct PairingStatus {
     paired: bool,
     gateway_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ConnectedNodeInfo {
+    address: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticInfo {
+    rssi_dbm: i8,
+    signal_quality: u8,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -176,6 +198,42 @@ fn device_to_info(d: &ScannedDevice) -> DeviceInfo {
             None => "Unknown".into(),
         },
     }
+}
+
+#[cfg(not(target_os = "android"))]
+fn load_pairing_artifacts(state: &AppState) -> Result<Arc<phase1::PairingArtifacts>, String> {
+    let mut guard = state.pairing_artifacts.lock().unwrap();
+    if guard.is_none() {
+        let store = FilePairingStore::new().map_err(|e| e.to_string())?;
+        match store.load_artifacts() {
+            Ok(Some(loaded)) => {
+                *guard = Some(Arc::new(loaded));
+            }
+            Ok(None) => {}
+            Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
+        }
+    }
+    guard
+        .clone()
+        .ok_or_else(|| "Not paired — run pair_gateway first".to_string())
+}
+
+#[cfg(target_os = "android")]
+fn load_pairing_artifacts(state: &AppState) -> Result<Arc<phase1::PairingArtifacts>, String> {
+    let mut guard = state.pairing_artifacts.lock().unwrap();
+    if guard.is_none() {
+        let store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
+        match store.load_artifacts() {
+            Ok(Some(loaded)) => {
+                *guard = Some(Arc::new(loaded));
+            }
+            Ok(None) => {}
+            Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
+        }
+    }
+    guard
+        .clone()
+        .ok_or_else(|| "Not paired — run pair_gateway first".to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -327,41 +385,55 @@ async fn provision_node(
     };
 
     let board_layout = resolve_board_layout(board_layout, i2c_sda, i2c_scl)?;
-
-    // Load artifacts from in-memory cache, falling back to file store.
-    let artifacts = {
-        let mut guard = state.pairing_artifacts.lock().unwrap();
-        if guard.is_none() {
-            let store = FilePairingStore::new().map_err(|e| e.to_string())?;
-            match store.load_artifacts() {
-                Ok(Some(loaded)) => {
-                    *guard = Some(Arc::new(loaded));
-                }
-                Ok(None) => {}
-                Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
-            }
-        }
-        guard
-            .clone()
-            .ok_or_else(|| "Not paired — run pair_gateway first".to_string())?
-    };
+    let artifacts = load_pairing_artifacts(&state)?;
 
     *state.phase.lock().unwrap() = "Provisioning".into();
-
+    let session = state.connected_node.lock().unwrap().take();
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async {
-            let mut transport = BtleplugTransport::new().await?;
             let rng = OsRng;
-            phase2::provision_node(
-                &mut transport,
-                &artifacts,
-                &rng,
-                &addr,
-                &node_id,
-                &[],
-                board_layout,
-            )
-            .await
+            match session {
+                Some(mut session) if session.address == addr => {
+                    let result = phase2::provision_connected_node(
+                        &mut session.transport,
+                        &artifacts,
+                        &rng,
+                        &node_id,
+                        &[],
+                        board_layout,
+                    )
+                    .await;
+                    let _ = session.transport.disconnect().await;
+                    result
+                }
+                Some(mut session) => {
+                    let _ = session.transport.disconnect().await;
+                    let mut transport = BtleplugTransport::new().await?;
+                    phase2::provision_node(
+                        &mut transport,
+                        &artifacts,
+                        &rng,
+                        &addr,
+                        &node_id,
+                        &[],
+                        board_layout,
+                    )
+                    .await
+                }
+                None => {
+                    let mut transport = BtleplugTransport::new().await?;
+                    phase2::provision_node(
+                        &mut transport,
+                        &artifacts,
+                        &rng,
+                        &addr,
+                        &node_id,
+                        &[],
+                        board_layout,
+                    )
+                    .await
+                }
+            }
         })
     })
     .await
@@ -378,6 +450,116 @@ async fn provision_node(
             Err(msg)
         }
     }
+}
+
+#[cfg(not(target_os = "android"))]
+#[tauri::command]
+async fn connect_node(
+    state: tauri::State<'_, AppState>,
+    address: String,
+) -> Result<ConnectedNodeInfo, String> {
+    *state.scanner.lock().unwrap() = None;
+
+    let addr = parse_address(&address).map_err(|e| {
+        *state.phase.lock().unwrap() = format!("Error: {e}");
+        e
+    })?;
+    let existing = state.connected_node.lock().unwrap().take();
+    *state.phase.lock().unwrap() = "Connecting".into();
+
+    let result: Result<ConnectedNodeSession<BtleplugTransport>, sonde_pair::error::PairingError> =
+        tokio::task::spawn_blocking(move || {
+            tokio::runtime::Handle::current().block_on(async move {
+                if let Some(mut session) = existing {
+                    if session.address == addr {
+                        return Ok(session);
+                    }
+                    let _ = session.transport.disconnect().await;
+                }
+
+                let mut transport = BtleplugTransport::new().await?;
+                transport.set_defer_bonding(true);
+                transport.connect(&addr).await?;
+                Ok::<_, sonde_pair::error::PairingError>(ConnectedNodeSession {
+                    address: addr,
+                    transport,
+                })
+            })
+        })
+        .await
+        .map_err(|e| format!("task panicked: {e}"))?;
+
+    match result {
+        Ok(session) => {
+            *state.connected_node.lock().unwrap() = Some(session);
+            *state.phase.lock().unwrap() = "Connected".into();
+            Ok(ConnectedNodeInfo { address })
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            *state.phase.lock().unwrap() = format!("Error: {msg}");
+            Err(msg)
+        }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+#[tauri::command]
+async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo, String> {
+    let session = state
+        .connected_node
+        .lock()
+        .unwrap()
+        .take()
+        .ok_or_else(|| "No connected node session".to_string())?;
+    let artifacts = load_pairing_artifacts(&state)?;
+    *state.phase.lock().unwrap() = "Signal Check".into();
+
+    let result = tokio::task::spawn_blocking(move || {
+        tokio::runtime::Handle::current().block_on(async move {
+            let mut session = session;
+            let outcome = phase2::check_rssi(&mut session.transport, &artifacts).await;
+            (session, outcome)
+        })
+    })
+    .await
+    .map_err(|e| format!("task panicked: {e}"))?;
+
+    let (session, outcome) = result;
+    *state.connected_node.lock().unwrap() = Some(session);
+    match outcome {
+        Ok(diag) => {
+            *state.phase.lock().unwrap() = "Connected".into();
+            Ok(DiagnosticInfo {
+                rssi_dbm: diag.rssi_dbm,
+                signal_quality: diag.signal_quality,
+            })
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            *state.phase.lock().unwrap() = format!("Error: {msg}");
+            Err(msg)
+        }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+#[tauri::command]
+async fn disconnect_node(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let session = state.connected_node.lock().unwrap().take();
+    if let Some(session) = session {
+        tokio::task::spawn_blocking(move || {
+            tokio::runtime::Handle::current().block_on(async move {
+                let mut session = session;
+                session.transport.disconnect().await
+            })
+        })
+        .await
+        .map_err(|e| format!("task panicked: {e}"))?
+        .map_err(|e| e.to_string())?;
+    }
+    *state.phase.lock().unwrap() = "Idle".into();
+    Ok(())
 }
 
 #[cfg(not(target_os = "android"))]
@@ -400,7 +582,19 @@ fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus
 
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
-fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
+async fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let session = state.connected_node.lock().unwrap().take();
+    if let Some(session) = session {
+        tokio::task::spawn_blocking(move || {
+            tokio::runtime::Handle::current().block_on(async move {
+                let mut session = session;
+                session.transport.disconnect().await
+            })
+        })
+        .await
+        .map_err(|e| format!("task panicked: {e}"))?
+        .map_err(|e| e.to_string())?;
+    }
     *state.pairing_artifacts.lock().unwrap() = None;
     let store = FilePairingStore::new().map_err(|e| e.to_string())?;
     store.clear().map_err(|e| e.to_string())?;
@@ -571,41 +765,55 @@ async fn provision_node(
     };
 
     let board_layout = resolve_board_layout(board_layout, i2c_sda, i2c_scl)?;
-
-    // Load artifacts from in-memory cache, falling back to Android secure storage.
-    let artifacts = {
-        let mut guard = state.pairing_artifacts.lock().unwrap();
-        if guard.is_none() {
-            let store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
-            match store.load_artifacts() {
-                Ok(Some(loaded)) => {
-                    *guard = Some(Arc::new(loaded));
-                }
-                Ok(None) => {}
-                Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
-            }
-        }
-        guard
-            .clone()
-            .ok_or_else(|| "Not paired — run pair_gateway first".to_string())?
-    };
+    let artifacts = load_pairing_artifacts(&state)?;
 
     *state.phase.lock().unwrap() = "Provisioning".into();
-
+    let session = state.connected_node.lock().unwrap().take();
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async {
-            let mut transport = AndroidBleTransport::from_cached_vm()?;
             let rng = OsRng;
-            phase2::provision_node(
-                &mut transport,
-                &artifacts,
-                &rng,
-                &addr,
-                &node_id,
-                &[],
-                board_layout,
-            )
-            .await
+            match session {
+                Some(mut session) if session.address == addr => {
+                    let result = phase2::provision_connected_node(
+                        &mut session.transport,
+                        &artifacts,
+                        &rng,
+                        &node_id,
+                        &[],
+                        board_layout,
+                    )
+                    .await;
+                    let _ = session.transport.disconnect().await;
+                    result
+                }
+                Some(mut session) => {
+                    let _ = session.transport.disconnect().await;
+                    let mut transport = AndroidBleTransport::from_cached_vm()?;
+                    phase2::provision_node(
+                        &mut transport,
+                        &artifacts,
+                        &rng,
+                        &addr,
+                        &node_id,
+                        &[],
+                        board_layout,
+                    )
+                    .await
+                }
+                None => {
+                    let mut transport = AndroidBleTransport::from_cached_vm()?;
+                    phase2::provision_node(
+                        &mut transport,
+                        &artifacts,
+                        &rng,
+                        &addr,
+                        &node_id,
+                        &[],
+                        board_layout,
+                    )
+                    .await
+                }
+            }
         })
     })
     .await
@@ -622,6 +830,116 @@ async fn provision_node(
             Err(msg)
         }
     }
+}
+
+#[cfg(target_os = "android")]
+#[tauri::command]
+async fn connect_node(
+    state: tauri::State<'_, AppState>,
+    address: String,
+) -> Result<ConnectedNodeInfo, String> {
+    *state.scanner.lock().unwrap() = None;
+
+    let addr = parse_address(&address).map_err(|e| {
+        *state.phase.lock().unwrap() = format!("Error: {e}");
+        e
+    })?;
+    let existing = state.connected_node.lock().unwrap().take();
+    *state.phase.lock().unwrap() = "Connecting".into();
+
+    let result: Result<ConnectedNodeSession<AndroidBleTransport>, sonde_pair::error::PairingError> =
+        tokio::task::spawn_blocking(move || {
+            tokio::runtime::Handle::current().block_on(async move {
+                if let Some(mut session) = existing {
+                    if session.address == addr {
+                        return Ok(session);
+                    }
+                    let _ = session.transport.disconnect().await;
+                }
+
+                let mut transport = AndroidBleTransport::from_cached_vm()?;
+                transport.set_defer_bonding(true);
+                transport.connect(&addr).await?;
+                Ok::<_, sonde_pair::error::PairingError>(ConnectedNodeSession {
+                    address: addr,
+                    transport,
+                })
+            })
+        })
+        .await
+        .map_err(|e| format!("task panicked: {e}"))?;
+
+    match result {
+        Ok(session) => {
+            *state.connected_node.lock().unwrap() = Some(session);
+            *state.phase.lock().unwrap() = "Connected".into();
+            Ok(ConnectedNodeInfo { address })
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            *state.phase.lock().unwrap() = format!("Error: {msg}");
+            Err(msg)
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+#[tauri::command]
+async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo, String> {
+    let session = state
+        .connected_node
+        .lock()
+        .unwrap()
+        .take()
+        .ok_or_else(|| "No connected node session".to_string())?;
+    let artifacts = load_pairing_artifacts(&state)?;
+    *state.phase.lock().unwrap() = "Signal Check".into();
+
+    let result = tokio::task::spawn_blocking(move || {
+        tokio::runtime::Handle::current().block_on(async move {
+            let mut session = session;
+            let outcome = phase2::check_rssi(&mut session.transport, &artifacts).await;
+            (session, outcome)
+        })
+    })
+    .await
+    .map_err(|e| format!("task panicked: {e}"))?;
+
+    let (session, outcome) = result;
+    *state.connected_node.lock().unwrap() = Some(session);
+    match outcome {
+        Ok(diag) => {
+            *state.phase.lock().unwrap() = "Connected".into();
+            Ok(DiagnosticInfo {
+                rssi_dbm: diag.rssi_dbm,
+                signal_quality: diag.signal_quality,
+            })
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            *state.phase.lock().unwrap() = format!("Error: {msg}");
+            Err(msg)
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+#[tauri::command]
+async fn disconnect_node(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let session = state.connected_node.lock().unwrap().take();
+    if let Some(session) = session {
+        tokio::task::spawn_blocking(move || {
+            tokio::runtime::Handle::current().block_on(async move {
+                let mut session = session;
+                session.transport.disconnect().await
+            })
+        })
+        .await
+        .map_err(|e| format!("task panicked: {e}"))?
+        .map_err(|e| e.to_string())?;
+    }
+    *state.phase.lock().unwrap() = "Idle".into();
+    Ok(())
 }
 
 #[cfg(target_os = "android")]
@@ -644,7 +962,19 @@ fn get_pairing_status(state: tauri::State<'_, AppState>) -> Result<PairingStatus
 
 #[cfg(target_os = "android")]
 #[tauri::command]
-fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
+async fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> {
+    let session = state.connected_node.lock().unwrap().take();
+    if let Some(session) = session {
+        tokio::task::spawn_blocking(move || {
+            tokio::runtime::Handle::current().block_on(async move {
+                let mut session = session;
+                session.transport.disconnect().await
+            })
+        })
+        .await
+        .map_err(|e| format!("task panicked: {e}"))?
+        .map_err(|e| e.to_string())?;
+    }
     let mut store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
     store.clear().map_err(|e| e.to_string())?;
     *state.pairing_artifacts.lock().unwrap() = None;
@@ -803,6 +1133,7 @@ pub fn run() {
 
     let state = AppState {
         scanner: Mutex::new(None),
+        connected_node: Mutex::new(None),
         phase: Arc::new(Mutex::new("Idle".into())),
         logs,
         pairing_artifacts: Mutex::new(None),
@@ -815,6 +1146,9 @@ pub fn run() {
             stop_scan,
             get_devices,
             pair_gateway,
+            connect_node,
+            check_rssi,
+            disconnect_node,
             provision_node,
             get_phase,
             get_pairing_status,

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@
 //! non-Send futures from [`sonde_pair::transport::BleTransport`] work on
 //! the tokio multi-threaded runtime.
 
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -138,6 +139,84 @@ fn parse_address(s: &str) -> Result<[u8; 6], String> {
     Ok(addr)
 }
 
+async fn stop_and_discard_scanner<T>(
+    scanner_slot: &Mutex<Option<DeviceScanner<T>>>,
+) -> Result<(), String>
+where
+    T: BleTransport + Send + 'static,
+{
+    let scanner = scanner_slot.lock().unwrap().take();
+    if let Some(scanner) = scanner {
+        tokio::task::spawn_blocking(move || {
+            tokio::runtime::Handle::current().block_on(async move {
+                let mut scanner = scanner;
+                scanner.stop().await.map_err(|e| e.to_string())
+            })
+        })
+        .await
+        .map_err(|e| format!("task panicked: {e}"))??;
+    }
+    Ok(())
+}
+
+async fn reuse_or_connect_session<T, F, Fut>(
+    existing: Option<ConnectedNodeSession<T>>,
+    addr: [u8; 6],
+    create_transport: F,
+) -> Result<ConnectedNodeSession<T>, PairingError>
+where
+    T: BleTransport,
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<T, PairingError>>,
+{
+    if let Some(mut session) = existing {
+        if session.address == addr {
+            return Ok(session);
+        }
+        let _ = session.transport.disconnect().await;
+    }
+
+    let mut transport = create_transport().await?;
+    transport.set_defer_bonding(true);
+    let mtu_result = transport.connect(&addr).await;
+    transport.set_defer_bonding(false);
+    let mtu = mtu_result?;
+    if mtu < BLE_MTU_MIN {
+        transport.disconnect().await.ok();
+        return Err(PairingError::MtuTooLow {
+            device: format_address(&addr),
+            negotiated: mtu,
+            required: BLE_MTU_MIN,
+        });
+    }
+    Ok(ConnectedNodeSession {
+        address: addr,
+        transport,
+    })
+}
+
+async fn finalize_signal_check<T: BleTransport>(
+    mut session: ConnectedNodeSession<T>,
+    outcome: Result<phase2::DiagnosticResult, PairingError>,
+) -> (
+    Option<ConnectedNodeSession<T>>,
+    Result<DiagnosticInfo, PairingError>,
+) {
+    match outcome {
+        Ok(diag) => (
+            Some(session),
+            Ok(DiagnosticInfo {
+                rssi_dbm: diag.rssi_dbm,
+                signal_quality: diag.signal_quality,
+            }),
+        ),
+        Err(e) => {
+            let _ = session.transport.disconnect().await;
+            (None, Err(e))
+        }
+    }
+}
+
 fn resolve_legacy_i2c_layout(
     i2c_sda: Option<u8>,
     i2c_scl: Option<u8>,
@@ -246,7 +325,7 @@ fn load_pairing_artifacts(state: &AppState) -> Result<Arc<phase1::PairingArtifac
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
 async fn start_scan(state: tauri::State<'_, AppState>) -> Result<(), String> {
-    *state.scanner.lock().unwrap() = None;
+    stop_and_discard_scanner(&state.scanner).await?;
     *state.phase.lock().unwrap() = "Scanning".into();
 
     let scanner = tokio::task::spawn_blocking(|| {
@@ -320,7 +399,7 @@ async fn pair_gateway(
     phone_label: String,
     _force: Option<bool>,
 ) -> Result<(), String> {
-    *state.scanner.lock().unwrap() = None;
+    stop_and_discard_scanner(&state.scanner).await?;
 
     let addr = match parse_address(&address) {
         Ok(a) => a,
@@ -377,7 +456,7 @@ async fn provision_node(
     i2c_sda: Option<u8>,
     i2c_scl: Option<u8>,
 ) -> Result<String, String> {
-    *state.scanner.lock().unwrap() = None;
+    stop_and_discard_scanner(&state.scanner).await?;
 
     let addr = match parse_address(&address) {
         Ok(a) => a,
@@ -461,7 +540,7 @@ async fn connect_node(
     state: tauri::State<'_, AppState>,
     address: String,
 ) -> Result<ConnectedNodeInfo, String> {
-    *state.scanner.lock().unwrap() = None;
+    stop_and_discard_scanner(&state.scanner).await?;
 
     let addr = parse_address(&address).map_err(|e| {
         *state.phase.lock().unwrap() = format!("Error: {e}");
@@ -473,30 +552,7 @@ async fn connect_node(
     let result: Result<ConnectedNodeSession<BtleplugTransport>, PairingError> =
         tokio::task::spawn_blocking(move || {
             tokio::runtime::Handle::current().block_on(async move {
-                if let Some(mut session) = existing {
-                    if session.address == addr {
-                        return Ok(session);
-                    }
-                    let _ = session.transport.disconnect().await;
-                }
-
-                let mut transport = BtleplugTransport::new().await?;
-                transport.set_defer_bonding(true);
-                let mtu_result = transport.connect(&addr).await;
-                transport.set_defer_bonding(false);
-                let mtu = mtu_result?;
-                if mtu < BLE_MTU_MIN {
-                    transport.disconnect().await.ok();
-                    return Err(PairingError::MtuTooLow {
-                        device: format_address(&addr),
-                        negotiated: mtu,
-                        required: BLE_MTU_MIN,
-                    });
-                }
-                Ok::<_, PairingError>(ConnectedNodeSession {
-                    address: addr,
-                    transport,
-                })
+                reuse_or_connect_session(existing, addr, || BtleplugTransport::new()).await
             })
         })
         .await
@@ -519,59 +575,47 @@ async fn connect_node(
 
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
-async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo, String> {
+async fn check_rssi(
+    state: tauri::State<'_, AppState>,
+    address: String,
+) -> Result<DiagnosticInfo, String> {
     let artifacts = load_pairing_artifacts(&state)?;
-    let session = state
-        .connected_node
-        .lock()
-        .unwrap()
-        .take()
-        .ok_or_else(|| "No connected node session".to_string())?;
+    let addr = parse_address(&address).map_err(|e| {
+        *state.phase.lock().unwrap() = format!("Error: {e}");
+        e
+    })?;
+    let session = state.connected_node.lock().unwrap().take();
     let cancel = Arc::new(AtomicBool::new(false));
     *state.signal_check_cancel.lock().unwrap() = Some(cancel.clone());
     *state.phase.lock().unwrap() = "Signal Check".into();
 
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async move {
+            let session =
+                reuse_or_connect_session(session, addr, || BtleplugTransport::new()).await?;
             let mut session = session;
-            let outcome = phase2::check_rssi(
-                &mut session.transport,
-                &artifacts,
-                &session.address,
-                cancel.as_ref(),
-            )
-            .await;
-            (session, outcome)
+            let outcome =
+                phase2::check_rssi(&mut session.transport, &artifacts, &addr, cancel.as_ref())
+                    .await;
+            Ok::<_, PairingError>(finalize_signal_check(session, outcome).await)
         })
     })
     .await
     .map_err(|e| format!("task panicked: {e}"))?;
 
-    let (session, outcome) = result;
+    let (session, outcome) = result.map_err(|e| e.to_string())?;
     *state.signal_check_cancel.lock().unwrap() = None;
+    *state.connected_node.lock().unwrap() = session;
     match outcome {
         Ok(diag) => {
-            *state.connected_node.lock().unwrap() = Some(session);
             *state.phase.lock().unwrap() = "Connected".into();
-            Ok(DiagnosticInfo {
-                rssi_dbm: diag.rssi_dbm,
-                signal_quality: diag.signal_quality,
-            })
+            Ok(diag)
         }
         Err(PairingError::Cancelled { .. }) => {
-            tokio::task::spawn_blocking(move || {
-                tokio::runtime::Handle::current().block_on(async move {
-                    let mut session = session;
-                    let _ = session.transport.disconnect().await;
-                })
-            })
-            .await
-            .map_err(|e| format!("task panicked: {e}"))?;
             *state.phase.lock().unwrap() = "Idle".into();
             Err("signal check cancelled".into())
         }
         Err(e) => {
-            *state.connected_node.lock().unwrap() = Some(session);
             let msg = e.to_string();
             *state.phase.lock().unwrap() = format!("Error: {msg}");
             Err(msg)
@@ -653,7 +697,7 @@ async fn clear_pairing(state: tauri::State<'_, AppState>) -> Result<(), String> 
 #[cfg(target_os = "android")]
 #[tauri::command]
 async fn start_scan(state: tauri::State<'_, AppState>) -> Result<(), String> {
-    *state.scanner.lock().unwrap() = None;
+    stop_and_discard_scanner(&state.scanner).await?;
     *state.phase.lock().unwrap() = "Scanning".into();
 
     let scanner = tokio::task::spawn_blocking(|| {
@@ -727,7 +771,7 @@ async fn pair_gateway(
     phone_label: String,
     _force: Option<bool>,
 ) -> Result<(), String> {
-    *state.scanner.lock().unwrap() = None;
+    stop_and_discard_scanner(&state.scanner).await?;
 
     let addr = match parse_address(&address) {
         Ok(a) => a,
@@ -798,7 +842,7 @@ async fn provision_node(
     i2c_sda: Option<u8>,
     i2c_scl: Option<u8>,
 ) -> Result<String, String> {
-    *state.scanner.lock().unwrap() = None;
+    stop_and_discard_scanner(&state.scanner).await?;
 
     let addr = match parse_address(&address) {
         Ok(a) => a,
@@ -882,7 +926,7 @@ async fn connect_node(
     state: tauri::State<'_, AppState>,
     address: String,
 ) -> Result<ConnectedNodeInfo, String> {
-    *state.scanner.lock().unwrap() = None;
+    stop_and_discard_scanner(&state.scanner).await?;
 
     let addr = parse_address(&address).map_err(|e| {
         *state.phase.lock().unwrap() = format!("Error: {e}");
@@ -894,30 +938,10 @@ async fn connect_node(
     let result: Result<ConnectedNodeSession<AndroidBleTransport>, PairingError> =
         tokio::task::spawn_blocking(move || {
             tokio::runtime::Handle::current().block_on(async move {
-                if let Some(mut session) = existing {
-                    if session.address == addr {
-                        return Ok(session);
-                    }
-                    let _ = session.transport.disconnect().await;
-                }
-
-                let mut transport = AndroidBleTransport::from_cached_vm()?;
-                transport.set_defer_bonding(true);
-                let mtu_result = transport.connect(&addr).await;
-                transport.set_defer_bonding(false);
-                let mtu = mtu_result?;
-                if mtu < BLE_MTU_MIN {
-                    transport.disconnect().await.ok();
-                    return Err(PairingError::MtuTooLow {
-                        device: format_address(&addr),
-                        negotiated: mtu,
-                        required: BLE_MTU_MIN,
-                    });
-                }
-                Ok::<_, PairingError>(ConnectedNodeSession {
-                    address: addr,
-                    transport,
+                reuse_or_connect_session(existing, addr, || async {
+                    AndroidBleTransport::from_cached_vm()
                 })
+                .await
             })
         })
         .await
@@ -940,59 +964,49 @@ async fn connect_node(
 
 #[cfg(target_os = "android")]
 #[tauri::command]
-async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo, String> {
+async fn check_rssi(
+    state: tauri::State<'_, AppState>,
+    address: String,
+) -> Result<DiagnosticInfo, String> {
     let artifacts = load_pairing_artifacts(&state)?;
-    let session = state
-        .connected_node
-        .lock()
-        .unwrap()
-        .take()
-        .ok_or_else(|| "No connected node session".to_string())?;
+    let addr = parse_address(&address).map_err(|e| {
+        *state.phase.lock().unwrap() = format!("Error: {e}");
+        e
+    })?;
+    let session = state.connected_node.lock().unwrap().take();
     let cancel = Arc::new(AtomicBool::new(false));
     *state.signal_check_cancel.lock().unwrap() = Some(cancel.clone());
     *state.phase.lock().unwrap() = "Signal Check".into();
 
     let result = tokio::task::spawn_blocking(move || {
         tokio::runtime::Handle::current().block_on(async move {
+            let session = reuse_or_connect_session(session, addr, || async {
+                AndroidBleTransport::from_cached_vm()
+            })
+            .await?;
             let mut session = session;
-            let outcome = phase2::check_rssi(
-                &mut session.transport,
-                &artifacts,
-                &session.address,
-                cancel.as_ref(),
-            )
-            .await;
-            (session, outcome)
+            let outcome =
+                phase2::check_rssi(&mut session.transport, &artifacts, &addr, cancel.as_ref())
+                    .await;
+            Ok::<_, PairingError>(finalize_signal_check(session, outcome).await)
         })
     })
     .await
     .map_err(|e| format!("task panicked: {e}"))?;
 
-    let (session, outcome) = result;
+    let (session, outcome) = result.map_err(|e| e.to_string())?;
     *state.signal_check_cancel.lock().unwrap() = None;
+    *state.connected_node.lock().unwrap() = session;
     match outcome {
         Ok(diag) => {
-            *state.connected_node.lock().unwrap() = Some(session);
             *state.phase.lock().unwrap() = "Connected".into();
-            Ok(DiagnosticInfo {
-                rssi_dbm: diag.rssi_dbm,
-                signal_quality: diag.signal_quality,
-            })
+            Ok(diag)
         }
         Err(PairingError::Cancelled { .. }) => {
-            tokio::task::spawn_blocking(move || {
-                tokio::runtime::Handle::current().block_on(async move {
-                    let mut session = session;
-                    let _ = session.transport.disconnect().await;
-                })
-            })
-            .await
-            .map_err(|e| format!("task panicked: {e}"))?;
             *state.phase.lock().unwrap() = "Idle".into();
             Err("signal check cancelled".into())
         }
         Err(e) => {
-            *state.connected_node.lock().unwrap() = Some(session);
             let msg = e.to_string();
             *state.phase.lock().unwrap() = format!("Error: {msg}");
             Err(msg)
@@ -1260,6 +1274,99 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sonde_pair::error::PairingError;
+    use sonde_pair::transport::{BleTransport, MockBleTransport};
+    use sonde_pair::types::{PairingMethod, ScannedDevice};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    struct CountingTransport {
+        inner: MockBleTransport,
+        disconnects: Arc<AtomicUsize>,
+        stop_scans: Arc<AtomicUsize>,
+    }
+
+    impl CountingTransport {
+        fn new(mtu: u16, disconnects: Arc<AtomicUsize>, stop_scans: Arc<AtomicUsize>) -> Self {
+            Self {
+                inner: MockBleTransport::new(mtu),
+                disconnects,
+                stop_scans,
+            }
+        }
+    }
+
+    impl BleTransport for CountingTransport {
+        fn start_scan(
+            &mut self,
+            service_uuids: &[u128],
+        ) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
+            self.inner.start_scan(service_uuids)
+        }
+
+        fn stop_scan(&mut self) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
+            self.stop_scans.fetch_add(1, AtomicOrdering::Relaxed);
+            self.inner.stop_scan()
+        }
+
+        fn get_discovered_devices(
+            &self,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<ScannedDevice>, PairingError>> + '_>> {
+            self.inner.get_discovered_devices()
+        }
+
+        fn connect(
+            &mut self,
+            address: &[u8; 6],
+        ) -> Pin<Box<dyn Future<Output = Result<u16, PairingError>> + '_>> {
+            self.inner.connect(address)
+        }
+
+        fn disconnect(&mut self) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
+            self.disconnects.fetch_add(1, AtomicOrdering::Relaxed);
+            self.inner.disconnect()
+        }
+
+        fn write_characteristic(
+            &mut self,
+            service: u128,
+            characteristic: u128,
+            data: &[u8],
+        ) -> Pin<Box<dyn Future<Output = Result<(), PairingError>> + '_>> {
+            self.inner
+                .write_characteristic(service, characteristic, data)
+        }
+
+        fn read_indication(
+            &mut self,
+            service: u128,
+            characteristic: u128,
+            timeout_ms: u64,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, PairingError>> + '_>> {
+            self.inner
+                .read_indication(service, characteristic, timeout_ms)
+        }
+
+        fn pairing_method(&self) -> Option<PairingMethod> {
+            self.inner.pairing_method()
+        }
+
+        fn set_defer_bonding(&mut self, defer: bool) {
+            self.inner.set_defer_bonding(defer);
+        }
+    }
+
+    fn run_async_test<F>(future: F)
+    where
+        F: Future<Output = ()>,
+    {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(future);
+    }
 
     #[test]
     fn resolve_legacy_i2c_layout_both_present() {
@@ -1338,5 +1445,101 @@ mod tests {
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("ADC-capable"));
+    }
+
+    #[test]
+    fn stop_and_discard_scanner_stops_active_scan() {
+        run_async_test(async {
+            let disconnects = Arc::new(AtomicUsize::new(0));
+            let stop_scans = Arc::new(AtomicUsize::new(0));
+            let transport = CountingTransport::new(247, disconnects, stop_scans.clone());
+            let mut scanner = DeviceScanner::new(transport);
+            scanner.start().await.unwrap();
+            let scanner_slot = Mutex::new(Some(scanner));
+
+            stop_and_discard_scanner(&scanner_slot).await.unwrap();
+
+            assert!(scanner_slot.lock().unwrap().is_none());
+            assert_eq!(stop_scans.load(AtomicOrdering::Relaxed), 1);
+        });
+    }
+
+    #[test]
+    fn reuse_or_connect_session_reuses_matching_session() {
+        run_async_test(async {
+            let disconnects = Arc::new(AtomicUsize::new(0));
+            let stop_scans = Arc::new(AtomicUsize::new(0));
+            let transport = CountingTransport::new(247, disconnects.clone(), stop_scans);
+            let existing = ConnectedNodeSession {
+                address: [0xAA; 6],
+                transport,
+            };
+
+            let session = reuse_or_connect_session(Some(existing), [0xAA; 6], || async {
+                Ok(CountingTransport::new(
+                    247,
+                    Arc::new(AtomicUsize::new(0)),
+                    Arc::new(AtomicUsize::new(0)),
+                ))
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(session.address, [0xAA; 6]);
+            assert_eq!(disconnects.load(AtomicOrdering::Relaxed), 0);
+        });
+    }
+
+    #[test]
+    fn reuse_or_connect_session_disconnects_stale_session() {
+        run_async_test(async {
+            let old_disconnects = Arc::new(AtomicUsize::new(0));
+            let old_stop_scans = Arc::new(AtomicUsize::new(0));
+            let mut old_transport =
+                CountingTransport::new(247, old_disconnects.clone(), old_stop_scans);
+            old_transport.inner.connected = true;
+            let existing = ConnectedNodeSession {
+                address: [0x11; 6],
+                transport: old_transport,
+            };
+            let new_disconnects = Arc::new(AtomicUsize::new(0));
+            let new_stop_scans = Arc::new(AtomicUsize::new(0));
+
+            let session = reuse_or_connect_session(Some(existing), [0x22; 6], || async {
+                Ok(CountingTransport::new(
+                    247,
+                    new_disconnects.clone(),
+                    new_stop_scans.clone(),
+                ))
+            })
+            .await
+            .unwrap();
+
+            assert_eq!(old_disconnects.load(AtomicOrdering::Relaxed), 1);
+            assert_eq!(session.address, [0x22; 6]);
+            assert!(session.transport.inner.connected);
+        });
+    }
+
+    #[test]
+    fn finalize_signal_check_drops_failed_session() {
+        run_async_test(async {
+            let disconnects = Arc::new(AtomicUsize::new(0));
+            let stop_scans = Arc::new(AtomicUsize::new(0));
+            let session = ConnectedNodeSession {
+                address: [0xAA; 6],
+                transport: CountingTransport::new(247, disconnects.clone(), stop_scans),
+            };
+
+            let (session, outcome) = finalize_signal_check(
+                session,
+                Err(PairingError::DiagnosticFailed("reconnect failed".into())),
+            )
+            .await;
+
+            assert!(session.is_none());
+            assert!(matches!(outcome, Err(PairingError::DiagnosticFailed(_))));
+            assert_eq!(disconnects.load(AtomicOrdering::Relaxed), 1);
+        });
     }
 }

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -20,10 +20,11 @@ use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 use sonde_pair::discovery::{service_type, DeviceScanner, ServiceType};
+use sonde_pair::error::PairingError;
 use sonde_pair::phase1::PairingProgress;
 use sonde_pair::rng::OsRng;
 use sonde_pair::transport::BleTransport;
-use sonde_pair::types::{BoardLayout, ScannedDevice};
+use sonde_pair::types::{BoardLayout, ScannedDevice, BLE_MTU_MIN};
 use sonde_pair::{phase1, phase2};
 
 #[cfg(not(target_os = "android"))]
@@ -467,7 +468,7 @@ async fn connect_node(
     let existing = state.connected_node.lock().unwrap().take();
     *state.phase.lock().unwrap() = "Connecting".into();
 
-    let result: Result<ConnectedNodeSession<BtleplugTransport>, sonde_pair::error::PairingError> =
+    let result: Result<ConnectedNodeSession<BtleplugTransport>, PairingError> =
         tokio::task::spawn_blocking(move || {
             tokio::runtime::Handle::current().block_on(async move {
                 if let Some(mut session) = existing {
@@ -479,8 +480,18 @@ async fn connect_node(
 
                 let mut transport = BtleplugTransport::new().await?;
                 transport.set_defer_bonding(true);
-                transport.connect(&addr).await?;
-                Ok::<_, sonde_pair::error::PairingError>(ConnectedNodeSession {
+                let mtu_result = transport.connect(&addr).await;
+                transport.set_defer_bonding(false);
+                let mtu = mtu_result?;
+                if mtu < BLE_MTU_MIN {
+                    transport.disconnect().await.ok();
+                    return Err(PairingError::MtuTooLow {
+                        device: format_address(&addr),
+                        negotiated: mtu,
+                        required: BLE_MTU_MIN,
+                    });
+                }
+                Ok::<_, PairingError>(ConnectedNodeSession {
                     address: addr,
                     transport,
                 })
@@ -506,13 +517,13 @@ async fn connect_node(
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
 async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo, String> {
+    let artifacts = load_pairing_artifacts(&state)?;
     let session = state
         .connected_node
         .lock()
         .unwrap()
         .take()
         .ok_or_else(|| "No connected node session".to_string())?;
-    let artifacts = load_pairing_artifacts(&state)?;
     *state.phase.lock().unwrap() = "Signal Check".into();
 
     let result = tokio::task::spawn_blocking(move || {
@@ -847,7 +858,7 @@ async fn connect_node(
     let existing = state.connected_node.lock().unwrap().take();
     *state.phase.lock().unwrap() = "Connecting".into();
 
-    let result: Result<ConnectedNodeSession<AndroidBleTransport>, sonde_pair::error::PairingError> =
+    let result: Result<ConnectedNodeSession<AndroidBleTransport>, PairingError> =
         tokio::task::spawn_blocking(move || {
             tokio::runtime::Handle::current().block_on(async move {
                 if let Some(mut session) = existing {
@@ -859,8 +870,18 @@ async fn connect_node(
 
                 let mut transport = AndroidBleTransport::from_cached_vm()?;
                 transport.set_defer_bonding(true);
-                transport.connect(&addr).await?;
-                Ok::<_, sonde_pair::error::PairingError>(ConnectedNodeSession {
+                let mtu_result = transport.connect(&addr).await;
+                transport.set_defer_bonding(false);
+                let mtu = mtu_result?;
+                if mtu < BLE_MTU_MIN {
+                    transport.disconnect().await.ok();
+                    return Err(PairingError::MtuTooLow {
+                        device: format_address(&addr),
+                        negotiated: mtu,
+                        required: BLE_MTU_MIN,
+                    });
+                }
+                Ok::<_, PairingError>(ConnectedNodeSession {
                     address: addr,
                     transport,
                 })
@@ -886,13 +907,13 @@ async fn connect_node(
 #[cfg(target_os = "android")]
 #[tauri::command]
 async fn check_rssi(state: tauri::State<'_, AppState>) -> Result<DiagnosticInfo, String> {
+    let artifacts = load_pairing_artifacts(&state)?;
     let session = state
         .connected_node
         .lock()
         .unwrap()
         .take()
         .ok_or_else(|| "No connected node session".to_string())?;
-    let artifacts = load_pairing_artifacts(&state)?;
     *state.phase.lock().unwrap() = "Signal Check".into();
 
     let result = tokio::task::spawn_blocking(move || {

--- a/crates/sonde-pair-ui/src/index.html
+++ b/crates/sonde-pair-ui/src/index.html
@@ -125,6 +125,7 @@
         <p class="signal-note">This check is informational only. You can continue even if the node reports weak signal or the diagnostic times out.</p>
         <div class="btn-row">
           <button id="btn-signal-abort" class="btn-danger">Abort</button>
+          <button id="btn-signal-recheck" disabled>Check Again</button>
           <button id="btn-signal-proceed" disabled>Proceed to Provision</button>
         </div>
       </div>

--- a/crates/sonde-pair-ui/src/index.html
+++ b/crates/sonde-pair-ui/src/index.html
@@ -105,6 +105,7 @@
     <section class="page" id="page-signal-check">
       <div class="card">
         <h2>Signal Check</h2>
+        <p class="status-text">Connected node: <span id="signal-node-address">--</span></p>
         <div class="signal-grid">
           <div>
             <h3>BLE RSSI</h3>

--- a/crates/sonde-pair-ui/src/index.html
+++ b/crates/sonde-pair-ui/src/index.html
@@ -79,7 +79,7 @@
       </div>
     </section>
 
-    <!-- Page 4: Node Scan & RSSI (PT-1217, PT-1221) -->
+    <!-- Page 4: Node Scan & BLE RSSI (PT-1217, PT-1221) -->
     <section class="page" id="page-node-scan">
       <div class="card">
         <h2>Node Scan</h2>
@@ -92,16 +92,45 @@
         </ul>
       </div>
       <div id="rssi-panel" class="card hidden">
-        <h2>Signal Quality</h2>
+        <h2>BLE Signal Quality</h2>
         <div class="rssi-indicator" id="rssi-indicator">
           <span class="rssi-value" id="rssi-value">--</span>
           <span class="rssi-label" id="rssi-label">--</span>
         </div>
       </div>
-      <button id="btn-to-provision" disabled>Continue to Provision</button>
+      <button id="btn-connect-node" disabled>Connect</button>
     </section>
 
-    <!-- Page 5: Node Provision (PT-1217) -->
+    <!-- Page 5: Signal Check (PT-1217, PT-1223, PT-1224, PT-1225) -->
+    <section class="page" id="page-signal-check">
+      <div class="card">
+        <h2>Signal Check</h2>
+        <div class="signal-grid">
+          <div>
+            <h3>BLE RSSI</h3>
+            <div class="rssi-indicator" id="diag-ble-indicator">
+              <span class="rssi-value" id="diag-ble-value">--</span>
+              <span class="rssi-label" id="diag-ble-label">--</span>
+            </div>
+          </div>
+          <div>
+            <h3>ESP-NOW RSSI</h3>
+            <div class="rssi-indicator" id="diag-espnow-indicator">
+              <span class="rssi-value" id="diag-espnow-value">--</span>
+              <span class="rssi-label" id="diag-espnow-label">Waiting</span>
+            </div>
+          </div>
+        </div>
+        <div id="signal-status" class="status-text hidden"></div>
+        <p class="signal-note">This check is informational only. You can continue even if the node reports weak signal or the diagnostic times out.</p>
+        <div class="btn-row">
+          <button id="btn-signal-abort" class="btn-danger">Abort</button>
+          <button id="btn-signal-proceed" disabled>Proceed to Provision</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Page 6: Node Provision (PT-1217) -->
     <section class="page" id="page-node-provision">
       <div class="card">
         <h2>Node Provisioning</h2>
@@ -144,7 +173,7 @@
       </div>
     </section>
 
-    <!-- Page 6: Done (PT-1217) -->
+    <!-- Page 7: Done (PT-1217) -->
     <section class="page" id="page-done">
       <div class="card">
         <h2>Provisioning Complete</h2>

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -1,36 +1,26 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 sonde contributors
 
-// Tauri v2 injects __TAURI__ when withGlobalTauri is true.
 const { invoke } = window.__TAURI__.core;
 
-// ---------------------------------------------------------------------------
-// DOM references
-// ---------------------------------------------------------------------------
-
-// Pages (PT-1217)
 const pages = [
   document.getElementById("page-welcome"),
   document.getElementById("page-gateway-scan"),
   document.getElementById("page-gateway-done"),
   document.getElementById("page-node-scan"),
+  document.getElementById("page-signal-check"),
   document.getElementById("page-node-provision"),
   document.getElementById("page-done"),
 ];
 
-// Stepper (PT-1218)
 const stepperSteps = document.querySelectorAll("#stepper .step");
-
-// Back button (PT-1220 AC 6–8)
 const btnBack = document.getElementById("btn-back");
 
-// Page 1: Welcome
 const pairingStatus = document.getElementById("pairing-status");
 const btnGetStarted = document.getElementById("btn-get-started");
 const btnSkipToNode = document.getElementById("btn-skip-to-node");
 const btnClear = document.getElementById("btn-clear");
 
-// Page 2: Gateway Scan
 const btnScanStartGw = document.getElementById("btn-scan-start-gw");
 const btnScanStopGw = document.getElementById("btn-scan-stop-gw");
 const deviceListGw = document.getElementById("device-list-gw");
@@ -38,12 +28,10 @@ const phoneLabel = document.getElementById("phone-label");
 const btnPair = document.getElementById("btn-pair");
 const pairStatus = document.getElementById("pair-status");
 
-// Page 3: Pairing Complete
 const pairDetails = document.getElementById("pair-details");
 const btnToNode = document.getElementById("btn-to-node");
 const btnClearGwDone = document.getElementById("btn-clear-gw-done");
 
-// Page 4: Node Scan
 const btnScanStartNode = document.getElementById("btn-scan-start-node");
 const btnScanStopNode = document.getElementById("btn-scan-stop-node");
 const deviceListNode = document.getElementById("device-list-node");
@@ -51,9 +39,18 @@ const rssiPanel = document.getElementById("rssi-panel");
 const rssiValue = document.getElementById("rssi-value");
 const rssiLabel = document.getElementById("rssi-label");
 const rssiIndicator = document.getElementById("rssi-indicator");
-const btnToProvision = document.getElementById("btn-to-provision");
+const btnConnectNode = document.getElementById("btn-connect-node");
 
-// Page 5: Node Provision
+const diagBleIndicator = document.getElementById("diag-ble-indicator");
+const diagBleValue = document.getElementById("diag-ble-value");
+const diagBleLabel = document.getElementById("diag-ble-label");
+const diagEspNowIndicator = document.getElementById("diag-espnow-indicator");
+const diagEspNowValue = document.getElementById("diag-espnow-value");
+const diagEspNowLabel = document.getElementById("diag-espnow-label");
+const signalStatus = document.getElementById("signal-status");
+const btnSignalAbort = document.getElementById("btn-signal-abort");
+const btnSignalProceed = document.getElementById("btn-signal-proceed");
+
 const nodeId = document.getElementById("node-id");
 const boardSelect = document.getElementById("board-select");
 const customPins = document.getElementById("custom-pins");
@@ -65,31 +62,24 @@ const customSensorEnable = document.getElementById("custom-sensor-enable");
 const btnProvision = document.getElementById("btn-provision");
 const provisionStatus = document.getElementById("provision-status");
 
-// Page 6: Done
 const provisionDetails = document.getElementById("provision-details");
 const btnProvisionAnother = document.getElementById("btn-provision-another");
 
-// Global
 const errorBar = document.getElementById("error-bar");
 const verboseToggle = document.getElementById("verbose-toggle");
 const logPanel = document.getElementById("log-panel");
 
-// ---------------------------------------------------------------------------
-// App state
-// ---------------------------------------------------------------------------
-
 let selectedAddressGw = null;
 let selectedAddressNode = null;
+let selectedNodeBleRssi = null;
 let scanning = false;
+let scanGeneration = 0;
 let pollTimer = null;
 let logTimer = null;
 let busy = false;
 let isPaired = false;
-let scanGeneration = 0;
-
-// ---------------------------------------------------------------------------
-// Board presets (PT-1216)
-// ---------------------------------------------------------------------------
+let signalLoopEnabled = false;
+let diagCurrentPromise = null;
 
 const BOARD_PRESETS = {
   rev_a: {
@@ -105,6 +95,166 @@ const BOARD_PRESETS = {
     layout: { i2c0Sda: 5, i2c0Scl: 6, oneWireData: null, batteryAdc: null, sensorEnable: null },
   },
 };
+
+const PAGE_TO_PHASE = [0, 0, 0, 1, 1, 1, 2];
+const STORAGE_KEY = "sonde-pair-page";
+
+class Navigator {
+  constructor() {
+    this.currentPage = 0;
+    this._skipPush = false;
+  }
+
+  goTo(pageIndex, { push = true } = {}) {
+    if (pageIndex < 0 || pageIndex >= pages.length) return;
+
+    const leavingPage = this.currentPage;
+    if (leavingPage === 1 || leavingPage === 3 || leavingPage === 4) {
+      const preserveNodeSelection = leavingPage === 3 && pageIndex === 4;
+      const preserveConnection = leavingPage === 4 && pageIndex === 5;
+      this._cleanupPage(leavingPage, { preserveNodeSelection, preserveConnection });
+    }
+
+    const direction = pageIndex >= this.currentPage ? "forward" : "back";
+    const oldPage = pages[this.currentPage];
+    const newPage = pages[pageIndex];
+
+    if (oldPage !== newPage) {
+      oldPage.classList.add(direction === "forward" ? "slide-out-left" : "slide-out-right");
+      newPage.classList.add(direction === "forward" ? "slide-in-right" : "slide-in-left");
+      newPage.classList.add("page--active");
+      setTimeout(() => {
+        oldPage.classList.remove("page--active", "slide-out-left", "slide-out-right");
+        newPage.classList.remove("slide-in-right", "slide-in-left");
+      }, 300);
+    }
+
+    this.currentPage = pageIndex;
+    this._updateStepper();
+    clearError();
+    localStorage.setItem(STORAGE_KEY, String(pageIndex));
+    if (push && !this._skipPush) history.pushState({ page: pageIndex }, "", "");
+  }
+
+  next() { this.goTo(this.currentPage + 1); }
+  back() { this.goTo(this.currentPage - 1); }
+
+  restore() {
+    history.replaceState({ page: 0, sentinel: true }, "", "");
+    const saved = parseInt(localStorage.getItem(STORAGE_KEY), 10);
+    let target = isPaired ? 3 : 0;
+    if (!Number.isNaN(saved) && saved >= 0 && saved < pages.length) target = saved;
+    if (target >= 2 && !isPaired) target = 0;
+    if (target >= 4) target = isPaired ? 3 : 0;
+    for (let i = 0; i <= target; i++) history.pushState({ page: i }, "", "");
+    this._skipPush = true;
+    try {
+      this.goTo(target, { push: false });
+    } finally {
+      this._skipPush = false;
+    }
+  }
+
+  get current() { return this.currentPage; }
+
+  _updateStepper() {
+    const activePhase = PAGE_TO_PHASE[this.currentPage];
+    stepperSteps.forEach((el, i) => {
+      el.classList.remove("step--active", "step--done");
+      if (i < activePhase) el.classList.add("step--done");
+      else if (i === activePhase) el.classList.add("step--active");
+    });
+    btnBack.classList.toggle("hidden", this.currentPage === 0);
+  }
+
+  _cleanupPage(pageIndex, { preserveNodeSelection = false, preserveConnection = false } = {}) {
+    if (pageIndex === 1 || pageIndex === 3) {
+      cleanupScanPage(pageIndex, preserveNodeSelection);
+    }
+    if (pageIndex === 4 && !preserveConnection) {
+      stopSignalLoop();
+      invoke("disconnect_node").catch(() => {});
+      resetSignalCheckView();
+    }
+  }
+}
+
+const navigator_ = new Navigator();
+
+function showError(msg) {
+  errorBar.textContent = String(msg);
+  errorBar.classList.remove("hidden");
+}
+
+function clearError() {
+  errorBar.textContent = "";
+  errorBar.classList.add("hidden");
+}
+
+function showStatus(el, msg) {
+  el.textContent = msg;
+  el.classList.remove("hidden");
+}
+
+function hideStatus(el) {
+  el.textContent = "";
+  el.classList.add("hidden");
+}
+
+function setBusy(value) {
+  busy = value;
+  btnPair.disabled = value || !selectedAddressGw;
+  btnProvision.disabled = value || !selectedAddressNode;
+  btnConnectNode.disabled = value || !selectedAddressNode;
+  btnSignalAbort.disabled = value;
+  btnSignalProceed.disabled = value || !selectedAddressNode || !signalLoopEnabled;
+  btnScanStartGw.disabled = value || scanning;
+  btnScanStopGw.disabled = value || !scanning || navigator_.current !== 1;
+  btnScanStartNode.disabled = value || scanning;
+  btnScanStopNode.disabled = value || !scanning || navigator_.current !== 3;
+}
+
+function classifyRssi(rssi) {
+  if (rssi >= -60) return { label: "Good", cls: "rssi--good" };
+  if (rssi >= -75) return { label: "Marginal", cls: "rssi--marginal" };
+  return { label: "Bad", cls: "rssi--bad" };
+}
+
+function setIndicator(panel, valueEl, labelEl, rssi, waitingLabel = "--") {
+  if (rssi == null) {
+    valueEl.textContent = "--";
+    labelEl.textContent = waitingLabel;
+    panel.className = "rssi-indicator";
+    return;
+  }
+  const quality = classifyRssi(rssi);
+  valueEl.textContent = `${rssi} dBm`;
+  labelEl.textContent = quality.label;
+  panel.className = `rssi-indicator ${quality.cls}`;
+}
+
+function updateBleSelectionIndicator(rssi) {
+  if (rssi == null) {
+    rssiPanel.classList.add("hidden");
+    setIndicator(rssiIndicator, rssiValue, rssiLabel, null);
+    return;
+  }
+  rssiPanel.classList.remove("hidden");
+  setIndicator(rssiIndicator, rssiValue, rssiLabel, rssi);
+}
+
+function updateSignalCheckIndicators(diagRssi = null) {
+  setIndicator(diagBleIndicator, diagBleValue, diagBleLabel, selectedNodeBleRssi, "Waiting");
+  setIndicator(diagEspNowIndicator, diagEspNowValue, diagEspNowLabel, diagRssi, "Waiting");
+}
+
+function resetSignalCheckView() {
+  signalLoopEnabled = false;
+  diagCurrentPromise = null;
+  updateSignalCheckIndicators(null);
+  hideStatus(signalStatus);
+  btnSignalProceed.disabled = true;
+}
 
 function initBoardSelect() {
   const customOption = boardSelect.querySelector('option[value="custom"]');
@@ -124,14 +274,19 @@ function parseOptionalPin(input, label) {
   const raw = input.value.trim();
   if (raw === "") return null;
   const value = Number(raw);
-  if (!Number.isInteger(value)) { showError(`Enter a whole GPIO number for ${label}`); return undefined; }
-  if (value < 0 || value > 21) { showError(`${label} must be 0–21`); return undefined; }
+  if (!Number.isInteger(value)) {
+    showError(`Enter a whole GPIO number for ${label}`);
+    return undefined;
+  }
+  if (value < 0 || value > 21) {
+    showError(`${label} must be 0–21`);
+    return undefined;
+  }
   return value;
 }
 
 function resolveBoardLayout() {
-  const board = boardSelect.value;
-  if (board === "custom") {
+  if (boardSelect.value === "custom") {
     const i2c0Sda = parseOptionalPin(customI2cSda, "I2C SDA");
     const i2c0Scl = parseOptionalPin(customI2cScl, "I2C SCL");
     const oneWireData = parseOptionalPin(customOneWire, "1-Wire data");
@@ -148,259 +303,51 @@ function resolveBoardLayout() {
     }
     return { i2c0Sda, i2c0Scl, oneWireData, batteryAdc, sensorEnable };
   }
-  const preset = BOARD_PRESETS[board];
-  if (!preset) { showError("Unknown board selection"); return null; }
+  const preset = BOARD_PRESETS[boardSelect.value];
+  if (!preset) {
+    showError("Unknown board selection");
+    return null;
+  }
   return preset.layout;
 }
 
-// ---------------------------------------------------------------------------
-// Navigator (PT-1217, PT-1218, PT-1219, PT-1220, PT-1222)
-// ---------------------------------------------------------------------------
-
-// Maps page index → stepper phase index (0=Gateway, 1=Node, 2=Done)
-const PAGE_TO_PHASE = [0, 0, 0, 1, 1, 2];
-const STORAGE_KEY = "sonde-pair-page";
-
-class Navigator {
-  constructor() {
-    this.currentPage = 0;
-    this._skipPush = false;
-  }
-
-  goTo(pageIndex, { push = true } = {}) {
-    if (pageIndex < 0 || pageIndex >= pages.length) return;
-
-    // Scan lifecycle: stop scan when leaving a scan page (pages 1=gw, 3=node)
-    // but preserve node selection when advancing from page 3→4 (node scan → provision)
-    const leavingPage = this.currentPage;
-    if (leavingPage === 1 || leavingPage === 3) {
-      const advancingToProvision = leavingPage === 3 && pageIndex === 4;
-      this._cleanupScanPage(leavingPage, { preserveSelection: advancingToProvision });
-    }
-
-    const direction = pageIndex >= this.currentPage ? "forward" : "back";
-    const oldPage = pages[this.currentPage];
-    const newPage = pages[pageIndex];
-
-    // Apply transition classes (PT-1222)
-    if (oldPage !== newPage) {
-      if (direction === "forward") {
-        oldPage.classList.add("slide-out-left");
-        newPage.classList.add("slide-in-right");
-      } else {
-        oldPage.classList.add("slide-out-right");
-        newPage.classList.add("slide-in-left");
-      }
-      newPage.classList.add("page--active");
-
-      // Remove old page and clean up animation classes after transition
-      setTimeout(() => {
-        oldPage.classList.remove("page--active", "slide-out-left", "slide-out-right");
-        newPage.classList.remove("slide-in-right", "slide-in-left");
-      }, 300);
-    }
-
-    this.currentPage = pageIndex;
-    this._updateStepper();
-    clearError();
-
-    // Persist (PT-1219)
-    localStorage.setItem(STORAGE_KEY, String(pageIndex));
-
-    // History (PT-1220)
-    if (push && !this._skipPush) {
-      history.pushState({ page: pageIndex }, "", "");
-    }
-  }
-
-  next() { this.goTo(this.currentPage + 1); }
-
-  back() { this.goTo(this.currentPage - 1); }
-
-  restore() {
-    // Seed history with sentinel at the bottom so back on page 1 is a no-op (PT-1220 AC 3)
-    history.replaceState({ page: 0, sentinel: true }, "", "");
-
-    const saved = parseInt(localStorage.getItem(STORAGE_KEY), 10);
-    const earliestValid = isPaired ? 3 : 0;
-    let target = earliestValid;
-    if (!isNaN(saved) && saved >= 0 && saved < pages.length) {
-      target = saved;
-    }
-
-    // Validate prerequisites: pages 2+ require pairing
-    if (target >= 2 && !isPaired) {
-      target = 0;
-    }
-
-    // Pages 5–6 require ephemeral state (selected node / provisioning-success context)
-    // that cannot survive a restart — fall back to Node Scan when paired,
-    // or Welcome when unpaired, consistent with the prerequisite check above (PT-1219 AC 4)
-    if (target >= 4) {
-      target = isPaired ? 3 : 0;
-    }
-
-    // Push all intermediate pages so back navigation traverses each step (PT-1220 AC 3)
-    for (let i = 0; i <= target; i++) {
-      history.pushState({ page: i }, "", "");
-    }
-
-    this._skipPush = true;
-    try {
-      this.goTo(target, { push: false });
-    } finally {
-      this._skipPush = false;
-    }
-  }
-
-  get current() { return this.currentPage; }
-
-  _updateStepper() {
-    const activePhase = PAGE_TO_PHASE[this.currentPage];
-    stepperSteps.forEach((el, i) => {
-      el.classList.remove("step--active", "step--done");
-      if (i < activePhase) {
-        el.classList.add("step--done");
-      } else if (i === activePhase) {
-        el.classList.add("step--active");
-      }
-    });
-    // PT-1220 AC 6–7: show back button on pages 2–6, hide on page 1
-    btnBack.classList.toggle("hidden", this.currentPage === 0);
-  }
-
-  _cleanupScanPage(pageIndex, { preserveSelection = false } = {}) {
-    if (scanning) {
-      invoke("stop_scan").catch(() => {});
-      if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
-      scanning = false;
-      scanGeneration++;
-    }
-    if (pageIndex === 1) {
-      selectedAddressGw = null;
-      btnPair.disabled = true;
-      btnScanStartGw.disabled = false;
-      btnScanStopGw.disabled = true;
-      renderDevices(deviceListGw, [], false);
-    } else if (pageIndex === 3) {
-      if (!preserveSelection) {
-        selectedAddressNode = null;
-        btnToProvision.disabled = true;
-        rssiPanel.classList.add("hidden");
-      }
-      btnScanStartNode.disabled = false;
-      btnScanStopNode.disabled = true;
-      renderDevices(deviceListNode, [], false);
-    }
-  }
-}
-
-const navigator_ = new Navigator();
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function showError(msg) {
-  errorBar.textContent = msg;
-  errorBar.classList.remove("hidden");
-}
-
-function clearError() {
-  errorBar.textContent = "";
-  errorBar.classList.add("hidden");
-}
-
-function showStatus(el, msg) {
-  el.textContent = msg;
-  el.classList.remove("hidden");
-}
-
-function hideStatus(el) {
-  el.textContent = "";
-  el.classList.add("hidden");
-}
-
-function setBusy(b) {
-  busy = b;
-  // Disable action buttons on the current page while busy
-  btnPair.disabled = b || !selectedAddressGw;
-  btnProvision.disabled = b || !selectedAddressNode;
-  btnScanStartGw.disabled = b || scanning;
-  btnScanStopGw.disabled = b || !scanning;
-  btnScanStartNode.disabled = b || scanning;
-  btnScanStopNode.disabled = b || !scanning;
-  btnToProvision.disabled = b || !selectedAddressNode;
-}
-
-// ---------------------------------------------------------------------------
-// RSSI quality classification (PT-1221)
-// ---------------------------------------------------------------------------
-
-function classifyRssi(rssi) {
-  if (rssi >= -60) return { level: "good", label: "Good", cls: "rssi--good" };
-  if (rssi >= -75) return { level: "marginal", label: "Marginal", cls: "rssi--marginal" };
-  return { level: "bad", label: "Bad", cls: "rssi--bad" };
-}
-
-function updateRssiIndicator(rssi) {
-  if (rssi == null) {
-    rssiPanel.classList.add("hidden");
-    return;
-  }
-  rssiPanel.classList.remove("hidden");
-  const q = classifyRssi(rssi);
-  rssiValue.textContent = rssi + " dBm";
-  rssiLabel.textContent = q.label;
-  rssiIndicator.className = "rssi-indicator " + q.cls;
-}
-
-// ---------------------------------------------------------------------------
-// Device list rendering
-// ---------------------------------------------------------------------------
-
 function renderDevices(listEl, devices, isScanning) {
   listEl.innerHTML = "";
-
   if (devices.length === 0) {
     const li = document.createElement("li");
     li.className = "placeholder";
-    li.textContent = isScanning ? "Scanning\u2026" : "No devices found";
+    li.textContent = isScanning ? "Scanning…" : "No devices found";
     listEl.appendChild(li);
     return;
   }
 
   const isGw = listEl === deviceListGw;
   const selectedAddr = isGw ? selectedAddressGw : selectedAddressNode;
-
-  for (const d of devices) {
+  for (const device of devices) {
     const li = document.createElement("li");
-    li.dataset.address = d.address;
-    if (d.address === selectedAddr) li.classList.add("selected");
+    li.dataset.address = device.address;
+    li.classList.toggle("selected", device.address === selectedAddr);
     li.onclick = () => {
-      if (isGw) {
-        selectGatewayDevice(d.address);
-      } else {
-        selectNodeDevice(d.address, d.rssi);
-      }
+      if (isGw) selectGatewayDevice(device.address);
+      else selectNodeDevice(device.address, device.rssi);
     };
 
     const name = document.createElement("span");
     name.className = "device-name";
-    name.textContent = d.name || "(unnamed)";
+    name.textContent = device.name || "(unnamed)";
 
     const meta = document.createElement("span");
     meta.className = "device-meta";
 
     const badge = document.createElement("span");
-    badge.className = "badge " + d.service_type.toLowerCase();
-    badge.textContent = d.service_type;
+    badge.className = `badge ${device.service_type.toLowerCase()}`;
+    badge.textContent = device.service_type;
 
-    const rssiSpan = document.createElement("span");
-    rssiSpan.textContent = d.rssi + " dBm";
+    const rssi = document.createElement("span");
+    rssi.textContent = `${device.rssi} dBm`;
 
     meta.appendChild(badge);
-    meta.appendChild(rssiSpan);
+    meta.appendChild(rssi);
     li.appendChild(name);
     li.appendChild(meta);
     listEl.appendChild(li);
@@ -409,24 +356,47 @@ function renderDevices(listEl, devices, isScanning) {
 
 function selectGatewayDevice(address) {
   selectedAddressGw = address;
-  for (const li of deviceListGw.children) {
-    li.classList.toggle("selected", li.dataset.address === address);
-  }
+  for (const li of deviceListGw.children) li.classList.toggle("selected", li.dataset.address === address);
   btnPair.disabled = busy || !address;
 }
 
 function selectNodeDevice(address, rssi) {
   selectedAddressNode = address;
-  for (const li of deviceListNode.children) {
-    li.classList.toggle("selected", li.dataset.address === address);
-  }
-  updateRssiIndicator(rssi);
-  btnToProvision.disabled = busy || !address;
+  selectedNodeBleRssi = rssi;
+  for (const li of deviceListNode.children) li.classList.toggle("selected", li.dataset.address === address);
+  updateBleSelectionIndicator(rssi);
+  updateSignalCheckIndicators(null);
+  btnConnectNode.disabled = busy || !address;
 }
 
-// ---------------------------------------------------------------------------
-// Scan
-// ---------------------------------------------------------------------------
+function cleanupScanPage(pageIndex, preserveNodeSelection) {
+  if (scanning) {
+    invoke("stop_scan").catch(() => {});
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+    scanning = false;
+    scanGeneration++;
+  }
+  if (pageIndex === 1) {
+    selectedAddressGw = null;
+    btnPair.disabled = true;
+    btnScanStartGw.disabled = false;
+    btnScanStopGw.disabled = true;
+    renderDevices(deviceListGw, [], false);
+  } else if (pageIndex === 3) {
+    if (!preserveNodeSelection) {
+      selectedAddressNode = null;
+      selectedNodeBleRssi = null;
+      btnConnectNode.disabled = true;
+      updateBleSelectionIndicator(null);
+    }
+    btnScanStartNode.disabled = false;
+    btnScanStopNode.disabled = true;
+    renderDevices(deviceListNode, [], false);
+  }
+}
 
 async function startScan() {
   clearError();
@@ -434,23 +404,24 @@ async function startScan() {
   try {
     await invoke("start_scan");
     scanning = true;
-    scanGeneration++;
-    const gen = scanGeneration;
-    const onGwPage = navigator_.current === 1;
-    if (onGwPage) {
+    scanGeneration += 1;
+    const generation = scanGeneration;
+    const gatewayPage = navigator_.current === 1;
+    if (gatewayPage) {
       selectedAddressGw = null;
       btnScanStartGw.disabled = true;
       btnScanStopGw.disabled = false;
     } else {
       selectedAddressNode = null;
-      updateRssiIndicator(null);
-      btnToProvision.disabled = true;
+      selectedNodeBleRssi = null;
+      btnConnectNode.disabled = true;
+      updateBleSelectionIndicator(null);
       btnScanStartNode.disabled = true;
       btnScanStopNode.disabled = false;
     }
-    const listEl = onGwPage ? deviceListGw : deviceListNode;
+    const listEl = gatewayPage ? deviceListGw : deviceListNode;
     renderDevices(listEl, [], true);
-    pollTimer = setInterval(() => pollDevices(listEl, gen), 1500);
+    pollTimer = setInterval(() => pollDevices(listEl, generation), 1500);
   } catch (e) {
     showError(e);
   } finally {
@@ -460,70 +431,59 @@ async function startScan() {
 
 async function stopScan() {
   clearError();
-  if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
   try {
     await invoke("stop_scan");
   } catch (e) {
     showError(e);
   }
   scanning = false;
-  scanGeneration++;
-  const onGwPage = navigator_.current === 1;
-  if (onGwPage) {
-    btnScanStartGw.disabled = false;
-    btnScanStopGw.disabled = true;
-  } else {
-    btnScanStartNode.disabled = false;
-    btnScanStopNode.disabled = true;
-  }
+  scanGeneration += 1;
+  btnScanStartGw.disabled = false;
+  btnScanStopGw.disabled = true;
+  btnScanStartNode.disabled = false;
+  btnScanStopNode.disabled = true;
 }
 
-async function pollDevices(listEl, gen) {
-  if (gen !== scanGeneration) return;
+async function pollDevices(listEl, generation) {
+  if (generation !== scanGeneration) return;
   try {
     const devices = await invoke("get_devices");
-    if (gen !== scanGeneration) return;
-    const isScanning = scanning;
-    renderDevices(listEl, devices, isScanning);
-
-    // Update RSSI for selected node device (PT-1221)
+    if (generation !== scanGeneration) return;
+    renderDevices(listEl, devices, scanning);
     if (listEl === deviceListNode && selectedAddressNode) {
-      const selected = devices.find(d => d.address === selectedAddressNode);
+      const selected = devices.find((device) => device.address === selectedAddressNode);
       if (selected) {
-        updateRssiIndicator(selected.rssi);
-      } else {
-        updateRssiIndicator(null);
+        selectedNodeBleRssi = selected.rssi;
+        updateBleSelectionIndicator(selected.rssi);
       }
     }
   } catch (_) {
-    // Ignore transient poll errors.
   }
 }
-
-// ---------------------------------------------------------------------------
-// Phase 1: Gateway Pairing
-// ---------------------------------------------------------------------------
 
 async function pairGateway() {
   if (!selectedAddressGw) return;
   clearError();
   if (scanning) await stopScan();
   setBusy(true);
-  showStatus(pairStatus, "Connecting\u2026");
+  showStatus(pairStatus, "Pairing…");
   try {
-    showStatus(pairStatus, "Pairing\u2026");
     await invoke("pair_gateway", {
       address: selectedAddressGw,
       phoneLabel: phoneLabel.value || "sonde-phone",
     });
-    showStatus(pairStatus, "Verifying\u2026");
     const status = await invoke("get_pairing_status");
     isPaired = !!status.paired;
     if (isPaired) {
-      pairingStatus.textContent = "Paired \u2014 Gateway " + (status.gateway_id || "").substring(0, 8) + "\u2026";
+      const gwLabel = `Gateway ${(status.gateway_id || "").substring(0, 8)}…`;
+      pairingStatus.textContent = `Paired — ${gwLabel}`;
       btnGetStarted.classList.add("hidden");
       btnSkipToNode.classList.remove("hidden");
-      pairDetails.textContent = "Gateway " + (status.gateway_id || "").substring(0, 8) + "\u2026";
+      pairDetails.textContent = gwLabel;
     }
     hideStatus(pairStatus);
     navigator_.next();
@@ -535,29 +495,109 @@ async function pairGateway() {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Phase 2: Node Provisioning
-// ---------------------------------------------------------------------------
+function stopSignalLoop() {
+  signalLoopEnabled = false;
+}
+
+async function waitForCurrentDiagnostic() {
+  if (diagCurrentPromise) {
+    try {
+      await diagCurrentPromise;
+    } catch (_) {
+    }
+  }
+}
+
+async function runSignalCheckLoop() {
+  if (!signalLoopEnabled) return;
+  diagCurrentPromise = (async () => {
+    try {
+      const result = await invoke("check_rssi");
+      updateSignalCheckIndicators(result.rssiDbm);
+      showStatus(signalStatus, `Last update: ${result.rssiDbm} dBm via ESP-NOW`);
+      btnSignalProceed.disabled = false;
+    } catch (e) {
+      showStatus(signalStatus, `Diagnostic unavailable: ${e}`);
+      btnSignalProceed.disabled = false;
+    } finally {
+      diagCurrentPromise = null;
+    }
+  })();
+
+  await diagCurrentPromise;
+  if (signalLoopEnabled) setTimeout(runSignalCheckLoop, 1000);
+}
+
+async function connectNode() {
+  if (!selectedAddressNode) return;
+  clearError();
+  if (scanning) await stopScan();
+  setBusy(true);
+  navigator_.next();
+  resetSignalCheckView();
+  updateSignalCheckIndicators(null);
+  showStatus(signalStatus, "Connecting to node…");
+  try {
+    await invoke("connect_node", { address: selectedAddressNode });
+    signalLoopEnabled = true;
+    btnSignalProceed.disabled = false;
+    showStatus(signalStatus, "Running ESP-NOW signal check…");
+    setBusy(false);
+    runSignalCheckLoop();
+  } catch (e) {
+    navigator_.back();
+    showError(e);
+    setBusy(false);
+  }
+}
+
+async function abortSignalCheck() {
+  clearError();
+  setBusy(true);
+  stopSignalLoop();
+  await waitForCurrentDiagnostic();
+  try {
+    await invoke("disconnect_node");
+  } catch (e) {
+    showError(e);
+  } finally {
+    resetSignalCheckView();
+    navigator_.goTo(3);
+    setBusy(false);
+  }
+}
+
+async function proceedFromSignalCheck() {
+  clearError();
+  setBusy(true);
+  stopSignalLoop();
+  await waitForCurrentDiagnostic();
+  btnProvision.disabled = !selectedAddressNode;
+  navigator_.next();
+  setBusy(false);
+}
 
 async function provisionNode() {
   if (!selectedAddressNode) return;
   const nid = nodeId.value.trim();
-  if (!nid) { showError("Enter a Node ID"); return; }
+  if (!nid) {
+    showError("Enter a Node ID");
+    return;
+  }
   const boardLayout = resolveBoardLayout();
   if (!boardLayout) return;
   clearError();
-  if (scanning) await stopScan();
   setBusy(true);
-  showStatus(provisionStatus, "Connecting to node\u2026");
+  showStatus(provisionStatus, "Provisioning…");
   try {
-    showStatus(provisionStatus, "Provisioning\u2026");
     await invoke("provision_node", {
       address: selectedAddressNode,
       nodeId: nid,
       boardLayout,
     });
     hideStatus(provisionStatus);
-    provisionDetails.textContent = "Node \"" + nid + "\" provisioned.";
+    resetSignalCheckView();
+    provisionDetails.textContent = `Node "${nid}" provisioned.`;
     navigator_.next();
   } catch (e) {
     hideStatus(provisionStatus);
@@ -567,17 +607,13 @@ async function provisionNode() {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Pairing status
-// ---------------------------------------------------------------------------
-
 async function refreshPairingStatus() {
   try {
-    const s = await invoke("get_pairing_status");
-    if (s.paired) {
+    const status = await invoke("get_pairing_status");
+    if (status.paired) {
       isPaired = true;
-      const gwLabel = "Gateway " + (s.gateway_id || "").substring(0, 8) + "\u2026";
-      pairingStatus.textContent = "Paired \u2014 " + gwLabel;
+      const gwLabel = `Gateway ${(status.gateway_id || "").substring(0, 8)}…`;
+      pairingStatus.textContent = `Paired — ${gwLabel}`;
       btnGetStarted.classList.add("hidden");
       btnSkipToNode.classList.remove("hidden");
       pairDetails.textContent = gwLabel;
@@ -588,15 +624,21 @@ async function refreshPairingStatus() {
       btnSkipToNode.classList.add("hidden");
     }
   } catch (e) {
-    pairingStatus.textContent = "Error: " + e;
+    pairingStatus.textContent = `Error: ${e}`;
   }
 }
 
 async function clearPairing() {
   clearError();
+  stopSignalLoop();
+  await waitForCurrentDiagnostic();
   try {
     await invoke("clear_pairing");
     isPaired = false;
+    selectedAddressNode = null;
+    selectedNodeBleRssi = null;
+    updateBleSelectionIndicator(null);
+    resetSignalCheckView();
     await refreshPairingStatus();
     navigator_.goTo(0);
   } catch (e) {
@@ -604,17 +646,13 @@ async function clearPairing() {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Verbose diagnostic mode
-// ---------------------------------------------------------------------------
-
 function toggleVerbose() {
-  const on = verboseToggle.checked;
-  logPanel.classList.toggle("hidden", !on);
-  if (on) {
-    logTimer = setInterval(pollLogs, 1000);
-  } else {
-    if (logTimer) { clearInterval(logTimer); logTimer = null; }
+  const enabled = verboseToggle.checked;
+  logPanel.classList.toggle("hidden", !enabled);
+  if (enabled) logTimer = setInterval(pollLogs, 1000);
+  else if (logTimer) {
+    clearInterval(logTimer);
+    logTimer = null;
   }
 }
 
@@ -622,81 +660,53 @@ async function pollLogs() {
   try {
     const lines = await invoke("get_logs");
     if (lines.length > 0) {
-      logPanel.textContent += lines.join("\n") + "\n";
+      logPanel.textContent += `${lines.join("\n")}\n`;
       logPanel.scrollTop = logPanel.scrollHeight;
     }
   } catch (_) {
-    // Ignore.
   }
 }
 
-// ---------------------------------------------------------------------------
-// Event bindings
-// ---------------------------------------------------------------------------
-
-// Header back button (PT-1220 AC 8)
 btnBack.addEventListener("click", () => history.back());
-
-// Page 1: Welcome
 btnGetStarted.addEventListener("click", () => navigator_.next());
 btnSkipToNode.addEventListener("click", () => navigator_.goTo(3));
 btnClear.addEventListener("click", clearPairing);
-
-// Page 2: Gateway Scan
 btnScanStartGw.addEventListener("click", startScan);
 btnScanStopGw.addEventListener("click", stopScan);
 btnPair.addEventListener("click", pairGateway);
-
-// Page 3: Pairing Complete
 btnToNode.addEventListener("click", () => navigator_.next());
 btnClearGwDone.addEventListener("click", clearPairing);
-
-// Page 4: Node Scan
 btnScanStartNode.addEventListener("click", startScan);
 btnScanStopNode.addEventListener("click", stopScan);
-btnToProvision.addEventListener("click", () => {
-  btnProvision.disabled = !selectedAddressNode;
-  navigator_.next();
-});
-
-// Page 5: Node Provision
+btnConnectNode.addEventListener("click", connectNode);
+btnSignalAbort.addEventListener("click", abortSignalCheck);
+btnSignalProceed.addEventListener("click", proceedFromSignalCheck);
 btnProvision.addEventListener("click", provisionNode);
 boardSelect.addEventListener("change", () => {
   customPins.classList.toggle("hidden", boardSelect.value !== "custom");
 });
-
-// Page 6: Done
 btnProvisionAnother.addEventListener("click", () => {
   nodeId.value = "";
   selectedAddressNode = null;
-  rssiPanel.classList.add("hidden");
-  btnToProvision.disabled = true;
+  selectedNodeBleRssi = null;
+  updateBleSelectionIndicator(null);
+  resetSignalCheckView();
   renderDevices(deviceListNode, [], false);
   navigator_.goTo(3);
 });
-
-// Diagnostics
 verboseToggle.addEventListener("change", toggleVerbose);
 
-// Back navigation (PT-1220)
-window.addEventListener("popstate", (e) => {
-  if (e.state && e.state.sentinel) {
-    // At the bottom of the history stack — navigate to page 1 and re-establish
-    // a no-exit floor so further back presses stay on page 1 (PT-1220 AC 2, 3)
+window.addEventListener("popstate", (event) => {
+  if (event.state && event.state.sentinel) {
     history.pushState({ page: 0 }, "", "");
     navigator_.goTo(0, { push: false });
     return;
   }
-  if (e.state && typeof e.state.page === "number") {
-    navigator_.goTo(e.state.page, { push: false });
+  if (event.state && typeof event.state.page === "number") {
+    navigator_.goTo(event.state.page, { push: false });
   }
 });
 
-// ---------------------------------------------------------------------------
-// Initialization
-// ---------------------------------------------------------------------------
-
 initBoardSelect();
-refreshPairingStatus().then(() => {
-  navigator_.restore();
-});
+resetSignalCheckView();
+refreshPairingStatus().then(() => navigator_.restore());

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -49,6 +49,7 @@ const diagEspNowValue = document.getElementById("diag-espnow-value");
 const diagEspNowLabel = document.getElementById("diag-espnow-label");
 const signalStatus = document.getElementById("signal-status");
 const btnSignalAbort = document.getElementById("btn-signal-abort");
+const btnSignalRecheck = document.getElementById("btn-signal-recheck");
 const btnSignalProceed = document.getElementById("btn-signal-proceed");
 
 const nodeId = document.getElementById("node-id");
@@ -78,8 +79,8 @@ let pollTimer = null;
 let logTimer = null;
 let busy = false;
 let isPaired = false;
-let signalLoopEnabled = false;
 let diagCurrentPromise = null;
+let signalReadyForProceed = false;
 
 const BOARD_PRESETS = {
   rev_a: {
@@ -172,7 +173,6 @@ class Navigator {
       cleanupScanPage(pageIndex, preserveNodeSelection);
     }
     if (pageIndex === 4 && !preserveConnection) {
-      stopSignalLoop();
       invoke("disconnect_node").catch(() => {});
       resetSignalCheckView();
     }
@@ -207,7 +207,8 @@ function setBusy(value) {
   btnProvision.disabled = value || !selectedAddressNode;
   btnConnectNode.disabled = value || !selectedAddressNode;
   btnSignalAbort.disabled = value;
-  btnSignalProceed.disabled = value || !selectedAddressNode || !signalLoopEnabled;
+  btnSignalRecheck.disabled = value || !selectedAddressNode || !!diagCurrentPromise;
+  btnSignalProceed.disabled = value || !selectedAddressNode || !signalReadyForProceed;
   btnScanStartGw.disabled = value || scanning;
   btnScanStopGw.disabled = value || !scanning || navigator_.current !== 1;
   btnScanStartNode.disabled = value || scanning;
@@ -267,10 +268,11 @@ function updateSignalCheckIndicators(diagRssi = null, signalQuality = null) {
 }
 
 function resetSignalCheckView() {
-  signalLoopEnabled = false;
   diagCurrentPromise = null;
+  signalReadyForProceed = false;
   updateSignalCheckIndicators(null);
   hideStatus(signalStatus);
+  btnSignalRecheck.disabled = true;
   btnSignalProceed.disabled = true;
 }
 
@@ -513,37 +515,33 @@ async function pairGateway() {
   }
 }
 
-function stopSignalLoop() {
-  signalLoopEnabled = false;
-}
-
-async function waitForCurrentDiagnostic() {
-  if (diagCurrentPromise) {
-    try {
-      await diagCurrentPromise;
-    } catch (_) {
-    }
-  }
-}
-
-async function runSignalCheckLoop() {
-  if (!signalLoopEnabled) return;
+async function runSignalCheck() {
+  if (diagCurrentPromise) return;
+  signalReadyForProceed = false;
+  btnSignalRecheck.disabled = true;
+  btnSignalProceed.disabled = true;
+  showStatus(signalStatus, "Running ESP-NOW signal check… The node will disconnect and reconnect automatically.");
   diagCurrentPromise = (async () => {
     try {
       const result = await invoke("check_rssi");
+      if (navigator_.current !== 4) return;
       updateSignalCheckIndicators(result.rssiDbm, result.signalQuality);
-      showStatus(signalStatus, `Last update: ${result.rssiDbm} dBm via ESP-NOW`);
-      btnSignalProceed.disabled = false;
+      showStatus(signalStatus, `Signal check complete: ${result.rssiDbm} dBm via ESP-NOW`);
+      signalReadyForProceed = true;
     } catch (e) {
-      showStatus(signalStatus, `Diagnostic unavailable: ${e}`);
-      btnSignalProceed.disabled = false;
+      if (String(e) !== "signal check cancelled" && navigator_.current === 4) {
+        showStatus(signalStatus, `Diagnostic unavailable: ${e}`);
+        signalReadyForProceed = true;
+      }
     } finally {
       diagCurrentPromise = null;
+      if (navigator_.current === 4) {
+        btnSignalRecheck.disabled = false;
+        btnSignalProceed.disabled = !signalReadyForProceed;
+      }
     }
   })();
-
   await diagCurrentPromise;
-  if (signalLoopEnabled) setTimeout(runSignalCheckLoop, 1000);
 }
 
 async function connectNode() {
@@ -556,11 +554,8 @@ async function connectNode() {
   try {
     await invoke("connect_node", { address: selectedAddressNode });
     navigator_.next();
-    signalLoopEnabled = true;
-    btnSignalProceed.disabled = false;
-    showStatus(signalStatus, "Running ESP-NOW signal check…");
     setBusy(false);
-    runSignalCheckLoop();
+    runSignalCheck();
   } catch (e) {
     showError(e);
     setBusy(false);
@@ -570,8 +565,7 @@ async function connectNode() {
 async function abortSignalCheck() {
   clearError();
   setBusy(true);
-  stopSignalLoop();
-  await waitForCurrentDiagnostic();
+  await invoke("cancel_signal_check").catch(() => {});
   try {
     await invoke("disconnect_node");
   } catch (e) {
@@ -585,12 +579,9 @@ async function abortSignalCheck() {
 
 async function proceedFromSignalCheck() {
   clearError();
-  setBusy(true);
-  stopSignalLoop();
-  await waitForCurrentDiagnostic();
+  if (diagCurrentPromise) return;
   btnProvision.disabled = !selectedAddressNode;
   navigator_.next();
-  setBusy(false);
 }
 
 async function provisionNode() {
@@ -646,8 +637,6 @@ async function refreshPairingStatus() {
 
 async function clearPairing() {
   clearError();
-  stopSignalLoop();
-  await waitForCurrentDiagnostic();
   try {
     await invoke("clear_pairing");
     isPaired = false;
@@ -696,6 +685,7 @@ btnScanStartNode.addEventListener("click", startScan);
 btnScanStopNode.addEventListener("click", stopScan);
 btnConnectNode.addEventListener("click", connectNode);
 btnSignalAbort.addEventListener("click", abortSignalCheck);
+btnSignalRecheck.addEventListener("click", runSignalCheck);
 btnSignalProceed.addEventListener("click", proceedFromSignalCheck);
 btnProvision.addEventListener("click", provisionNode);
 boardSelect.addEventListener("change", () => {

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -220,6 +220,17 @@ function classifyRssi(rssi) {
   return { label: "Bad", cls: "rssi--bad" };
 }
 
+function classifySignalQuality(signalQuality) {
+  switch (signalQuality) {
+    case 0:
+      return { label: "Good", cls: "rssi--good" };
+    case 1:
+      return { label: "Marginal", cls: "rssi--marginal" };
+    default:
+      return { label: "Bad", cls: "rssi--bad" };
+  }
+}
+
 function setIndicator(panel, valueEl, labelEl, rssi, waitingLabel = "--") {
   if (rssi == null) {
     valueEl.textContent = "--";
@@ -243,9 +254,16 @@ function updateBleSelectionIndicator(rssi) {
   setIndicator(rssiIndicator, rssiValue, rssiLabel, rssi);
 }
 
-function updateSignalCheckIndicators(diagRssi = null) {
+function updateSignalCheckIndicators(diagRssi = null, signalQuality = null) {
   setIndicator(diagBleIndicator, diagBleValue, diagBleLabel, selectedNodeBleRssi, "Waiting");
-  setIndicator(diagEspNowIndicator, diagEspNowValue, diagEspNowLabel, diagRssi, "Waiting");
+  if (diagRssi == null || signalQuality == null) {
+    setIndicator(diagEspNowIndicator, diagEspNowValue, diagEspNowLabel, null, "Waiting");
+    return;
+  }
+  const quality = classifySignalQuality(signalQuality);
+  diagEspNowValue.textContent = `${diagRssi} dBm`;
+  diagEspNowLabel.textContent = quality.label;
+  diagEspNowIndicator.className = `rssi-indicator ${quality.cls}`;
 }
 
 function resetSignalCheckView() {
@@ -513,7 +531,7 @@ async function runSignalCheckLoop() {
   diagCurrentPromise = (async () => {
     try {
       const result = await invoke("check_rssi");
-      updateSignalCheckIndicators(result.rssiDbm);
+      updateSignalCheckIndicators(result.rssiDbm, result.signalQuality);
       showStatus(signalStatus, `Last update: ${result.rssiDbm} dBm via ESP-NOW`);
       btnSignalProceed.disabled = false;
     } catch (e) {
@@ -533,19 +551,17 @@ async function connectNode() {
   clearError();
   if (scanning) await stopScan();
   setBusy(true);
-  navigator_.next();
   resetSignalCheckView();
   updateSignalCheckIndicators(null);
-  showStatus(signalStatus, "Connecting to node…");
   try {
     await invoke("connect_node", { address: selectedAddressNode });
+    navigator_.next();
     signalLoopEnabled = true;
     btnSignalProceed.disabled = false;
     showStatus(signalStatus, "Running ESP-NOW signal check…");
     setBusy(false);
     runSignalCheckLoop();
   } catch (e) {
-    navigator_.back();
     showError(e);
     setBusy(false);
   }

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -47,6 +47,7 @@ const diagBleLabel = document.getElementById("diag-ble-label");
 const diagEspNowIndicator = document.getElementById("diag-espnow-indicator");
 const diagEspNowValue = document.getElementById("diag-espnow-value");
 const diagEspNowLabel = document.getElementById("diag-espnow-label");
+const signalNodeAddress = document.getElementById("signal-node-address");
 const signalStatus = document.getElementById("signal-status");
 const btnSignalAbort = document.getElementById("btn-signal-abort");
 const btnSignalRecheck = document.getElementById("btn-signal-recheck");
@@ -267,6 +268,10 @@ function updateSignalCheckIndicators(diagRssi = null, signalQuality = null) {
   diagEspNowIndicator.className = `rssi-indicator ${quality.cls}`;
 }
 
+function updateSignalCheckNodeIdentity() {
+  signalNodeAddress.textContent = selectedAddressNode || "--";
+}
+
 function resetSignalCheckView() {
   diagCurrentPromise = null;
   signalReadyForProceed = false;
@@ -386,6 +391,7 @@ function selectNodeDevice(address, rssi) {
   for (const li of deviceListNode.children) li.classList.toggle("selected", li.dataset.address === address);
   updateBleSelectionIndicator(rssi);
   updateSignalCheckIndicators(null);
+  updateSignalCheckNodeIdentity();
   btnConnectNode.disabled = busy || !address;
 }
 
@@ -411,10 +417,11 @@ function cleanupScanPage(pageIndex, preserveNodeSelection) {
       selectedNodeBleRssi = null;
       btnConnectNode.disabled = true;
       updateBleSelectionIndicator(null);
+      updateSignalCheckNodeIdentity();
+      renderDevices(deviceListNode, [], false);
     }
     btnScanStartNode.disabled = false;
     btnScanStopNode.disabled = true;
-    renderDevices(deviceListNode, [], false);
   }
 }
 
@@ -436,6 +443,7 @@ async function startScan() {
       selectedNodeBleRssi = null;
       btnConnectNode.disabled = true;
       updateBleSelectionIndicator(null);
+      updateSignalCheckNodeIdentity();
       btnScanStartNode.disabled = true;
       btnScanStopNode.disabled = false;
     }
@@ -523,7 +531,7 @@ async function runSignalCheck() {
   showStatus(signalStatus, "Running ESP-NOW signal check… The node will disconnect and reconnect automatically.");
   diagCurrentPromise = (async () => {
     try {
-      const result = await invoke("check_rssi");
+      const result = await invoke("check_rssi", { address: selectedAddressNode });
       if (navigator_.current !== 4) return;
       updateSignalCheckIndicators(result.rssiDbm, result.signalQuality);
       showStatus(signalStatus, `Signal check complete: ${result.rssiDbm} dBm via ESP-NOW`);
@@ -643,6 +651,7 @@ async function clearPairing() {
     selectedAddressNode = null;
     selectedNodeBleRssi = null;
     updateBleSelectionIndicator(null);
+    updateSignalCheckNodeIdentity();
     resetSignalCheckView();
     await refreshPairingStatus();
     navigator_.goTo(0);
@@ -696,6 +705,7 @@ btnProvisionAnother.addEventListener("click", () => {
   selectedAddressNode = null;
   selectedNodeBleRssi = null;
   updateBleSelectionIndicator(null);
+  updateSignalCheckNodeIdentity();
   resetSignalCheckView();
   renderDevices(deviceListNode, [], false);
   navigator_.goTo(3);
@@ -714,5 +724,6 @@ window.addEventListener("popstate", (event) => {
 });
 
 initBoardSelect();
+updateSignalCheckNodeIdentity();
 resetSignalCheckView();
 refreshPairingStatus().then(() => navigator_.restore());

--- a/crates/sonde-pair-ui/src/styles.css
+++ b/crates/sonde-pair-ui/src/styles.css
@@ -409,6 +409,22 @@ label {
   border: 1px solid var(--error);
 }
 
+.signal-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.signal-grid h3 {
+  margin-bottom: 8px;
+  font-size: 14px;
+}
+
+.signal-note {
+  margin-top: 14px;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+
 /* Success info */
 .success-info {
   padding: 10px 0;

--- a/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
+++ b/crates/sonde-pair/java/io/sonde/pair/BleHelper.java
@@ -90,10 +90,10 @@ public class BleHelper {
     private volatile boolean bondReceiverRegistered;
     private volatile BluetoothDevice bondTarget;
     // When true, createBond() is called AFTER the GATT connect latch
-    // instead of before it.  Used for node connections where the node
-    // calls ble_gap_security_initiate() in on_connect — calling
-    // createBond() before the latch causes a dual-initiation race that
-    // confuses NimBLE's SMP state machine.
+    // instead of before it. Used for node connections, which use the
+    // standard Android client-driven bonding flow for headless Just Works
+    // pairing. Calling createBond() before the latch caused repeated
+    // connect/disconnect churn on some C3 nodes.
     private volatile boolean deferBonding;
 
     // --- Pairing method observation (PT-0904) -----------------------------
@@ -509,10 +509,10 @@ public class BleHelper {
     /**
      * When set, {@link #connect} calls {@code createBond()} after the GATT
      * connect latch (the original Android BLE flow) instead of before it.
-     * Used for node connections where the node calls
-     * {@code ble_gap_security_initiate()} in its {@code on_connect} callback;
-     * calling {@code createBond()} before the latch causes a dual-initiation
-     * race that confuses NimBLE's SMP state machine.
+     * Used for node connections, which use the standard Android client-driven
+     * bonding flow for headless Just Works pairing. Calling
+     * {@code createBond()} before the latch caused repeated
+     * connect/disconnect churn on some C3 nodes.
      */
     public void setDeferBonding(boolean defer) {
         this.deferBonding = defer;
@@ -623,11 +623,10 @@ public class BleHelper {
         //
         // When deferBondingForThisConnect is TRUE (node / Phase 2):
         //   Wait for the GATT connect latch first, THEN call createBond().
-        //   The node calls ble_gap_security_initiate() in on_connect and
-        //   expects the client to participate in SMP for on_authentication_complete
-        //   to fire.  Calling createBond() before the latch causes dual-initiation
-        //   that confuses NimBLE's SMP state machine.  Calling it after the latch
-        //   is the standard Android BLE flow and works correctly with Just Works.
+        //   The node uses standard Android client-driven bonding for headless
+        //   Just Works pairing. Calling createBond() before the latch caused
+        //   repeated connect/disconnect churn on some C3 nodes; calling it
+        //   after the latch follows the normal Android BLE flow.
         if (!deferBondingForThisConnect) {
             callCreateBond(device);
         }

--- a/crates/sonde-pair/src/error.rs
+++ b/crates/sonde-pair/src/error.rs
@@ -164,6 +164,9 @@ pub enum PairingError {
     #[error("diagnostic failed: {0}")]
     DiagnosticFailed(String),
 
+    #[error("{operation} cancelled")]
+    Cancelled { operation: &'static str },
+
     #[error("BLE pairing used insecure method `{method}` — Numeric Comparison (LESC) is required")]
     InsecurePairingMethod { method: PairingMethod },
 

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -55,6 +55,54 @@ pub async fn provision_node(
     sensors: &[crate::types::SensorDescriptor],
     board_layout: Option<BoardLayout>,
 ) -> Result<NodeProvisionResult, PairingError> {
+    // Step 6: Connect to node
+    // Defer createBond() until after the GATT connect latch.  The node
+    // calls ble_gap_security_initiate() in its on_connect callback;
+    // calling createBond() before the latch causes a dual-initiation race
+    // that confuses NimBLE's SMP state machine.  Deferring createBond()
+    // to after the latch is the standard Android BLE flow and works
+    // correctly with the node's Just Works pairing.
+    transport.set_defer_bonding(true);
+    debug!(address = ?device_address, "connecting to node (AEAD provision)");
+    let mtu_result = transport.connect(device_address).await;
+    // Reset defer-bonding hint immediately (one-shot) so any subsequent
+    // connection on the same transport uses the default bonding flow.
+    transport.set_defer_bonding(false);
+    let mtu = mtu_result?;
+    if mtu < BLE_MTU_MIN {
+        transport.disconnect().await.ok();
+        return Err(PairingError::MtuTooLow {
+            device: format_device_address(device_address),
+            negotiated: mtu,
+            required: BLE_MTU_MIN,
+        });
+    }
+    debug!(address = ?device_address, mtu, "connected to node");
+
+    // Note: enforce_lesc() is intentionally NOT called for node connections.
+    // The node uses LESC Just Works (ND-0904) because it has no display or
+    // input for Numeric Comparison.  PT-0904 (LESC Numeric Comparison
+    // enforcement) applies only to the modem connection in Phase 1.
+    // LESC Just Works still provides link-layer encryption but does not
+    // protect against active MITM — this residual risk is accepted for
+    // headless nodes per the protocol spec (ble-pairing-protocol.md §8.2).
+
+    let result =
+        provision_connected_node(transport, artifacts, rng, node_id, sensors, board_layout).await;
+
+    transport.disconnect().await.ok();
+    result
+}
+
+/// Provision a node over an already-connected BLE session.
+pub async fn provision_connected_node(
+    transport: &mut dyn BleTransport,
+    artifacts: &crate::phase1::PairingArtifacts,
+    rng: &dyn RngProvider,
+    node_id: &str,
+    sensors: &[crate::types::SensorDescriptor],
+    board_layout: Option<BoardLayout>,
+) -> Result<NodeProvisionResult, PairingError> {
     // Step 1: Validate node_id
     validate_node_id(node_id)?;
 
@@ -88,41 +136,9 @@ pub async fn provision_node(
     // Step 5: Encrypt with phone_psk and wrap in ESP-NOW AEAD PEER_REQUEST frame.
     let encrypted_frame = crypto::encrypt_pairing_request(&artifacts.phone_psk, &cbor)?;
 
-    // Step 6: Connect to node
-    // Defer createBond() until after the GATT connect latch.  The node
-    // calls ble_gap_security_initiate() in its on_connect callback;
-    // calling createBond() before the latch causes a dual-initiation race
-    // that confuses NimBLE's SMP state machine.  Deferring createBond()
-    // to after the latch is the standard Android BLE flow and works
-    // correctly with the node's Just Works pairing.
-    transport.set_defer_bonding(true);
-    debug!(address = ?device_address, "connecting to node (AEAD provision)");
-    let mtu_result = transport.connect(device_address).await;
-    // Reset defer-bonding hint immediately (one-shot) so any subsequent
-    // connection on the same transport uses the default bonding flow.
-    transport.set_defer_bonding(false);
-    let mtu = mtu_result?;
-    if mtu < BLE_MTU_MIN {
-        transport.disconnect().await.ok();
-        return Err(PairingError::MtuTooLow {
-            device: format_device_address(device_address),
-            negotiated: mtu,
-            required: BLE_MTU_MIN,
-        });
-    }
-    debug!(address = ?device_address, mtu, "connected to node");
-
-    // Note: enforce_lesc() is intentionally NOT called for node connections.
-    // The node uses LESC Just Works (ND-0904) because it has no display or
-    // input for Numeric Comparison.  PT-0904 (LESC Numeric Comparison
-    // enforcement) applies only to the modem connection in Phase 1.
-    // LESC Just Works still provides link-layer encryption but does not
-    // protect against active MITM — this residual risk is accepted for
-    // headless nodes per the protocol spec (ble-pairing-protocol.md §8.2).
-
     // Step 7: Build NODE_PROVISION payload (AEAD format per spec §6.6):
     // node_key_hint(2) || node_psk(32) || rf_channel(1) || payload_len(2) || encrypted_payload
-    let result = do_provision_node(
+    do_provision_node(
         transport,
         node_key_hint,
         &node_psk,
@@ -130,10 +146,7 @@ pub async fn provision_node(
         &encrypted_frame,
         board_layout,
     )
-    .await;
-
-    transport.disconnect().await.ok();
-    result
+    .await
 }
 
 /// Inner implementation for AEAD node provisioning.
@@ -424,6 +437,42 @@ mod tests {
             37 + payload_len,
             "body length must be exactly 37 + payload_len when no pin config"
         );
+    }
+
+    #[tokio::test]
+    async fn provision_connected_node_happy_path() {
+        use crate::phase1::PairingArtifacts;
+
+        let artifacts = PairingArtifacts {
+            phone_psk: Zeroizing::new([0x55u8; 32]),
+            phone_key_hint: compute_key_hint(&[0x55u8; 32]),
+            rf_channel: 6,
+            phone_label: "test".into(),
+        };
+
+        let rng = MockRng::new([0x42u8; 32]);
+
+        let ack_body = [0x00u8];
+        let mut ack_envelope = Vec::new();
+        ack_envelope.push(NODE_ACK);
+        ack_envelope.extend_from_slice(&(ack_body.len() as u16).to_be_bytes());
+        ack_envelope.extend_from_slice(&ack_body);
+
+        let mut transport = MockBleTransport::new(247);
+        transport.connected = true;
+        transport.queue_response(Ok(ack_envelope));
+
+        let result =
+            provision_connected_node(&mut transport, &artifacts, &rng, "test-node", &[], None)
+                .await;
+
+        assert!(
+            result.is_ok(),
+            "provision_connected_node should succeed: {result:?}"
+        );
+        assert_eq!(result.unwrap().status, NodeAckStatus::Success);
+        assert_eq!(transport.written.len(), 1);
+        assert_eq!(transport.disconnect_count, 0);
     }
 
     #[tokio::test]

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -24,6 +24,9 @@ const DIAG_RELAY_ACK_TIMEOUT_MS: u64 = 5_000;
 /// FETCH_DIAG_RESULT indication timeout in milliseconds.
 const DIAG_RELAY_FETCH_TIMEOUT_MS: u64 = 5_000;
 
+/// Poll interval for cancellation-aware diagnostic indication waits.
+const DIAG_RELAY_READ_POLL_MS: u64 = 250;
+
 /// Maximum time to wait for the node to resume advertising after an accepted diagnostic.
 const DIAG_RELAY_RECONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -316,13 +319,14 @@ pub async fn check_rssi(
         .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &envelope)
         .await?;
 
-    let response = transport
-        .read_indication(
-            NODE_SERVICE_UUID,
-            NODE_COMMAND_UUID,
-            DIAG_RELAY_ACK_TIMEOUT_MS,
-        )
-        .await?;
+    let response = read_indication_with_cancellation(
+        transport,
+        NODE_SERVICE_UUID,
+        NODE_COMMAND_UUID,
+        DIAG_RELAY_ACK_TIMEOUT_MS,
+        cancelled,
+    )
+    .await?;
     let (msg_type, body) = sonde_protocol::parse_ble_envelope(&response).ok_or_else(|| {
         PairingError::InvalidResponse {
             msg_type: 0,
@@ -373,13 +377,14 @@ pub async fn check_rssi(
         .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &fetch_envelope)
         .await?;
 
-    let response = transport
-        .read_indication(
-            NODE_SERVICE_UUID,
-            NODE_COMMAND_UUID,
-            DIAG_RELAY_FETCH_TIMEOUT_MS,
-        )
-        .await?;
+    let response = read_indication_with_cancellation(
+        transport,
+        NODE_SERVICE_UUID,
+        NODE_COMMAND_UUID,
+        DIAG_RELAY_FETCH_TIMEOUT_MS,
+        cancelled,
+    )
+    .await?;
     let (msg_type, body) = sonde_protocol::parse_ble_envelope(&response).ok_or_else(|| {
         PairingError::InvalidResponse {
             msg_type: 0,
@@ -433,6 +438,32 @@ fn check_cancelled(cancelled: &AtomicBool) -> Result<(), PairingError> {
         });
     }
     Ok(())
+}
+
+async fn read_indication_with_cancellation(
+    transport: &mut dyn BleTransport,
+    service: u128,
+    characteristic: u128,
+    total_timeout_ms: u64,
+    cancelled: &AtomicBool,
+) -> Result<Vec<u8>, PairingError> {
+    let deadline = Instant::now() + Duration::from_millis(total_timeout_ms);
+    loop {
+        check_cancelled(cancelled)?;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let timeout_ms = remaining.as_millis().min(DIAG_RELAY_READ_POLL_MS as u128) as u64;
+        match transport
+            .read_indication(service, characteristic, timeout_ms.max(1))
+            .await
+        {
+            Ok(response) => return Ok(response),
+            Err(PairingError::IndicationTimeout { device: _ }) if Instant::now() < deadline => {}
+            Err(PairingError::IndicationTimeout { device }) => {
+                return Err(PairingError::IndicationTimeout { device });
+            }
+            Err(e) => return Err(e),
+        }
+    }
 }
 
 async fn reconnect_after_diag(

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -10,20 +10,35 @@ use crate::transport::BleTransport;
 use crate::types::*;
 use crate::validation::{compute_key_hint, validate_node_id};
 use sonde_protocol::encode_board_layout_cbor;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 use tracing::{debug, info, trace};
 use zeroize::Zeroizing;
 
 /// NODE_ACK indication timeout in milliseconds (PT-1002).
 const NODE_ACK_TIMEOUT_MS: u64 = 5_000;
 
-/// DIAG_RELAY_RESPONSE indication timeout in milliseconds (PT-1303).
-const DIAG_RELAY_TIMEOUT_MS: u64 = 10_000;
+/// START_DIAG_RELAY acknowledgement timeout in milliseconds.
+const DIAG_RELAY_ACK_TIMEOUT_MS: u64 = 5_000;
+
+/// FETCH_DIAG_RESULT indication timeout in milliseconds.
+const DIAG_RELAY_FETCH_TIMEOUT_MS: u64 = 5_000;
+
+/// Maximum time to wait for the node to resume advertising after an accepted diagnostic.
+const DIAG_RELAY_RECONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Delay between reconnect attempts during an in-flight diagnostic.
+const DIAG_RELAY_RECONNECT_POLL: Duration = Duration::from_millis(250);
 
 /// Map a BLE provisioning message type byte to its spec name (PT-0702).
 fn msg_type_name(t: u8) -> &'static str {
     match t {
         NODE_PROVISION => "NODE_PROVISION",
         NODE_ACK => "NODE_ACK",
+        sonde_protocol::BLE_START_DIAG_RELAY => "START_DIAG_RELAY",
+        sonde_protocol::BLE_FETCH_DIAG_RESULT => "FETCH_DIAG_RESULT",
+        sonde_protocol::BLE_DIAG_RELAY_ACK => "DIAG_RELAY_ACK",
+        sonde_protocol::BLE_DIAG_RELAY_RESULT => "DIAG_RELAY_RESULT",
         MSG_ERROR => "ERROR",
         _ => "UNKNOWN",
     }
@@ -284,56 +299,111 @@ pub struct DiagnosticResult {
 pub async fn check_rssi(
     transport: &mut dyn BleTransport,
     artifacts: &crate::phase1::PairingArtifacts,
+    device_address: &[u8; 6],
+    cancelled: &AtomicBool,
 ) -> Result<DiagnosticResult, PairingError> {
-    // 1. Build DIAG_REQUEST frame (PT-1301).
+    check_cancelled(cancelled)?;
     let (diag_frame, request_nonce) =
         crate::crypto::build_diag_request_frame(&artifacts.phone_psk)?;
 
-    // 2. Wrap in DIAG_RELAY_REQUEST BLE envelope (PT-1302).
-    let relay_body = sonde_protocol::encode_diag_relay_request(artifacts.rf_channel, &diag_frame)
+    let relay_body = sonde_protocol::encode_start_diag_relay(artifacts.rf_channel, &diag_frame)
         .map_err(|e| PairingError::DiagnosticFailed(format!("relay encode: {}", e)))?;
     let envelope =
-        sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_REQUEST, &relay_body)
+        sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_START_DIAG_RELAY, &relay_body)
             .ok_or_else(|| PairingError::DiagnosticFailed("BLE envelope too large".into()))?;
 
-    // 3. Write to node BLE characteristic.
     transport
         .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &envelope)
         .await?;
 
-    // 4. Wait for DIAG_RELAY_RESPONSE (timeout per PT-1303).
     let response = transport
-        .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, DIAG_RELAY_TIMEOUT_MS)
+        .read_indication(
+            NODE_SERVICE_UUID,
+            NODE_COMMAND_UUID,
+            DIAG_RELAY_ACK_TIMEOUT_MS,
+        )
         .await?;
-
-    // 5. Parse BLE envelope.
     let (msg_type, body) = sonde_protocol::parse_ble_envelope(&response).ok_or_else(|| {
         PairingError::InvalidResponse {
             msg_type: 0,
             reason: "malformed BLE envelope".into(),
         }
     })?;
-    if msg_type != sonde_protocol::BLE_DIAG_RELAY_RESPONSE {
+    if msg_type != sonde_protocol::BLE_DIAG_RELAY_ACK {
         return Err(PairingError::InvalidResponse {
             msg_type,
             reason: format!(
-                "expected DIAG_RELAY_RESPONSE (0x82), got 0x{:02x}",
-                msg_type
+                "expected DIAG_RELAY_ACK (0x{:02x}), got 0x{msg_type:02x}",
+                sonde_protocol::BLE_DIAG_RELAY_ACK
             ),
         });
     }
+    let status =
+        sonde_protocol::decode_diag_relay_ack(body).map_err(|e| PairingError::InvalidResponse {
+            msg_type,
+            reason: format!("decode relay ack: {}", e),
+        })?;
+    match status {
+        sonde_protocol::DIAG_RELAY_ACK_ACCEPTED => {}
+        sonde_protocol::DIAG_RELAY_ACK_BUSY => {
+            return Err(PairingError::DiagnosticFailed(
+                "node is busy with a previous diagnostic result — retry after reconnect".into(),
+            ));
+        }
+        sonde_protocol::DIAG_RELAY_ACK_INVALID => {
+            return Err(PairingError::DiagnosticFailed(
+                "node rejected the diagnostic request — verify RF channel and payload".into(),
+            ));
+        }
+        other => {
+            return Err(PairingError::DiagnosticFailed(format!(
+                "unknown diagnostic acknowledgement: 0x{other:02x}"
+            )));
+        }
+    }
 
-    // 6. Parse relay response status.
-    let (status, payload) = sonde_protocol::decode_diag_relay_response(body).map_err(|e| {
+    check_cancelled(cancelled)?;
+    transport.disconnect().await.ok();
+    reconnect_after_diag(transport, device_address, cancelled).await?;
+
+    let fetch_envelope =
+        sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_FETCH_DIAG_RESULT, &[])
+            .ok_or_else(|| PairingError::DiagnosticFailed("BLE envelope too large".into()))?;
+    transport
+        .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &fetch_envelope)
+        .await?;
+
+    let response = transport
+        .read_indication(
+            NODE_SERVICE_UUID,
+            NODE_COMMAND_UUID,
+            DIAG_RELAY_FETCH_TIMEOUT_MS,
+        )
+        .await?;
+    let (msg_type, body) = sonde_protocol::parse_ble_envelope(&response).ok_or_else(|| {
+        PairingError::InvalidResponse {
+            msg_type: 0,
+            reason: "malformed BLE envelope".into(),
+        }
+    })?;
+    if msg_type != sonde_protocol::BLE_DIAG_RELAY_RESULT {
+        return Err(PairingError::InvalidResponse {
+            msg_type,
+            reason: format!(
+                "expected DIAG_RELAY_RESULT (0x{:02x}), got 0x{msg_type:02x}",
+                sonde_protocol::BLE_DIAG_RELAY_RESULT
+            ),
+        });
+    }
+    let (status, payload) = sonde_protocol::decode_diag_relay_result(body).map_err(|e| {
         PairingError::InvalidResponse {
             msg_type,
-            reason: format!("decode relay response: {}", e),
+            reason: format!("decode relay result: {}", e),
         }
     })?;
 
     match status {
-        sonde_protocol::DIAG_RELAY_STATUS_OK => {
-            // 7. Decrypt DIAG_REPLY (PT-1303 AC-2).
+        sonde_protocol::DIAG_RELAY_RESULT_OK => {
             let (rssi_dbm, signal_quality) =
                 crate::crypto::decrypt_diag_reply(payload, &artifacts.phone_psk, request_nonce)?;
             Ok(DiagnosticResult {
@@ -341,16 +411,63 @@ pub async fn check_rssi(
                 signal_quality,
             })
         }
-        sonde_protocol::DIAG_RELAY_STATUS_TIMEOUT => Err(PairingError::DiagnosticFailed(
+        sonde_protocol::DIAG_RELAY_RESULT_TIMEOUT => Err(PairingError::DiagnosticFailed(
             "no response from gateway — verify gateway is running and modem is connected".into(),
         )),
-        sonde_protocol::DIAG_RELAY_STATUS_CHANNEL_ERROR => Err(PairingError::DiagnosticFailed(
+        sonde_protocol::DIAG_RELAY_RESULT_CHANNEL_ERROR => Err(PairingError::DiagnosticFailed(
             "channel error — verify RF channel configuration".into(),
         )),
+        sonde_protocol::DIAG_RELAY_RESULT_NO_RESULT => Err(PairingError::DiagnosticFailed(
+            "node has no completed diagnostic result — retry the signal check".into(),
+        )),
         other => Err(PairingError::DiagnosticFailed(format!(
-            "unknown relay status: 0x{:02x}",
-            other
+            "unknown relay result status: 0x{other:02x}"
         ))),
+    }
+}
+
+fn check_cancelled(cancelled: &AtomicBool) -> Result<(), PairingError> {
+    if cancelled.load(Ordering::Relaxed) {
+        return Err(PairingError::Cancelled {
+            operation: "signal check",
+        });
+    }
+    Ok(())
+}
+
+async fn reconnect_after_diag(
+    transport: &mut dyn BleTransport,
+    device_address: &[u8; 6],
+    cancelled: &AtomicBool,
+) -> Result<(), PairingError> {
+    let deadline = Instant::now() + DIAG_RELAY_RECONNECT_TIMEOUT;
+    let device = format_device_address(device_address);
+    loop {
+        check_cancelled(cancelled)?;
+        transport.set_defer_bonding(true);
+        let mtu_result = transport.connect(device_address).await;
+        transport.set_defer_bonding(false);
+        match mtu_result {
+            Ok(mtu) => {
+                if mtu < BLE_MTU_MIN {
+                    transport.disconnect().await.ok();
+                    return Err(PairingError::MtuTooLow {
+                        device,
+                        negotiated: mtu,
+                        required: BLE_MTU_MIN,
+                    });
+                }
+                return Ok(());
+            }
+            Err(_) if Instant::now() < deadline => std::thread::sleep(DIAG_RELAY_RECONNECT_POLL),
+            Err(_) => {
+                return Err(PairingError::Timeout {
+                    device: Some(device),
+                    operation: "diagnostic reconnect",
+                    duration_secs: DIAG_RELAY_RECONNECT_TIMEOUT.as_secs(),
+                });
+            }
+        }
     }
 }
 
@@ -811,46 +928,99 @@ mod tests {
     #[tokio::test]
     async fn check_rssi_timeout_status() {
         let artifacts = mock_artifacts();
+        let cancelled = AtomicBool::new(false);
 
-        let relay_body = sonde_protocol::encode_diag_relay_response(
-            sonde_protocol::DIAG_RELAY_STATUS_TIMEOUT,
+        let ack_body =
+            sonde_protocol::encode_diag_relay_ack(sonde_protocol::DIAG_RELAY_ACK_ACCEPTED).unwrap();
+        let ack_response =
+            sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_ACK, &ack_body)
+                .unwrap();
+        let relay_body = sonde_protocol::encode_diag_relay_result(
+            sonde_protocol::DIAG_RELAY_RESULT_TIMEOUT,
             &[],
         )
         .unwrap();
-        let ble_response = sonde_protocol::encode_ble_envelope(
-            sonde_protocol::BLE_DIAG_RELAY_RESPONSE,
-            &relay_body,
-        )
-        .unwrap();
+        let ble_response =
+            sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_RESULT, &relay_body)
+                .unwrap();
 
         let mut transport = MockBleTransport::new(247);
+        transport.connected = true;
+        transport.queue_response(Ok(ack_response));
         transport.queue_response(Ok(ble_response));
 
-        let result = check_rssi(&mut transport, &artifacts).await;
+        let result = check_rssi(&mut transport, &artifacts, &[0xAA; 6], &cancelled).await;
         assert!(matches!(result, Err(PairingError::DiagnosticFailed(_))));
-        assert_eq!(transport.written.len(), 1);
+        assert_eq!(transport.written.len(), 2);
+        assert_eq!(transport.disconnect_count, 1);
     }
 
     #[tokio::test]
     async fn check_rssi_channel_error_status() {
         let artifacts = mock_artifacts();
+        let cancelled = AtomicBool::new(false);
 
-        let relay_body = sonde_protocol::encode_diag_relay_response(
-            sonde_protocol::DIAG_RELAY_STATUS_CHANNEL_ERROR,
+        let ack_body =
+            sonde_protocol::encode_diag_relay_ack(sonde_protocol::DIAG_RELAY_ACK_ACCEPTED).unwrap();
+        let ack_response =
+            sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_ACK, &ack_body)
+                .unwrap();
+        let relay_body = sonde_protocol::encode_diag_relay_result(
+            sonde_protocol::DIAG_RELAY_RESULT_CHANNEL_ERROR,
             &[],
         )
         .unwrap();
-        let ble_response = sonde_protocol::encode_ble_envelope(
-            sonde_protocol::BLE_DIAG_RELAY_RESPONSE,
-            &relay_body,
+        let ble_response =
+            sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_RESULT, &relay_body)
+                .unwrap();
+
+        let mut transport = MockBleTransport::new(247);
+        transport.connected = true;
+        transport.queue_response(Ok(ack_response));
+        transport.queue_response(Ok(ble_response));
+
+        let result = check_rssi(&mut transport, &artifacts, &[0xAA; 6], &cancelled).await;
+        assert!(matches!(result, Err(PairingError::DiagnosticFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn check_rssi_reconnects_and_fetches_result() {
+        let artifacts = mock_artifacts();
+        let cancelled = AtomicBool::new(false);
+        let ack_body =
+            sonde_protocol::encode_diag_relay_ack(sonde_protocol::DIAG_RELAY_ACK_ACCEPTED).unwrap();
+        let ack_response =
+            sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_ACK, &ack_body)
+                .unwrap();
+        let result_body = sonde_protocol::encode_diag_relay_result(
+            sonde_protocol::DIAG_RELAY_RESULT_NO_RESULT,
+            &[],
+        )
+        .unwrap();
+        let result_response = sonde_protocol::encode_ble_envelope(
+            sonde_protocol::BLE_DIAG_RELAY_RESULT,
+            &result_body,
         )
         .unwrap();
 
         let mut transport = MockBleTransport::new(247);
-        transport.queue_response(Ok(ble_response));
+        transport.connected = true;
+        transport.queue_response(Ok(ack_response));
+        transport.queue_response(Ok(result_response));
 
-        let result = check_rssi(&mut transport, &artifacts).await;
+        let result = check_rssi(&mut transport, &artifacts, &[0xAA; 6], &cancelled).await;
+
         assert!(matches!(result, Err(PairingError::DiagnosticFailed(_))));
+        assert_eq!(transport.disconnect_count, 1);
+        assert_eq!(transport.written.len(), 2);
+        assert_eq!(
+            transport.written[0].2[0],
+            sonde_protocol::BLE_START_DIAG_RELAY
+        );
+        assert_eq!(
+            transport.written[1].2[0],
+            sonde_protocol::BLE_FETCH_DIAG_RESULT
+        );
     }
 
     /// Validates: PT-1214 AC2 — board layout CBOR deterministic encoding.

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -74,12 +74,10 @@ pub async fn provision_node(
     board_layout: Option<BoardLayout>,
 ) -> Result<NodeProvisionResult, PairingError> {
     // Step 6: Connect to node
-    // Defer createBond() until after the GATT connect latch.  The node
-    // calls ble_gap_security_initiate() in its on_connect callback;
-    // calling createBond() before the latch causes a dual-initiation race
-    // that confuses NimBLE's SMP state machine.  Deferring createBond()
-    // to after the latch is the standard Android BLE flow and works
-    // correctly with the node's Just Works pairing.
+    // Defer createBond() until after the GATT connect latch. Node pairing
+    // uses the standard Android client-driven bonding flow for headless
+    // Just Works pairing; calling createBond() before the latch caused
+    // repeated connect/disconnect churn on some C3 nodes.
     transport.set_defer_bonding(true);
     debug!(address = ?device_address, "connecting to node (AEAD provision)");
     let mtu_result = transport.connect(device_address).await;

--- a/crates/sonde-protocol/src/ble_envelope.rs
+++ b/crates/sonde-protocol/src/ble_envelope.rs
@@ -50,21 +50,21 @@ pub fn encode_ble_envelope(msg_type: u8, body: &[u8]) -> Option<Vec<u8>> {
     Some(out)
 }
 
-/// Encode a DIAG_RELAY_REQUEST BLE body.
+/// Encode a START_DIAG_RELAY BLE body.
 ///
 /// Body format: `rf_channel (1B) | payload_len (2B BE) | payload`.
 /// Returns `Err` if `rf_channel` is outside 1–13, `payload` is empty,
 /// or `payload` exceeds `MAX_FRAME_SIZE`.
-pub fn encode_diag_relay_request(rf_channel: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError> {
+pub fn encode_start_diag_relay(rf_channel: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError> {
     if !(1..=13).contains(&rf_channel) {
         return Err(EncodeError::InvalidParameter(alloc::format!(
-            "DIAG_RELAY_REQUEST rf_channel {} out of range 1-13",
+            "START_DIAG_RELAY rf_channel {} out of range 1-13",
             rf_channel
         )));
     }
     if payload.is_empty() {
         return Err(EncodeError::InvalidParameter(
-            "DIAG_RELAY_REQUEST payload must not be empty".into(),
+            "START_DIAG_RELAY payload must not be empty".into(),
         ));
     }
     if payload.len() > MAX_FRAME_SIZE {
@@ -78,12 +78,8 @@ pub fn encode_diag_relay_request(rf_channel: u8, payload: &[u8]) -> Result<Vec<u
     Ok(body)
 }
 
-/// Decode a DIAG_RELAY_REQUEST BLE body.
-///
-/// Returns `(rf_channel, payload)` on success. Rejects truncated bodies,
-/// bodies with trailing bytes, out-of-range channels, empty payloads,
-/// and oversized payloads.
-pub fn decode_diag_relay_request(body: &[u8]) -> Result<(u8, &[u8]), DecodeError> {
+/// Decode a START_DIAG_RELAY BLE body.
+pub fn decode_start_diag_relay(body: &[u8]) -> Result<(u8, &[u8]), DecodeError> {
     if body.len() < 3 {
         return Err(DecodeError::TooShort);
     }
@@ -111,14 +107,30 @@ pub fn decode_diag_relay_request(body: &[u8]) -> Result<(u8, &[u8]), DecodeError
     Ok((rf_channel, &body[3..3 + payload_len]))
 }
 
-/// Encode a DIAG_RELAY_RESPONSE BLE body.
+/// Encode a DIAG_RELAY_ACK BLE body.
+pub fn encode_diag_relay_ack(status: u8) -> Result<Vec<u8>, EncodeError> {
+    Ok(alloc::vec![status])
+}
+
+/// Decode a DIAG_RELAY_ACK BLE body.
+pub fn decode_diag_relay_ack(body: &[u8]) -> Result<u8, DecodeError> {
+    if body.is_empty() {
+        return Err(DecodeError::TooShort);
+    }
+    if body.len() > 1 {
+        return Err(DecodeError::TooLong);
+    }
+    Ok(body[0])
+}
+
+/// Encode a DIAG_RELAY_RESULT BLE body.
 ///
 /// Body format: `status (1B) | payload_len (2B BE) | payload`.
-/// When `status` ≠ `DIAG_RELAY_STATUS_OK`, `payload` must be empty.
-pub fn encode_diag_relay_response(status: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError> {
-    if status != crate::constants::DIAG_RELAY_STATUS_OK && !payload.is_empty() {
+/// When `status` ≠ `DIAG_RELAY_RESULT_OK`, `payload` must be empty.
+pub fn encode_diag_relay_result(status: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError> {
+    if status != crate::constants::DIAG_RELAY_RESULT_OK && !payload.is_empty() {
         return Err(EncodeError::InvalidParameter(
-            "DIAG_RELAY_RESPONSE payload must be empty for non-OK status".into(),
+            "DIAG_RELAY_RESULT payload must be empty for non-OK status".into(),
         ));
     }
     if payload.len() > MAX_FRAME_SIZE {
@@ -132,11 +144,8 @@ pub fn encode_diag_relay_response(status: u8, payload: &[u8]) -> Result<Vec<u8>,
     Ok(body)
 }
 
-/// Decode a DIAG_RELAY_RESPONSE BLE body.
-///
-/// Returns `(status, payload)` on success. Rejects truncated bodies,
-/// bodies with trailing bytes, and payloads exceeding `MAX_FRAME_SIZE`.
-pub fn decode_diag_relay_response(body: &[u8]) -> Result<(u8, &[u8]), DecodeError> {
+/// Decode a DIAG_RELAY_RESULT BLE body.
+pub fn decode_diag_relay_result(body: &[u8]) -> Result<(u8, &[u8]), DecodeError> {
     if body.len() < 3 {
         return Err(DecodeError::TooShort);
     }
@@ -144,7 +153,7 @@ pub fn decode_diag_relay_response(body: &[u8]) -> Result<(u8, &[u8]), DecodeErro
     let payload_len = u16::from_be_bytes([body[1], body[2]]) as usize;
     if payload_len > MAX_FRAME_SIZE {
         return Err(DecodeError::InvalidParameter(alloc::format!(
-            "DIAG_RELAY_RESPONSE payload_len {} exceeds MAX_FRAME_SIZE {}",
+            "DIAG_RELAY_RESULT payload_len {} exceeds MAX_FRAME_SIZE {}",
             payload_len,
             MAX_FRAME_SIZE
         )));
@@ -155,18 +164,37 @@ pub fn decode_diag_relay_response(body: &[u8]) -> Result<(u8, &[u8]), DecodeErro
     if body.len() > 3 + payload_len {
         return Err(DecodeError::TooLong);
     }
-    if status != crate::DIAG_RELAY_STATUS_OK && payload_len != 0 {
+    if status != crate::DIAG_RELAY_RESULT_OK && payload_len != 0 {
         return Err(DecodeError::InvalidParameter(
-            "non-OK DIAG_RELAY_RESPONSE must have empty payload".into(),
+            "non-OK DIAG_RELAY_RESULT must have empty payload".into(),
         ));
     }
     Ok((status, &body[3..3 + payload_len]))
 }
 
+pub fn encode_diag_relay_request(rf_channel: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError> {
+    encode_start_diag_relay(rf_channel, payload)
+}
+
+pub fn decode_diag_relay_request(body: &[u8]) -> Result<(u8, &[u8]), DecodeError> {
+    decode_start_diag_relay(body)
+}
+
+pub fn encode_diag_relay_response(status: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError> {
+    encode_diag_relay_result(status, payload)
+}
+
+pub fn decode_diag_relay_response(body: &[u8]) -> Result<(u8, &[u8]), DecodeError> {
+    decode_diag_relay_result(body)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constants::{BLE_DIAG_RELAY_REQUEST, BLE_DIAG_RELAY_RESPONSE};
+    use crate::constants::{
+        BLE_DIAG_RELAY_ACK, BLE_DIAG_RELAY_RESULT, BLE_START_DIAG_RELAY,
+        DIAG_RELAY_RESULT_NO_RESULT,
+    };
     use alloc::vec;
 
     #[test] // T-P100: BLE envelope round-trip
@@ -205,11 +233,11 @@ mod tests {
     #[test]
     fn diag_relay_request_round_trip() {
         let payload = [0x42u8; 50];
-        let body = encode_diag_relay_request(6, &payload).unwrap();
-        let envelope = encode_ble_envelope(BLE_DIAG_RELAY_REQUEST, &body).unwrap();
+        let body = encode_start_diag_relay(6, &payload).unwrap();
+        let envelope = encode_ble_envelope(BLE_START_DIAG_RELAY, &body).unwrap();
         let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
-        assert_eq!(msg_type, BLE_DIAG_RELAY_REQUEST);
-        let (rf_channel, decoded_payload) = decode_diag_relay_request(decoded_body).unwrap();
+        assert_eq!(msg_type, BLE_START_DIAG_RELAY);
+        let (rf_channel, decoded_payload) = decode_start_diag_relay(decoded_body).unwrap();
         assert_eq!(rf_channel, 6);
         assert_eq!(decoded_payload, &payload);
     }
@@ -218,78 +246,86 @@ mod tests {
     #[test]
     fn diag_relay_request_invalid_channel() {
         let payload = [0x42u8; 50];
-        assert!(encode_diag_relay_request(0, &payload).is_err());
-        assert!(encode_diag_relay_request(14, &payload).is_err());
-        assert!(encode_diag_relay_request(1, &payload).is_ok());
-        assert!(encode_diag_relay_request(13, &payload).is_ok());
+        assert!(encode_start_diag_relay(0, &payload).is_err());
+        assert!(encode_start_diag_relay(14, &payload).is_err());
+        assert!(encode_start_diag_relay(1, &payload).is_ok());
+        assert!(encode_start_diag_relay(13, &payload).is_ok());
     }
 
-    // T-P116: DIAG_RELAY_RESPONSE round-trip (success, timeout, channel_error)
+    // T-P116: DIAG_RELAY_ACK and DIAG_RELAY_RESULT round-trip
     #[test]
     fn diag_relay_response_round_trip() {
-        // status=0x00 with payload
+        let ack_body = encode_diag_relay_ack(0x00).unwrap();
+        let ack_envelope = encode_ble_envelope(BLE_DIAG_RELAY_ACK, &ack_body).unwrap();
+        let (msg_type, decoded_body) = parse_ble_envelope(&ack_envelope).unwrap();
+        assert_eq!(msg_type, BLE_DIAG_RELAY_ACK);
+        assert_eq!(decode_diag_relay_ack(decoded_body).unwrap(), 0x00);
+
         let payload = [0xAA; 30];
-        let body = encode_diag_relay_response(0x00, &payload).unwrap();
-        let envelope = encode_ble_envelope(BLE_DIAG_RELAY_RESPONSE, &body).unwrap();
+        let body = encode_diag_relay_result(0x00, &payload).unwrap();
+        let envelope = encode_ble_envelope(BLE_DIAG_RELAY_RESULT, &body).unwrap();
         let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
-        assert_eq!(msg_type, BLE_DIAG_RELAY_RESPONSE);
-        let (status, decoded_payload) = decode_diag_relay_response(decoded_body).unwrap();
+        assert_eq!(msg_type, BLE_DIAG_RELAY_RESULT);
+        let (status, decoded_payload) = decode_diag_relay_result(decoded_body).unwrap();
         assert_eq!(status, 0x00);
         assert_eq!(decoded_payload, &payload);
 
-        // status=0x01 (timeout), empty payload
-        let body = encode_diag_relay_response(0x01, &[]).unwrap();
-        let (status, decoded_payload) = decode_diag_relay_response(&body).unwrap();
+        let body = encode_diag_relay_result(0x01, &[]).unwrap();
+        let (status, decoded_payload) = decode_diag_relay_result(&body).unwrap();
         assert_eq!(status, 0x01);
         assert!(decoded_payload.is_empty());
 
-        // status=0x02 (channel_error), empty payload
-        let body = encode_diag_relay_response(0x02, &[]).unwrap();
-        let (status, decoded_payload) = decode_diag_relay_response(&body).unwrap();
+        let body = encode_diag_relay_result(0x02, &[]).unwrap();
+        let (status, decoded_payload) = decode_diag_relay_result(&body).unwrap();
         assert_eq!(status, 0x02);
+        assert!(decoded_payload.is_empty());
+
+        let body = encode_diag_relay_result(DIAG_RELAY_RESULT_NO_RESULT, &[]).unwrap();
+        let (status, decoded_payload) = decode_diag_relay_result(&body).unwrap();
+        assert_eq!(status, DIAG_RELAY_RESULT_NO_RESULT);
         assert!(decoded_payload.is_empty());
     }
 
     // T-P115 additional: empty payload rejected
     #[test]
     fn diag_relay_request_empty_payload_rejected() {
-        assert!(encode_diag_relay_request(6, &[]).is_err());
+        assert!(encode_start_diag_relay(6, &[]).is_err());
     }
 
     #[test]
     fn diag_relay_request_decode_out_of_range_channel() {
         let body = [14, 0, 1, 0xAA]; // rf_channel=14
-        assert!(decode_diag_relay_request(&body).is_err());
+        assert!(decode_start_diag_relay(&body).is_err());
     }
 
     #[test]
     fn diag_relay_request_decode_zero_payload_len() {
         let body = [6, 0, 0]; // payload_len=0
-        assert!(decode_diag_relay_request(&body).is_err());
+        assert!(decode_start_diag_relay(&body).is_err());
     }
 
     #[test]
     fn diag_relay_request_decode_trailing_bytes() {
         let body = [6, 0, 1, 0xAA, 0xBB]; // payload_len=1 but 2 data bytes
-        assert!(decode_diag_relay_request(&body).is_err());
+        assert!(decode_start_diag_relay(&body).is_err());
     }
 
     #[test]
     fn diag_relay_request_decode_truncated() {
         let body = [6, 0, 5, 0xAA, 0xBB]; // payload_len=5 but only 2 data bytes
-        assert!(decode_diag_relay_request(&body).is_err());
+        assert!(decode_start_diag_relay(&body).is_err());
     }
 
     #[test]
     fn diag_relay_response_non_ok_with_payload_rejected() {
-        assert!(encode_diag_relay_response(0x01, &[0xAA]).is_err());
-        assert!(encode_diag_relay_response(0x02, &[0xBB]).is_err());
+        assert!(encode_diag_relay_result(0x01, &[0xAA]).is_err());
+        assert!(encode_diag_relay_result(0x02, &[0xBB]).is_err());
     }
 
     #[test]
     fn diag_relay_response_decode_trailing_bytes() {
         let body = [0x00, 0, 1, 0xAA, 0xBB]; // payload_len=1 but 2 data bytes
-        assert!(decode_diag_relay_response(&body).is_err());
+        assert!(decode_diag_relay_result(&body).is_err());
     }
 
     #[test]
@@ -300,6 +336,6 @@ mod tests {
         body.extend_from_slice(&oversized_len.to_be_bytes());
         // Don't need to provide actual payload bytes — the length check
         // should reject before reaching the slice bounds check.
-        assert!(decode_diag_relay_response(&body).is_err());
+        assert!(decode_diag_relay_result(&body).is_err());
     }
 }

--- a/crates/sonde-protocol/src/constants.rs
+++ b/crates/sonde-protocol/src/constants.rs
@@ -108,12 +108,28 @@ pub const SIGNAL_QUALITY_BAD: u8 = 2;
 
 // BLE envelope message types (Node Command characteristic)
 pub const BLE_NODE_PROVISION: u8 = 0x01;
-pub const BLE_DIAG_RELAY_REQUEST: u8 = 0x02;
+pub const BLE_START_DIAG_RELAY: u8 = 0x02;
+pub const BLE_FETCH_DIAG_RESULT: u8 = 0x03;
 pub const BLE_NODE_ACK: u8 = 0x81;
-pub const BLE_DIAG_RELAY_RESPONSE: u8 = 0x82;
+pub const BLE_DIAG_RELAY_ACK: u8 = 0x82;
+pub const BLE_DIAG_RELAY_RESULT: u8 = 0x83;
 pub const BLE_ERROR: u8 = 0xFF;
 
-// DIAG_RELAY_RESPONSE status codes
-pub const DIAG_RELAY_STATUS_OK: u8 = 0x00;
-pub const DIAG_RELAY_STATUS_TIMEOUT: u8 = 0x01;
-pub const DIAG_RELAY_STATUS_CHANNEL_ERROR: u8 = 0x02;
+// DIAG_RELAY_ACK status codes
+pub const DIAG_RELAY_ACK_ACCEPTED: u8 = 0x00;
+pub const DIAG_RELAY_ACK_BUSY: u8 = 0x01;
+pub const DIAG_RELAY_ACK_INVALID: u8 = 0x02;
+
+// DIAG_RELAY_RESULT status codes
+pub const DIAG_RELAY_RESULT_OK: u8 = 0x00;
+pub const DIAG_RELAY_RESULT_TIMEOUT: u8 = 0x01;
+pub const DIAG_RELAY_RESULT_CHANNEL_ERROR: u8 = 0x02;
+pub const DIAG_RELAY_RESULT_NO_RESULT: u8 = 0x03;
+
+// Legacy aliases retained while downstream callers migrate to the split
+// async diagnostic start / ack / result model.
+pub const BLE_DIAG_RELAY_REQUEST: u8 = BLE_START_DIAG_RELAY;
+pub const BLE_DIAG_RELAY_RESPONSE: u8 = BLE_DIAG_RELAY_RESULT;
+pub const DIAG_RELAY_STATUS_OK: u8 = DIAG_RELAY_RESULT_OK;
+pub const DIAG_RELAY_STATUS_TIMEOUT: u8 = DIAG_RELAY_RESULT_TIMEOUT;
+pub const DIAG_RELAY_STATUS_CHANNEL_ERROR: u8 = DIAG_RELAY_RESULT_CHANNEL_ERROR;

--- a/crates/sonde-protocol/src/constants.rs
+++ b/crates/sonde-protocol/src/constants.rs
@@ -126,10 +126,9 @@ pub const DIAG_RELAY_RESULT_TIMEOUT: u8 = 0x01;
 pub const DIAG_RELAY_RESULT_CHANNEL_ERROR: u8 = 0x02;
 pub const DIAG_RELAY_RESULT_NO_RESULT: u8 = 0x03;
 
-// Legacy aliases retained while downstream callers migrate to the split
-// async diagnostic start / ack / result model.
+// Legacy aliases retained only where the split async diagnostic model
+// preserved the underlying wire value.
 pub const BLE_DIAG_RELAY_REQUEST: u8 = BLE_START_DIAG_RELAY;
-pub const BLE_DIAG_RELAY_RESPONSE: u8 = BLE_DIAG_RELAY_RESULT;
 pub const DIAG_RELAY_STATUS_OK: u8 = DIAG_RELAY_RESULT_OK;
 pub const DIAG_RELAY_STATUS_TIMEOUT: u8 = DIAG_RELAY_RESULT_TIMEOUT;
 pub const DIAG_RELAY_STATUS_CHANNEL_ERROR: u8 = DIAG_RELAY_RESULT_CHANNEL_ERROR;

--- a/crates/sonde-protocol/src/lib.rs
+++ b/crates/sonde-protocol/src/lib.rs
@@ -19,8 +19,10 @@ pub mod traits;
 
 pub use aead_codec::{build_gcm_nonce, decode_frame, encode_frame, open_frame, DecodedFrame};
 pub use ble_envelope::{
-    decode_diag_relay_request, decode_diag_relay_response, encode_ble_envelope,
-    encode_diag_relay_request, encode_diag_relay_response, parse_ble_envelope,
+    decode_diag_relay_ack, decode_diag_relay_request, decode_diag_relay_response,
+    decode_diag_relay_result, decode_start_diag_relay, encode_ble_envelope, encode_diag_relay_ack,
+    encode_diag_relay_request, encode_diag_relay_response, encode_diag_relay_result,
+    encode_start_diag_relay, parse_ble_envelope,
 };
 pub use board_layout::{
     decode_board_layout_cbor, encode_board_layout_cbor, BoardLayout, BOARD_LAYOUT_KEY_BATTERY_ADC,

--- a/crates/sonde-protocol/tests/validation.rs
+++ b/crates/sonde-protocol/tests/validation.rs
@@ -2839,9 +2839,9 @@ fn test_p116_diag_relay_response_round_trip() {
     // status=OK with non-empty payload
     let payload = [0xABu8; 30];
     let body = encode_diag_relay_response(DIAG_RELAY_STATUS_OK, &payload).unwrap();
-    let envelope = encode_ble_envelope(BLE_DIAG_RELAY_RESPONSE, &body).unwrap();
+    let envelope = encode_ble_envelope(BLE_DIAG_RELAY_RESULT, &body).unwrap();
     let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
-    assert_eq!(msg_type, BLE_DIAG_RELAY_RESPONSE);
+    assert_eq!(msg_type, BLE_DIAG_RELAY_RESULT);
     let (status, decoded_payload) = decode_diag_relay_response(decoded_body).unwrap();
     assert_eq!(status, DIAG_RELAY_STATUS_OK);
     assert_eq!(decoded_payload, &payload);

--- a/docs/ble-pairing-protocol.md
+++ b/docs/ble-pairing-protocol.md
@@ -158,9 +158,11 @@ Total envelope overhead: 3 bytes.
 | Type | Direction | Name | Description |
 |------|-----------|------|-------------|
 | 0x01 | Phone → Node | `NODE_PROVISION` | Provision PSK + encrypted payload. |
-| 0x02 | Phone → Node | `DIAG_RELAY_REQUEST` | Diagnostic relay request. See §6a. |
+| 0x02 | Phone → Node | `START_DIAG_RELAY` | Start an asynchronous diagnostic relay. See §6a. |
+| 0x03 | Phone → Node | `FETCH_DIAG_RESULT` | Fetch the completed diagnostic result after reconnect. See §6a. |
 | 0x81 | Node → Phone | `NODE_ACK` | Provision acknowledgement. |
-| 0x82 | Node → Phone | `DIAG_RELAY_RESPONSE` | Diagnostic relay response. See §6a. |
+| 0x82 | Node → Phone | `DIAG_RELAY_ACK` | Start-diagnostic acknowledgement. See §6a. |
+| 0x83 | Node → Phone | `DIAG_RELAY_RESULT` | Completed diagnostic result. See §6a. |
 | 0xFF | Either | `ERROR` | Error response. |
 
 ---
@@ -392,13 +394,13 @@ Offset  Size  Field
 
 ### 6a.1  Overview
 
-Before provisioning, the pairing tool may request an RF link quality check by using the node as a **dumb radio relay**. The node does not decrypt or interpret the diagnostic payload — it relays an opaque ESP-NOW frame to the gateway and forwards the reply back.
+Before provisioning, the pairing tool may request an RF link quality check by using the node as a **dumb radio relay**. The node does not decrypt or interpret the diagnostic payload — it relays an opaque ESP-NOW frame to the gateway and later returns the reply to the tool after a BLE reconnect.
 
-This step is **optional** (the installer may skip it) and **repeatable** (the installer may run it multiple times to test different node positions).
+This step is **optional** (the installer may skip it) and **repeatable** (the installer may run it multiple times to test different node positions), but each run is a **single asynchronous cycle** rather than a continuously repeating poll loop.
 
 ### 6a.2  BLE message formats
 
-#### DIAG_RELAY_REQUEST (0x02, Phone → Node)
+#### START_DIAG_RELAY (0x02, Phone → Node)
 
 ```
 ┌──────────────┬──────────────┬───────────────────────────┐
@@ -413,7 +415,26 @@ This step is **optional** (the installer may skip it) and **repeatable** (the in
 | `payload_len` | 2 bytes, BE | Length of the opaque ESP-NOW frame. |
 | `payload` | variable | Complete `DIAG_REQUEST` ESP-NOW frame (header + ciphertext + GCM tag), built by the pairing tool. |
 
-#### DIAG_RELAY_RESPONSE (0x82, Node → Phone)
+#### DIAG_RELAY_ACK (0x82, Node → Phone)
+
+```
+┌──────────────┐
+│ status       │
+│ (1 byte)     │
+└──────────────┘
+```
+
+| Field | Size | Description |
+|---|---|---|
+| `status` | 1 byte | `0x00` = accepted; node will intentionally disconnect BLE and run the diagnostic. `0x01` = busy (another diagnostic in progress or result not yet fetched). `0x02` = invalid request (bad channel or payload size). |
+
+#### FETCH_DIAG_RESULT (0x03, Phone → Node)
+
+**Body: 0 bytes.**
+
+The pairing tool sends `FETCH_DIAG_RESULT` only after reconnecting to the node following an accepted `START_DIAG_RELAY`.
+
+#### DIAG_RELAY_RESULT (0x83, Node → Phone)
 
 ```
 ┌──────────────┬──────────────┬───────────────────────────┐
@@ -424,20 +445,23 @@ This step is **optional** (the installer may skip it) and **repeatable** (the in
 
 | Field | Size | Description |
 |---|---|---|
-| `status` | 1 byte | `0x00` = success (payload contains `DIAG_REPLY`), `0x01` = timeout (no reply after retries), `0x02` = channel error. |
+| `status` | 1 byte | `0x00` = success (payload contains `DIAG_REPLY`), `0x01` = timeout (no reply after retries), `0x02` = channel error while executing the diagnostic, `0x03` = no completed result available. |
 | `payload_len` | 2 bytes, BE | Length of the opaque ESP-NOW reply frame. Zero if `status` ≠ `0x00`. |
 | `payload` | variable | Raw `DIAG_REPLY` ESP-NOW frame from gateway (if status is `0x00`). |
 
 ### 6a.3  Node relay behavior
 
-1. Node receives `DIAG_RELAY_REQUEST` on the Node Command BLE characteristic.
-2. Node temporarily tunes the ESP-NOW radio to `rf_channel`.
-3. Node broadcasts `payload` as a raw ESP-NOW frame (broadcast MAC `FF:FF:FF:FF:FF:FF`).
-4. Node listens for an inbound ESP-NOW frame with `msg_type` = `0x85` (`DIAG_REPLY`) in the header (byte offset 2).
-5. **Retry behavior**: up to **3 retransmissions** with **200 ms** backoff between attempts, **2-second** listen window per attempt.
-6. If a valid `DIAG_REPLY` frame is received, node sends `DIAG_RELAY_RESPONSE(status=0x00, payload=<raw frame>)` via BLE indication.
-7. If all retries are exhausted without receiving a reply, node sends `DIAG_RELAY_RESPONSE(status=0x01, payload_len=0)`.
-8. Node restores its previous radio state after the diagnostic completes.
+1. Node receives `START_DIAG_RELAY` on the Node Command BLE characteristic.
+2. Node validates `rf_channel` and `payload_len`. On validation failure it sends `DIAG_RELAY_ACK(status=0x02)` and does not start a diagnostic.
+3. If the request is accepted, node sends `DIAG_RELAY_ACK(status=0x00)`.
+4. After the indication is acknowledged, the node intentionally disables BLE and stops advertising **without rebooting**.
+5. Node temporarily tunes the ESP-NOW radio to `rf_channel`.
+6. Node broadcasts `payload` as a raw ESP-NOW frame (broadcast MAC `FF:FF:FF:FF:FF:FF`).
+7. Node listens for an inbound ESP-NOW frame with `msg_type` = `0x85` (`DIAG_REPLY`) in the header (byte offset 2).
+8. **Retry behavior**: up to **3 retransmissions** with **200 ms** backoff between attempts, **2-second** listen window per attempt.
+9. When the diagnostic finishes, node stores the completed result (`success`, `timeout`, or `channel error`) in pairing-session state, restores its previous ESP-NOW radio state, and re-enables BLE advertising.
+10. After the phone reconnects and sends `FETCH_DIAG_RESULT`, node responds with `DIAG_RELAY_RESULT(...)` via BLE indication and keeps the BLE connection open for follow-on actions such as provisioning.
+11. After a successful `DIAG_RELAY_RESULT` delivery, the node clears the stored diagnostic result so future fetches do not return stale data.
 
 The node identifies reply frames by inspecting the `msg_type` byte at header offset 2 — this field is plaintext (part of the AAD, not the ciphertext). The node does not decrypt or validate the reply payload.
 
@@ -448,17 +472,20 @@ The node identifies reply frames by inspecting the `msg_type` byte at header off
    - Header: `[phone_key_hint (2B) | msg_type=0x06 (1B) | random_nonce (8B)]`
    - CBOR payload: `{ 1: 0x01 }` (diagnostic_type = DIAG_RSSI)
    - AES-256-GCM encryption using `phone_psk`, AAD = 11-byte header
-3. Tool sends `DIAG_RELAY_REQUEST(rf_channel, payload=<frame>)` via BLE write.
-4. Tool waits up to **10 seconds** for `DIAG_RELAY_RESPONSE`.
-5. On `status=0x00`: tool decrypts the `DIAG_REPLY` payload using `phone_psk`, displays RSSI and signal quality assessment.
-6. On `status=0x01` (timeout) or `status=0x02` (channel error): tool displays an error message with guidance.
-7. If signal quality is `2` (bad): tool displays a warning and requires installer confirmation before allowing provisioning to proceed.
+3. Tool sends `START_DIAG_RELAY(rf_channel, payload=<frame>)` via BLE write.
+4. Tool waits for `DIAG_RELAY_ACK`.
+5. On `status=0x00` (accepted): tool treats the subsequent BLE disconnect as **expected**, automatically reconnects to the same node when it resumes advertising, then sends `FETCH_DIAG_RESULT`.
+6. On `DIAG_RELAY_RESULT(status=0x00)`: tool decrypts the `DIAG_REPLY` payload using `phone_psk`, displays RSSI and signal quality assessment, and keeps the reconnected BLE session open for provisioning.
+7. On `DIAG_RELAY_RESULT(status=0x01)` (timeout) or `status=0x02` (channel error): tool displays an error message with guidance and keeps the reconnected BLE session open.
+8. On `DIAG_RELAY_ACK(status=0x01)` (busy), `status=0x02` (invalid request), or `DIAG_RELAY_RESULT(status=0x03)` (no completed result available): tool surfaces an actionable error and remains on the signal-check step.
+9. A repeat diagnostic starts a new `START_DIAG_RELAY` / reconnect / `FETCH_DIAG_RESULT` cycle.
 
 ### 6a.5  Timing
 
 | Parameter | Value |
 |-----------|-------|
-| BLE diagnostic timeout (pairing tool) | 10 seconds |
+| BLE diagnostic start-ack timeout (pairing tool) | 5 seconds |
+| BLE diagnostic fetch timeout (pairing tool) | 5 seconds |
 | ESP-NOW listen window (node, per attempt) | 2 seconds |
 | ESP-NOW retry backoff (node) | 200 ms |
 | ESP-NOW max retries (node) | 3 |
@@ -468,11 +495,13 @@ The node identifies reply frames by inspecting the `msg_type` byte at header off
 
 | Condition | Behavior |
 |-----------|----------|
-| `rf_channel` outside 1–13 | Node sends `DIAG_RELAY_RESPONSE(status=0x02)`. |
-| `payload_len` = 0 or exceeds MAX_FRAME_SIZE (250) | Node sends `DIAG_RELAY_RESPONSE(status=0x02)`. |
-| No `DIAG_REPLY` received after 3 retries | Node sends `DIAG_RELAY_RESPONSE(status=0x01)`. |
-| BLE disconnect during diagnostic | Node aborts relay, restores radio state. |
-| Gateway cannot decrypt (wrong PSK / revoked) | Gateway silently discards. Node times out. |
+| `rf_channel` outside 1–13 | Node sends `DIAG_RELAY_ACK(status=0x02)`. |
+| `payload_len` = 0 or exceeds MAX_FRAME_SIZE (250) | Node sends `DIAG_RELAY_ACK(status=0x02)`. |
+| Start request arrives while a prior diagnostic is still running or not yet fetched | Node sends `DIAG_RELAY_ACK(status=0x01)`. |
+| No `DIAG_REPLY` received after 3 retries | Node stores `DIAG_RELAY_RESULT(status=0x01, payload_len=0)` and returns it after reconnect. |
+| ESP-NOW radio/channel setup fails during execution | Node stores `DIAG_RELAY_RESULT(status=0x02, payload_len=0)` and returns it after reconnect. |
+| Tool fetches before any completed diagnostic result exists | Node sends `DIAG_RELAY_RESULT(status=0x03)`. |
+| Gateway cannot decrypt (wrong PSK / revoked) | Gateway silently discards. Node times out and later returns `DIAG_RELAY_RESULT(status=0x01)`. |
 
 ---
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -893,7 +893,7 @@ Each wizard page is a `<section class="page">` element in `index.html` with a pa
 | 2 | `page-gateway-scan` | Scan controls, device list, phone label, pair button | Gateway |
 | 3 | `page-gateway-done` | Pairing success, channel/key hint info | Gateway |
 | 4 | `page-node-scan` | Scan controls, device list, BLE RSSI indicator, Connect button | Node |
-| 5 | `page-node-diagnostic` | Connected-node identity, live ESP-NOW RSSI / signal quality, proceed / abort controls | Node |
+| 5 | `page-signal-check` | Connected-node identity, live ESP-NOW RSSI / signal quality, proceed / abort controls | Node |
 | 6 | `page-node-provision` | Node ID, board selector, provision button | Node |
 | 7 | `page-done` | Success summary, "Provision Another" button | Done |
 
@@ -976,9 +976,9 @@ The indicator shows the numeric RSSI value and a text label ("Good", "Marginal",
 
 ### Connected node session and ESP-NOW signal check
 
-After the installer selects a node on page 4 and presses **Connect**, the frontend invokes a new Tauri `connect_node(address)` command.  This command creates or reuses a `BleTransport`, connects to the selected node, negotiates MTU ≥ 247, enforces LESC requirements, and stores the connected node session in `AppState`.
+After the installer selects a node on page 4 and presses **Connect**, the frontend invokes a new Tauri `connect_node(address)` command.  This command creates or reuses a `BleTransport`, connects to the selected node, validates the negotiated MTU is at least 247, and stores the connected node session in `AppState`.
 
-Page 5 (`page-node-diagnostic`) is shown only after `connect_node()` succeeds.  On entry, the frontend starts a single-flight diagnostic loop driven by a new Tauri `check_rssi()` command backed by `sonde_pair::phase2::check_rssi()`.  The loop waits for each diagnostic to complete before scheduling the next one; when the previous request completed quickly, the next request starts about 1000 ms later.  The loop never overlaps requests because `ble-pairing-protocol.md` §6a still permits multi-second diagnostic latency on timeout/retry paths.
+Page 5 (`page-signal-check`) is shown only after `connect_node()` succeeds.  On entry, the frontend starts a single-flight diagnostic loop driven by a new Tauri `check_rssi()` command backed by `sonde_pair::phase2::check_rssi()`.  The loop waits for each diagnostic to complete before scheduling the next one; when the previous request completed quickly, the next request starts about 1000 ms later.  The loop never overlaps requests because `ble-pairing-protocol.md` §6a still permits multi-second diagnostic latency on timeout/retry paths.
 
 The page 5 UI shows:
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -159,7 +159,7 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
 
 ### 4.3  Phase 2 state machine — Node provisioning
 
-The Phase 2 state machine implements the node provisioning flow from [ble-pairing-protocol.md §6](ble-pairing-protocol.md).  `provision_node()` takes a `BleTransport`, `PairingArtifacts` (from Phase 1), `RngProvider`, device address, operator-supplied `node_id`, sensor descriptors, and an optional `BoardLayout`, and returns `Result<NodeProvisionResult, PairingError>`.
+The Phase 2 state machine implements the node provisioning flow from [ble-pairing-protocol.md §6](ble-pairing-protocol.md).  `provision_node()` takes a `BleTransport`, `PairingArtifacts` (from Phase 1), `RngProvider`, device address, operator-supplied `node_id`, sensor descriptors, and an optional `BoardLayout`, and returns `Result<NodeProvisionResult, PairingError>`.  The same connected-node transport is also used by `check_rssi()` during the pre-provision signal-check step from [ble-pairing-protocol.md §6a](ble-pairing-protocol.md#6a--pairing-time-rssi-diagnostic).
 
 ```
 ┌─────────────┐
@@ -792,7 +792,9 @@ pub fn decode_envelope(data: &[u8]) -> Result<(u8, &[u8]), PairingError> {
 | ~~`GW_INFO_RESPONSE`~~ | ~~`0x81`~~ | ~~GW → Phone~~ | ~~Gateway Command~~ — **RETIRED** (issue #495) |
 | `PHONE_REGISTERED` | `0x82` | GW → Phone | Gateway Command |
 | `NODE_PROVISION` | `0x01` | Phone → Node | Node Command |
+| `DIAG_RELAY_REQUEST` | `0x02` | Phone → Node | Node Command |
 | `NODE_ACK` | `0x81` | Node → Phone | Node Command |
+| `DIAG_RELAY_RESPONSE` | `0x82` | Node → Phone | Node Command |
 | `ERROR` | `0xFF` | Either | Either |
 
 ---
@@ -877,7 +879,7 @@ When provided, `boardLayout` contains nullable fields for `i2cSda`, `i2cScl`, `o
 
 ---
 
-## 12.2  Multi-page wizard navigation (PT-1217–PT-1222)
+## 12.2  Multi-page wizard navigation (PT-1217–PT-1225)
 
 The pairing tool UI uses a multi-page wizard flow instead of a single-page layout.  All navigation is client-side — no server-side routing or SPA framework.
 
@@ -890,9 +892,10 @@ Each wizard page is a `<section class="page">` element in `index.html` with a pa
 | 1 | `page-welcome` | Pairing status; "Get Started" or "Provision Node" | Gateway |
 | 2 | `page-gateway-scan` | Scan controls, device list, phone label, pair button | Gateway |
 | 3 | `page-gateway-done` | Pairing success, channel/key hint info | Gateway |
-| 4 | `page-node-scan` | Scan controls, device list, RSSI indicator | Node |
-| 5 | `page-node-provision` | Node ID, board selector, provision button | Node |
-| 6 | `page-done` | Success summary, "Provision Another" button | Done |
+| 4 | `page-node-scan` | Scan controls, device list, BLE RSSI indicator, Connect button | Node |
+| 5 | `page-node-diagnostic` | Connected-node identity, live ESP-NOW RSSI / signal quality, proceed / abort controls | Node |
+| 6 | `page-node-provision` | Node ID, board selector, provision button | Node |
+| 7 | `page-done` | Success summary, "Provision Another" button | Done |
 
 ### Navigator class
 
@@ -913,15 +916,15 @@ class Navigator {
 
 **Page transitions:** `goTo()` applies CSS classes (`slide-in-right` for forward, `slide-in-left` for back) to animate the transition.  Transitions are ≤ 300 ms.  The previous page gets `slide-out-left` or `slide-out-right` respectively.
 
-**Persistence:** `goTo()` saves `currentPage` (0-based) to `localStorage` key `sonde-pair-page`.  `restore()` reads this key on startup, validates prerequisites (pairing artifacts for pages 3–6; non-ephemeral context for pages 5–6), and navigates to the saved page or the earliest valid page if prerequisites are missing.  Pages 5–6 (Node Provision, Done) require ephemeral state (selected node address and provisioning-success context respectively) that cannot survive a restart; if the saved page is 5 or 6, `restore()` falls back to page 4 (Node Scan).  Invalid or out-of-range values default to the earliest valid page (page 1 if unpaired, page 4 if paired).  After determining the target page N, `restore()` pushes all intermediate states (pages 1 through N) into the history stack so that back navigation traverses each page in sequence.
+**Persistence:** `goTo()` saves `currentPage` (0-based) to `localStorage` key `sonde-pair-page`.  `restore()` reads this key on startup, validates prerequisites (pairing artifacts for pages 3–7; non-ephemeral context for pages 5–7), and navigates to the saved page or the earliest valid page if prerequisites are missing.  Pages 5–7 (Node Signal Check, Node Provision, Done) require ephemeral connected-node or provisioning-success context that cannot survive a restart; if the saved page is 5, 6, or 7, `restore()` falls back to page 4 (Node Scan).  Invalid or out-of-range values default to the earliest valid page (page 1 if unpaired, page 4 if paired).  After determining the target page N, `restore()` pushes all intermediate states (pages 1 through N) into the history stack so that back navigation traverses each page in sequence.
 
 ### Stepper bar
 
 A horizontal stepper bar in `<header>` with three steps:
 
 1. **Gateway** — active during pages 1–3
-2. **Node** — active during pages 4–5
-3. **Done** — active on page 6
+2. **Node** — active during pages 4–6
+3. **Done** — active on page 7
 
 Each step element uses CSS classes:
 - `step--active` — currently active phase (filled/highlighted)
@@ -942,7 +945,7 @@ On Android, the Tauri WebView dispatches hardware-back as a browser back event, 
 
 A `←` back arrow button is rendered inside the `<header>` element, to the left of the app title.  The button:
 
-- Is hidden on page 1 (Welcome) and visible on pages 2–6.
+- Is hidden on page 1 (Welcome) and visible on pages 2–7.
 - Calls `history.back()` on click, which triggers the existing `popstate` handler and correctly pops the history stack (matching PT-1220's "same as platform back action" semantics).
 - Uses `id="btn-back"` and is styled as a borderless icon button that blends with the header.
 
@@ -957,9 +960,9 @@ When navigating away from a scan page (page 2 or page 4):
 
 When navigating to a scan page, the scan does NOT auto-start — the user must explicitly press "Start Scan".  This prevents unexpected BLE activity and battery drain.
 
-### RSSI signal quality indicator
+### BLE RSSI signal quality indicator
 
-Page 4 (Node Scan) displays a visual signal quality indicator for the selected device.  The indicator is a `<div class="rssi-indicator">` element that updates on each device poll (1.5 s interval).
+Page 4 (Node Scan) displays a visual BLE RSSI signal quality indicator for the selected device while the installer is deciding which node to connect to.  The indicator is a `<div class="rssi-indicator">` element that updates on each device poll (1.5 s interval).
 
 RSSI thresholds (per protocol):
 
@@ -970,6 +973,21 @@ RSSI thresholds (per protocol):
 | Bad | < −75 dBm | `rssi--bad` | Red (`#e74c3c`) |
 
 The indicator shows the numeric RSSI value and a text label ("Good", "Marginal", "Bad").
+
+### Connected node session and ESP-NOW signal check
+
+After the installer selects a node on page 4 and presses **Connect**, the frontend invokes a new Tauri `connect_node(address)` command.  This command creates or reuses a `BleTransport`, connects to the selected node, negotiates MTU ≥ 247, enforces LESC requirements, and stores the connected node session in `AppState`.
+
+Page 5 (`page-node-diagnostic`) is shown only after `connect_node()` succeeds.  On entry, the frontend starts a single-flight diagnostic loop driven by a new Tauri `check_rssi()` command backed by `sonde_pair::phase2::check_rssi()`.  The loop waits for each diagnostic to complete before scheduling the next one; when the previous request completed quickly, the next request starts about 1000 ms later.  The loop never overlaps requests because `ble-pairing-protocol.md` §6a still permits multi-second diagnostic latency on timeout/retry paths.
+
+The page 5 UI shows:
+
+- Connected node identity (address / advertised name if available)
+- Current diagnostic state (`checking`, `good`, `marginal`, `bad`, `timeout`, `channel error`)
+- Last successful gateway-measured RSSI in dBm and signal-quality label
+- A **Proceed to Provision** action and an **Abort / Disconnect** action
+
+The ESP-NOW diagnostic is informational only.  A `bad` result, timeout, or channel error leaves the installer on page 5 with the proceed action still available.  The abort action invokes `disconnect_node()` to release the BLE session and returns to page 4.  Proceeding to page 6 stops the diagnostic loop and calls `provision_node(address, nodeId, boardLayout?)`; when an active connected-node session exists for `address`, the backend reuses that session instead of reconnecting.
 
 ### Verbose diagnostic mode
 
@@ -1033,7 +1051,7 @@ Platform-specific BLE transport and storage implementations, plus the Tauri UI s
 |---|---|---|---|
 | P4.1 | `BtleplugTransport` | `BleTransport` implementation for Windows/Linux/macOS using `btleplug` | Manual BLE hardware test |
 | P4.2 | `FilePairingStore` | JSON file storage for Windows/Linux/macOS with restricted permissions | Unit tests + manual |
-| P4.3 | Tauri UI | Scan toggle, device list, pair button, node_id input, status area, error display | Manual test, PT-1206 |
+| P4.3 | Tauri UI | Scan toggle, device list, connect button, BLE RSSI, ESP-NOW diagnostic page, node_id input, status area, error display | Manual test, PT-1206 |
 
 **Exit criteria (P4):** Phase 1 and Phase 2 work end-to-end on physical hardware (Windows, Android) against a real gateway and node.  All PT-1206 manual test scenarios pass.
 
@@ -1113,6 +1131,6 @@ No log event at any level may include key material: PSKs, ephemeral private keys
 | §11 RNG provider | PT-0901, PT-0903 |
 | §12 Input validation | PT-0403, PT-0406, PT-0409 |
 | §12.1 Board selector UI | PT-1216, PT-1214, PT-0700 |
-| §12.2 Multi-page wizard navigation | PT-0700, PT-0701, PT-1217–PT-1222 |
+| §12.2 Multi-page wizard navigation | PT-0700, PT-0701, PT-1217–PT-1225 |
 | §13 Implementation order | PT-0700, PT-0701, PT-0702, PT-1200–PT-1206 |
 | §14 Diagnostic logging | PT-0702, PT-0900, PT-1207–PT-1212 |

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -159,7 +159,7 @@ The Phase 1 state machine drives the gateway pairing flow defined in [ble-pairin
 
 ### 4.3  Phase 2 state machine — Node provisioning
 
-The Phase 2 state machine implements the node provisioning flow from [ble-pairing-protocol.md §6](ble-pairing-protocol.md).  `provision_node()` takes a `BleTransport`, `PairingArtifacts` (from Phase 1), `RngProvider`, device address, operator-supplied `node_id`, sensor descriptors, and an optional `BoardLayout`, and returns `Result<NodeProvisionResult, PairingError>`.  The same connected-node transport is also used by `check_rssi()` during the pre-provision signal-check step from [ble-pairing-protocol.md §6a](ble-pairing-protocol.md#6a--pairing-time-rssi-diagnostic).
+The Phase 2 state machine implements the node provisioning flow from [ble-pairing-protocol.md §6](ble-pairing-protocol.md). `provision_node()` takes a `BleTransport`, `PairingArtifacts` (from Phase 1), `RngProvider`, device address, operator-supplied `node_id`, sensor descriptors, and an optional `BoardLayout`, and returns `Result<NodeProvisionResult, PairingError>`. The same connected-node transport is also used by the asynchronous pre-provision signal-check flow from [ble-pairing-protocol.md §6a](ble-pairing-protocol.md#6a--pairing-time-rssi-diagnostic), which performs a start / reconnect / fetch cycle before provisioning.
 
 ```
 ┌─────────────┐
@@ -792,9 +792,11 @@ pub fn decode_envelope(data: &[u8]) -> Result<(u8, &[u8]), PairingError> {
 | ~~`GW_INFO_RESPONSE`~~ | ~~`0x81`~~ | ~~GW → Phone~~ | ~~Gateway Command~~ — **RETIRED** (issue #495) |
 | `PHONE_REGISTERED` | `0x82` | GW → Phone | Gateway Command |
 | `NODE_PROVISION` | `0x01` | Phone → Node | Node Command |
-| `DIAG_RELAY_REQUEST` | `0x02` | Phone → Node | Node Command |
+| `START_DIAG_RELAY` | `0x02` | Phone → Node | Node Command |
+| `FETCH_DIAG_RESULT` | `0x03` | Phone → Node | Node Command |
 | `NODE_ACK` | `0x81` | Node → Phone | Node Command |
-| `DIAG_RELAY_RESPONSE` | `0x82` | Node → Phone | Node Command |
+| `DIAG_RELAY_ACK` | `0x82` | Node → Phone | Node Command |
+| `DIAG_RELAY_RESULT` | `0x83` | Node → Phone | Node Command |
 | `ERROR` | `0xFF` | Either | Either |
 
 ---
@@ -978,16 +980,26 @@ The indicator shows the numeric RSSI value and a text label ("Good", "Marginal",
 
 After the installer selects a node on page 4 and presses **Connect**, the frontend invokes a new Tauri `connect_node(address)` command.  This command creates or reuses a `BleTransport`, connects to the selected node, validates the negotiated MTU is at least 247, and stores the connected node session in `AppState`.
 
-Page 5 (`page-signal-check`) is shown only after `connect_node()` succeeds.  On entry, the frontend starts a single-flight diagnostic loop driven by a new Tauri `check_rssi()` command backed by `sonde_pair::phase2::check_rssi()`.  The loop waits for each diagnostic to complete before scheduling the next one; when the previous request completed quickly, the next request starts about 1000 ms later.  The loop never overlaps requests because `ble-pairing-protocol.md` §6a still permits multi-second diagnostic latency on timeout/retry paths.
+Page 5 (`page-signal-check`) is shown only after `connect_node()` succeeds. On entry, the frontend starts **one** asynchronous diagnostic cycle driven by a Tauri command that wraps the full protocol sequence from `ble-pairing-protocol.md` §6a:
+
+1. build and send `START_DIAG_RELAY`
+2. wait for `DIAG_RELAY_ACK`
+3. treat the subsequent BLE disconnect as expected
+4. automatically reconnect to the same node when it resumes advertising
+5. send `FETCH_DIAG_RESULT`
+6. decrypt and return the result
+
+The frontend does not run a continuous polling loop on page 5. After a diagnostic completes, page 5 remains idle until the installer explicitly presses **Check Again**. Only one diagnostic cycle may be in flight at a time.
 
 The page 5 UI shows:
 
 - Connected node identity (address / advertised name if available)
-- Current diagnostic state (`checking`, `good`, `marginal`, `bad`, `timeout`, `channel error`)
+- Current diagnostic state (`starting`, `waiting for reconnect`, `reconnecting`, `fetching result`, `good`, `marginal`, `bad`, `timeout`, `channel error`)
 - Last successful gateway-measured RSSI in dBm and signal-quality label
+- A **Check Again** action once the previous diagnostic has completed
 - A **Proceed to Provision** action and an **Abort / Disconnect** action
 
-The ESP-NOW diagnostic is informational only.  A `bad` result, timeout, or channel error leaves the installer on page 5 with the proceed action still available.  The abort action invokes `disconnect_node()` to release the BLE session and returns to page 4.  Proceeding to page 6 stops the diagnostic loop and calls `provision_node(address, nodeId, boardLayout?)`; when an active connected-node session exists for `address`, the backend reuses that session instead of reconnecting.
+The ESP-NOW diagnostic is informational only. A `bad` result, timeout, or channel error leaves the installer on page 5 with the proceed action still available. The abort action invokes `disconnect_node()` to release the BLE session and returns to page 4. Proceeding to page 6 calls `provision_node(address, nodeId, boardLayout?)`; when an active connected-node session exists for `address`, the backend reuses the **reconnected** session from the completed diagnostic cycle instead of reconnecting again.
 
 ### Verbose diagnostic mode
 

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -1330,7 +1330,7 @@ The UI SHOULD use CSS transitions for page changes.  Forward navigation slides t
 **Source:** ble-pairing-protocol.md §6a, USER-REQUEST
 
 **Description:**  
-After the installer selects a node on page 4 and clicks **Connect**, the tool MUST establish the BLE connection to the node and then transition to a dedicated page 5 signal-check step before provisioning.  This step is distinct from the page 4 BLE RSSI view and exists to show the node↔gateway ESP-NOW diagnostic results.
+After the installer selects a node on page 4 and clicks **Connect**, the tool MUST establish the BLE connection to the node and then transition to a dedicated page 5 signal-check step before provisioning. This step is distinct from the page 4 BLE RSSI view and exists to show the node↔gateway ESP-NOW diagnostic results. Because the ESP32-C3 diagnostic flow intentionally drops BLE while the node performs ESP-NOW receive, page 5 MUST treat a disconnect during an accepted diagnostic run as an expected part of the workflow rather than a terminal error.
 
 **Acceptance criteria:**
 
@@ -1338,26 +1338,29 @@ After the installer selects a node on page 4 and clicks **Connect**, the tool MU
 2. A successful BLE connection transitions the UI from page 4 to page 5.
 3. A failed BLE connection leaves the installer on page 4 and displays an actionable error.
 4. Page 5 displays the connected node identity and the current ESP-NOW diagnostic status.
-5. Page 5 provides controls to proceed to page 6 (Provision) or abort and return to page 4.
+5. After an accepted diagnostic start request, the expected node-initiated BLE disconnect does not eject the installer from page 5 or surface as a fatal connection error.
+6. After the tool reconnects and fetches the diagnostic result, the resulting BLE session remains available for page 6 (Provision).
+7. Page 5 provides controls to proceed to page 6 (Provision) or abort and return to page 4.
 
 ---
 
-### PT-1224  Live ESP-NOW diagnostic polling
+### PT-1224  Async ESP-NOW diagnostic handoff
 
 **Priority:** Must  
 **Source:** ble-pairing-protocol.md §6a, USER-REQUEST
 
 **Description:**  
-While page 5 is active and the node BLE connection remains established, the tool MUST run the pairing-time ESP-NOW RSSI diagnostic repeatedly and update the UI after each completed diagnostic result.  The tool targets a 1000 ms cadence between completed checks when responses are fast, but it MUST preserve the existing protocol timing from ble-pairing-protocol.md §6a and MUST NOT overlap diagnostic requests.
+Page 5 runs the pairing-time ESP-NOW RSSI diagnostic as a **single asynchronous cycle**: start diagnostic over BLE, accept the expected BLE disconnect while the node runs ESP-NOW with BLE disabled, automatically reconnect to the same node, explicitly fetch the completed result, and update the UI. Entering page 5 starts one diagnostic automatically; additional diagnostics require an explicit re-check action. The tool MUST NOT overlap diagnostic requests or continuously repeat disconnect/reconnect cycles in the background.
 
 **Acceptance criteria:**
 
-1. Entering page 5 automatically starts the first diagnostic check.
-2. The tool never has more than one diagnostic request in flight at a time.
-3. On a successful diagnostic result, page 5 shows the gateway-measured RSSI in dBm and the signal-quality assessment (`good`, `marginal`, or `bad`).
-4. When the previous diagnostic completes quickly, the next diagnostic starts about 1000 ms after completion.
+1. Entering page 5 automatically starts exactly one diagnostic cycle.
+2. The tool never has more than one diagnostic cycle in flight at a time.
+3. After an accepted start request, the tool automatically reconnects to the same node and explicitly fetches the completed result.
+4. On a successful diagnostic result, page 5 shows the gateway-measured RSSI in dBm and the signal-quality assessment (`good`, `marginal`, or `bad`).
 5. When a diagnostic times out or returns a channel error, page 5 shows an actionable status message and remains on the signal-check step.
-6. Leaving page 5 stops the repeating diagnostic loop.
+6. Completing a diagnostic does not automatically start another one; page 5 exposes an explicit re-check action for additional runs.
+7. Leaving page 5 stops any reconnect attempt or in-flight diagnostic cycle.
 
 ---
 
@@ -1367,14 +1370,15 @@ While page 5 is active and the node BLE connection remains established, the tool
 **Source:** ble-pairing-protocol.md §6a.4, USER-REQUEST
 
 **Description:**  
-The page 5 ESP-NOW diagnostic is advisory only.  The tool MUST let the installer decide whether to proceed with provisioning or abort after reviewing the live node↔gateway signal readings.  The tool MUST NOT automatically block or force provisioning based on signal quality or diagnostic failures.
+The page 5 ESP-NOW diagnostic is advisory only. The tool MUST let the installer decide whether to proceed with provisioning, re-run the signal check, or abort after reviewing the most recently fetched node↔gateway signal result. The tool MUST NOT automatically block or force provisioning based on signal quality or diagnostic failures.
 
 **Acceptance criteria:**
 
 1. A `bad` ESP-NOW signal result does not automatically start provisioning and does not force the installer off page 5.
 2. The control to proceed to page 6 remains available after any completed diagnostic result, including `bad` signal, timeout, or channel-error outcomes.
 3. The installer can abort from page 5 and return to page 4 without provisioning the node.
-4. Proceeding from page 5 to page 6 does not require an additional override dialog solely because the last diagnostic result was `bad`.
+4. The tool provides an explicit re-check action after any completed diagnostic result.
+5. Proceeding from page 5 to page 6 does not require an additional override dialog solely because the last diagnostic result was `bad`.
 
 ---
 
@@ -1460,5 +1464,5 @@ The page 5 ESP-NOW diagnostic is advisory only.  The tool MUST let the installer
 | PT-1221 | BLE RSSI signal quality indicator | Active |
 | PT-1222 | Page transition animations | Active |
 | PT-1223 | Pre-provision ESP-NOW signal-check step | Active |
-| PT-1224 | Live ESP-NOW diagnostic polling | Active |
+| PT-1224 | Async ESP-NOW diagnostic handoff | Active |
 | PT-1225 | Informational-only ESP-NOW guidance | Active |

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -1201,7 +1201,7 @@ A "Custom" option MUST also be available, which reveals editable fields for the 
 **Source:** pairing-tool-ui-redesign.md §Phase A, issue #673
 
 **Description:**  
-The UI MUST be organized as a multi-page wizard with 6 pages, each implemented as a `<section>` element.  Client-side routing uses show/hide logic managed by a `Navigator` class.  No server-side routing or SPA framework is required.
+The UI MUST be organized as a multi-page wizard with 7 pages, each implemented as a `<section>` element.  Client-side routing uses show/hide logic managed by a `Navigator` class.  No server-side routing or SPA framework is required.
 
 The page layout is:
 
@@ -1210,9 +1210,10 @@ The page layout is:
 | 1 | Welcome / Status | Pairing status check; "Get Started" (unpaired) or "Provision Node" (paired) | Gateway |
 | 2 | Gateway Scan & Pair | Scan controls, device list, phone label input, pair button | Gateway |
 | 3 | Pairing Complete | Success confirmation, channel and key hint info | Gateway |
-| 4 | Node Scan & RSSI | Scan for nodes, device list, live RSSI indicator | Node |
-| 5 | Node Provision | Node ID input, board selector, provision button, progress | Node |
-| 6 | Done | Success summary, "Provision Another" button | Done |
+| 4 | Node Scan & BLE RSSI | Scan for nodes, device list, BLE RSSI indicator, Connect button | Node |
+| 5 | Node Signal Check | Connected-node identity, live ESP-NOW RSSI / signal quality, proceed / abort controls | Node |
+| 6 | Node Provision | Node ID input, board selector, provision button, progress | Node |
+| 7 | Done | Success summary, "Provision Another" button | Done |
 
 **Acceptance criteria:**
 
@@ -1220,7 +1221,7 @@ The page layout is:
 2. Each page is a `<section>` element with a unique `id` attribute.
 3. Navigation between pages is managed by a `Navigator` class in JavaScript.
 4. Navigation follows a linear forward/backward flow between adjacent pages, except that the navigator MAY skip ahead to the earliest valid page permitted by the current pairing state (e.g., page 1 → page 4 when the gateway is already paired).  Arbitrary random access to later pages is not allowed.
-5. All existing functionality (scan, pair, provision, status, diagnostics) works through the multi-page flow.
+5. All existing functionality (scan, pair, ESP-NOW signal check, provision, status, diagnostics) works through the multi-page flow.
 
 ---
 
@@ -1234,7 +1235,7 @@ The UI MUST display a stepper bar at the top of every page showing three phases:
 
 **Acceptance criteria:**
 
-1. The stepper bar is visible on all 6 pages.
+1. The stepper bar is visible on all 7 pages.
 2. The stepper shows exactly three steps: Gateway, Node, Done.
 3. The currently active phase is visually distinct (highlighted).
 4. Completed phases are visually marked as done (e.g., checkmark).
@@ -1253,9 +1254,9 @@ The UI MUST persist the current page index to `localStorage` so that the wizard 
 **Acceptance criteria:**
 
 1. On page transition, the current page index (0-based) is saved to `localStorage`.
-2. On app launch, the saved page index is read and the corresponding page is displayed, provided the page's prerequisites are met (e.g., pairing artifacts for pages 3–6).
+2. On app launch, the saved page index is read and the corresponding page is displayed, provided the page's prerequisites are met (e.g., pairing artifacts for pages 3–7).
 3. If `localStorage` is empty, contains an invalid page index, or the saved page's prerequisites are not met, the app navigates to the earliest valid page (page 1 if unpaired, page 4 if already paired).
-4. The selected BLE node address is ephemeral and is never persisted across restarts.  Page 5 (Node Provision) requires a selected node address; page 6 (Done) requires in-memory provisioning-success context.  Both are ephemeral.  If the saved page is 5 or 6, the app MUST fall back to page 4 (Node Scan) if page 4's prerequisites are met (i.e., the app is paired); otherwise, the app MUST fall back to the earliest valid page as defined in AC 3.
+4. The selected BLE node address and any active BLE node connection are ephemeral and are never persisted across restarts.  Pages 5–7 require ephemeral connected-node or provisioning-success context.  If the saved page is 5, 6, or 7, the app MUST fall back to page 4 (Node Scan) if page 4's prerequisites are met (i.e., the app is paired); otherwise, the app MUST fall back to the earliest valid page as defined in AC 3.
 
 ---
 
@@ -1271,24 +1272,24 @@ Additionally, a visible back arrow button MUST be rendered in the header bar on 
 
 **Acceptance criteria:**
 
-1. Pressing back on pages 2–6 navigates to the previous page.
+1. Pressing back on pages 2–7 navigates to the previous page.
 2. Pressing back on page 1 does nothing (the app does not exit).
 3. Back navigation uses the History API (`pushState`/`popstate`) with a sentinel state at the bottom of the history stack.  When the app restores to page N on launch, all intermediate pages (1 through N) MUST be pushed into history so that back navigation traverses each page in sequence.  On encountering the sentinel, the app MUST update the visible UI to page 1 (Welcome) and MUST re-establish a no-exit state so that further back actions while on page 1 remain on page 1 and do not navigate away.
 4. The stepper bar updates correctly on back navigation.
 5. Navigating back from a scan page stops any active scan and clears the selected device.
-6. A back arrow button is visible in the header on pages 2–6.
+6. A back arrow button is visible in the header on pages 2–7.
 7. The back arrow button is hidden on page 1 (Welcome).
 8. Clicking the back arrow navigates to the previous page (same behavior as AC 1).
 
 ---
 
-### PT-1221  RSSI signal quality indicator
+### PT-1221  BLE RSSI signal quality indicator
 
 **Priority:** Must  
 **Source:** pairing-tool-ui-redesign.md §Step 4, issue #673
 
 **Description:**  
-The Node Scan page (page 4) MUST display a visual RSSI signal quality indicator for the selected BLE device.  The indicator uses three quality levels based on protocol-defined thresholds:
+The Node Scan page (page 4) MUST display a visual BLE RSSI signal quality indicator for the selected device while the installer is choosing which node to connect to.  The indicator uses three quality levels based on protocol-defined thresholds:
 
 | Level | RSSI Range | Visual |
 |-------|-----------|--------|
@@ -1298,7 +1299,7 @@ The Node Scan page (page 4) MUST display a visual RSSI signal quality indicator 
 
 **Acceptance criteria:**
 
-1. The RSSI indicator is displayed on page 4 when a device is selected.
+1. The BLE RSSI indicator is displayed on page 4 when a device is selected.
 2. Good signal (≥ −60 dBm) shows a green indicator.
 3. Marginal signal (−75 ≤ RSSI < −60 dBm) shows a yellow/amber indicator.
 4. Bad signal (< −75 dBm) shows a red indicator.
@@ -1320,6 +1321,60 @@ The UI SHOULD use CSS transitions for page changes.  Forward navigation slides t
 2. Back navigation animates the page sliding in from the left.
 3. The transition duration is ≤ 300 ms.
 4. Navigation remains functional if CSS transitions are disabled (graceful degradation).
+
+---
+
+### PT-1223  Pre-provision ESP-NOW signal-check step
+
+**Priority:** Must  
+**Source:** ble-pairing-protocol.md §6a, USER-REQUEST
+
+**Description:**  
+After the installer selects a node on page 4 and clicks **Connect**, the tool MUST establish the BLE connection to the node and then transition to a dedicated page 5 signal-check step before provisioning.  This step is distinct from the page 4 BLE RSSI view and exists to show the node↔gateway ESP-NOW diagnostic results.
+
+**Acceptance criteria:**
+
+1. Page 4 includes a **Connect** action that is disabled until a node device is selected.
+2. A successful BLE connection transitions the UI from page 4 to page 5.
+3. A failed BLE connection leaves the installer on page 4 and displays an actionable error.
+4. Page 5 displays the connected node identity and the current ESP-NOW diagnostic status.
+5. Page 5 provides controls to proceed to page 6 (Provision) or abort and return to page 4.
+
+---
+
+### PT-1224  Live ESP-NOW diagnostic polling
+
+**Priority:** Must  
+**Source:** ble-pairing-protocol.md §6a, USER-REQUEST
+
+**Description:**  
+While page 5 is active and the node BLE connection remains established, the tool MUST run the pairing-time ESP-NOW RSSI diagnostic repeatedly and update the UI after each completed diagnostic result.  The tool targets a 1000 ms cadence between completed checks when responses are fast, but it MUST preserve the existing protocol timing from ble-pairing-protocol.md §6a and MUST NOT overlap diagnostic requests.
+
+**Acceptance criteria:**
+
+1. Entering page 5 automatically starts the first diagnostic check.
+2. The tool never has more than one diagnostic request in flight at a time.
+3. On a successful diagnostic result, page 5 shows the gateway-measured RSSI in dBm and the signal-quality assessment (`good`, `marginal`, or `bad`).
+4. When the previous diagnostic completes quickly, the next diagnostic starts about 1000 ms after completion.
+5. When a diagnostic times out or returns a channel error, page 5 shows an actionable status message and remains on the signal-check step.
+6. Leaving page 5 stops the repeating diagnostic loop.
+
+---
+
+### PT-1225  Informational-only ESP-NOW guidance
+
+**Priority:** Must  
+**Source:** ble-pairing-protocol.md §6a.4, USER-REQUEST
+
+**Description:**  
+The page 5 ESP-NOW diagnostic is advisory only.  The tool MUST let the installer decide whether to proceed with provisioning or abort after reviewing the live node↔gateway signal readings.  The tool MUST NOT automatically block or force provisioning based on signal quality or diagnostic failures.
+
+**Acceptance criteria:**
+
+1. A `bad` ESP-NOW signal result does not automatically start provisioning and does not force the installer off page 5.
+2. The control to proceed to page 6 remains available after any completed diagnostic result, including `bad` signal, timeout, or channel-error outcomes.
+3. The installer can abort from page 5 and return to page 4 without provisioning the node.
+4. Proceeding from page 5 to page 6 does not require an additional override dialog solely because the last diagnostic result was `bad`.
 
 ---
 
@@ -1402,5 +1457,8 @@ The UI SHOULD use CSS transitions for page changes.  Forward navigation slides t
 | PT-1218 | Stepper progress bar | Active |
 | PT-1219 | Wizard page persistence | Active |
 | PT-1220 | Back navigation | Active |
-| PT-1221 | RSSI signal quality indicator | Active |
+| PT-1221 | BLE RSSI signal quality indicator | Active |
 | PT-1222 | Page transition animations | Active |
+| PT-1223 | Pre-provision ESP-NOW signal-check step | Active |
+| PT-1224 | Live ESP-NOW diagnostic polling | Active |
+| PT-1225 | Informational-only ESP-NOW guidance | Active |

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1629,45 +1629,57 @@ TestNode {
 
 ### T-PT-1224a  ESP-NOW diagnostic result updates signal-check page
 
-**Validates:** PT-1224 (AC 1, 3)  
+**Validates:** PT-1224 (AC 1, 3, 4)  
 **Type:** CI / mock transport test
 
 **Procedure:**
 1. Connect to a node and enter page 5.
-2. Configure the mock transport so `check_rssi()` returns a successful diagnostic result with RSSI = −67 dBm and `signal_quality = marginal`.
+2. Configure the mock transport so the diagnostic start is accepted, the node disconnects intentionally, the tool reconnects automatically, and `FETCH_DIAG_RESULT` returns RSSI = −67 dBm with `signal_quality = marginal`.
 3. Wait for the first diagnostic cycle to complete.
 4. Assert: page 5 shows `−67 dBm`.
 5. Assert: page 5 labels the result as `Marginal`.
 
 ---
 
-### T-PT-1224b  ESP-NOW diagnostic loop is single-flight
+### T-PT-1224b  Expected disconnect triggers automatic reconnect and fetch
 
-**Validates:** PT-1224 (AC 2, 4, 6)  
+**Validates:** PT-1223 (AC 5, 6), PT-1224 (AC 2, 3)  
 **Type:** CI / mock transport test
 
 **Procedure:**
-1. Enter page 5 with a mock `check_rssi()` implementation that delays completion.
-2. While the first diagnostic is still in flight, observe the frontend scheduling state for the next poll.
-3. Assert: no second diagnostic request is issued before the first completes.
-4. Let the first diagnostic complete quickly.
-5. Assert: the next diagnostic begins about 1000 ms after completion.
-6. Navigate away from page 5.
-7. Assert: no further diagnostic requests are issued.
+1. Enter page 5 with a mock transport that accepts `START_DIAG_RELAY` and then disconnects BLE as part of the diagnostic flow.
+2. Assert: the UI stays on page 5 and shows an in-progress reconnect state rather than a fatal BLE error.
+3. Let the tool reconnect automatically.
+4. Assert: the tool sends `FETCH_DIAG_RESULT` after reconnect.
+5. Assert: the reconnected BLE session remains available after the result is fetched.
 
 ---
 
-### T-PT-1224c  Diagnostic timeout or channel error remains on signal-check page
+### T-PT-1224c  Diagnostic completion does not auto-repeat
 
-**Validates:** PT-1224 (AC 5)  
+**Validates:** PT-1224 (AC 6, 7), PT-1225 (AC 4)  
 **Type:** CI / mock transport test
 
 **Procedure:**
-1. Enter page 5 with a mock `check_rssi()` implementation that returns a timeout error.
+1. Enter page 5 and let the initial diagnostic cycle complete.
+2. Observe the frontend state for 2 additional seconds.
+3. Assert: no second diagnostic cycle is started automatically.
+4. Click **Check Again**.
+5. Assert: exactly one new diagnostic cycle starts.
+
+---
+
+### T-PT-1224d  Diagnostic timeout or channel error remains on signal-check page
+
+**Validates:** PT-1224 (AC 5), PT-1225 (AC 1, 2)  
+**Type:** CI / mock transport test
+
+**Procedure:**
+1. Enter page 5 with a mock diagnostic flow that returns `DIAG_RELAY_RESULT(status=timeout)`.
 2. Wait for the diagnostic cycle to complete.
 3. Assert: page 5 remains visible.
 4. Assert: the UI shows an actionable timeout status.
-5. Re-run the diagnostic with a mock `check_rssi()` implementation that returns a channel error.
+5. Re-run the diagnostic with a mock flow that returns `DIAG_RELAY_RESULT(status=channel error)`.
 6. Assert: page 5 remains visible.
 7. Assert: the UI shows an actionable channel-error status.
 8. Assert: provisioning has not started automatically.
@@ -1676,7 +1688,7 @@ TestNode {
 
 ### T-PT-1225a  Bad ESP-NOW signal does not block proceed
 
-**Validates:** PT-1223 (AC 5), PT-1225 (AC 1, 2, 4)  
+**Validates:** PT-1223 (AC 7), PT-1225 (AC 1, 2, 5)  
 **Type:** Manual / platform test
 
 **Procedure:**
@@ -1690,7 +1702,7 @@ TestNode {
 
 ### T-PT-1225b  Abort from signal-check page returns to BLE scan
 
-**Validates:** PT-1223 (AC 5), PT-1225 (AC 3)  
+**Validates:** PT-1223 (AC 7), PT-1225 (AC 3)  
 **Type:** Manual / platform test
 
 **Procedure:**
@@ -1708,11 +1720,23 @@ TestNode {
 **Type:** CI / mock transport test
 
 **Procedure:**
-1. Enter page 5 with a mock `check_rssi()` implementation that returns a timeout error.
-2. Wait for the diagnostic cycle to complete.
-3. Assert: the **Proceed to Provision** action remains enabled.
-4. Click **Proceed to Provision**.
-5. Assert: page 6 (Node Provision) becomes visible.
+1. Enter page 5 with a completed diagnostic timeout result.
+2. Assert: the **Proceed to Provision** action remains enabled.
+3. Click **Proceed to Provision**.
+4. Assert: page 6 (Node Provision) becomes visible.
+
+---
+
+### T-PT-1225d  Completed diagnostic exposes explicit re-check action
+
+**Validates:** PT-1225 (AC 4)  
+**Type:** Manual / platform test
+
+**Procedure:**
+1. Enter page 5 and let the automatic diagnostic complete.
+2. Assert: a **Check Again** action is visible.
+3. Click **Check Again**.
+4. Assert: a new diagnostic cycle starts without leaving page 5.
 
 ---
 
@@ -1846,8 +1870,10 @@ TestNode {
 | T-PT-1223a | PT-1223 | Connect action transitions from BLE scan to signal-check page |
 | T-PT-1223b | PT-1223 | Connect failure leaves installer on scan page |
 | T-PT-1224a | PT-1224 | ESP-NOW diagnostic result updates signal-check page |
-| T-PT-1224b | PT-1224 | ESP-NOW diagnostic loop is single-flight |
-| T-PT-1224c | PT-1224 | Diagnostic timeout or channel error remains on signal-check page |
+| T-PT-1224b | PT-1224 | Expected disconnect triggers automatic reconnect and fetch |
+| T-PT-1224c | PT-1224 | Diagnostic completion does not auto-repeat |
+| T-PT-1224d | PT-1224 | Diagnostic timeout or channel error remains on signal-check page |
 | T-PT-1225a | PT-1225 | Bad ESP-NOW signal does not block proceed |
 | T-PT-1225b | PT-1225 | Abort from signal-check page returns to BLE scan |
 | T-PT-1225c | PT-1225 | Timeout does not disable proceed |
+| T-PT-1225d | PT-1225 | Completed diagnostic exposes explicit re-check action |

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -267,8 +267,8 @@ TestNode {
 
 **Procedure:**
 1. Launch the pairing tool.
-2. Assert: the UI shows a multi-page wizard flow with 6 pages.
-3. Navigate through all pages and assert: scan toggle, device list, device select, pair action, node ID input, board selector, status area, and error display are present on the appropriate pages.
+2. Assert: the UI shows a multi-page wizard flow with 7 pages.
+3. Navigate through all pages and assert: scan toggle, device list, device select, connect action, ESP-NOW signal-check view, node ID input, board selector, status area, and error display are present on the appropriate pages.
 4. Assert: the UI does not include management, monitoring, or telemetry features.
 
 ---
@@ -283,7 +283,7 @@ TestNode {
 3. Assert: Gateway step is active on pages 1–3.
 4. Navigate to page 4.
 5. Assert: Gateway step is marked done; Node step is active.
-6. Navigate to page 6.
+6. Navigate to page 7.
 7. Assert: Gateway and Node steps are marked done; Done step is active.
 8. Assert: stepper steps are not clickable.
 
@@ -1333,15 +1333,15 @@ TestNode {
 
 ## 13  Multi-page wizard navigation tests
 
-### T-PT-1217a  Six pages rendered and only one visible at a time
+### T-PT-1217a  Seven pages rendered and only one visible at a time
 
 **Validates:** PT-1217 (AC 1, 2)  
 **Type:** Manual / platform test
 
 **Procedure:**
 1. Launch the pairing tool.
-2. Assert: 6 `<section>` elements with IDs `page-welcome`, `page-gateway-scan`, `page-gateway-done`, `page-node-scan`, `page-node-provision`, `page-done` exist in the DOM.
-3. Assert: exactly one page is visible; the other 5 are hidden.
+2. Assert: 7 `<section>` elements with IDs `page-welcome`, `page-gateway-scan`, `page-gateway-done`, `page-node-scan`, `page-node-diagnostic`, `page-node-provision`, `page-done` exist in the DOM.
+3. Assert: exactly one page is visible; the other 6 are hidden.
 
 ---
 
@@ -1353,7 +1353,7 @@ TestNode {
 **Procedure:**
 1. Launch the pairing tool on page 1.
 2. Complete gateway pairing (or simulate via mock) and navigate forward through each page.
-3. Assert: each page becomes visible in order (1 → 2 → 3 → 4 → 5 → 6).
+3. Assert: each page becomes visible in order (1 → 2 → 3 → 4 → 5 → 6 → 7).
 4. Assert: the previous page is hidden when the next page becomes visible.
 
 ---
@@ -1365,8 +1365,8 @@ TestNode {
 
 **Procedure:**
 1. Launch the pairing tool.
-2. Complete a full workflow: check status (page 1) → scan and pair gateway (page 2) → confirm pairing (page 3) → scan and select node (page 4) → provision node (page 5) → view success (page 6).
-3. Assert: all Tauri commands (`start_scan`, `pair_gateway`, `provision_node`, `get_pairing_status`) are invoked correctly and produce the expected results.
+2. Complete a full workflow: check status (page 1) → scan and pair gateway (page 2) → confirm pairing (page 3) → scan and select node (page 4) → connect and view signal check (page 5) → provision node (page 6) → view success (page 7).
+3. Assert: all Tauri commands (`start_scan`, `pair_gateway`, `connect_node`, `check_rssi`, `provision_node`, `get_pairing_status`) are invoked correctly and produce the expected results.
 
 ---
 
@@ -1393,7 +1393,7 @@ TestNode {
 2. Assert: Gateway step has `step--active` class; Node and Done are dimmed.
 3. Navigate to page 4 (Node Scan).
 4. Assert: Gateway step has `step--done` class; Node step has `step--active` class; Done is dimmed.
-5. Navigate to page 6 (Done).
+5. Navigate to page 7 (Done).
 6. Assert: Gateway and Node steps have `step--done` class; Done step has `step--active` class.
 
 ---
@@ -1425,12 +1425,15 @@ TestNode {
 7. Clear pairing artifacts and set `localStorage.setItem('sonde-pair-page', '4')`.
 8. Reload the app.
 9. Assert: page 1 (Welcome) is visible (prerequisites not met, redirects to earliest valid page).
-10. With pairing artifacts present, set `localStorage.setItem('sonde-pair-page', '4')` (0-based index for Node Provision page).
+10. With pairing artifacts present, set `localStorage.setItem('sonde-pair-page', '4')` (0-based index for Node Signal Check page).
 11. Reload the app.
-12. Assert: page 4 (Node Scan) is visible — the provision page requires an ephemeral selected-node address; the app falls back to the node scan page (PT-1219 AC 4).
-13. With pairing artifacts present, set `localStorage.setItem('sonde-pair-page', '5')` (0-based index for Done page).
+12. Assert: page 4 (Node Scan) is visible — the signal-check page requires an ephemeral connected-node session; the app falls back to the node scan page (PT-1219 AC 4).
+13. With pairing artifacts present, set `localStorage.setItem('sonde-pair-page', '5')` (0-based index for Node Provision page).
 14. Reload the app.
-15. Assert: page 4 (Node Scan) is visible — the done page requires ephemeral provisioning-success context; the app falls back to the node scan page (PT-1219 AC 4).
+15. Assert: page 4 (Node Scan) is visible — the provision page requires an ephemeral connected-node session; the app falls back to the node scan page (PT-1219 AC 4).
+16. With pairing artifacts present, set `localStorage.setItem('sonde-pair-page', '6')` (0-based index for Done page).
+17. Reload the app.
+18. Assert: page 4 (Node Scan) is visible — the done page requires ephemeral provisioning-success context; the app falls back to the node scan page (PT-1219 AC 4).
 
 ---
 
@@ -1499,7 +1502,7 @@ TestNode {
 
 ---
 
-### T-PT-1221a  RSSI indicator shows correct quality level
+### T-PT-1221a  BLE RSSI indicator shows correct quality level
 
 **Validates:** PT-1221 (AC 1–4)  
 **Type:** Manual / platform test
@@ -1507,15 +1510,15 @@ TestNode {
 **Procedure:**
 1. Navigate to page 4 (Node Scan) and start a scan.
 2. Mock a device with RSSI = −50 dBm and select it.
-3. Assert: RSSI indicator shows "Good" with green styling (`rssi--good` class).
+3. Assert: the BLE RSSI indicator shows "Good" with green styling (`rssi--good` class).
 4. Update mock device RSSI to −65 dBm.
-5. Assert: RSSI indicator shows "Marginal" with amber styling (`rssi--marginal` class).
+5. Assert: the BLE RSSI indicator shows "Marginal" with amber styling (`rssi--marginal` class).
 6. Update mock device RSSI to −80 dBm.
-7. Assert: RSSI indicator shows "Bad" with red styling (`rssi--bad` class).
+7. Assert: the BLE RSSI indicator shows "Bad" with red styling (`rssi--bad` class).
 
 ---
 
-### T-PT-1221b  RSSI indicator updates on poll interval
+### T-PT-1221b  BLE RSSI indicator updates on poll interval
 
 **Validates:** PT-1221 (AC 5)  
 **Type:** Manual / platform test
@@ -1524,11 +1527,11 @@ TestNode {
 1. Navigate to page 4, start a scan, and select a device.
 2. Change the mock device RSSI from −50 to −80 dBm.
 3. Wait for 1 device poll cycle (≤ 1.5 s).
-4. Assert: the RSSI indicator updates from "Good" to "Bad".
+4. Assert: the BLE RSSI indicator updates from "Good" to "Bad".
 
 ---
 
-### T-PT-1221c  RSSI boundary values classified correctly
+### T-PT-1221c  BLE RSSI boundary values classified correctly
 
 **Validates:** PT-1221 (AC 2, 3, 4)  
 **Type:** Manual / platform test
@@ -1536,11 +1539,11 @@ TestNode {
 **Procedure:**
 1. Navigate to page 4, start a scan, and select a device.
 2. Set mock device RSSI to exactly −60 dBm.
-3. Assert: RSSI indicator shows "Good" (≥ −60 threshold is inclusive).
+3. Assert: the BLE RSSI indicator shows "Good" (≥ −60 threshold is inclusive).
 4. Set mock device RSSI to exactly −75 dBm.
-5. Assert: RSSI indicator shows "Marginal" (−75 ≤ x < −60, −75 is inclusive).
+5. Assert: the BLE RSSI indicator shows "Marginal" (−75 ≤ x < −60, −75 is inclusive).
 6. Set mock device RSSI to −76 dBm.
-7. Assert: RSSI indicator shows "Bad".
+7. Assert: the BLE RSSI indicator shows "Bad".
 
 ---
 
@@ -1592,6 +1595,124 @@ TestNode {
 1. Disable CSS transitions (e.g., via `* { transition: none !important; }`).
 2. Navigate forward and backward through all pages.
 3. Assert: all pages display correctly; no visual glitches or stuck states.
+
+---
+
+### T-PT-1223a  Connect action transitions from BLE scan to signal-check page
+
+**Validates:** PT-1223 (AC 1, 2, 4)  
+**Type:** Manual / platform test
+
+**Procedure:**
+1. Navigate to page 4 (Node Scan) with no device selected.
+2. Assert: the **Connect** action is disabled.
+3. Select a node device.
+4. Assert: the **Connect** action becomes enabled.
+5. Click **Connect** and allow the BLE connection to succeed.
+6. Assert: page 5 (`page-node-diagnostic`) becomes visible.
+7. Assert: page 5 shows the connected node identity and an initial diagnostic status.
+
+---
+
+### T-PT-1223b  Connect failure leaves installer on scan page
+
+**Validates:** PT-1223 (AC 3)  
+**Type:** CI / mock transport test
+
+**Procedure:**
+1. Configure the mock transport so node connection fails with a recoverable error.
+2. Navigate to page 4, select a node device, and click **Connect**.
+3. Assert: page 4 remains visible.
+4. Assert: the UI shows an actionable error message explaining the connection failure.
+
+---
+
+### T-PT-1224a  ESP-NOW diagnostic result updates signal-check page
+
+**Validates:** PT-1224 (AC 1, 3)  
+**Type:** CI / mock transport test
+
+**Procedure:**
+1. Connect to a node and enter page 5.
+2. Configure the mock transport so `check_rssi()` returns a successful diagnostic result with RSSI = −67 dBm and `signal_quality = marginal`.
+3. Wait for the first diagnostic cycle to complete.
+4. Assert: page 5 shows `−67 dBm`.
+5. Assert: page 5 labels the result as `Marginal`.
+
+---
+
+### T-PT-1224b  ESP-NOW diagnostic loop is single-flight
+
+**Validates:** PT-1224 (AC 2, 4, 6)  
+**Type:** CI / mock transport test
+
+**Procedure:**
+1. Enter page 5 with a mock `check_rssi()` implementation that delays completion.
+2. While the first diagnostic is still in flight, observe the frontend scheduling state for the next poll.
+3. Assert: no second diagnostic request is issued before the first completes.
+4. Let the first diagnostic complete quickly.
+5. Assert: the next diagnostic begins about 1000 ms after completion.
+6. Navigate away from page 5.
+7. Assert: no further diagnostic requests are issued.
+
+---
+
+### T-PT-1224c  Diagnostic timeout or channel error remains on signal-check page
+
+**Validates:** PT-1224 (AC 5)  
+**Type:** CI / mock transport test
+
+**Procedure:**
+1. Enter page 5 with a mock `check_rssi()` implementation that returns a timeout error.
+2. Wait for the diagnostic cycle to complete.
+3. Assert: page 5 remains visible.
+4. Assert: the UI shows an actionable timeout status.
+5. Re-run the diagnostic with a mock `check_rssi()` implementation that returns a channel error.
+6. Assert: page 5 remains visible.
+7. Assert: the UI shows an actionable channel-error status.
+8. Assert: provisioning has not started automatically.
+
+---
+
+### T-PT-1225a  Bad ESP-NOW signal does not block proceed
+
+**Validates:** PT-1223 (AC 5), PT-1225 (AC 1, 2, 4)  
+**Type:** Manual / platform test
+
+**Procedure:**
+1. Enter page 5 and provide a completed diagnostic result with `signal_quality = bad`.
+2. Assert: the page remains on the signal-check step.
+3. Assert: the **Proceed to Provision** action is still enabled.
+4. Click **Proceed to Provision**.
+5. Assert: page 6 (Node Provision) becomes visible without any additional override dialog.
+
+---
+
+### T-PT-1225b  Abort from signal-check page returns to BLE scan
+
+**Validates:** PT-1223 (AC 5), PT-1225 (AC 3)  
+**Type:** Manual / platform test
+
+**Procedure:**
+1. Enter page 5 with an active connected-node session.
+2. Click **Abort** or **Disconnect**.
+3. Assert: page 4 (Node Scan) becomes visible.
+4. Assert: the BLE connection to the node is released.
+5. Assert: no provisioning write is sent.
+
+---
+
+### T-PT-1225c  Timeout does not disable proceed
+
+**Validates:** PT-1225 (AC 2)  
+**Type:** CI / mock transport test
+
+**Procedure:**
+1. Enter page 5 with a mock `check_rssi()` implementation that returns a timeout error.
+2. Wait for the diagnostic cycle to complete.
+3. Assert: the **Proceed to Provision** action remains enabled.
+4. Click **Proceed to Provision**.
+5. Assert: page 6 (Node Provision) becomes visible.
 
 ---
 
@@ -1704,7 +1825,7 @@ TestNode {
 | T-PT-1216e | PT-1216, PT-0409 | Provision with partial I2C layout rejected |
 | T-PT-1216f | PT-1216 | Espressif preset remains available |
 | T-PT-1216g | PT-1216 | Tauri provision_node command accepts structured board layout |
-| T-PT-1217a | PT-1217 | Six pages rendered and only one visible at a time |
+| T-PT-1217a | PT-1217 | Seven pages rendered and only one visible at a time |
 | T-PT-1217b | PT-1217 | Forward navigation through all pages |
 | T-PT-1217c | PT-1217 | Existing functionality works through wizard flow |
 | T-PT-1218a | PT-1218 | Stepper bar shows three phases |
@@ -1716,9 +1837,17 @@ TestNode {
 | T-PT-1220c | PT-1220 | Scan stopped when navigating away from scan page |
 | T-PT-1220d | PT-1220 | Visible back button in header (desktop) |
 | T-PT-1220e | PT-1220 | Back navigation works after app restore to mid-flow page |
-| T-PT-1221a | PT-1221 | RSSI indicator shows correct quality level |
-| T-PT-1221b | PT-1221 | RSSI indicator updates on poll interval |
-| T-PT-1221c | PT-1221 | RSSI boundary values classified correctly |
+| T-PT-1221a | PT-1221 | BLE RSSI indicator shows correct quality level |
+| T-PT-1221b | PT-1221 | BLE RSSI indicator updates on poll interval |
+| T-PT-1221c | PT-1221 | BLE RSSI boundary values classified correctly |
 | T-PT-1222a | PT-1222 | Page transition animation (forward) |
 | T-PT-1222b | PT-1222 | Page transition animation (back) |
 | T-PT-1222c | PT-1222 | Navigation works without CSS transitions |
+| T-PT-1223a | PT-1223 | Connect action transitions from BLE scan to signal-check page |
+| T-PT-1223b | PT-1223 | Connect failure leaves installer on scan page |
+| T-PT-1224a | PT-1224 | ESP-NOW diagnostic result updates signal-check page |
+| T-PT-1224b | PT-1224 | ESP-NOW diagnostic loop is single-flight |
+| T-PT-1224c | PT-1224 | Diagnostic timeout or channel error remains on signal-check page |
+| T-PT-1225a | PT-1225 | Bad ESP-NOW signal does not block proceed |
+| T-PT-1225b | PT-1225 | Abort from signal-check page returns to BLE scan |
+| T-PT-1225c | PT-1225 | Timeout does not disable proceed |

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1340,7 +1340,7 @@ TestNode {
 
 **Procedure:**
 1. Launch the pairing tool.
-2. Assert: 7 `<section>` elements with IDs `page-welcome`, `page-gateway-scan`, `page-gateway-done`, `page-node-scan`, `page-node-diagnostic`, `page-node-provision`, `page-done` exist in the DOM.
+2. Assert: 7 `<section>` elements with IDs `page-welcome`, `page-gateway-scan`, `page-gateway-done`, `page-node-scan`, `page-signal-check`, `page-node-provision`, `page-done` exist in the DOM.
 3. Assert: exactly one page is visible; the other 6 are hidden.
 
 ---
@@ -1609,7 +1609,7 @@ TestNode {
 3. Select a node device.
 4. Assert: the **Connect** action becomes enabled.
 5. Click **Connect** and allow the BLE connection to succeed.
-6. Assert: page 5 (`page-node-diagnostic`) becomes visible.
+6. Assert: page 5 (`page-signal-check`) becomes visible.
 7. Assert: page 5 shows the connected node identity and an initial diagnostic status.
 
 ---

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -668,10 +668,10 @@ phone connects → server calls ble_gap_security_initiate() → LESC pairing →
     ↓
 buffered GATT write flushed (if any) → handle_node_provision() → NODE_ACK indicate
     ↓
-phone disconnects → return → reboot (ND-0907)
+ordinary phone disconnects → return → reboot (ND-0907)
 ```
 
-The main loop polls for pending GATT writes and disconnection events at 100 ms intervals. On disconnect, the function returns and the caller reboots into normal wake-cycle mode with the newly provisioned credentials.
+The main loop polls for pending GATT writes and disconnection events at 100 ms intervals. On an ordinary disconnect, the function returns and the caller reboots into normal wake-cycle mode with the newly provisioned credentials. The asynchronous diagnostic flow in §15.8 is the exception: it intentionally suspends BLE, completes the radio relay, and resumes advertising without returning from pairing mode.
 
 ### 15.6  Platform-independent handler
 
@@ -722,18 +722,28 @@ If WAKE fails (no response or AEAD decryption failure) after `reg_complete` is s
 
 ### 15.8  Diagnostic relay (pre-provisioning)
 
-> **Requirements:** ND-1100 (BLE diagnostic relay command), ND-1101 (diagnostic ESP-NOW broadcast), ND-1102 (diagnostic reply reception), ND-1103 (diagnostic retry behavior), ND-1104 (diagnostic timeout handling), ND-1105 (diagnostic BLE response forwarding), ND-1106 (diagnostic radio state restoration).
+> **Requirements:** ND-1100 (asynchronous BLE diagnostic commands), ND-1101 (diagnostic BLE suspend and resume), ND-1102 (diagnostic ESP-NOW broadcast and reply reception), ND-1103 (diagnostic retry behavior), ND-1104 (diagnostic result persistence and fetch), ND-1105 (diagnostic pairing-mode continuity), ND-1106 (diagnostic radio state restoration).
 
-While in BLE pairing mode (before `NODE_PROVISION` is received), the node can act as a **dumb radio relay** for pairing-time diagnostics. The pairing tool uses this to measure the node→gateway RF link quality before committing to provisioning.
+While in BLE pairing mode (before `NODE_PROVISION` is received), the node can act as a **dumb radio relay** for pairing-time diagnostics. Because ESP32-C3 cannot reliably perform BLE and ESP-NOW receive concurrently, the relay runs as an asynchronous suspend/reconnect cycle rather than a synchronous same-connection response.
 
 **BLE command handling (ND-1100):**
 
-The node's BLE GATT handler processes `DIAG_RELAY_REQUEST` (envelope type `0x02`) on the Node Command characteristic:
+The node's BLE GATT handler processes two diagnostic commands on the Node Command characteristic:
 
-1. Parse the envelope body: `rf_channel` (1 byte), `payload_len` (2 bytes BE), `payload` (variable).
-2. Validate: `rf_channel` ∈ 1–13 and 0 < `payload_len` ≤ 250. On validation failure → respond with `DIAG_RELAY_RESPONSE(status=0x02)`.
+1. `START_DIAG_RELAY` (envelope type `0x02`) with body `rf_channel` + `payload_len` + `payload`
+2. `FETCH_DIAG_RESULT` (envelope type `0x03`) with an empty body
 
-**ESP-NOW relay (ND-1101, ND-1102):**
+For `START_DIAG_RELAY`, the node validates `rf_channel` ∈ 1–13 and 0 < `payload_len` ≤ 250. On validation failure it sends `DIAG_RELAY_ACK(status=0x02)`. If a prior diagnostic is already running or a completed result has not yet been fetched, it sends `DIAG_RELAY_ACK(status=0x01)`. Otherwise it sends `DIAG_RELAY_ACK(status=0x00)` and transitions into the diagnostic execution path.
+
+**BLE suspend / resume (ND-1101, ND-1105):**
+
+1. Deliver `DIAG_RELAY_ACK(status=0x00)` while BLE is still active.
+2. After the indication is acknowledged, stop advertising and tear down BLE without returning from `run_ble_pairing_mode()`.
+3. Execute the diagnostic with BLE absent.
+4. Restart advertising after the diagnostic completes and wait for the phone to reconnect.
+5. After reconnect, respond to `FETCH_DIAG_RESULT` and keep BLE active so provisioning can continue on the same session.
+
+**ESP-NOW relay (ND-1102, ND-1103):**
 
 1. Save the current ESP-NOW channel (if any).
 2. Tune the ESP-NOW radio to `rf_channel`.
@@ -741,23 +751,21 @@ The node's BLE GATT handler processes `DIAG_RELAY_REQUEST` (envelope type `0x02`
 4. Listen for inbound ESP-NOW frames.
 5. Accept the first frame whose `msg_type` byte (header offset 2) = `0x85` (`DIAG_REPLY`).
 6. Ignore frames with any other `msg_type`.
+7. Retry up to 3 retransmissions with 200 ms backoff and a 2-second listen window per attempt.
 
-**Retry behavior (ND-1103):**
+**Result persistence and fetch (ND-1104):**
 
-Matches the WAKE cycle retry parameters:
-- Up to 3 retransmissions.
-- 200 ms backoff between attempts.
-- 2-second listen window per attempt.
-- A reply received during any attempt terminates the loop.
+When the diagnostic finishes, the node stores one completed result in pairing-session state:
 
-**Response (ND-1104, ND-1105):**
+- success with raw `DIAG_REPLY` frame
+- timeout after all retries
+- channel/radio execution error
 
-- On reply received: send `DIAG_RELAY_RESPONSE(status=0x00, payload=<raw DIAG_REPLY frame>)` via BLE indication.
-- On timeout after all retries: send `DIAG_RELAY_RESPONSE(status=0x01, payload_len=0)`.
+On `FETCH_DIAG_RESULT`, the node sends `DIAG_RELAY_RESULT(...)` via BLE indication. After a successful result delivery, it clears the stored result so future fetches cannot return stale data.
 
 **Radio state restoration (ND-1106):**
 
-After the relay completes, restore the ESP-NOW channel to its previous value. The node remains in BLE pairing mode and can accept further diagnostic relay requests or proceed to `NODE_PROVISION`.
+After the relay completes, restore the ESP-NOW channel to its previous value before restarting BLE advertising.
 
 ---
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -967,12 +967,13 @@ On a valid NODE_PROVISION the node MUST write the node PSK (NVS key `psk`), key 
 **Source:** ble-pairing-protocol.md §8.2, steps 5–6
 
 **Description:**  
-The node MUST remain in BLE pairing mode after a successful NODE_PROVISION (allowing re-provision on error) and MUST reboot when the BLE connection disconnects.
+The node MUST remain in BLE pairing mode after a successful NODE_PROVISION (allowing re-provision on error). On an ordinary BLE disconnect, the node MUST return from pairing mode and reboot. However, the pairing-time diagnostic flow (ND-1100–ND-1106) MAY intentionally suspend BLE, run ESP-NOW, and resume BLE advertising **without** rebooting.
 
 **Acceptance criteria:**
 
 1. A second NODE_PROVISION can be sent on the same BLE connection after a successful first provision.
-2. The node reboots when the BLE connection is terminated.
+2. The node reboots when an ordinary BLE connection is terminated.
+3. An intentional diagnostic BLE suspend/resume path does not reboot the node.
 
 ---
 
@@ -1446,52 +1447,55 @@ The node MUST log the WiFi / ESP-NOW channel number at boot using `warn!()` leve
 
 ## 12  Diagnostic relay
 
-### ND-1100  BLE diagnostic relay command
+### ND-1100  Asynchronous BLE diagnostic commands
 
 **Priority:** Must  
 **Source:** ble-pairing-protocol.md §6a, protocol.md §5.8
 
 **Description:**  
-In BLE pairing mode, the node MUST accept `DIAG_RELAY_REQUEST` (BLE envelope type `0x02`) on the Node Command characteristic. The node MUST NOT require provisioning to have completed — the diagnostic relay is available as soon as BLE pairing mode is active.
+In BLE pairing mode, the node MUST accept `START_DIAG_RELAY` (BLE envelope type `0x02`) and `FETCH_DIAG_RESULT` (BLE envelope type `0x03`) on the Node Command characteristic. The node MUST NOT require provisioning to have completed — the diagnostic relay is available as soon as BLE pairing mode is active.
 
 **Acceptance criteria:**
 
-1. `DIAG_RELAY_REQUEST` messages are accepted on the Node Command characteristic while in BLE pairing mode.
-2. The node parses `rf_channel` (1 byte), `payload_len` (2 bytes BE), and `payload` (variable) from the BLE envelope body.
-3. The node rejects requests with `rf_channel` outside 1–13 by sending `DIAG_RELAY_RESPONSE(status=0x02)`.
-4. The node rejects requests with `payload_len` = 0 or `payload_len` > 250 by sending `DIAG_RELAY_RESPONSE(status=0x02)`.
+1. `START_DIAG_RELAY` and `FETCH_DIAG_RESULT` messages are accepted on the Node Command characteristic while in BLE pairing mode.
+2. For `START_DIAG_RELAY`, the node parses `rf_channel` (1 byte), `payload_len` (2 bytes BE), and `payload` (variable) from the BLE envelope body.
+3. The node rejects `START_DIAG_RELAY` requests with `rf_channel` outside 1–13 by sending `DIAG_RELAY_ACK(status=0x02)`.
+4. The node rejects `START_DIAG_RELAY` requests with `payload_len` = 0 or `payload_len` > 250 by sending `DIAG_RELAY_ACK(status=0x02)`.
+5. While a diagnostic is already running or a completed result is still pending fetch, the node rejects new `START_DIAG_RELAY` requests with `DIAG_RELAY_ACK(status=0x01)`.
 
 ---
 
-### ND-1101  Diagnostic ESP-NOW broadcast
+### ND-1101  Diagnostic BLE suspend and resume
 
 **Priority:** Must  
 **Source:** ble-pairing-protocol.md §6a.3, protocol.md §6.6
 
 **Description:**  
-Upon receiving a valid `DIAG_RELAY_REQUEST`, the node MUST temporarily tune the ESP-NOW radio to the specified `rf_channel` and broadcast the `payload` as a raw ESP-NOW frame using the broadcast MAC address (`FF:FF:FF:FF:FF:FF`). The node MUST NOT decrypt or interpret the payload.
+Upon receiving a valid `START_DIAG_RELAY`, the node MUST acknowledge the request over BLE, then intentionally disable BLE and stop advertising **without rebooting**, perform the diagnostic, and finally re-enable BLE advertising so the pairing tool can reconnect.
 
 **Acceptance criteria:**
 
-1. The node tunes to the specified `rf_channel` before transmitting.
-2. The payload is transmitted verbatim as a broadcast ESP-NOW frame.
-3. The node does not attempt to decrypt, parse, or validate the payload contents.
+1. The node sends `DIAG_RELAY_ACK(status=0x00)` before disabling BLE.
+2. After the acknowledgement is delivered, the node disables BLE and stops advertising without rebooting.
+3. After the diagnostic completes, the node re-enables BLE advertising and remains in pairing mode awaiting reconnect.
 
 ---
 
-### ND-1102  Diagnostic reply reception
+### ND-1102  Diagnostic ESP-NOW broadcast and reply reception
 
 **Priority:** Must  
 **Source:** ble-pairing-protocol.md §6a.3, protocol.md §5.9
 
 **Description:**  
-After broadcasting the diagnostic payload, the node MUST listen for an inbound ESP-NOW frame whose `msg_type` byte (header offset 2) is `0x85` (`DIAG_REPLY`). The node identifies reply frames by inspecting the plaintext `msg_type` byte in the frame header — no decryption is required.
+After accepting `START_DIAG_RELAY`, the node MUST temporarily tune the ESP-NOW radio to the specified `rf_channel`, broadcast the `payload` as a raw ESP-NOW frame using the broadcast MAC address (`FF:FF:FF:FF:FF:FF`), and listen for an inbound ESP-NOW frame whose `msg_type` byte (header offset 2) is `0x85` (`DIAG_REPLY`). The node identifies reply frames by inspecting the plaintext `msg_type` byte in the frame header — no decryption is required.
 
 **Acceptance criteria:**
 
-1. The node accepts inbound ESP-NOW frames with `msg_type` = `0x85` as diagnostic replies.
-2. The node ignores inbound frames with any other `msg_type` during the listen window.
-3. The node does not decrypt or validate the reply payload.
+1. The node tunes to the specified `rf_channel` before transmitting.
+2. The payload is transmitted verbatim as a broadcast ESP-NOW frame.
+3. The node accepts inbound ESP-NOW frames with `msg_type` = `0x85` as diagnostic replies.
+4. The node ignores inbound frames with any other `msg_type` during the listen window.
+5. The node does not decrypt, parse, or validate either the request payload or the reply payload contents.
 
 ---
 
@@ -1512,34 +1516,37 @@ The node MUST retry the ESP-NOW broadcast up to **3 times** with a **200 ms** ba
 
 ---
 
-### ND-1104  Diagnostic timeout handling
+### ND-1104  Diagnostic result persistence and fetch
 
 **Priority:** Must  
 **Source:** ble-pairing-protocol.md §6a.6
 
 **Description:**  
-If no `DIAG_REPLY` is received after all retry attempts, the node MUST send `DIAG_RELAY_RESPONSE(status=0x01, payload_len=0)` to the pairing tool via BLE indication.
+When the diagnostic finishes, the node MUST store the completed result in pairing-session state and return it only after the pairing tool reconnects and sends `FETCH_DIAG_RESULT`. The result MAY be `success`, `timeout`, or `channel error`.
 
 **Acceptance criteria:**
 
-1. After 3 failed retry attempts, the node sends `DIAG_RELAY_RESPONSE` with status `0x01` (timeout).
-2. The `payload_len` is 0 and no payload is included in the timeout response.
+1. After a successful diagnostic reply, the node stores the raw `DIAG_REPLY` frame until `FETCH_DIAG_RESULT` is received.
+2. After 3 failed retry attempts, the node stores `DIAG_RELAY_RESULT(status=0x01)` with `payload_len=0`.
+3. If the diagnostic fails because the radio/channel operation could not be executed, the node stores `DIAG_RELAY_RESULT(status=0x02)` with `payload_len=0`.
+4. On `FETCH_DIAG_RESULT`, the node returns the stored result via `DIAG_RELAY_RESULT`.
+5. After a successful result delivery, the stored diagnostic result is cleared so later fetches do not return stale data.
 
 ---
 
-### ND-1105  Diagnostic BLE response forwarding
+### ND-1105  Diagnostic pairing-mode continuity
 
 **Priority:** Must  
 **Source:** ble-pairing-protocol.md §6a.3
 
 **Description:**  
-When a `DIAG_REPLY` frame is received, the node MUST forward the raw frame to the pairing tool as `DIAG_RELAY_RESPONSE(status=0x00, payload=<raw frame>)` via a BLE indication on the Node Command characteristic.
+The asynchronous diagnostic flow MUST keep the node in BLE pairing mode across the intentional BLE suspend/reconnect cycle. Completing a diagnostic MUST NOT force a reboot or exit from pairing mode, and the node MUST remain ready for either another diagnostic run or `NODE_PROVISION` after the result is fetched.
 
 **Acceptance criteria:**
 
-1. The raw `DIAG_REPLY` ESP-NOW frame is forwarded verbatim in the `DIAG_RELAY_RESPONSE` payload.
-2. The BLE indication uses envelope type `0x82`.
-3. The response status is `0x00` (success).
+1. The node does not reboot when it intentionally suspends BLE for a diagnostic.
+2. After the pairing tool reconnects and fetches the result, BLE remains connected and functional for `NODE_PROVISION`.
+3. The node can accept another diagnostic request after the previous result has been fetched.
 
 ---
 
@@ -1554,8 +1561,8 @@ After a diagnostic relay completes (whether by receiving a reply or exhausting r
 **Acceptance criteria:**
 
 1. The radio channel is restored to its pre-diagnostic value after the relay completes.
-2. BLE connectivity is maintained throughout the diagnostic relay operation.
-3. The node remains in BLE pairing mode after the diagnostic completes and can accept further `DIAG_RELAY_REQUEST` or `NODE_PROVISION` commands.
+2. The node remains in BLE pairing mode after the diagnostic completes.
+3. After reconnect, the node can accept further diagnostic commands or `NODE_PROVISION`.
 
 ---
 
@@ -1645,10 +1652,10 @@ After a diagnostic relay completes (whether by receiving a reply or exhausting r
 | ND-1014 | Error diagnostic observability | Must |
 | ND-1015 | Boot version visibility | Must |
 | ND-1016 | ESP-NOW channel logging at boot | Must |
-| ND-1100 | BLE diagnostic relay command | Must |
-| ND-1101 | Diagnostic ESP-NOW broadcast | Must |
-| ND-1102 | Diagnostic reply reception | Must |
+| ND-1100 | Asynchronous BLE diagnostic commands | Must |
+| ND-1101 | Diagnostic BLE suspend and resume | Must |
+| ND-1102 | Diagnostic ESP-NOW broadcast and reply reception | Must |
 | ND-1103 | Diagnostic retry behavior | Must |
-| ND-1104 | Diagnostic timeout handling | Must |
-| ND-1105 | Diagnostic BLE response forwarding | Must |
+| ND-1104 | Diagnostic result persistence and fetch | Must |
+| ND-1105 | Diagnostic pairing-mode continuity | Must |
 | ND-1106 | Diagnostic radio state restoration | Must |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -382,7 +382,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Procedure:**
 1. Boot an unpaired node; assert it enters BLE pairing mode (boot path 1).
 2. Provision the node via NODE_PROVISION with valid credentials; assert NODE_ACK(0x00).
-3. Disconnect BLE; node reboots.
+3. Disconnect BLE through the ordinary provisioning path (not the diagnostic suspend path); node reboots.
 4. Assert: node enters PEER_REQUEST path (boot path 2 — PSK stored, `reg_complete` not set).
 5. Mock gateway responds with a valid PEER_ACK; assert `reg_complete` is set in NVS.
 6. Node reboots; assert it enters normal WAKE cycle (boot path 3).
@@ -2000,64 +2000,69 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ## 12  Diagnostic relay tests
 
-### T-N1100  DIAG_RELAY_REQUEST accepted in pairing mode
+### T-N1100  START_DIAG_RELAY accepted in pairing mode
 
 **Validates:** ND-1100
 
 **Procedure:**
 1. Boot node into BLE pairing mode (no PSK stored).
-2. Connect via BLE and send a `DIAG_RELAY_REQUEST` (envelope type 0x02) with `rf_channel=6` and a valid 50-byte payload.
+2. Connect via BLE and send a `START_DIAG_RELAY` (envelope type 0x02) with `rf_channel=6` and a valid 50-byte payload.
 3. Assert: the node processes the request (does not reject or ignore it).
-4. Assert: a `DIAG_RELAY_RESPONSE` (envelope type 0x82) is received via BLE indication.
+4. Assert: a `DIAG_RELAY_ACK(status=0x00)` (envelope type 0x82) is received via BLE indication.
 
 ---
 
-### T-N1101  DIAG_RELAY_REQUEST invalid channel rejected
+### T-N1101  START_DIAG_RELAY invalid channel rejected
 
 **Validates:** ND-1100
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with `rf_channel=14` (out of range).
-3. Assert: node responds with `DIAG_RELAY_RESPONSE(status=0x02)`.
+2. Send `START_DIAG_RELAY` with `rf_channel=14` (out of range).
+3. Assert: node responds with `DIAG_RELAY_ACK(status=0x02)`.
 4. Assert: no ESP-NOW frame is broadcast.
 
 ---
 
-### T-N1102  DIAG_RELAY_REQUEST empty payload rejected
+### T-N1102  START_DIAG_RELAY empty payload rejected
 
 **Validates:** ND-1100
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with `rf_channel=6` and `payload_len=0`.
-3. Assert: node responds with `DIAG_RELAY_RESPONSE(status=0x02)`.
+2. Send `START_DIAG_RELAY` with `rf_channel=6` and `payload_len=0`.
+3. Assert: node responds with `DIAG_RELAY_ACK(status=0x02)`.
 
 ---
 
-### T-N1103  Diagnostic ESP-NOW broadcast
+### T-N1103  Diagnostic BLE suspend and advertising resume
 
-**Validates:** ND-1101
+**Validates:** ND-1101, ND-1102, ND-1105
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
 2. Set up an ESP-NOW receiver on channel 6.
-3. Send `DIAG_RELAY_REQUEST` with `rf_channel=6` and a known payload.
-4. Assert: the ESP-NOW receiver captures a broadcast frame matching the payload exactly.
-5. Assert: the destination MAC is `FF:FF:FF:FF:FF:FF`.
+3. Send `START_DIAG_RELAY` with `rf_channel=6` and a known payload.
+4. Assert: the node acknowledges the request, then disconnects BLE without rebooting.
+5. Assert: the ESP-NOW receiver captures a broadcast frame matching the payload exactly.
+6. Assert: the destination MAC is `FF:FF:FF:FF:FF:FF`.
+7. Assert: after the diagnostic completes, the node resumes BLE advertising.
+8. Reconnect via BLE.
+9. Assert: the node is still in pairing mode and accepts `FETCH_DIAG_RESULT`.
 
 ---
 
-### T-N1104  Diagnostic reply reception and forwarding
+### T-N1104  Diagnostic reply reception and fetched result forwarding
 
-**Validates:** ND-1102, ND-1105
+**Validates:** ND-1102, ND-1104
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with a valid payload.
+2. Send `START_DIAG_RELAY` with a valid payload and accept the expected BLE disconnect.
 3. From a test ESP-NOW transmitter, send a frame with `msg_type=0x85` at header offset 2 to the node.
-4. Assert: node forwards the frame in a `DIAG_RELAY_RESPONSE(status=0x00, payload=<frame>)` BLE indication.
-5. Assert: the forwarded payload is byte-identical to the ESP-NOW frame sent.
+4. Reconnect to the node over BLE and send `FETCH_DIAG_RESULT`.
+5. Assert: node forwards the frame in a `DIAG_RELAY_RESULT(status=0x00, payload=<frame>)` BLE indication.
+6. Assert: the forwarded payload is byte-identical to the ESP-NOW frame sent.
 
 ---
 
@@ -2067,10 +2072,11 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST`.
+2. Send `START_DIAG_RELAY`.
 3. During the listen window, send ESP-NOW frames with `msg_type=0x81` (COMMAND) and `msg_type=0x04` (APP_DATA).
-4. Assert: node does not forward these frames to the pairing tool.
-5. After the listen window expires (no `msg_type=0x85` received), assert `DIAG_RELAY_RESPONSE(status=0x01)`.
+4. Assert: node does not treat these frames as a successful diagnostic reply.
+5. Reconnect after the diagnostic completes and fetch the result.
+6. Assert: `DIAG_RELAY_RESULT(status=0x01)` is returned.
 
 ---
 
@@ -2081,10 +2087,11 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Procedure:**
 1. Boot node into BLE pairing mode.
 2. Set up an ESP-NOW receiver that counts broadcasts but does NOT send a reply.
-3. Send `DIAG_RELAY_REQUEST`.
+3. Send `START_DIAG_RELAY`.
 4. Assert: the receiver counts exactly 4 broadcasts (1 initial + 3 retries).
 5. Assert: the time between consecutive broadcasts is approximately 2.2 seconds (2s listen + 200ms backoff).
-6. Assert: node sends `DIAG_RELAY_RESPONSE(status=0x01)` after all retries.
+6. Reconnect and fetch the result.
+7. Assert: node returns `DIAG_RELAY_RESULT(status=0x01)` after all retries.
 
 ---
 
@@ -2094,32 +2101,33 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with no gateway or modem available (no ESP-NOW reply will arrive).
-3. Assert: node sends `DIAG_RELAY_RESPONSE(status=0x01, payload_len=0)` within approximately 9 seconds.
+2. Send `START_DIAG_RELAY` with no gateway or modem available (no ESP-NOW reply will arrive).
+3. Reconnect after the node resumes advertising and send `FETCH_DIAG_RESULT`.
+4. Assert: node sends `DIAG_RELAY_RESULT(status=0x01, payload_len=0)` within approximately 9 seconds of the start request.
 
 ---
 
 ### T-N1108  Radio state restored after diagnostic
 
-**Validates:** ND-1106
+**Validates:** ND-1106, ND-1105
 
 **Procedure:**
 1. Boot node into BLE pairing mode. Record the initial ESP-NOW channel (or lack thereof).
-2. Send `DIAG_RELAY_REQUEST` with `rf_channel=11`.
-3. Wait for `DIAG_RELAY_RESPONSE`.
+2. Send `START_DIAG_RELAY` with `rf_channel=11`.
+3. Reconnect after the diagnostic completes and fetch the result.
 4. Assert: the ESP-NOW radio is restored to its pre-diagnostic state.
-5. Assert: BLE remains connected and functional (send a second `DIAG_RELAY_REQUEST` successfully).
+5. Assert: BLE remains connected and functional (send a second `START_DIAG_RELAY` successfully).
 
 ---
 
 ### T-N1109  Diagnostic followed by provisioning
 
-**Validates:** ND-1106, ND-1100
+**Validates:** ND-1100, ND-1104, ND-1105, ND-1106
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Run a complete diagnostic relay (send `DIAG_RELAY_REQUEST`, receive response).
-3. Send `NODE_PROVISION` with valid provisioning data.
+2. Run a complete diagnostic relay (`START_DIAG_RELAY`, disconnect, reconnect, `FETCH_DIAG_RESULT`).
+3. Send `NODE_PROVISION` with valid provisioning data on the reconnected BLE session.
 4. Assert: provisioning succeeds (`NODE_ACK` status=0x00).
 5. Assert: NVS contains the expected PSK and channel.
 
@@ -2127,15 +2135,15 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ### T-N1110  Multiple diagnostics in sequence
 
-**Validates:** ND-1100, ND-1106
+**Validates:** ND-1100, ND-1104, ND-1105, ND-1106
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with `rf_channel=1`. Wait for response.
-3. Send `DIAG_RELAY_REQUEST` with `rf_channel=6`. Wait for response.
-4. Send `DIAG_RELAY_REQUEST` with `rf_channel=11`. Wait for response.
+2. Send `START_DIAG_RELAY` with `rf_channel=1`, reconnect, and fetch the result.
+3. Send `START_DIAG_RELAY` with `rf_channel=6`, reconnect, and fetch the result.
+4. Send `START_DIAG_RELAY` with `rf_channel=11`, reconnect, and fetch the result.
 5. Assert: all three diagnostics complete successfully.
-6. Assert: BLE remains connected and functional after all three.
+6. Assert: BLE remains connected and functional after all three fetches.
 
 ---
 
@@ -2227,10 +2235,10 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-1016 | T-N1023 |
 | ND-1100 | T-N1100, T-N1101, T-N1102, T-N1109, T-N1110 |
 | ND-1101 | T-N1103 |
-| ND-1102 | T-N1104, T-N1105 |
+| ND-1102 | T-N1103, T-N1104, T-N1105 |
 | ND-1103 | T-N1106 |
-| ND-1104 | T-N1107 |
-| ND-1105 | T-N1104 |
+| ND-1104 | T-N1104, T-N1107, T-N1109, T-N1110 |
+| ND-1105 | T-N1103, T-N1108, T-N1109, T-N1110 |
 | ND-1106 | T-N1108, T-N1109, T-N1110 |
 
 ---

--- a/docs/pairing-tool-ui-redesign.md
+++ b/docs/pairing-tool-ui-redesign.md
@@ -167,18 +167,20 @@ node→gateway ESP-NOW RSSI before provisioning.
 
 **UI elements:**
 - Connected node identity
-- Live ESP-NOW RSSI readout and signal quality label
+- ESP-NOW RSSI readout and signal quality label for the most recent completed check
 - Status text for `checking`, timeout, or channel-error outcomes
-- Guidance that the installer can move or re-orient the node and watch
-  the readout update
+- Guidance that the installer can move or re-orient the node and run
+  another check
 - "Proceed to Provision" button → Step 6
+- "Check Again" button → repeat the diagnostic
 - "Abort" / "Disconnect" button → back to Step 4
 
 **Behavior notes:**
 - The diagnostic starts automatically after BLE connection succeeds.
-- The tool updates after each completed diagnostic result and targets a
-  1-second cadence only when replies are fast; protocol timeouts remain
-  governed by `ble-pairing-protocol.md` §6a.
+- The tool runs one asynchronous diagnostic cycle per request and shows
+  the most recent completed result. Additional checks require an explicit
+  installer action via "Check Again"; protocol timeouts remain governed by
+  `ble-pairing-protocol.md` §6a.
 - The diagnostic is informational only: bad signal or timeout does not
   block proceeding.
 

--- a/docs/pairing-tool-ui-redesign.md
+++ b/docs/pairing-tool-ui-redesign.md
@@ -22,7 +22,7 @@ who sets up the entire site:
 3. Pair the phone with the gateway
 4. Download the node plan (bundle manifest)
 5. Walk through each node: view setup instructions, connect sensors,
-   pair, check signal quality, provision
+   pair, connect over BLE, check ESP-NOW signal quality, provision
 6. Track progress across all nodes at the site
 
 ## Workflow Overview
@@ -48,17 +48,21 @@ who sets up the entire site:
     │             │     - Setup media (photos/videos from bundle)
     │             │
     │  4. Pair &  │  ← Scan for node BLE service
-    │     RSSI    │     Select physical device
-    │             │     Live RSSI signal quality indicator
-    │             │     "Signal good — ready to provision"
+    │     Connect │     Select physical device
+    │             │     BLE RSSI signal quality indicator
+    │             │     Connect to the node over BLE
     │             │
-    │  5. Prov-   │  ← Progress: Connect → Provision → ACK
+    │  5. Signal  │  ← Live ESP-NOW node→gateway RSSI
+    │     Check   │     Adjust orientation/position
+    │             │     Proceed or abort
+    │             │
+    │  6. Prov-   │  ← Progress: Provision → ACK
     │     ision   │     Success/failure with actionable errors
     │             │     "Next Node" returns to step 2
     └─────────────┘
           ▼
 ┌─────────────────────┐
-│  6. All Done        │  Summary: "8/8 nodes provisioned."
+│  7. All Done        │  Summary: "8/8 nodes provisioned."
 │                     │  List of all nodes with final status.
 └─────────────────────┘
 ```
@@ -135,31 +139,55 @@ before initiating the wireless pairing.
 - The checklist is informational (not enforced by the app)
 - Pin config is displayed for reference; validated during provisioning
 
-### Step 4 — Pair & Signal Check
+### Step 4 — Pair & Connect
 
-**Purpose:** Find the physical node via BLE and verify RF signal
-quality before committing to provisioning.
+**Purpose:** Find the physical node via BLE and verify BLE link quality
+before establishing a connected node session.
 
 **UI elements:**
 - Auto-start BLE scan for node provisioning service UUID
 - List of discovered nodes with:
   - Device address
   - Signal strength (animated bars)
-- Tap to select → show detailed RSSI panel:
-  - **Live RSSI gauge** (good ≥ −60 dBm / marginal −60 to −75 dBm / bad < −75 dBm)
-  - "Move the node closer" warning if signal is bad
-  - RSSI history graph (last 10 seconds)
-- "Signal Good — Provision" button → Step 5
-  - Enabled when RSSI is good or marginal (≥ −75 dBm)
-  - "Provision Anyway" override shown when RSSI is bad (< −75 dBm)
+- Tap to select → show detailed BLE RSSI panel:
+  - **Live BLE RSSI gauge** (good ≥ −60 dBm / marginal −60 to −75 dBm / bad < −75 dBm)
+  - Signal strength for selecting the best nearby node to connect to
+- "Connect" button → Step 5
 
 **Backend requirements:**
 - Existing `start_scan()` / `get_devices()` Tauri commands
 - RSSI data from scan results (already available)
-- **New (future):** DIAG_REQUEST/DIAG_REPLY for gateway-side RSSI
-  measurement (protocol already defined, not yet in pairing tool)
+- **New:** `connect_node()` Tauri command that establishes BLE connection
+  and MTU negotiation before entering Step 5
 
-### Step 5 — Provision
+### Step 5 — ESP-NOW Signal Check
+
+**Purpose:** Use the node as a BLE-connected relay to measure the
+node→gateway ESP-NOW RSSI before provisioning.
+
+**UI elements:**
+- Connected node identity
+- Live ESP-NOW RSSI readout and signal quality label
+- Status text for `checking`, timeout, or channel-error outcomes
+- Guidance that the installer can move or re-orient the node and watch
+  the readout update
+- "Proceed to Provision" button → Step 6
+- "Abort" / "Disconnect" button → back to Step 4
+
+**Behavior notes:**
+- The diagnostic starts automatically after BLE connection succeeds.
+- The tool updates after each completed diagnostic result and targets a
+  1-second cadence only when replies are fast; protocol timeouts remain
+  governed by `ble-pairing-protocol.md` §6a.
+- The diagnostic is informational only: bad signal or timeout does not
+  block proceeding.
+
+**Backend requirements:**
+- Existing `sonde-pair::phase2::check_rssi()` core flow
+- **New:** Tauri command surface for `check_rssi()` and connected-node
+  session management
+
+### Step 6 — Provision
 
 **Purpose:** Execute the Phase 2 provisioning protocol.
 
@@ -167,7 +195,7 @@ quality before committing to provisioning.
 - Progress steps with animated indicators:
   1. "Connecting to node…" (spinner)
   2. "Provisioning…" (spinner)
-  3. "Waiting for acknowledgment…" (spinner)
+  2. "Waiting for acknowledgment…" (spinner)
 - On success:
   - Green checkmark animation
   - Node details: ID, key hint, channel
@@ -184,7 +212,7 @@ quality before committing to provisioning.
   and forward `PinConfig` from the bundle manifest (the current command
   does not support passing pin config)
 
-### Step 6 — All Done
+### Step 7 — All Done
 
 **Purpose:** Summary and completion confirmation.
 
@@ -212,7 +240,7 @@ quality before committing to provisioning.
 The current `index.html` is a single-page layout. The redesign uses
 client-side page routing (hash-based or simple show/hide of `<section>`
 elements). No framework dependency is required — vanilla JS with a
-simple state machine is sufficient for 6 pages.
+simple state machine is sufficient for 7 pages.
 
 **Suggested approach:**
 - Each step is a `<section class="page" id="page-N">` element
@@ -225,6 +253,9 @@ simple state machine is sufficient for 6 pages.
 Most backend commands already exist:
 - `start_scan()`, `stop_scan()`, `get_devices()` — scanning
 - `pair_gateway()` — Phase 1
+- `connect_node()` — establish the connected node session for Step 5
+- `check_rssi()` — run one node↔gateway diagnostic over the connected BLE session
+- `disconnect_node()` — release the connected node session when aborting
 - `provision_node()` — Phase 2
 - `get_pairing_status()` — status check
 

--- a/docs/pairing-tool-ui-redesign.md
+++ b/docs/pairing-tool-ui-redesign.md
@@ -195,7 +195,7 @@ node→gateway ESP-NOW RSSI before provisioning.
 - Progress steps with animated indicators:
   1. "Connecting to node…" (spinner)
   2. "Provisioning…" (spinner)
-  2. "Waiting for acknowledgment…" (spinner)
+  3. "Waiting for acknowledgment…" (spinner)
 - On success:
   - Green checkmark animation
   - Node details: ID, key hint, channel

--- a/docs/protocol-crate-design.md
+++ b/docs/protocol-crate-design.md
@@ -111,15 +111,23 @@ pub const SIGNAL_QUALITY_BAD: u8 = 2;
 
 // BLE envelope message types (Node Command characteristic — separate from ESP-NOW msg_types)
 pub const BLE_NODE_PROVISION: u8 = 0x01;
-pub const BLE_DIAG_RELAY_REQUEST: u8 = 0x02;
+pub const BLE_START_DIAG_RELAY: u8 = 0x02;
+pub const BLE_FETCH_DIAG_RESULT: u8 = 0x03;
 pub const BLE_NODE_ACK: u8 = 0x81;
-pub const BLE_DIAG_RELAY_RESPONSE: u8 = 0x82;
+pub const BLE_DIAG_RELAY_ACK: u8 = 0x82;
+pub const BLE_DIAG_RELAY_RESULT: u8 = 0x83;
 pub const BLE_ERROR: u8 = 0xFF;
 
-// DIAG_RELAY_RESPONSE status codes
-pub const DIAG_RELAY_STATUS_OK: u8 = 0x00;
-pub const DIAG_RELAY_STATUS_TIMEOUT: u8 = 0x01;
-pub const DIAG_RELAY_STATUS_CHANNEL_ERROR: u8 = 0x02;
+// DIAG_RELAY_ACK status codes
+pub const DIAG_RELAY_ACK_ACCEPTED: u8 = 0x00;
+pub const DIAG_RELAY_ACK_BUSY: u8 = 0x01;
+pub const DIAG_RELAY_ACK_INVALID: u8 = 0x02;
+
+// DIAG_RELAY_RESULT status codes
+pub const DIAG_RELAY_RESULT_OK: u8 = 0x00;
+pub const DIAG_RELAY_RESULT_TIMEOUT: u8 = 0x01;
+pub const DIAG_RELAY_RESULT_CHANNEL_ERROR: u8 = 0x02;
+pub const DIAG_RELAY_RESULT_NO_RESULT: u8 = 0x03;
 
 // CBOR integer keys (program image — separate keyspace)
 pub const IMG_KEY_BYTECODE: u64 = 1;
@@ -547,9 +555,9 @@ Implements a minimal Type-Length-Value envelope used for BLE GATT messages in th
 
 ## 12  Diagnostic message codec
 
-Implements encoding and decoding for `DIAG_REQUEST` (`msg_type` 0x06) and `DIAG_REPLY` (`msg_type` 0x85) messages, and for the BLE `DIAG_RELAY_REQUEST` / `DIAG_RELAY_RESPONSE` envelopes.
+Implements encoding and decoding for `DIAG_REQUEST` (`msg_type` 0x06) and `DIAG_REPLY` (`msg_type` 0x85) messages, and for the BLE `START_DIAG_RELAY` / `DIAG_RELAY_ACK` / `DIAG_RELAY_RESULT` envelopes.
 
-> **Requirements:** ND-1100 (BLE diagnostic relay command), GW-1700 (DIAG_REQUEST reception), GW-1704 (DIAG_REPLY construction), PT-1301 (diagnostic request construction), PT-1302 (BLE diagnostic relay).
+> **Requirements:** ND-1100 (asynchronous BLE diagnostic commands), GW-1700 (DIAG_REQUEST reception), GW-1704 (DIAG_REPLY construction), PT-1301 (diagnostic request construction), PT-1302 (BLE diagnostic relay).
 
 ### 12.1  ESP-NOW diagnostic messages
 
@@ -561,7 +569,7 @@ Encoding and decoding are handled by the existing `NodeMessage::encode/decode` a
 
 The BLE envelope for diagnostic relay uses the same `TYPE | LEN | BODY` format as other BLE messages (§11). The body formats are:
 
-**DIAG_RELAY_REQUEST (type 0x02):**
+**START_DIAG_RELAY (type 0x02):**
 
 ```
 rf_channel: u8      // WiFi channel 1–13
@@ -569,17 +577,31 @@ payload_len: u16 BE // Length of ESP-NOW frame
 payload: [u8]       // Complete DIAG_REQUEST ESP-NOW frame
 ```
 
-**DIAG_RELAY_RESPONSE (type 0x82):**
+**FETCH_DIAG_RESULT (type 0x03):**
 
 ```
-status: u8          // 0x00=ok, 0x01=timeout, 0x02=channel_error
+// empty body
+```
+
+**DIAG_RELAY_ACK (type 0x82):**
+
+```
+status: u8          // 0x00=accepted, 0x01=busy, 0x02=invalid_request
+```
+
+**DIAG_RELAY_RESULT (type 0x83):**
+
+```
+status: u8          // 0x00=ok, 0x01=timeout, 0x02=channel_error, 0x03=no_result
 payload_len: u16 BE // Length of ESP-NOW reply (0 if status ≠ 0x00)
 payload: [u8]       // Raw DIAG_REPLY ESP-NOW frame (if status=0x00)
 ```
 
 **Public API:**
 
-- `encode_diag_relay_request(rf_channel: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError>` — encode a `DIAG_RELAY_REQUEST` body. Validates `rf_channel` ∈ 1–13 and `payload.len()` ≤ `MAX_FRAME_SIZE`. Wrap the returned body with `encode_ble_envelope(...)` to produce the full BLE `TYPE | LEN | BODY` message.
-- `decode_diag_relay_request(body: &[u8]) -> Result<(u8, &[u8]), DecodeError>` — decode a `DIAG_RELAY_REQUEST` body, returning `(rf_channel, payload)`. Validates channel range, payload size, and rejects trailing bytes.
-- `encode_diag_relay_response(status: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError>` — encode a `DIAG_RELAY_RESPONSE` body. Enforces payload must be empty for non-OK status. Wrap the returned body with `encode_ble_envelope(...)` to produce the full BLE message.
-- `decode_diag_relay_response(body: &[u8]) -> Result<(u8, &[u8]), DecodeError>` — decode a `DIAG_RELAY_RESPONSE` body, returning `(status, payload)`. Rejects truncated and trailing-byte inputs.
+- `encode_start_diag_relay(rf_channel: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError>` — encode a `START_DIAG_RELAY` body. Validates `rf_channel` ∈ 1–13 and `payload.len()` ≤ `MAX_FRAME_SIZE`. Wrap the returned body with `encode_ble_envelope(...)` to produce the full BLE `TYPE | LEN | BODY` message.
+- `decode_start_diag_relay(body: &[u8]) -> Result<(u8, &[u8]), DecodeError>` — decode a `START_DIAG_RELAY` body, returning `(rf_channel, payload)`. Validates channel range, payload size, and rejects trailing bytes.
+- `encode_diag_relay_ack(status: u8) -> Result<Vec<u8>, EncodeError>` — encode a `DIAG_RELAY_ACK` body.
+- `decode_diag_relay_ack(body: &[u8]) -> Result<u8, DecodeError>` — decode a `DIAG_RELAY_ACK` body.
+- `encode_diag_relay_result(status: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError>` — encode a `DIAG_RELAY_RESULT` body. Enforces payload must be empty for non-OK status. Wrap the returned body with `encode_ble_envelope(...)` to produce the full BLE message.
+- `decode_diag_relay_result(body: &[u8]) -> Result<(u8, &[u8]), DecodeError>` — decode a `DIAG_RELAY_RESULT` body, returning `(status, payload)`. Rejects truncated and trailing-byte inputs.

--- a/docs/protocol-crate-validation.md
+++ b/docs/protocol-crate-validation.md
@@ -1049,40 +1049,44 @@ impl Sha256Provider for SoftwareSha256 { /* RustCrypto sha2 */ }
 
 ---
 
-### T-P114  DIAG_RELAY_REQUEST round-trip
+### T-P114  START_DIAG_RELAY round-trip
 
 **Validates:** protocol-crate-design.md §12.2
 
 **Procedure:**
-1. Call `encode_diag_relay_request(rf_channel=6, payload=&[0x42; 50])`.
-2. Wrap in BLE envelope with type `BLE_DIAG_RELAY_REQUEST`.
+1. Call `encode_start_diag_relay(rf_channel=6, payload=&[0x42; 50])`.
+2. Wrap in BLE envelope with type `BLE_START_DIAG_RELAY`.
 3. Parse the BLE envelope.
-4. Call `decode_diag_relay_request(body)`.
+4. Call `decode_start_diag_relay(body)`.
 5. Assert: `rf_channel` = 6, `payload` = `[0x42; 50]`.
 
 ---
 
-### T-P115  DIAG_RELAY_REQUEST invalid channel rejected
+### T-P115  START_DIAG_RELAY invalid channel rejected
 
 **Validates:** protocol-crate-design.md §12.2, ND-1100
 
 **Procedure:**
-1. Call `encode_diag_relay_request(rf_channel=14, payload=&[0x42; 50])`.
+1. Call `encode_start_diag_relay(rf_channel=14, payload=&[0x42; 50])`.
 2. Assert: returns `Err(EncodeError)` — channel 14 is out of range (valid: 1–13).
 
 ---
 
-### T-P116  DIAG_RELAY_RESPONSE round-trip (success and timeout)
+### T-P116  DIAG_RELAY_ACK and DIAG_RELAY_RESULT round-trip
 
 **Validates:** protocol-crate-design.md §12.2
 
 **Procedure:**
-1. Encode `DIAG_RELAY_RESPONSE` with `status=0x00` and a non-empty payload.
-2. Decode and assert: `status` = 0x00, payload matches.
-3. Encode `DIAG_RELAY_RESPONSE` with `status=0x01` and empty payload.
-4. Decode and assert: `status` = 0x01, `payload_len` = 0.
-5. Encode `DIAG_RELAY_RESPONSE` with `status=0x02` and empty payload.
-6. Decode and assert: `status` = 0x02, `payload_len` = 0.
+1. Encode `DIAG_RELAY_ACK` with `status=0x00`.
+2. Decode and assert: `status` = 0x00.
+3. Encode `DIAG_RELAY_RESULT` with `status=0x00` and a non-empty payload.
+4. Decode and assert: `status` = 0x00, payload matches.
+5. Encode `DIAG_RELAY_RESULT` with `status=0x01` and empty payload.
+6. Decode and assert: `status` = 0x01, `payload_len` = 0.
+7. Encode `DIAG_RELAY_RESULT` with `status=0x02` and empty payload.
+8. Decode and assert: `status` = 0x02, `payload_len` = 0.
+9. Encode `DIAG_RELAY_RESULT` with `status=0x03` and empty payload.
+10. Decode and assert: `status` = 0x03, `payload_len` = 0.
 
 ---
 


### PR DESCRIPTION
## Summary
- add the dedicated node signal-check page and one-shot ESP-NOW diagnostic flow to the pairing UI
- reuse or re-establish a connected node session in the Tauri backend for diagnostics and provisioning, with explicit scanner cleanup and broken-session discard
- update the approved pairing-tool requirements, design, validation, and redesign docs for the 7-page flow

## Testing
- cargo build --workspace
- cargo clippy --workspace -- -D warnings
- cargo test --workspace