### PR TITLE
Implement rebooted pre-provisioning test mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6696,6 +6696,7 @@ dependencies = [
  "jni 0.22.4",
  "serde",
  "sonde-pair",
+ "sonde-protocol",
  "tauri",
  "tauri-build",
  "tokio",

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -345,14 +345,8 @@ mod tests {
             select_boot_mode(true, false, false),
             BootMode::PreProvisioningTest
         );
-        assert_eq!(
-            select_boot_mode(true, true, true),
-            BootMode::BlePairing
-        );
-        assert_eq!(
-            select_boot_mode(true, true, false),
-            BootMode::WakeCycle
-        );
+        assert_eq!(select_boot_mode(true, true, true), BootMode::BlePairing);
+        assert_eq!(select_boot_mode(true, true, false), BootMode::WakeCycle);
     }
 
     #[test]

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -234,18 +234,7 @@ fn main() {
             let mut pairing_hal = EspHal::new(pairing_board_layout);
             pairing_hal.enter_active_gpio_state();
 
-            // Try to initialize ESP-NOW for pre-provisioning test mode.
-            // If this fails, BLE pairing still works — just without diagnostic runs.
-            let diag_channel = storage.read_channel().unwrap_or(1);
-            let mut diag_transport =
-                EspNowTransport::new(peripherals.modem, sysloop, nvs_partition, diag_channel).ok();
-
-            match run_ble_pairing_mode(
-                &mut storage,
-                &mut map_storage,
-                button_held,
-                diag_transport.as_mut(),
-            ) {
+            match run_ble_pairing_mode(&mut storage, &mut map_storage, button_held) {
                 Ok(()) => {
                     info!("BLE pairing mode exited — rebooting");
                     pairing_hal.prepare_for_sleep();

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -14,6 +14,23 @@ fn main() {
     std::process::exit(1);
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BootMode {
+    PreProvisioningTest,
+    BlePairing,
+    WakeCycle,
+}
+
+fn select_boot_mode(has_staged_test: bool, has_psk: bool, button_held: bool) -> BootMode {
+    if has_staged_test {
+        BootMode::PreProvisioningTest
+    } else if !has_psk || button_held {
+        BootMode::BlePairing
+    } else {
+        BootMode::WakeCycle
+    }
+}
+
 #[cfg(feature = "esp")]
 fn main() {
     use esp_idf_hal::gpio::{PinDriver, Pull};
@@ -23,6 +40,7 @@ fn main() {
     use esp_idf_svc::nvs::EspDefaultNvsPartition;
     use log::{info, warn};
 
+    use sonde_node::ble_pairing::execute_staged_test_command;
     use sonde_node::board_layout::stage_runtime_board_layout;
     use sonde_node::crypto::{EspRng, SoftwareSha256};
     use sonde_node::esp_ble_pairing::run_ble_pairing_mode;
@@ -105,12 +123,15 @@ fn main() {
     // Boot priority (ND-0900)
     //
     // Check in order:
-    //   1. No PSK OR pairing button held ≥ 500 ms → BLE pairing mode
-    //   2. PSK stored, reg_complete NOT set → PEER_REQUEST mode (WAKE cycle variant)
-    //   3. PSK stored, reg_complete set → normal WAKE cycle
+    //   1. Staged pre-provisioning test command → test mode
+    //   2. No PSK OR pairing button held ≥ 500 ms → BLE pairing mode
+    //   3. PSK stored, reg_complete NOT set → PEER_REQUEST mode (WAKE cycle variant)
+    //   4. PSK stored, reg_complete set → normal WAKE cycle
     // ---------------------------------------------------------------------------
 
-    // (1) No PSK, or pairing button held ≥ 500 ms → BLE pairing mode.
+    let has_staged_test = storage.read_staged_test_command().is_some();
+
+    // (2) No PSK, or pairing button held ≥ 500 ms → BLE pairing mode.
     //
     // Pairing button is GPIO 9 on the ESP32-C3 DevKitM-1 (active LOW).
     // We sample it for 500 ms immediately after boot.  If the pin is
@@ -144,46 +165,100 @@ fn main() {
         held
     };
 
-    if storage.read_key().is_none() || button_held {
-        info!(
-            "entering BLE pairing mode (no PSK={}, button_held={})",
-            storage.read_key().is_none(),
-            button_held
-        );
+    let has_psk = storage.read_key().is_some();
 
-        let pairing_board_layout = storage
-            .read_board_layout()
-            .unwrap_or(sonde_protocol::BoardLayout::SONDE_SENSOR_NODE_REV_A);
-        let mut pairing_hal = EspHal::new(pairing_board_layout);
-        pairing_hal.enter_active_gpio_state();
+    match select_boot_mode(has_staged_test, has_psk, button_held) {
+        BootMode::PreProvisioningTest => {
+            let staged_command = storage
+                .read_staged_test_command()
+                .expect("boot mode selected pre-provisioning test without staged command");
+            info!(
+                "entering pre-provisioning test mode (test_type={}, rf_channel={:?})",
+                staged_command.test_type, staged_command.rf_channel
+            );
 
-        // Try to initialize ESP-NOW for diagnostic relay (ND-1100).
-        // If this fails, BLE pairing still works — just without RSSI diagnostics.
-        // Use stored channel if available; the relay handler switches to the
-        // requested rf_channel before broadcasting anyway.
-        let diag_channel = storage.read_channel().unwrap_or(1);
-        let mut diag_transport =
-            EspNowTransport::new(peripherals.modem, sysloop, nvs_partition, diag_channel).ok();
+            let test_channel = staged_command
+                .rf_channel
+                .or_else(|| storage.read_channel())
+                .unwrap_or(1);
+            let clock = EspClock;
 
-        match run_ble_pairing_mode(
-            &mut storage,
-            &mut map_storage,
-            button_held,
-            diag_transport.as_mut(),
-        ) {
-            Ok(()) => {
-                info!("BLE pairing mode exited — rebooting");
-                pairing_hal.prepare_for_sleep();
-                sleep_ctrl.reboot();
+            match EspNowTransport::new(peripherals.modem, sysloop, nvs_partition, test_channel) {
+                Ok(mut transport) => {
+                    match execute_staged_test_command(&mut storage, &mut transport, &clock) {
+                        Ok(Some(result)) => {
+                            info!(
+                                "pre-provisioning test completed: status=0x{:02x} attempts={} elapsed_ms={}",
+                                result.status, result.attempt_count, result.elapsed_ms
+                            );
+                        }
+                        Ok(None) => {
+                            warn!("pre-provisioning test mode entered without a staged command");
+                        }
+                        Err(err) => {
+                            warn!("pre-provisioning test execution failed: {}", err);
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!(
+                        "failed to initialize ESP-NOW for pre-provisioning test mode: {}",
+                        err
+                    );
+                    let _ = storage.write_test_result(&sonde_protocol::TestResult {
+                        status: sonde_protocol::TEST_RESULT_EXECUTION_ERROR,
+                        test_type: Some(staged_command.test_type),
+                        reply_frame: None,
+                        reply_rssi_dbm: None,
+                        attempt_count: 0,
+                        elapsed_ms: 0,
+                    });
+                    let _ = storage.clear_staged_test_command();
+                }
             }
-            Err(e) => {
-                // BLE GATT server not yet implemented — deep sleep to conserve
-                // battery until firmware is updated with BLE support.
-                warn!("BLE pairing mode failed: {} — entering deep sleep", e);
-                pairing_hal.prepare_for_sleep();
-                sleep_ctrl.enter_deep_sleep(60);
+
+            info!("pre-provisioning test mode finished — rebooting to BLE pairing mode");
+            sleep_ctrl.reboot();
+        }
+        BootMode::BlePairing => {
+            info!(
+                "entering BLE pairing mode (no PSK={}, button_held={})",
+                !has_psk, button_held
+            );
+
+            let pairing_board_layout = storage
+                .read_board_layout()
+                .unwrap_or(sonde_protocol::BoardLayout::SONDE_SENSOR_NODE_REV_A);
+            let mut pairing_hal = EspHal::new(pairing_board_layout);
+            pairing_hal.enter_active_gpio_state();
+
+            // Try to initialize ESP-NOW for pre-provisioning test mode.
+            // If this fails, BLE pairing still works — just without diagnostic runs.
+            let diag_channel = storage.read_channel().unwrap_or(1);
+            let mut diag_transport =
+                EspNowTransport::new(peripherals.modem, sysloop, nvs_partition, diag_channel).ok();
+
+            match run_ble_pairing_mode(
+                &mut storage,
+                &mut map_storage,
+                button_held,
+                diag_transport.as_mut(),
+            ) {
+                Ok(()) => {
+                    info!("BLE pairing mode exited — rebooting");
+                    pairing_hal.prepare_for_sleep();
+                    sleep_ctrl.reboot();
+                }
+                Err(e) => {
+                    // BLE GATT server not yet implemented — deep sleep to conserve
+                    // battery until firmware is updated with BLE support.
+                    warn!("BLE pairing mode failed: {} — entering deep sleep", e);
+                    pairing_hal.prepare_for_sleep();
+                    sleep_ctrl.enter_deep_sleep(60);
+                }
             }
         }
+        BootMode::WakeCycle => {}
     }
 
     // (3) + (4) PSK is present. reg_complete flag determines whether we
@@ -252,5 +327,41 @@ fn main() {
             info!("unexpected unpaired state — rebooting");
             sleep_ctrl.reboot();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{select_boot_mode, BootMode};
+
+    #[test]
+    fn staged_test_takes_priority_over_ble_pairing_conditions() {
+        assert_eq!(
+            select_boot_mode(true, false, true),
+            BootMode::PreProvisioningTest
+        );
+        assert_eq!(
+            select_boot_mode(true, false, false),
+            BootMode::PreProvisioningTest
+        );
+        assert_eq!(
+            select_boot_mode(true, true, true),
+            BootMode::PreProvisioningTest
+        );
+        assert_eq!(
+            select_boot_mode(true, true, false),
+            BootMode::PreProvisioningTest
+        );
+    }
+
+    #[test]
+    fn ble_pairing_selected_only_without_staged_test() {
+        assert_eq!(select_boot_mode(false, false, false), BootMode::BlePairing);
+        assert_eq!(select_boot_mode(false, true, true), BootMode::BlePairing);
+    }
+
+    #[test]
+    fn wake_cycle_selected_only_for_paired_node_without_staged_test() {
+        assert_eq!(select_boot_mode(false, true, false), BootMode::WakeCycle);
     }
 }

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -251,8 +251,8 @@ fn main() {
                     sleep_ctrl.reboot();
                 }
                 Err(e) => {
-                    // BLE GATT server not yet implemented — deep sleep to conserve
-                    // battery until firmware is updated with BLE support.
+                    // BLE pairing mode failed to initialize or run. Enter deep
+                    // sleep to conserve battery until the operator retries.
                     warn!("BLE pairing mode failed: {} — entering deep sleep", e);
                     pairing_hal.prepare_for_sleep();
                     sleep_ctrl.enter_deep_sleep(60);

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -24,7 +24,7 @@ enum BootMode {
 
 #[cfg(any(feature = "esp", test))]
 fn select_boot_mode(has_staged_test: bool, has_psk: bool, button_held: bool) -> BootMode {
-    if has_staged_test {
+    if has_staged_test && !has_psk {
         BootMode::PreProvisioningTest
     } else if !has_psk || button_held {
         BootMode::BlePairing
@@ -131,8 +131,6 @@ fn main() {
     //   4. PSK stored, reg_complete set → normal WAKE cycle
     // ---------------------------------------------------------------------------
 
-    let has_staged_test = storage.read_staged_test_command().is_some();
-
     // (2) No PSK, or pairing button held ≥ 500 ms → BLE pairing mode.
     //
     // Pairing button is GPIO 9 on the ESP32-C3 DevKitM-1 (active LOW).
@@ -168,6 +166,18 @@ fn main() {
     };
 
     let has_psk = storage.read_key().is_some();
+    let mut has_staged_test = storage.read_staged_test_command().is_some();
+    if has_staged_test && has_psk {
+        warn!("ignoring stale staged pre-provisioning test command on paired node");
+        if let Err(err) = storage.clear_staged_test_command() {
+            warn!(
+                "failed to clear stale staged pre-provisioning test command: {}",
+                err
+            );
+        } else {
+            has_staged_test = false;
+        }
+    }
 
     match select_boot_mode(has_staged_test, has_psk, button_held) {
         BootMode::PreProvisioningTest => {
@@ -337,11 +347,11 @@ mod tests {
         );
         assert_eq!(
             select_boot_mode(true, true, true),
-            BootMode::PreProvisioningTest
+            BootMode::BlePairing
         );
         assert_eq!(
             select_boot_mode(true, true, false),
-            BootMode::PreProvisioningTest
+            BootMode::WakeCycle
         );
     }
 

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -34,6 +34,19 @@ fn select_boot_mode(has_staged_test: bool, has_psk: bool, button_held: bool) -> 
 }
 
 #[cfg(feature = "esp")]
+fn boot_reason_label(reset_reason: esp_idf_svc::sys::esp_reset_reason_t) -> &'static str {
+    if reset_reason == esp_idf_svc::sys::esp_reset_reason_t_ESP_RST_DEEPSLEEP {
+        "deep_sleep_wake"
+    } else if reset_reason == esp_idf_svc::sys::esp_reset_reason_t_ESP_RST_SW {
+        "software_reset"
+    } else if reset_reason == esp_idf_svc::sys::esp_reset_reason_t_ESP_RST_POWERON {
+        "power_on"
+    } else {
+        "other_reset"
+    }
+}
+
+#[cfg(feature = "esp")]
 fn main() {
     use esp_idf_hal::gpio::{PinDriver, Pull};
     use esp_idf_hal::peripherals::Peripherals;
@@ -73,11 +86,7 @@ fn main() {
 
     // Log boot reason (ND-1000).
     let reset_reason = unsafe { esp_idf_svc::sys::esp_reset_reason() };
-    let boot_reason = if reset_reason == esp_idf_svc::sys::esp_reset_reason_t_ESP_RST_DEEPSLEEP {
-        "deep_sleep_wake"
-    } else {
-        "power_on"
-    };
+    let boot_reason = boot_reason_label(reset_reason);
     info!("boot_reason={} (ND-1000)", boot_reason);
 
     // Register the main task with the ESP-IDF task watchdog (ND-0919).

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -14,6 +14,7 @@ fn main() {
     std::process::exit(1);
 }
 
+#[cfg(any(feature = "esp", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BootMode {
     PreProvisioningTest,
@@ -21,6 +22,7 @@ enum BootMode {
     WakeCycle,
 }
 
+#[cfg(any(feature = "esp", test))]
 fn select_boot_mode(has_staged_test: bool, has_psk: bool, button_held: bool) -> BootMode {
     if has_staged_test {
         BootMode::PreProvisioningTest

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -410,7 +410,7 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
                 let before = std::time::Instant::now();
                 match transport.recv_with_metadata(remaining_ms) {
                     Ok(Some(frame))
-                        if frame.data.len() >= sonde_protocol::HEADER_SIZE
+                        if frame.data.len() >= sonde_protocol::MIN_FRAME_SIZE
                             && frame.data[sonde_protocol::OFFSET_MSG_TYPE]
                                 == sonde_protocol::MSG_DIAG_REPLY =>
                     {
@@ -467,7 +467,7 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
         #[cfg(not(feature = "esp"))]
         {
             if let Ok(Some(frame)) = transport.recv_with_metadata(TEST_LISTEN_TIMEOUT_MS) {
-                if frame.data.len() >= sonde_protocol::HEADER_SIZE
+                if frame.data.len() >= sonde_protocol::MIN_FRAME_SIZE
                     && frame.data[sonde_protocol::OFFSET_MSG_TYPE] == sonde_protocol::MSG_DIAG_REPLY
                 {
                     return success_result(
@@ -1523,6 +1523,22 @@ mod tests {
                 0,
                 0,
                 1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
             ],
             rssi_dbm: Some(-67),
         };
@@ -1563,6 +1579,22 @@ mod tests {
                 0,
                 0,
                 1,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
             ],
             rssi_dbm: None,
         };
@@ -1601,6 +1633,42 @@ mod tests {
         assert_eq!(result.attempt_count, 4);
         assert_eq!(transport.sends.len(), 4);
         assert_eq!(*clock.delays_ms.borrow(), vec![200, 200, 200]);
+    }
+
+    #[test]
+    fn execute_staged_test_command_rejects_truncated_diag_reply() {
+        let mut storage = MockStorage::new();
+        storage.staged_test_command = Some(StagedTestCommand {
+            test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(6),
+            payload: vec![0x42; 50],
+        });
+        let truncated_reply = crate::traits::ReceivedFrame {
+            data: vec![
+                0x12,
+                0x34,
+                sonde_protocol::MSG_DIAG_REPLY,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+            ],
+            rssi_dbm: Some(-67),
+        };
+        let mut transport = MockTransport::new(vec![Some(truncated_reply), None, None, None]);
+        let clock = MockClock::default();
+
+        let result = execute_staged_test_command(&mut storage, &mut transport, &clock)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.status, sonde_protocol::TEST_RESULT_TIMEOUT);
+        assert_eq!(result.attempt_count, 4);
+        assert_eq!(transport.sends.len(), 4);
     }
 
     #[test]

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -5,6 +5,7 @@
 //!
 //! Implements the platform-independent portion of BLE pairing mode:
 //! - NODE_PROVISION message parsing (ble-pairing-protocol.md §6.6)
+//! - `RUN_TEST_COMMAND` staging and `READ_TEST_RESULT` readback (§6a)
 //! - NVS persistence of PSK, key_hint, channel, peer_payload, reg_complete
 //! - NODE_ACK response encoding (ble-pairing-protocol.md §6.7)
 //! - Factory-reset-before-provision when the pairing button was held at boot
@@ -13,9 +14,10 @@
 //! pairing) is in `esp_ble_pairing.rs` and is only compiled with the `esp`
 //! feature.
 
+use crate::error::NodeResult;
 use crate::key_store::KeyStore;
 use crate::map_storage::MapStorage;
-use crate::traits::PlatformStorage;
+use crate::traits::{PlatformStorage, StagedTestCommand, Transport};
 use sonde_protocol::{decode_board_layout_cbor, BoardLayout};
 
 // ---------------------------------------------------------------------------
@@ -270,133 +272,212 @@ pub fn handle_node_provision<S: PlatformStorage>(
 }
 
 // ---------------------------------------------------------------------------
-// Diagnostic relay (ble-pairing-protocol.md §6a, ND-1100 through ND-1106)
+// Pre-provisioning test mode (ble-pairing-protocol.md §6a, ND-1100..ND-1107)
 // ---------------------------------------------------------------------------
 
-/// Parsed DIAG_RELAY_REQUEST parameters.
-pub struct DiagRelayParams {
-    pub rf_channel: u8,
-    pub payload: Vec<u8>,
+const TEST_MAX_RETRIES: u64 = 3;
+const TEST_RETRY_DELAY_MS: u32 = 200;
+const TEST_LISTEN_TIMEOUT_MS: u32 = 2_000;
+
+/// Encode a `RUN_TEST_ACK` BLE envelope.
+pub fn encode_run_test_ack(status: u8) -> Vec<u8> {
+    let body = sonde_protocol::encode_run_test_ack(status).unwrap_or_default();
+    encode_ble_envelope(sonde_protocol::BLE_RUN_TEST_ACK, &body).unwrap_or_default()
 }
 
-/// Parse and validate a DIAG_RELAY_REQUEST BLE envelope body.
-///
-/// Returns `Ok(params)` on success, or `Err(encoded_error_response)` if
-/// the request is invalid (bad channel or payload size).
-pub fn handle_diag_relay_request(body: &[u8]) -> Result<DiagRelayParams, Vec<u8>> {
-    use sonde_protocol::{
-        decode_diag_relay_request, BLE_DIAG_RELAY_RESPONSE, DIAG_RELAY_STATUS_CHANNEL_ERROR,
-        MAX_FRAME_SIZE,
+/// Encode a `TEST_RESULT` BLE envelope.
+pub fn encode_test_result_response(result: &sonde_protocol::TestResult) -> Vec<u8> {
+    let body = sonde_protocol::encode_test_result(result).unwrap_or_default();
+    encode_ble_envelope(sonde_protocol::BLE_TEST_RESULT, &body).unwrap_or_default()
+}
+
+/// Parse, validate, and stage a `RUN_TEST_COMMAND`.
+pub fn handle_run_test_command<S: PlatformStorage>(
+    body: &[u8],
+    storage: &mut S,
+) -> (u8, Option<StagedTestCommand>) {
+    let Ok(command) = sonde_protocol::decode_run_test_command(body) else {
+        return (sonde_protocol::RUN_TEST_ACK_INVALID, None);
     };
 
-    let (rf_channel, payload) = decode_diag_relay_request(body).map_err(|_| {
-        encode_ble_envelope(
-            BLE_DIAG_RELAY_RESPONSE,
-            &encode_diag_relay_status(DIAG_RELAY_STATUS_CHANNEL_ERROR),
-        )
-        .expect("error response fits")
-    })?;
-
-    if !(1..=13).contains(&rf_channel) || payload.is_empty() || payload.len() > MAX_FRAME_SIZE {
-        return Err(encode_ble_envelope(
-            BLE_DIAG_RELAY_RESPONSE,
-            &encode_diag_relay_status(DIAG_RELAY_STATUS_CHANNEL_ERROR),
-        )
-        .expect("error response fits"));
+    if command.test_type != sonde_protocol::TEST_TYPE_DIAG_FRAME {
+        return (sonde_protocol::RUN_TEST_ACK_UNSUPPORTED, None);
     }
 
-    Ok(DiagRelayParams {
-        rf_channel,
-        payload: payload.to_vec(),
-    })
+    let staged = StagedTestCommand {
+        test_type: command.test_type,
+        rf_channel: command.rf_channel,
+        payload: command.payload.to_vec(),
+    };
+
+    if storage.write_staged_test_command(&staged).is_err() {
+        return (sonde_protocol::RUN_TEST_ACK_INVALID, None);
+    }
+
+    (sonde_protocol::RUN_TEST_ACK_OK, Some(staged))
 }
 
-fn encode_diag_relay_status(status: u8) -> Vec<u8> {
-    sonde_protocol::encode_diag_relay_response(status, &[]).unwrap_or_default()
+/// Read the retained latest `TEST_RESULT`.
+pub fn handle_read_test_result<S: PlatformStorage>(
+    body: &[u8],
+    storage: &S,
+) -> Result<sonde_protocol::TestResult, &'static str> {
+    sonde_protocol::decode_read_test_result(body)
+        .map_err(|_| "READ_TEST_RESULT body must be empty")?;
+    Ok(storage
+        .read_test_result()
+        .unwrap_or(sonde_protocol::TestResult {
+            status: sonde_protocol::TEST_RESULT_NO_RESULT,
+            test_type: None,
+            reply_frame: None,
+            reply_rssi_dbm: None,
+            attempt_count: 0,
+            elapsed_ms: 0,
+        }))
 }
 
-/// Encode a DIAG_RELAY_RESPONSE BLE envelope.
-pub fn encode_diag_relay_response(status: u8, payload: &[u8]) -> Vec<u8> {
-    let body = sonde_protocol::encode_diag_relay_response(status, payload)
-        .unwrap_or_else(|_| encode_diag_relay_status(status));
-    encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_RESPONSE, &body).unwrap_or_default()
-}
-
-/// Execute the diagnostic relay: broadcast on ESP-NOW, listen for DIAG_REPLY.
-///
-/// Retries up to 3 times with 200ms backoff and 2s listen window per attempt
-/// (matching WAKE retry parameters per ND-1103).
-///
-/// **Channel switching** (ND-1101): The caller is responsible for tuning the
-/// ESP-NOW radio to `params.rf_channel` before calling this function and
-/// restoring it afterwards (ND-1106). On ESP32, this is done in
-/// `esp_ble_pairing.rs` using `esp_wifi_set_channel()`. This function is
-/// platform-independent and operates on whatever channel the transport is
-/// currently configured for.
-pub fn do_diag_relay<T: crate::traits::Transport>(
+/// Execute the staged pre-provisioning test command, store the latest result,
+/// and clear the staged command.
+pub fn execute_staged_test_command<S: PlatformStorage, T: Transport, C: crate::traits::Clock>(
+    storage: &mut S,
     transport: &mut T,
-    params: &DiagRelayParams,
-) -> Vec<u8> {
-    const DIAG_MAX_RETRIES: u32 = 3;
-    const DIAG_RETRY_DELAY_MS: u64 = 200;
-    const DIAG_LISTEN_TIMEOUT_MS: u32 = 2000;
+    clock: &C,
+) -> NodeResult<Option<sonde_protocol::TestResult>> {
+    let Some(command) = storage.read_staged_test_command() else {
+        return Ok(None);
+    };
 
-    for attempt in 0..=DIAG_MAX_RETRIES {
+    let result = match command.test_type {
+        sonde_protocol::TEST_TYPE_DIAG_FRAME => execute_diag_frame_test(transport, clock, &command),
+        _ => sonde_protocol::TestResult {
+            status: sonde_protocol::TEST_RESULT_EXECUTION_ERROR,
+            test_type: Some(command.test_type),
+            reply_frame: None,
+            reply_rssi_dbm: None,
+            attempt_count: 0,
+            elapsed_ms: 0,
+        },
+    };
+
+    storage.write_test_result(&result)?;
+    storage.clear_staged_test_command()?;
+    Ok(Some(result))
+}
+
+fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
+    transport: &mut T,
+    clock: &C,
+    command: &StagedTestCommand,
+) -> sonde_protocol::TestResult {
+    let start_ms = clock.elapsed_ms();
+
+    let Some(rf_channel) = command.rf_channel else {
+        return execution_error_result(command.test_type, 0, 0);
+    };
+    if !(1..=13).contains(&rf_channel)
+        || command.payload.is_empty()
+        || command.payload.len() > sonde_protocol::MAX_FRAME_SIZE
+    {
+        return execution_error_result(command.test_type, 0, 0);
+    }
+
+    let mut attempt_count = 0u64;
+    for attempt in 0..=TEST_MAX_RETRIES {
         if attempt > 0 {
-            #[cfg(feature = "esp")]
-            std::thread::sleep(std::time::Duration::from_millis(DIAG_RETRY_DELAY_MS));
-            #[cfg(not(feature = "esp"))]
-            {
-                let _ = DIAG_RETRY_DELAY_MS; // avoid unused warning in tests
-            }
+            clock.delay_ms(TEST_RETRY_DELAY_MS);
         }
+        attempt_count = attempt + 1;
+        let _ = transport.send(&command.payload);
 
-        if transport.send(&params.payload).is_err() {
-            continue;
-        }
-
-        // Listen for DIAG_REPLY (msg_type 0x85 at header byte offset 2),
-        // ignoring other msg_types until the per-attempt listen window expires.
         #[cfg(feature = "esp")]
         {
-            let mut remaining_ms = DIAG_LISTEN_TIMEOUT_MS;
+            let mut remaining_ms = TEST_LISTEN_TIMEOUT_MS;
             loop {
                 if remaining_ms == 0 {
                     break;
                 }
                 let before = std::time::Instant::now();
-                match transport.recv(remaining_ms) {
-                    Ok(Some(raw)) => {
-                        if raw.len() >= 3
-                            && raw[sonde_protocol::OFFSET_MSG_TYPE]
-                                == sonde_protocol::MSG_DIAG_REPLY
-                        {
-                            return encode_diag_relay_response(
-                                sonde_protocol::DIAG_RELAY_STATUS_OK,
-                                &raw,
-                            );
-                        }
+                match transport.recv_with_metadata(remaining_ms) {
+                    Ok(Some(frame))
+                        if frame.data.len() >= sonde_protocol::HEADER_SIZE
+                            && frame.data[sonde_protocol::OFFSET_MSG_TYPE]
+                                == sonde_protocol::MSG_DIAG_REPLY =>
+                    {
+                        return success_result(
+                            command.test_type,
+                            frame.data,
+                            frame.rssi_dbm,
+                            attempt_count,
+                            clock.elapsed_ms().saturating_sub(start_ms),
+                        );
+                    }
+                    Ok(Some(_)) => {
                         let elapsed = before.elapsed().as_millis() as u32;
                         remaining_ms = remaining_ms.saturating_sub(elapsed.max(1));
                     }
-                    _ => break,
+                    Ok(None) | Err(_) => break,
                 }
             }
         }
+
         #[cfg(not(feature = "esp"))]
         {
-            // In test builds, recv returns immediately; single attempt per retry.
-            if let Ok(Some(raw)) = transport.recv(DIAG_LISTEN_TIMEOUT_MS) {
-                if raw.len() >= 3
-                    && raw[sonde_protocol::OFFSET_MSG_TYPE] == sonde_protocol::MSG_DIAG_REPLY
+            if let Ok(Some(frame)) = transport.recv_with_metadata(TEST_LISTEN_TIMEOUT_MS) {
+                if frame.data.len() >= sonde_protocol::HEADER_SIZE
+                    && frame.data[sonde_protocol::OFFSET_MSG_TYPE] == sonde_protocol::MSG_DIAG_REPLY
                 {
-                    return encode_diag_relay_response(sonde_protocol::DIAG_RELAY_STATUS_OK, &raw);
+                    return success_result(
+                        command.test_type,
+                        frame.data,
+                        frame.rssi_dbm,
+                        attempt_count,
+                        clock.elapsed_ms().saturating_sub(start_ms),
+                    );
                 }
             }
         }
     }
 
-    encode_diag_relay_response(sonde_protocol::DIAG_RELAY_STATUS_TIMEOUT, &[])
+    sonde_protocol::TestResult {
+        status: sonde_protocol::TEST_RESULT_TIMEOUT,
+        test_type: Some(command.test_type),
+        reply_frame: None,
+        reply_rssi_dbm: None,
+        attempt_count,
+        elapsed_ms: clock.elapsed_ms().saturating_sub(start_ms),
+    }
+}
+
+fn success_result(
+    test_type: u64,
+    reply_frame: Vec<u8>,
+    reply_rssi_dbm: Option<i8>,
+    attempt_count: u64,
+    elapsed_ms: u64,
+) -> sonde_protocol::TestResult {
+    sonde_protocol::TestResult {
+        status: sonde_protocol::TEST_RESULT_OK,
+        test_type: Some(test_type),
+        reply_frame: Some(reply_frame),
+        reply_rssi_dbm,
+        attempt_count,
+        elapsed_ms,
+    }
+}
+
+fn execution_error_result(
+    test_type: u64,
+    attempt_count: u64,
+    elapsed_ms: u64,
+) -> sonde_protocol::TestResult {
+    sonde_protocol::TestResult {
+        status: sonde_protocol::TEST_RESULT_EXECUTION_ERROR,
+        test_type: Some(test_type),
+        reply_frame: None,
+        reply_rssi_dbm: None,
+        attempt_count,
+        elapsed_ms,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -417,11 +498,16 @@ mod tests {
         peer_payload: Option<Vec<u8>>,
         reg_complete: bool,
         board_layout: Option<BoardLayout>,
+        staged_test_command: Option<StagedTestCommand>,
+        test_result: Option<sonde_protocol::TestResult>,
         fail_write_key: bool,
         fail_write_channel: bool,
         fail_write_peer_payload: bool,
         fail_write_reg_complete: bool,
         fail_write_board_layout: bool,
+        fail_write_staged_test_command: bool,
+        fail_write_test_result: bool,
+        fail_clear_staged_test_command: bool,
     }
 
     impl MockStorage {
@@ -432,11 +518,16 @@ mod tests {
                 peer_payload: None,
                 reg_complete: false,
                 board_layout: None,
+                staged_test_command: None,
+                test_result: None,
                 fail_write_key: false,
                 fail_write_channel: false,
                 fail_write_peer_payload: false,
                 fail_write_reg_complete: false,
                 fail_write_board_layout: false,
+                fail_write_staged_test_command: false,
+                fail_write_test_result: false,
+                fail_clear_staged_test_command: false,
             }
         }
 
@@ -542,6 +633,39 @@ mod tests {
             self.board_layout = Some(*layout);
             Ok(())
         }
+        fn read_staged_test_command(&self) -> Option<StagedTestCommand> {
+            self.staged_test_command.clone()
+        }
+        fn write_staged_test_command(&mut self, command: &StagedTestCommand) -> NodeResult<()> {
+            if self.fail_write_staged_test_command {
+                return Err(NodeError::StorageError(
+                    "injected write_staged_test_command failure",
+                ));
+            }
+            self.staged_test_command = Some(command.clone());
+            Ok(())
+        }
+        fn clear_staged_test_command(&mut self) -> NodeResult<()> {
+            if self.fail_clear_staged_test_command {
+                return Err(NodeError::StorageError(
+                    "injected clear_staged_test_command failure",
+                ));
+            }
+            self.staged_test_command = None;
+            Ok(())
+        }
+        fn read_test_result(&self) -> Option<sonde_protocol::TestResult> {
+            self.test_result.clone()
+        }
+        fn write_test_result(&mut self, result: &sonde_protocol::TestResult) -> NodeResult<()> {
+            if self.fail_write_test_result {
+                return Err(NodeError::StorageError(
+                    "injected write_test_result failure",
+                ));
+            }
+            self.test_result = Some(result.clone());
+            Ok(())
+        }
     }
 
     // --- Helper ---
@@ -553,6 +677,57 @@ mod tests {
             rf_channel: channel,
             encrypted_payload: payload.to_vec(),
             board_layout: ProvisionedBoardLayout::Absent,
+        }
+    }
+
+    #[derive(Default)]
+    struct MockClock {
+        elapsed_ms: std::cell::Cell<u64>,
+        delays_ms: std::cell::RefCell<Vec<u32>>,
+    }
+
+    impl crate::traits::Clock for MockClock {
+        fn elapsed_ms(&self) -> u64 {
+            self.elapsed_ms.get()
+        }
+
+        fn delay_ms(&self, ms: u32) {
+            self.delays_ms.borrow_mut().push(ms);
+            self.elapsed_ms
+                .set(self.elapsed_ms.get().saturating_add(ms as u64));
+        }
+    }
+
+    struct MockTransport {
+        sends: Vec<Vec<u8>>,
+        replies: std::collections::VecDeque<Option<crate::traits::ReceivedFrame>>,
+    }
+
+    impl MockTransport {
+        fn new(replies: Vec<Option<crate::traits::ReceivedFrame>>) -> Self {
+            Self {
+                sends: Vec::new(),
+                replies: replies.into(),
+            }
+        }
+    }
+
+    impl crate::traits::Transport for MockTransport {
+        fn send(&mut self, frame: &[u8]) -> NodeResult<()> {
+            self.sends.push(frame.to_vec());
+            Ok(())
+        }
+
+        fn recv(&mut self, timeout_ms: u32) -> NodeResult<Option<Vec<u8>>> {
+            self.recv_with_metadata(timeout_ms)
+                .map(|frame| frame.map(|frame| frame.data))
+        }
+
+        fn recv_with_metadata(
+            &mut self,
+            _timeout_ms: u32,
+        ) -> NodeResult<Option<crate::traits::ReceivedFrame>> {
+            Ok(self.replies.pop_front().flatten())
         }
     }
 
@@ -1135,6 +1310,247 @@ mod tests {
             BLE_MIN_ATT_MTU, 247,
             "BLE_MIN_ATT_MTU must be 247 per ND-0904"
         );
+    }
+
+    #[test]
+    fn run_test_command_valid_is_staged() {
+        let body = sonde_protocol::encode_run_test_command(
+            sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            Some(6),
+            &[0x42; 50],
+        )
+        .unwrap();
+        let mut storage = MockStorage::new();
+
+        let (status, staged) = handle_run_test_command(&body, &mut storage);
+        assert_eq!(status, sonde_protocol::RUN_TEST_ACK_OK);
+        assert_eq!(staged, storage.read_staged_test_command());
+        assert_eq!(
+            storage.read_staged_test_command().unwrap().rf_channel,
+            Some(6)
+        );
+    }
+
+    #[test]
+    fn run_test_command_invalid_diag_frame_is_rejected() {
+        let body = sonde_protocol::encode_ble_envelope(
+            sonde_protocol::BLE_RUN_TEST_COMMAND,
+            &[0xA3, 0x01, 0x01, 0x02, 0x0E, 0x03, 0x41, 0xAA],
+        )
+        .unwrap();
+        let (_, body) = sonde_protocol::parse_ble_envelope(&body).unwrap();
+        let mut storage = MockStorage::new();
+
+        let (status, staged) = handle_run_test_command(body, &mut storage);
+        assert_eq!(status, sonde_protocol::RUN_TEST_ACK_INVALID);
+        assert!(staged.is_none());
+        assert!(storage.read_staged_test_command().is_none());
+    }
+
+    #[test]
+    fn run_test_command_unsupported_type_is_rejected() {
+        let body = sonde_protocol::encode_run_test_command(0x99, None, &[]).unwrap();
+        let mut storage = MockStorage::new();
+
+        let (status, staged) = handle_run_test_command(&body, &mut storage);
+        assert_eq!(status, sonde_protocol::RUN_TEST_ACK_UNSUPPORTED);
+        assert!(staged.is_none());
+        assert!(storage.read_staged_test_command().is_none());
+    }
+
+    #[test]
+    fn read_test_result_returns_retained_result_and_no_result_fallback() {
+        let mut storage = MockStorage::new();
+        let no_result = handle_read_test_result(&[], &storage).unwrap();
+        assert_eq!(no_result.status, sonde_protocol::TEST_RESULT_NO_RESULT);
+        assert!(no_result.test_type.is_none());
+
+        let retained = sonde_protocol::TestResult {
+            status: sonde_protocol::TEST_RESULT_TIMEOUT,
+            test_type: Some(sonde_protocol::TEST_TYPE_DIAG_FRAME),
+            reply_frame: None,
+            reply_rssi_dbm: None,
+            attempt_count: 4,
+            elapsed_ms: 8_600,
+        };
+        storage.test_result = Some(retained.clone());
+        assert_eq!(handle_read_test_result(&[], &storage).unwrap(), retained);
+    }
+
+    #[test]
+    fn execute_staged_test_command_stores_success_result() {
+        let mut storage = MockStorage::new();
+        storage.staged_test_command = Some(StagedTestCommand {
+            test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(6),
+            payload: vec![0x42; 50],
+        });
+        let reply = crate::traits::ReceivedFrame {
+            data: vec![
+                0x12,
+                0x34,
+                sonde_protocol::MSG_DIAG_REPLY,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+            ],
+            rssi_dbm: Some(-67),
+        };
+        let mut transport = MockTransport::new(vec![Some(reply.clone())]);
+        let clock = MockClock::default();
+
+        let result = execute_staged_test_command(&mut storage, &mut transport, &clock)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.status, sonde_protocol::TEST_RESULT_OK);
+        assert_eq!(result.test_type, Some(sonde_protocol::TEST_TYPE_DIAG_FRAME));
+        assert_eq!(result.reply_frame, Some(reply.data));
+        assert_eq!(result.reply_rssi_dbm, Some(-67));
+        assert_eq!(result.attempt_count, 1);
+        assert!(storage.read_staged_test_command().is_none());
+        assert_eq!(storage.read_test_result(), Some(result));
+    }
+
+    #[test]
+    fn execute_staged_test_command_times_out_after_retries() {
+        let mut storage = MockStorage::new();
+        storage.staged_test_command = Some(StagedTestCommand {
+            test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(6),
+            payload: vec![0x42; 50],
+        });
+        let mut transport = MockTransport::new(vec![None, None, None, None]);
+        let clock = MockClock::default();
+
+        let result = execute_staged_test_command(&mut storage, &mut transport, &clock)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.status, sonde_protocol::TEST_RESULT_TIMEOUT);
+        assert_eq!(result.attempt_count, 4);
+        assert_eq!(transport.sends.len(), 4);
+        assert_eq!(*clock.delays_ms.borrow(), vec![200, 200, 200]);
+    }
+
+    #[test]
+    fn execute_staged_test_command_rejects_invalid_staged_command() {
+        let mut storage = MockStorage::new();
+        storage.staged_test_command = Some(StagedTestCommand {
+            test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            rf_channel: None,
+            payload: vec![0x42; 50],
+        });
+        let mut transport = MockTransport::new(vec![]);
+        let clock = MockClock::default();
+
+        let result = execute_staged_test_command(&mut storage, &mut transport, &clock)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.status, sonde_protocol::TEST_RESULT_EXECUTION_ERROR);
+        assert_eq!(result.test_type, Some(sonde_protocol::TEST_TYPE_DIAG_FRAME));
+        assert!(storage.read_staged_test_command().is_none());
+    }
+
+    #[test]
+    fn retained_result_remains_readable_until_overwritten() {
+        let mut storage = MockStorage::new();
+        let first = sonde_protocol::TestResult {
+            status: sonde_protocol::TEST_RESULT_OK,
+            test_type: Some(sonde_protocol::TEST_TYPE_DIAG_FRAME),
+            reply_frame: Some(vec![0x12, 0x34, sonde_protocol::MSG_DIAG_REPLY]),
+            reply_rssi_dbm: Some(-61),
+            attempt_count: 1,
+            elapsed_ms: 900,
+        };
+        storage.write_test_result(&first).unwrap();
+
+        assert_eq!(handle_read_test_result(&[], &storage).unwrap(), first);
+        assert_eq!(handle_read_test_result(&[], &storage).unwrap(), first);
+
+        storage.staged_test_command = Some(StagedTestCommand {
+            test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(6),
+            payload: vec![0x42; 50],
+        });
+        let reply = crate::traits::ReceivedFrame {
+            data: vec![
+                0x12,
+                0x34,
+                sonde_protocol::MSG_DIAG_REPLY,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2,
+            ],
+            rssi_dbm: Some(-72),
+        };
+        let mut transport = MockTransport::new(vec![Some(reply.clone())]);
+        let clock = MockClock::default();
+
+        let second = execute_staged_test_command(&mut storage, &mut transport, &clock)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(handle_read_test_result(&[], &storage).unwrap(), second);
+        assert_ne!(second, first);
+    }
+
+    #[test]
+    fn node_provision_succeeds_after_test_execution() {
+        let mut storage = MockStorage::new();
+        storage.staged_test_command = Some(StagedTestCommand {
+            test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(6),
+            payload: vec![0x42; 50],
+        });
+        let reply = crate::traits::ReceivedFrame {
+            data: vec![
+                0x12,
+                0x34,
+                sonde_protocol::MSG_DIAG_REPLY,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                3,
+            ],
+            rssi_dbm: Some(-67),
+        };
+        let mut transport = MockTransport::new(vec![Some(reply)]);
+        let clock = MockClock::default();
+        let mut map_storage = MapStorage::new(1024);
+
+        execute_staged_test_command(&mut storage, &mut transport, &clock)
+            .unwrap()
+            .unwrap();
+
+        let provision = NodeProvision {
+            key_hint: 0x1234,
+            psk: [0x42; 32],
+            rf_channel: 6,
+            encrypted_payload: vec![0xAA; 32],
+            board_layout: ProvisionedBoardLayout::Absent,
+        };
+        let status =
+            handle_node_provision(&provision, &mut storage, &mut map_storage, false, false);
+        assert_eq!(status, NODE_ACK_SUCCESS);
+        assert_eq!(storage.read_key(), Some((0x1234, [0x42; 32])));
+        assert_eq!(storage.read_channel(), Some(6));
+        assert_eq!(storage.read_peer_payload(), Some(vec![0xAA; 32]));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -388,7 +388,14 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
             clock.delay_ms(TEST_RETRY_DELAY_MS);
         }
         attempt_count = attempt + 1;
-        if transport.send(&command.payload).is_err() {
+        log::info!(
+            "diag test attempt {} sending {} bytes on channel {}",
+            attempt_count,
+            command.payload.len(),
+            rf_channel
+        );
+        if let Err(err) = transport.send(&command.payload) {
+            log::warn!("diag test attempt {} send failed: {}", attempt_count, err);
             continue;
         }
         send_succeeded = true;
@@ -407,6 +414,12 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
                             && frame.data[sonde_protocol::OFFSET_MSG_TYPE]
                                 == sonde_protocol::MSG_DIAG_REPLY =>
                     {
+                        log::info!(
+                            "diag test attempt {} received DIAG_REPLY len={} rssi={:?}",
+                            attempt_count,
+                            frame.data.len(),
+                            frame.rssi_dbm
+                        );
                         let Some(reply_rssi_dbm) = frame.rssi_dbm else {
                             return execution_error_result(
                                 command.test_type,
@@ -422,11 +435,38 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
                             clock.elapsed_ms().saturating_sub(start_ms),
                         );
                     }
-                    Ok(Some(_)) => {
+                    Ok(Some(frame)) => {
+                        let msg_type = if frame.data.len() > sonde_protocol::OFFSET_MSG_TYPE {
+                            frame.data[sonde_protocol::OFFSET_MSG_TYPE]
+                        } else {
+                            0xFF
+                        };
+                        log::info!(
+                            "diag test attempt {} ignored frame msg_type=0x{:02x} len={} rssi={:?}",
+                            attempt_count,
+                            msg_type,
+                            frame.data.len(),
+                            frame.rssi_dbm
+                        );
                         let elapsed = before.elapsed().as_millis() as u32;
                         remaining_ms = remaining_ms.saturating_sub(elapsed.max(1));
                     }
-                    Ok(None) | Err(_) => break,
+                    Ok(None) => {
+                        log::info!(
+                            "diag test attempt {} receive wait expired after {} ms",
+                            attempt_count,
+                            before.elapsed().as_millis()
+                        );
+                        break;
+                    }
+                    Err(err) => {
+                        log::warn!(
+                            "diag test attempt {} receive failed: {}",
+                            attempt_count,
+                            err
+                        );
+                        break;
+                    }
                 }
             }
         }

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -420,17 +420,10 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
                             frame.data.len(),
                             frame.rssi_dbm
                         );
-                        let Some(reply_rssi_dbm) = frame.rssi_dbm else {
-                            return execution_error_result(
-                                command.test_type,
-                                attempt_count,
-                                clock.elapsed_ms().saturating_sub(start_ms),
-                            );
-                        };
                         return success_result(
                             command.test_type,
                             frame.data,
-                            reply_rssi_dbm,
+                            frame.rssi_dbm,
                             attempt_count,
                             clock.elapsed_ms().saturating_sub(start_ms),
                         );
@@ -477,17 +470,10 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
                 if frame.data.len() >= sonde_protocol::HEADER_SIZE
                     && frame.data[sonde_protocol::OFFSET_MSG_TYPE] == sonde_protocol::MSG_DIAG_REPLY
                 {
-                    let Some(reply_rssi_dbm) = frame.rssi_dbm else {
-                        return execution_error_result(
-                            command.test_type,
-                            attempt_count,
-                            clock.elapsed_ms().saturating_sub(start_ms),
-                        );
-                    };
                     return success_result(
                         command.test_type,
                         frame.data,
-                        reply_rssi_dbm,
+                        frame.rssi_dbm,
                         attempt_count,
                         clock.elapsed_ms().saturating_sub(start_ms),
                     );
@@ -517,7 +503,7 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
 fn success_result(
     test_type: u64,
     reply_frame: Vec<u8>,
-    reply_rssi_dbm: i8,
+    reply_rssi_dbm: Option<i8>,
     attempt_count: u64,
     elapsed_ms: u64,
 ) -> sonde_protocol::TestResult {
@@ -525,7 +511,7 @@ fn success_result(
         status: sonde_protocol::TEST_RESULT_OK,
         test_type: Some(test_type),
         reply_frame: Some(reply_frame),
-        reply_rssi_dbm: Some(reply_rssi_dbm),
+        reply_rssi_dbm,
         attempt_count,
         elapsed_ms,
     }
@@ -1557,7 +1543,7 @@ mod tests {
     }
 
     #[test]
-    fn execute_staged_test_command_rejects_success_without_reply_rssi() {
+    fn execute_staged_test_command_allows_success_without_reply_rssi() {
         let mut storage = MockStorage::new();
         storage.staged_test_command = Some(StagedTestCommand {
             test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
@@ -1587,9 +1573,9 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(result.status, sonde_protocol::TEST_RESULT_EXECUTION_ERROR);
+        assert_eq!(result.status, sonde_protocol::TEST_RESULT_OK);
         assert_eq!(result.test_type, Some(sonde_protocol::TEST_TYPE_DIAG_FRAME));
-        assert!(result.reply_frame.is_none());
+        assert!(result.reply_frame.is_some());
         assert!(result.reply_rssi_dbm.is_none());
         assert_eq!(result.attempt_count, 1);
         assert!(storage.read_staged_test_command().is_none());

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -434,7 +434,7 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
                         } else {
                             0xFF
                         };
-                        log::info!(
+                        log::debug!(
                             "diag test attempt {} ignored frame msg_type=0x{:02x} len={} rssi={:?}",
                             attempt_count,
                             msg_type,

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -307,7 +307,7 @@ pub fn handle_run_test_command<S: PlatformStorage>(
     let staged = StagedTestCommand {
         test_type: command.test_type,
         rf_channel: command.rf_channel,
-        payload: command.payload.to_vec(),
+        payload: command.payload,
     };
 
     if storage.write_staged_test_command(&staged).is_err() {
@@ -382,12 +382,16 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
     }
 
     let mut attempt_count = 0u64;
+    let mut send_succeeded = false;
     for attempt in 0..=TEST_MAX_RETRIES {
         if attempt > 0 {
             clock.delay_ms(TEST_RETRY_DELAY_MS);
         }
         attempt_count = attempt + 1;
-        let _ = transport.send(&command.payload);
+        if transport.send(&command.payload).is_err() {
+            continue;
+        }
+        send_succeeded = true;
 
         #[cfg(feature = "esp")]
         {
@@ -436,6 +440,14 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
                 }
             }
         }
+    }
+
+    if !send_succeeded {
+        return execution_error_result(
+            command.test_type,
+            attempt_count,
+            clock.elapsed_ms().saturating_sub(start_ms),
+        );
     }
 
     sonde_protocol::TestResult {
@@ -1456,6 +1468,42 @@ mod tests {
         assert_eq!(result.status, sonde_protocol::TEST_RESULT_EXECUTION_ERROR);
         assert_eq!(result.test_type, Some(sonde_protocol::TEST_TYPE_DIAG_FRAME));
         assert!(storage.read_staged_test_command().is_none());
+    }
+
+    #[test]
+    fn execute_staged_test_command_returns_execution_error_when_all_sends_fail() {
+        struct FailingSendTransport {
+            send_calls: usize,
+        }
+
+        impl crate::traits::Transport for FailingSendTransport {
+            fn send(&mut self, _frame: &[u8]) -> NodeResult<()> {
+                self.send_calls += 1;
+                Err(NodeError::Transport("injected send failure"))
+            }
+
+            fn recv(&mut self, _timeout_ms: u32) -> NodeResult<Option<Vec<u8>>> {
+                Ok(None)
+            }
+        }
+
+        let mut storage = MockStorage::new();
+        storage.staged_test_command = Some(StagedTestCommand {
+            test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(6),
+            payload: vec![0x42; 50],
+        });
+        let mut transport = FailingSendTransport { send_calls: 0 };
+        let clock = MockClock::default();
+
+        let result = execute_staged_test_command(&mut storage, &mut transport, &clock)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.status, sonde_protocol::TEST_RESULT_EXECUTION_ERROR);
+        assert_eq!(result.attempt_count, 4);
+        assert_eq!(transport.send_calls, 4);
+        assert_eq!(*clock.delays_ms.borrow(), vec![200, 200, 200]);
     }
 
     #[test]

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -407,10 +407,17 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
                             && frame.data[sonde_protocol::OFFSET_MSG_TYPE]
                                 == sonde_protocol::MSG_DIAG_REPLY =>
                     {
+                        let Some(reply_rssi_dbm) = frame.rssi_dbm else {
+                            return execution_error_result(
+                                command.test_type,
+                                attempt_count,
+                                clock.elapsed_ms().saturating_sub(start_ms),
+                            );
+                        };
                         return success_result(
                             command.test_type,
                             frame.data,
-                            frame.rssi_dbm,
+                            reply_rssi_dbm,
                             attempt_count,
                             clock.elapsed_ms().saturating_sub(start_ms),
                         );
@@ -430,10 +437,17 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
                 if frame.data.len() >= sonde_protocol::HEADER_SIZE
                     && frame.data[sonde_protocol::OFFSET_MSG_TYPE] == sonde_protocol::MSG_DIAG_REPLY
                 {
+                    let Some(reply_rssi_dbm) = frame.rssi_dbm else {
+                        return execution_error_result(
+                            command.test_type,
+                            attempt_count,
+                            clock.elapsed_ms().saturating_sub(start_ms),
+                        );
+                    };
                     return success_result(
                         command.test_type,
                         frame.data,
-                        frame.rssi_dbm,
+                        reply_rssi_dbm,
                         attempt_count,
                         clock.elapsed_ms().saturating_sub(start_ms),
                     );
@@ -463,7 +477,7 @@ fn execute_diag_frame_test<T: Transport, C: crate::traits::Clock>(
 fn success_result(
     test_type: u64,
     reply_frame: Vec<u8>,
-    reply_rssi_dbm: Option<i8>,
+    reply_rssi_dbm: i8,
     attempt_count: u64,
     elapsed_ms: u64,
 ) -> sonde_protocol::TestResult {
@@ -471,7 +485,7 @@ fn success_result(
         status: sonde_protocol::TEST_RESULT_OK,
         test_type: Some(test_type),
         reply_frame: Some(reply_frame),
-        reply_rssi_dbm,
+        reply_rssi_dbm: Some(reply_rssi_dbm),
         attempt_count,
         elapsed_ms,
     }
@@ -1424,6 +1438,46 @@ mod tests {
         assert_eq!(result.test_type, Some(sonde_protocol::TEST_TYPE_DIAG_FRAME));
         assert_eq!(result.reply_frame, Some(reply.data));
         assert_eq!(result.reply_rssi_dbm, Some(-67));
+        assert_eq!(result.attempt_count, 1);
+        assert!(storage.read_staged_test_command().is_none());
+        assert_eq!(storage.read_test_result(), Some(result));
+    }
+
+    #[test]
+    fn execute_staged_test_command_rejects_success_without_reply_rssi() {
+        let mut storage = MockStorage::new();
+        storage.staged_test_command = Some(StagedTestCommand {
+            test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(6),
+            payload: vec![0x42; 50],
+        });
+        let reply = crate::traits::ReceivedFrame {
+            data: vec![
+                0x12,
+                0x34,
+                sonde_protocol::MSG_DIAG_REPLY,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+            ],
+            rssi_dbm: None,
+        };
+        let mut transport = MockTransport::new(vec![Some(reply)]);
+        let clock = MockClock::default();
+
+        let result = execute_staged_test_command(&mut storage, &mut transport, &clock)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.status, sonde_protocol::TEST_RESULT_EXECUTION_ERROR);
+        assert_eq!(result.test_type, Some(sonde_protocol::TEST_TYPE_DIAG_FRAME));
+        assert!(result.reply_frame.is_none());
+        assert!(result.reply_rssi_dbm.is_none());
         assert_eq!(result.attempt_count, 1);
         assert!(storage.read_staged_test_command().is_none());
         assert_eq!(storage.read_test_result(), Some(result));

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -356,7 +356,10 @@ pub fn execute_staged_test_command<S: PlatformStorage, T: Transport, C: crate::t
         },
     };
 
-    storage.write_test_result(&result)?;
+    if let Err(err) = storage.write_test_result(&result) {
+        let _ = storage.clear_staged_test_command();
+        return Err(err);
+    }
     storage.clear_staged_test_command()?;
     Ok(Some(result))
 }
@@ -1628,6 +1631,41 @@ mod tests {
         assert_eq!(result.attempt_count, 4);
         assert_eq!(transport.send_calls, 4);
         assert_eq!(*clock.delays_ms.borrow(), vec![200, 200, 200]);
+    }
+
+    #[test]
+    fn execute_staged_test_command_clears_staged_command_when_result_write_fails() {
+        let mut storage = MockStorage::new();
+        storage.fail_write_test_result = true;
+        storage.staged_test_command = Some(StagedTestCommand {
+            test_type: sonde_protocol::TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(6),
+            payload: vec![0x42; 50],
+        });
+        let reply = crate::traits::ReceivedFrame {
+            data: vec![
+                0x12,
+                0x34,
+                sonde_protocol::MSG_DIAG_REPLY,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+            ],
+            rssi_dbm: Some(-67),
+        };
+        let mut transport = MockTransport::new(vec![Some(reply)]);
+        let clock = MockClock::default();
+
+        let err = execute_staged_test_command(&mut storage, &mut transport, &clock).unwrap_err();
+
+        assert!(matches!(err, NodeError::StorageError(_)));
+        assert!(storage.read_staged_test_command().is_none());
+        assert!(storage.read_test_result().is_none());
     }
 
     #[test]

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -287,8 +287,11 @@ pub fn encode_run_test_ack(status: u8) -> Vec<u8> {
 
 /// Encode a `TEST_RESULT` BLE envelope.
 pub fn encode_test_result_response(result: &sonde_protocol::TestResult) -> Vec<u8> {
-    let body = sonde_protocol::encode_test_result(result).unwrap_or_default();
-    encode_ble_envelope(sonde_protocol::BLE_TEST_RESULT, &body).unwrap_or_default()
+    let sanitized = sanitize_test_result(result);
+    let body = sonde_protocol::encode_test_result(&sanitized)
+        .expect("sanitize_test_result must produce an encodable TEST_RESULT");
+    encode_ble_envelope(sonde_protocol::BLE_TEST_RESULT, &body)
+        .expect("TEST_RESULT body always fits in BLE envelope")
 }
 
 /// Parse, validate, and stage a `RUN_TEST_COMMAND`.
@@ -326,14 +329,8 @@ pub fn handle_read_test_result<S: PlatformStorage>(
         .map_err(|_| "READ_TEST_RESULT body must be empty")?;
     Ok(storage
         .read_test_result()
-        .unwrap_or(sonde_protocol::TestResult {
-            status: sonde_protocol::TEST_RESULT_NO_RESULT,
-            test_type: None,
-            reply_frame: None,
-            reply_rssi_dbm: None,
-            attempt_count: 0,
-            elapsed_ms: 0,
-        }))
+        .map(|result| sanitize_test_result(&result))
+        .unwrap_or_else(no_result_result))
 }
 
 /// Execute the staged pre-provisioning test command, store the latest result,
@@ -491,6 +488,17 @@ fn success_result(
     }
 }
 
+fn no_result_result() -> sonde_protocol::TestResult {
+    sonde_protocol::TestResult {
+        status: sonde_protocol::TEST_RESULT_NO_RESULT,
+        test_type: None,
+        reply_frame: None,
+        reply_rssi_dbm: None,
+        attempt_count: 0,
+        elapsed_ms: 0,
+    }
+}
+
 fn execution_error_result(
     test_type: u64,
     attempt_count: u64,
@@ -503,6 +511,19 @@ fn execution_error_result(
         reply_rssi_dbm: None,
         attempt_count,
         elapsed_ms,
+    }
+}
+
+fn sanitize_test_result(result: &sonde_protocol::TestResult) -> sonde_protocol::TestResult {
+    if sonde_protocol::validate_test_result(result).is_ok() {
+        return result.clone();
+    }
+
+    match result.test_type {
+        Some(test_type) => {
+            execution_error_result(test_type, result.attempt_count, result.elapsed_ms)
+        }
+        None => no_result_result(),
     }
 }
 
@@ -1401,6 +1422,55 @@ mod tests {
         };
         storage.test_result = Some(retained.clone());
         assert_eq!(handle_read_test_result(&[], &storage).unwrap(), retained);
+    }
+
+    #[test]
+    fn read_test_result_sanitizes_invalid_retained_result() {
+        let mut storage = MockStorage::new();
+        storage.test_result = Some(sonde_protocol::TestResult {
+            status: sonde_protocol::TEST_RESULT_OK,
+            test_type: Some(sonde_protocol::TEST_TYPE_DIAG_FRAME),
+            reply_frame: None,
+            reply_rssi_dbm: Some(-67),
+            attempt_count: 2,
+            elapsed_ms: 1_500,
+        });
+
+        let result = handle_read_test_result(&[], &storage).unwrap();
+
+        assert_eq!(result.status, sonde_protocol::TEST_RESULT_EXECUTION_ERROR);
+        assert_eq!(result.test_type, Some(sonde_protocol::TEST_TYPE_DIAG_FRAME));
+        assert!(result.reply_frame.is_none());
+        assert!(result.reply_rssi_dbm.is_none());
+        assert_eq!(result.attempt_count, 2);
+        assert_eq!(result.elapsed_ms, 1_500);
+    }
+
+    #[test]
+    fn encode_test_result_response_sanitizes_invalid_payload() {
+        let invalid = sonde_protocol::TestResult {
+            status: sonde_protocol::TEST_RESULT_OK,
+            test_type: Some(sonde_protocol::TEST_TYPE_DIAG_FRAME),
+            reply_frame: None,
+            reply_rssi_dbm: Some(-67),
+            attempt_count: 2,
+            elapsed_ms: 1_500,
+        };
+
+        let response = encode_test_result_response(&invalid);
+        let (msg_type, body) = parse_ble_envelope(&response).unwrap();
+        let decoded = sonde_protocol::decode_test_result(body).unwrap();
+
+        assert_eq!(msg_type, sonde_protocol::BLE_TEST_RESULT);
+        assert_eq!(decoded.status, sonde_protocol::TEST_RESULT_EXECUTION_ERROR);
+        assert_eq!(
+            decoded.test_type,
+            Some(sonde_protocol::TEST_TYPE_DIAG_FRAME)
+        );
+        assert!(decoded.reply_frame.is_none());
+        assert!(decoded.reply_rssi_dbm.is_none());
+        assert_eq!(decoded.attempt_count, 2);
+        assert_eq!(decoded.elapsed_ms, 1_500);
     }
 
     #[test]

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -261,7 +261,8 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         // esp32-nimble doesn't dispatch BLE_GAP_EVENT_ENC_CHANGE on this
         // build), check the connection's encryption status directly.
         let is_auth = authenticated.lock().map(|a| *a).unwrap_or(false);
-        let is_auth = is_auth || check_encryption_fallback(&conn_handle, &authenticated, &ble_server);
+        let is_auth =
+            is_auth || check_encryption_fallback(&conn_handle, &authenticated, &ble_server);
         let write_data = if is_auth {
             if let Ok(mut p) = pending_write.lock() {
                 p.take()

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -262,7 +262,7 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         // build), check the connection's encryption status directly.
         let is_auth = authenticated.lock().map(|a| *a).unwrap_or(false);
         let is_auth =
-            is_auth || check_encryption_fallback(&conn_handle, &authenticated, ble_server);
+            is_auth || check_encryption_fallback(&conn_handle, &authenticated, &mut ble_server);
         let write_data = if is_auth {
             if let Ok(mut p) = pending_write.lock() {
                 p.take()

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -261,7 +261,7 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         // esp32-nimble doesn't dispatch BLE_GAP_EVENT_ENC_CHANGE on this
         // build), check the connection's encryption status directly.
         let is_auth = authenticated.lock().map(|a| *a).unwrap_or(false);
-        let is_auth = is_auth || check_encryption_fallback(&conn_handle, &authenticated);
+        let is_auth = is_auth || check_encryption_fallback(&conn_handle, &authenticated, &ble_server);
         let write_data = if is_auth {
             if let Ok(mut p) = pending_write.lock() {
                 p.take()
@@ -342,8 +342,7 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
                     if let Err(e) = chr.notify_with(&ack, handle) {
                         warn!("BLE: indication failed: {:?}", e);
                     } else if disconnect_after_ack {
-                        let server = BLEDevice::take().get_server();
-                        let _ = server.disconnect(handle);
+                        let _ = ble_server.disconnect(handle);
                     }
                 } else {
                     warn!("BLE: no active connection for indication");
@@ -377,6 +376,7 @@ mod tests {}
 fn check_encryption_fallback(
     conn_handle: &Arc<Mutex<Option<u16>>>,
     authenticated: &Arc<Mutex<bool>>,
+    ble_server: &esp32_nimble::BLEServer,
 ) -> bool {
     let handle = match conn_handle.lock().ok().and_then(|h| *h) {
         Some(h) => h,
@@ -413,8 +413,7 @@ fn check_encryption_fallback(
             "BLE: encrypted but MTU too low ({} < {}); disconnecting (ND-0904)",
             mtu, BLE_MIN_ATT_MTU
         );
-        let server = BLEDevice::take().get_server();
-        let _ = server.disconnect(handle);
+        let _ = ble_server.disconnect(handle);
         return false;
     }
     info!("BLE: encryption detected via poll, MTU={}", mtu);

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -33,15 +33,13 @@ use esp32_nimble::{
 use log::{info, warn};
 
 use crate::ble_pairing::{
-    do_diag_relay, encode_diag_relay_response, encode_node_ack, handle_diag_relay_request,
-    handle_node_provision, is_mtu_acceptable, parse_ble_envelope, parse_node_provision,
-    BLE_MIN_ATT_MTU, BLE_MSG_NODE_PROVISION,
+    encode_node_ack, encode_run_test_ack, encode_test_result_response, handle_node_provision,
+    handle_read_test_result, handle_run_test_command, is_mtu_acceptable, parse_ble_envelope,
+    parse_node_provision, BLE_MIN_ATT_MTU, BLE_MSG_NODE_PROVISION,
 };
 use crate::error::NodeResult;
-use crate::esp_transport::EspNowTransport;
 use crate::map_storage::MapStorage;
 use crate::traits::PlatformStorage;
-use sonde_protocol::BLE_DIAG_RELAY_REQUEST;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -70,18 +68,12 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// NODE_PROVISION triggers a factory reset before writing new credentials
 /// (ND-0917).
 ///
-/// `transport`: optional ESP-NOW transport for DIAG_RELAY_REQUEST support
-/// (ND-1100). When `Some`, diagnostic relay requests are forwarded over
-/// the radio with channel switching (ND-1101, ND-1106). When `None`,
-/// relay requests return `DIAG_RELAY_STATUS_CHANNEL_ERROR`.
-///
 /// Returns `Ok(())` when the BLE connection is terminated (the caller should
 /// reboot per ND-0907), or `Err` if BLE initialisation fails.
 pub fn run_ble_pairing_mode<S: PlatformStorage>(
     storage: &mut S,
     map_storage: &mut MapStorage,
     button_held: bool,
-    mut transport: Option<&mut EspNowTransport>,
 ) -> NodeResult<()> {
     let paired_on_entry = storage.read_key().is_some();
 
@@ -282,6 +274,7 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
 
         if let Some(data) = write_data {
             info!("BLE: GATT write received ({} bytes)", data.len());
+            let mut disconnect_after_ack = false;
 
             // Parse BLE envelope. Silently discard malformed/unknown
             // messages -- the phone will time out waiting for NODE_ACK.
@@ -305,70 +298,27 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
                         }
                     }
                 }
-                Some((msg_type, body)) if msg_type == BLE_DIAG_RELAY_REQUEST => {
-                    match (handle_diag_relay_request(body), transport.as_deref_mut()) {
-                        (Ok(params), Some(t)) => {
-                            info!(
-                                "BLE: DIAG_RELAY_REQUEST rf_channel={} (ND-1100)",
-                                params.rf_channel
-                            );
-                            // Save current channel, switch, relay, restore (ND-1101, ND-1106).
-                            let mut orig_primary: u8 = 0;
-                            let mut orig_secondary: esp_idf_sys::wifi_second_chan_t = 0;
-                            let got_channel = unsafe {
-                                esp_idf_sys::esp_wifi_get_channel(
-                                    &mut orig_primary,
-                                    &mut orig_secondary,
-                                ) == esp_idf_sys::ESP_OK
-                            };
-                            if !got_channel {
-                                // Fall back to stored channel so we can still restore (ND-1106).
-                                orig_primary = storage.read_channel().unwrap_or(1);
-                                orig_secondary =
-                                    esp_idf_sys::wifi_second_chan_t_WIFI_SECOND_CHAN_NONE;
-                                warn!(
-                                    "BLE: esp_wifi_get_channel failed, will restore to channel {}",
-                                    orig_primary
-                                );
-                            }
-                            let set_ok = unsafe {
-                                let rc = esp_idf_sys::esp_wifi_set_channel(
-                                    params.rf_channel,
-                                    esp_idf_sys::wifi_second_chan_t_WIFI_SECOND_CHAN_NONE,
-                                );
-                                if rc != esp_idf_sys::ESP_OK {
-                                    warn!("BLE: failed to set Wi-Fi channel {} for DIAG relay: err={}", params.rf_channel, rc);
-                                }
-                                rc == esp_idf_sys::ESP_OK
-                            };
-                            if !set_ok {
-                                Some(encode_diag_relay_response(
-                                    sonde_protocol::DIAG_RELAY_STATUS_CHANNEL_ERROR,
-                                    &[],
-                                ))
-                            } else {
-                                let response = do_diag_relay(t, &params);
-                                // Always restore channel (ND-1106).
-                                unsafe {
-                                    let rc = esp_idf_sys::esp_wifi_set_channel(
-                                        orig_primary,
-                                        orig_secondary,
-                                    );
-                                    if rc != esp_idf_sys::ESP_OK {
-                                        warn!("BLE: failed to restore Wi-Fi channel after DIAG relay: err={}", rc);
-                                    }
-                                }
-                                Some(response)
-                            }
+                Some((msg_type, body)) if msg_type == sonde_protocol::BLE_RUN_TEST_COMMAND => {
+                    if storage.read_key().is_some() {
+                        Some(encode_run_test_ack(sonde_protocol::RUN_TEST_ACK_INVALID))
+                    } else {
+                        let (status, staged) = handle_run_test_command(body, storage);
+                        if staged.is_some() && status == sonde_protocol::RUN_TEST_ACK_OK {
+                            disconnect_after_ack = true;
+                            info!("BLE: RUN_TEST_COMMAND accepted and staged");
+                        } else {
+                            info!("BLE: RUN_TEST_COMMAND rejected status=0x{:02x}", status);
                         }
-                        (Ok(_), None) => {
-                            warn!("BLE: DIAG_RELAY_REQUEST but no transport available");
-                            Some(encode_diag_relay_response(
-                                sonde_protocol::DIAG_RELAY_STATUS_CHANNEL_ERROR,
-                                &[],
-                            ))
+                        Some(encode_run_test_ack(status))
+                    }
+                }
+                Some((msg_type, body)) if msg_type == sonde_protocol::BLE_READ_TEST_RESULT => {
+                    match handle_read_test_result(body, storage) {
+                        Ok(result) => Some(encode_test_result_response(&result)),
+                        Err(err) => {
+                            warn!("BLE: READ_TEST_RESULT parse error: {}", err);
+                            None
                         }
-                        (Err(error_response), _) => Some(error_response),
                     }
                 }
                 Some((msg_type, _)) => {
@@ -384,16 +334,19 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
                 }
             };
 
-            // Send NODE_ACK indication if we have a valid response.
+            // Send indication if we have a valid response.
             if let Some(ack) = ack_data {
                 let current_handle = conn_handle.lock().ok().and_then(|h| *h);
                 if let Some(handle) = current_handle {
                     let chr = node_cmd_char.lock();
                     if let Err(e) = chr.notify_with(&ack, handle) {
-                        warn!("BLE: NODE_ACK indication failed: {:?}", e);
+                        warn!("BLE: indication failed: {:?}", e);
+                    } else if disconnect_after_ack {
+                        let server = BLEDevice::take().get_server();
+                        let _ = server.disconnect(handle);
                     }
                 } else {
-                    warn!("BLE: no active connection for NODE_ACK indication");
+                    warn!("BLE: no active connection for indication");
                 }
             }
         }

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -97,7 +97,7 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         .set_auth(AuthReq::all())
         .set_io_cap(SecurityIOCap::NoInputNoOutput);
 
-    let ble_server = ble_device.get_server();
+    let mut ble_server = ble_device.get_server();
 
     // --- Connection event ---
     let disc_connect = Arc::clone(&disconnected);
@@ -376,7 +376,7 @@ mod tests {}
 fn check_encryption_fallback(
     conn_handle: &Arc<Mutex<Option<u16>>>,
     authenticated: &Arc<Mutex<bool>>,
-    ble_server: &esp32_nimble::BLEServer,
+    ble_server: &mut esp32_nimble::BLEServer,
 ) -> bool {
     let handle = match conn_handle.lock().ok().and_then(|h| *h) {
         Some(h) => h,

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -262,7 +262,7 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
         // build), check the connection's encryption status directly.
         let is_auth = authenticated.lock().map(|a| *a).unwrap_or(false);
         let is_auth =
-            is_auth || check_encryption_fallback(&conn_handle, &authenticated, &ble_server);
+            is_auth || check_encryption_fallback(&conn_handle, &authenticated, ble_server);
         let write_data = if is_auth {
             if let Ok(mut p) = pending_write.lock() {
                 p.take()

--- a/crates/sonde-node/src/esp_storage.rs
+++ b/crates/sonde-node/src/esp_storage.rs
@@ -619,17 +619,21 @@ impl crate::traits::PlatformStorage for NvsStorage {
             }
             Some(result.reply_frame[..len].to_vec())
         };
-        Some(TestResult {
+        let decoded = TestResult {
             status: result.status,
             test_type: (result.test_type_present != 0).then_some(result.test_type),
             reply_frame,
             reply_rssi_dbm: (result.reply_rssi_present != 0).then_some(result.reply_rssi_dbm),
             attempt_count: result.attempt_count,
             elapsed_ms: result.elapsed_ms,
-        })
+        };
+        sonde_protocol::validate_test_result(&decoded).ok()?;
+        Some(decoded)
     }
 
     fn write_test_result(&mut self, result: &TestResult) -> NodeResult<()> {
+        sonde_protocol::validate_test_result(result)
+            .map_err(|_| NodeError::StorageError("invalid retained test result"))?;
         let reply_len = result
             .reply_frame
             .as_ref()

--- a/crates/sonde-node/src/esp_storage.rs
+++ b/crates/sonde-node/src/esp_storage.rs
@@ -20,13 +20,19 @@
 //! It is reset on power loss or hardware reset, which is acceptable — a
 //! missed early wake is harmless. The retained battery value used for the
 //! next `WAKE.battery_mv` is also stored in RTC slow SRAM via `LAST_BATTERY_*`.
+//! Pre-provisioning test staging and latest-result retention use the same
+//! RTC-backed approach so one rebooted test run can hand off state without
+//! a flash write.
 
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use esp_idf_svc::nvs::{EspNvs, EspNvsPartition, NvsDefault};
-use sonde_protocol::{decode_board_layout_cbor, encode_board_layout_cbor, BoardLayout};
+use sonde_protocol::{
+    decode_board_layout_cbor, encode_board_layout_cbor, BoardLayout, TestResult, MAX_FRAME_SIZE,
+};
 
 use crate::error::{NodeError, NodeResult};
+use crate::traits::StagedTestCommand;
 
 const NVS_NAMESPACE: &str = "sonde";
 const MAGIC_VALUE: u32 = 0xDEAD_BEEF;
@@ -48,6 +54,66 @@ static LAST_BATTERY_MV: AtomicU32 = AtomicU32::new(0);
 
 #[link_section = ".rtc.data"]
 static LAST_BATTERY_VALID: AtomicU32 = AtomicU32::new(0);
+
+#[repr(C)]
+struct RtcStagedTestCommand {
+    valid: u32,
+    test_type: u64,
+    rf_channel_present: u32,
+    rf_channel: u8,
+    payload_len: u16,
+    payload: [u8; MAX_FRAME_SIZE],
+}
+
+impl RtcStagedTestCommand {
+    const fn zero() -> Self {
+        Self {
+            valid: 0,
+            test_type: 0,
+            rf_channel_present: 0,
+            rf_channel: 0,
+            payload_len: 0,
+            payload: [0u8; MAX_FRAME_SIZE],
+        }
+    }
+}
+
+#[repr(C)]
+struct RtcTestResult {
+    valid: u32,
+    status: u8,
+    test_type_present: u32,
+    test_type: u64,
+    reply_frame_len: u16,
+    reply_frame: [u8; MAX_FRAME_SIZE],
+    reply_rssi_present: u32,
+    reply_rssi_dbm: i8,
+    attempt_count: u64,
+    elapsed_ms: u64,
+}
+
+impl RtcTestResult {
+    const fn zero() -> Self {
+        Self {
+            valid: 0,
+            status: 0,
+            test_type_present: 0,
+            test_type: 0,
+            reply_frame_len: 0,
+            reply_frame: [0u8; MAX_FRAME_SIZE],
+            reply_rssi_present: 0,
+            reply_rssi_dbm: 0,
+            attempt_count: 0,
+            elapsed_ms: 0,
+        }
+    }
+}
+
+#[link_section = ".rtc.data"]
+static mut STAGED_TEST_COMMAND: RtcStagedTestCommand = RtcStagedTestCommand::zero();
+
+#[link_section = ".rtc.data"]
+static mut LATEST_TEST_RESULT: RtcTestResult = RtcTestResult::zero();
 
 /// NVS-backed implementation of [`crate::traits::PlatformStorage`].
 pub struct NvsStorage {
@@ -489,6 +555,111 @@ impl crate::traits::PlatformStorage for NvsStorage {
     fn write_last_battery_mv(&mut self, battery_mv: u32) -> NodeResult<()> {
         LAST_BATTERY_MV.store(battery_mv, Ordering::Relaxed);
         LAST_BATTERY_VALID.store(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn read_staged_test_command(&self) -> Option<StagedTestCommand> {
+        let command = unsafe { &STAGED_TEST_COMMAND };
+        if command.valid == 0 {
+            return None;
+        }
+        let payload_len = usize::from(command.payload_len);
+        if payload_len == 0 || payload_len > MAX_FRAME_SIZE {
+            return None;
+        }
+        Some(StagedTestCommand {
+            test_type: command.test_type,
+            rf_channel: (command.rf_channel_present != 0).then_some(command.rf_channel),
+            payload: command.payload[..payload_len].to_vec(),
+        })
+    }
+
+    fn write_staged_test_command(&mut self, command: &StagedTestCommand) -> NodeResult<()> {
+        if command.payload.is_empty() || command.payload.len() > MAX_FRAME_SIZE {
+            return Err(NodeError::StorageError(
+                "staged test payload must be 1..=250 bytes",
+            ));
+        }
+        let payload_len = u16::try_from(command.payload.len())
+            .map_err(|_| NodeError::StorageError("staged test payload too large"))?;
+        let rtc = unsafe { &mut STAGED_TEST_COMMAND };
+        rtc.valid = 0;
+        rtc.test_type = command.test_type;
+        rtc.rf_channel_present = u32::from(command.rf_channel.is_some());
+        rtc.rf_channel = command.rf_channel.unwrap_or(0);
+        rtc.payload_len = payload_len;
+        rtc.payload[..command.payload.len()].copy_from_slice(&command.payload);
+        rtc.payload[command.payload.len()..].fill(0);
+        rtc.valid = 1;
+        Ok(())
+    }
+
+    fn clear_staged_test_command(&mut self) -> NodeResult<()> {
+        let rtc = unsafe { &mut STAGED_TEST_COMMAND };
+        rtc.valid = 0;
+        rtc.test_type = 0;
+        rtc.rf_channel_present = 0;
+        rtc.rf_channel = 0;
+        rtc.payload_len = 0;
+        rtc.payload.fill(0);
+        Ok(())
+    }
+
+    fn read_test_result(&self) -> Option<TestResult> {
+        let result = unsafe { &LATEST_TEST_RESULT };
+        if result.valid == 0 {
+            return None;
+        }
+        let reply_frame = if result.reply_frame_len == 0 {
+            None
+        } else {
+            let len = usize::from(result.reply_frame_len);
+            if len > MAX_FRAME_SIZE {
+                return None;
+            }
+            Some(result.reply_frame[..len].to_vec())
+        };
+        Some(TestResult {
+            status: result.status,
+            test_type: (result.test_type_present != 0).then_some(result.test_type),
+            reply_frame,
+            reply_rssi_dbm: (result.reply_rssi_present != 0).then_some(result.reply_rssi_dbm),
+            attempt_count: result.attempt_count,
+            elapsed_ms: result.elapsed_ms,
+        })
+    }
+
+    fn write_test_result(&mut self, result: &TestResult) -> NodeResult<()> {
+        let reply_len = result
+            .reply_frame
+            .as_ref()
+            .map(|frame| frame.len())
+            .unwrap_or(0);
+        if reply_len > MAX_FRAME_SIZE {
+            return Err(NodeError::StorageError(
+                "retained test reply frame too large",
+            ));
+        }
+        let reply_len = u16::try_from(reply_len)
+            .map_err(|_| NodeError::StorageError("retained test reply frame too large"))?;
+
+        let rtc = unsafe { &mut LATEST_TEST_RESULT };
+        rtc.valid = 0;
+        rtc.status = result.status;
+        rtc.test_type_present = u32::from(result.test_type.is_some());
+        rtc.test_type = result.test_type.unwrap_or(0);
+        rtc.reply_frame_len = reply_len;
+        rtc.reply_rssi_present = u32::from(result.reply_rssi_dbm.is_some());
+        rtc.reply_rssi_dbm = result.reply_rssi_dbm.unwrap_or(0);
+        rtc.attempt_count = result.attempt_count;
+        rtc.elapsed_ms = result.elapsed_ms;
+        if let Some(frame) = &result.reply_frame {
+            rtc.reply_frame[..frame.len()].copy_from_slice(frame);
+            rtc.reply_frame[frame.len()..].fill(0);
+        } else {
+            rtc.reply_frame.fill(0);
+        }
+        rtc.valid = 1;
         Ok(())
     }
 }

--- a/crates/sonde-node/src/esp_storage.rs
+++ b/crates/sonde-node/src/esp_storage.rs
@@ -20,9 +20,9 @@
 //! It is reset on power loss or hardware reset, which is acceptable — a
 //! missed early wake is harmless. The retained battery value used for the
 //! next `WAKE.battery_mv` is also stored in RTC slow SRAM via `LAST_BATTERY_*`.
-//! Pre-provisioning test staging and latest-result retention use the same
-//! RTC-backed approach so one rebooted test run can hand off state without
-//! a flash write.
+//! Pre-provisioning test staging and latest-result retention use RTC no-init
+//! storage so one software-rebooted test run can hand off state without a
+//! flash write.
 
 use core::sync::atomic::{AtomicU32, Ordering};
 
@@ -36,6 +36,8 @@ use crate::traits::StagedTestCommand;
 
 const NVS_NAMESPACE: &str = "sonde";
 const MAGIC_VALUE: u32 = 0xDEAD_BEEF;
+const RTC_STAGED_TEST_MAGIC: u32 = 0x5354_434D;
+const RTC_TEST_RESULT_MAGIC: u32 = 0x5452_4553;
 
 /// Default wake interval in seconds (5 minutes).
 const DEFAULT_INTERVAL_S: u32 = 300;
@@ -57,6 +59,7 @@ static LAST_BATTERY_VALID: AtomicU32 = AtomicU32::new(0);
 
 #[repr(C)]
 struct RtcStagedTestCommand {
+    magic: u32,
     valid: u32,
     test_type: u64,
     rf_channel_present: u32,
@@ -68,6 +71,7 @@ struct RtcStagedTestCommand {
 impl RtcStagedTestCommand {
     const fn zero() -> Self {
         Self {
+            magic: 0,
             valid: 0,
             test_type: 0,
             rf_channel_present: 0,
@@ -80,6 +84,7 @@ impl RtcStagedTestCommand {
 
 #[repr(C)]
 struct RtcTestResult {
+    magic: u32,
     valid: u32,
     status: u8,
     test_type_present: u32,
@@ -95,6 +100,7 @@ struct RtcTestResult {
 impl RtcTestResult {
     const fn zero() -> Self {
         Self {
+            magic: 0,
             valid: 0,
             status: 0,
             test_type_present: 0,
@@ -109,11 +115,19 @@ impl RtcTestResult {
     }
 }
 
-#[link_section = ".rtc.data"]
+#[link_section = ".rtc_noinit"]
 static mut STAGED_TEST_COMMAND: RtcStagedTestCommand = RtcStagedTestCommand::zero();
 
-#[link_section = ".rtc.data"]
+#[link_section = ".rtc_noinit"]
 static mut LATEST_TEST_RESULT: RtcTestResult = RtcTestResult::zero();
+
+fn staged_test_command_is_valid(command: &RtcStagedTestCommand) -> bool {
+    command.magic == RTC_STAGED_TEST_MAGIC && command.valid == 1
+}
+
+fn retained_test_result_is_valid(result: &RtcTestResult) -> bool {
+    result.magic == RTC_TEST_RESULT_MAGIC && result.valid == 1
+}
 
 /// NVS-backed implementation of [`crate::traits::PlatformStorage`].
 pub struct NvsStorage {
@@ -560,7 +574,7 @@ impl crate::traits::PlatformStorage for NvsStorage {
 
     fn read_staged_test_command(&self) -> Option<StagedTestCommand> {
         let command = unsafe { &STAGED_TEST_COMMAND };
-        if command.valid == 0 {
+        if !staged_test_command_is_valid(command) {
             return None;
         }
         let payload_len = usize::from(command.payload_len);
@@ -583,6 +597,7 @@ impl crate::traits::PlatformStorage for NvsStorage {
         let payload_len = u16::try_from(command.payload.len())
             .map_err(|_| NodeError::StorageError("staged test payload too large"))?;
         let rtc = unsafe { &mut STAGED_TEST_COMMAND };
+        rtc.magic = 0;
         rtc.valid = 0;
         rtc.test_type = command.test_type;
         rtc.rf_channel_present = u32::from(command.rf_channel.is_some());
@@ -590,12 +605,14 @@ impl crate::traits::PlatformStorage for NvsStorage {
         rtc.payload_len = payload_len;
         rtc.payload[..command.payload.len()].copy_from_slice(&command.payload);
         rtc.payload[command.payload.len()..].fill(0);
+        rtc.magic = RTC_STAGED_TEST_MAGIC;
         rtc.valid = 1;
         Ok(())
     }
 
     fn clear_staged_test_command(&mut self) -> NodeResult<()> {
         let rtc = unsafe { &mut STAGED_TEST_COMMAND };
+        rtc.magic = 0;
         rtc.valid = 0;
         rtc.test_type = 0;
         rtc.rf_channel_present = 0;
@@ -607,7 +624,7 @@ impl crate::traits::PlatformStorage for NvsStorage {
 
     fn read_test_result(&self) -> Option<TestResult> {
         let result = unsafe { &LATEST_TEST_RESULT };
-        if result.valid == 0 {
+        if !retained_test_result_is_valid(result) {
             return None;
         }
         let reply_frame = if result.reply_frame_len == 0 {
@@ -648,6 +665,7 @@ impl crate::traits::PlatformStorage for NvsStorage {
             .map_err(|_| NodeError::StorageError("retained test reply frame too large"))?;
 
         let rtc = unsafe { &mut LATEST_TEST_RESULT };
+        rtc.magic = 0;
         rtc.valid = 0;
         rtc.status = result.status;
         rtc.test_type_present = u32::from(result.test_type.is_some());
@@ -663,7 +681,40 @@ impl crate::traits::PlatformStorage for NvsStorage {
         } else {
             rtc.reply_frame.fill(0);
         }
+        rtc.magic = RTC_TEST_RESULT_MAGIC;
         rtc.valid = 1;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        retained_test_result_is_valid, staged_test_command_is_valid, RtcStagedTestCommand,
+        RtcTestResult, RTC_STAGED_TEST_MAGIC, RTC_TEST_RESULT_MAGIC,
+    };
+
+    #[test]
+    fn staged_test_command_requires_magic_and_valid_flag() {
+        let mut command = RtcStagedTestCommand::zero();
+        assert!(!staged_test_command_is_valid(&command));
+
+        command.magic = RTC_STAGED_TEST_MAGIC;
+        assert!(!staged_test_command_is_valid(&command));
+
+        command.valid = 1;
+        assert!(staged_test_command_is_valid(&command));
+    }
+
+    #[test]
+    fn retained_test_result_requires_magic_and_valid_flag() {
+        let mut result = RtcTestResult::zero();
+        assert!(!retained_test_result_is_valid(&result));
+
+        result.magic = RTC_TEST_RESULT_MAGIC;
+        assert!(!retained_test_result_is_valid(&result));
+
+        result.valid = 1;
+        assert!(retained_test_result_is_valid(&result));
     }
 }

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -175,7 +175,7 @@ unsafe extern "C" fn raw_recv_cb(
     let payload = unsafe { core::slice::from_raw_parts(data, len) };
     let rssi_dbm = recv_rssi_dbm(recv_info);
     if rssi_dbm.is_none() {
-        log::warn!(
+        log::debug!(
             "ESP-NOW RX missing metadata: msg_type={} len={}",
             espnow_msg_type_label(payload),
             len

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -22,6 +22,7 @@ use esp_idf_svc::wifi::{BlockingWifi, ClientConfiguration, Configuration, EspWif
 use sonde_protocol::modem::ESPNOW_MAX_DATA_SIZE;
 
 use crate::error::{NodeError, NodeResult};
+use crate::traits::ReceivedFrame;
 
 /// Broadcast MAC used for all node → gateway transmissions.
 const BROADCAST_MAC: [u8; 6] = [0xFF; 6];
@@ -34,6 +35,7 @@ const RX_RING_CAP: usize = 16;
 struct FrameSlot {
     data: [u8; ESPNOW_MAX_DATA_SIZE],
     len: usize,
+    rssi_dbm: i8,
 }
 
 impl Default for FrameSlot {
@@ -41,6 +43,7 @@ impl Default for FrameSlot {
         Self {
             data: [0u8; ESPNOW_MAX_DATA_SIZE],
             len: 0,
+            rssi_dbm: 0,
         }
     }
 }
@@ -74,13 +77,14 @@ impl RxRing {
     /// is full or the payload exceeds `ESPNOW_MAX_DATA_SIZE`.
     ///
     /// No heap allocation; safe to call from the WiFi task context.
-    fn push(&mut self, payload: &[u8]) -> bool {
+    fn push(&mut self, payload: &[u8], rssi_dbm: i8) -> bool {
         if self.count >= RX_RING_CAP || payload.len() > ESPNOW_MAX_DATA_SIZE {
             return false;
         }
         let slot = &mut self.slots[self.head];
         slot.len = payload.len();
         slot.data[..payload.len()].copy_from_slice(payload);
+        slot.rssi_dbm = rssi_dbm;
         self.head = (self.head + 1) % RX_RING_CAP;
         self.count += 1;
         true
@@ -89,7 +93,7 @@ impl RxRing {
     /// Copy the oldest frame's payload into `buf`, returning the number of
     /// bytes copied. Only `data[..len]` bytes are copied under the lock,
     /// avoiding a full 250-byte memcpy. Returns `None` if the ring is empty.
-    fn pop_into(&mut self, buf: &mut [u8; ESPNOW_MAX_DATA_SIZE]) -> Option<usize> {
+    fn pop_into(&mut self, buf: &mut [u8; ESPNOW_MAX_DATA_SIZE]) -> Option<(usize, i8)> {
         if self.count == 0 {
             return None;
         }
@@ -98,7 +102,7 @@ impl RxRing {
         buf[..len].copy_from_slice(&slot.data[..len]);
         self.tail = (self.tail + 1) % RX_RING_CAP;
         self.count -= 1;
-        Some(len)
+        Some((len, slot.rssi_dbm))
     }
 }
 
@@ -129,6 +133,7 @@ unsafe extern "C" fn raw_recv_cb(
         return;
     }
     let payload = unsafe { core::slice::from_raw_parts(data, len) };
+    let rssi_dbm = unsafe { (*recv_info).rx_ctrl.rssi };
     if let Some(state) = RECV_STATE.get() {
         let enqueued = {
             // Match try_lock errors explicitly: recover on Poisoned so
@@ -142,7 +147,7 @@ unsafe extern "C" fn raw_recv_cb(
                 }
                 Err(std::sync::TryLockError::Poisoned(p)) => p.into_inner(),
             };
-            if guard.push(payload) {
+            if guard.push(payload, rssi_dbm) {
                 true
             } else {
                 guard.drop_count = guard.drop_count.saturating_add(1);
@@ -256,6 +261,11 @@ impl crate::traits::Transport for EspNowTransport {
     }
 
     fn recv(&mut self, timeout_ms: u32) -> NodeResult<Option<Vec<u8>>> {
+        self.recv_with_metadata(timeout_ms)
+            .map(|frame| frame.map(|frame| frame.data))
+    }
+
+    fn recv_with_metadata(&mut self, timeout_ms: u32) -> NodeResult<Option<ReceivedFrame>> {
         let deadline = Instant::now() + std::time::Duration::from_millis(timeout_ms as u64);
         // Pre-allocate buffer outside the lock for pop_into to copy into.
         let mut buf = [0u8; ESPNOW_MAX_DATA_SIZE];
@@ -278,7 +288,7 @@ impl crate::traits::Transport for EspNowTransport {
             }
         };
         loop {
-            if let Some(len) = ring.pop_into(&mut buf) {
+            if let Some((len, rssi_dbm)) = ring.pop_into(&mut buf) {
                 // Re-read drop_count right before returning so drops
                 // that occurred during wait_timeout are captured.
                 let full_drops = ring.drop_count;
@@ -287,7 +297,10 @@ impl crate::traits::Transport for EspNowTransport {
                 if full_drops > 0 {
                     log::warn!("ESP-NOW recv ring: {} full drop(s)", full_drops);
                 }
-                return Ok(Some(buf[..len].to_vec()));
+                return Ok(Some(ReceivedFrame {
+                    data: buf[..len].to_vec(),
+                    rssi_dbm: Some(rssi_dbm),
+                }));
             }
             let now = Instant::now();
             if now >= deadline {

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -116,6 +116,19 @@ struct RecvState {
 /// Global callback state — set once during [`EspNowTransport::new`].
 static RECV_STATE: std::sync::OnceLock<RecvState> = std::sync::OnceLock::new();
 
+fn recv_rssi_dbm(recv_info: *const esp_idf_sys::esp_now_recv_info_t) -> Option<i8> {
+    if recv_info.is_null() {
+        return None;
+    }
+    // SAFETY: The caller supplies a valid `recv_info` pointer from ESP-IDF.
+    let rx_ctrl = unsafe { (*recv_info).rx_ctrl };
+    if rx_ctrl.is_null() {
+        return None;
+    }
+    // SAFETY: `rx_ctrl` was checked for null above and comes from ESP-IDF.
+    i8::try_from(unsafe { (*rx_ctrl).rssi() }).ok()
+}
+
 /// Raw ESP-NOW receive callback — copies frame data into the ring buffer.
 ///
 /// Uses `try_lock` to avoid blocking the ESP-NOW/WiFi task and drops
@@ -133,9 +146,8 @@ unsafe extern "C" fn raw_recv_cb(
         return;
     }
     let payload = unsafe { core::slice::from_raw_parts(data, len) };
-    let rssi_dbm = match i8::try_from(unsafe { (*(*recv_info).rx_ctrl).rssi() }) {
-        Ok(rssi_dbm) => rssi_dbm,
-        Err(_) => return,
+    let Some(rssi_dbm) = recv_rssi_dbm(recv_info) else {
+        return;
     };
     if let Some(state) = RECV_STATE.get() {
         let enqueued = {
@@ -162,6 +174,27 @@ unsafe extern "C" fn raw_recv_cb(
         if enqueued {
             state.condvar.notify_one();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::recv_rssi_dbm;
+
+    #[test]
+    fn recv_rssi_dbm_rejects_null_recv_info() {
+        assert_eq!(recv_rssi_dbm(core::ptr::null()), None);
+    }
+
+    #[test]
+    fn recv_rssi_dbm_rejects_null_rx_ctrl() {
+        let recv_info = esp_idf_sys::esp_now_recv_info_t {
+            src_addr: core::ptr::null(),
+            des_addr: core::ptr::null(),
+            rx_ctrl: core::ptr::null_mut(),
+        };
+
+        assert_eq!(recv_rssi_dbm(&recv_info), None);
     }
 }
 

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -35,7 +35,7 @@ const RX_RING_CAP: usize = 16;
 struct FrameSlot {
     data: [u8; ESPNOW_MAX_DATA_SIZE],
     len: usize,
-    rssi_dbm: i8,
+    rssi_dbm: Option<i8>,
 }
 
 impl Default for FrameSlot {
@@ -43,7 +43,7 @@ impl Default for FrameSlot {
         Self {
             data: [0u8; ESPNOW_MAX_DATA_SIZE],
             len: 0,
-            rssi_dbm: 0,
+            rssi_dbm: None,
         }
     }
 }
@@ -77,7 +77,7 @@ impl RxRing {
     /// is full or the payload exceeds `ESPNOW_MAX_DATA_SIZE`.
     ///
     /// No heap allocation; safe to call from the WiFi task context.
-    fn push(&mut self, payload: &[u8], rssi_dbm: i8) -> bool {
+    fn push(&mut self, payload: &[u8], rssi_dbm: Option<i8>) -> bool {
         if self.count >= RX_RING_CAP || payload.len() > ESPNOW_MAX_DATA_SIZE {
             return false;
         }
@@ -93,7 +93,7 @@ impl RxRing {
     /// Copy the oldest frame's payload into `buf`, returning the number of
     /// bytes copied. Only `data[..len]` bytes are copied under the lock,
     /// avoiding a full 250-byte memcpy. Returns `None` if the ring is empty.
-    fn pop_into(&mut self, buf: &mut [u8; ESPNOW_MAX_DATA_SIZE]) -> Option<(usize, i8)> {
+    fn pop_into(&mut self, buf: &mut [u8; ESPNOW_MAX_DATA_SIZE]) -> Option<(usize, Option<i8>)> {
         if self.count == 0 {
             return None;
         }
@@ -173,14 +173,14 @@ unsafe extern "C" fn raw_recv_cb(
         return;
     }
     let payload = unsafe { core::slice::from_raw_parts(data, len) };
-    let Some(rssi_dbm) = recv_rssi_dbm(recv_info) else {
+    let rssi_dbm = recv_rssi_dbm(recv_info);
+    if rssi_dbm.is_none() {
         log::warn!(
-            "ESP-NOW RX drop: missing rx metadata msg_type={} len={}",
+            "ESP-NOW RX missing metadata: msg_type={} len={}",
             espnow_msg_type_label(payload),
             len
         );
-        return;
-    };
+    }
     if let Some(state) = RECV_STATE.get() {
         let enqueued = {
             // Match try_lock errors explicitly: recover on Poisoned so
@@ -199,7 +199,7 @@ unsafe extern "C" fn raw_recv_cb(
             } else {
                 guard.drop_count = guard.drop_count.saturating_add(1);
                 log::warn!(
-                    "ESP-NOW RX drop: ring full msg_type={} len={} rssi={}",
+                    "ESP-NOW RX drop: ring full msg_type={} len={} rssi={:?}",
                     espnow_msg_type_label(payload),
                     len,
                     rssi_dbm
@@ -211,7 +211,7 @@ unsafe extern "C" fn raw_recv_cb(
         // into immediate contention on the same mutex.
         if enqueued {
             log::info!(
-                "ESP-NOW RX enqueue: msg_type={} len={} rssi={}",
+                "ESP-NOW RX enqueue: msg_type={} len={} rssi={:?}",
                 espnow_msg_type_label(payload),
                 len,
                 rssi_dbm
@@ -378,14 +378,14 @@ impl crate::traits::Transport for EspNowTransport {
                     log::warn!("ESP-NOW recv ring: {} full drop(s)", full_drops);
                 }
                 log::info!(
-                    "ESP-NOW RX dequeue: msg_type={} len={} rssi={}",
+                    "ESP-NOW RX dequeue: msg_type={} len={} rssi={:?}",
                     espnow_msg_type_label(&buf[..len]),
                     len,
                     rssi_dbm
                 );
                 return Ok(Some(ReceivedFrame {
                     data: buf[..len].to_vec(),
-                    rssi_dbm: Some(rssi_dbm),
+                    rssi_dbm,
                 }));
             }
             let now = Instant::now();

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -133,7 +133,7 @@ unsafe extern "C" fn raw_recv_cb(
         return;
     }
     let payload = unsafe { core::slice::from_raw_parts(data, len) };
-    let rssi_dbm = unsafe { (*(*recv_info).rx_ctrl).rssi };
+    let rssi_dbm = unsafe { (*(*recv_info).rx_ctrl).rssi() };
     if let Some(state) = RECV_STATE.get() {
         let enqueued = {
             // Match try_lock errors explicitly: recover on Poisoned so

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -133,7 +133,7 @@ unsafe extern "C" fn raw_recv_cb(
         return;
     }
     let payload = unsafe { core::slice::from_raw_parts(data, len) };
-    let rssi_dbm = unsafe { (*recv_info).rx_ctrl.rssi };
+    let rssi_dbm = unsafe { (*(*recv_info).rx_ctrl).rssi };
     if let Some(state) = RECV_STATE.get() {
         let enqueued = {
             // Match try_lock errors explicitly: recover on Poisoned so

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -116,6 +116,26 @@ struct RecvState {
 /// Global callback state — set once during [`EspNowTransport::new`].
 static RECV_STATE: std::sync::OnceLock<RecvState> = std::sync::OnceLock::new();
 
+fn espnow_msg_type_label(frame: &[u8]) -> &'static str {
+    if frame.len() <= sonde_protocol::OFFSET_MSG_TYPE {
+        return "short";
+    }
+    match frame[sonde_protocol::OFFSET_MSG_TYPE] {
+        sonde_protocol::MSG_WAKE => "WAKE",
+        sonde_protocol::MSG_GET_CHUNK => "GET_CHUNK",
+        sonde_protocol::MSG_PROGRAM_ACK => "PROGRAM_ACK",
+        sonde_protocol::MSG_APP_DATA => "APP_DATA",
+        sonde_protocol::MSG_PEER_REQUEST => "PEER_REQUEST",
+        sonde_protocol::MSG_DIAG_REQUEST => "DIAG_REQUEST",
+        sonde_protocol::MSG_COMMAND => "COMMAND",
+        sonde_protocol::MSG_CHUNK => "CHUNK",
+        sonde_protocol::MSG_APP_DATA_REPLY => "APP_DATA_REPLY",
+        sonde_protocol::MSG_PEER_ACK => "PEER_ACK",
+        sonde_protocol::MSG_DIAG_REPLY => "DIAG_REPLY",
+        _ => "unknown",
+    }
+}
+
 fn recv_rssi_dbm(recv_info: *const esp_idf_sys::esp_now_recv_info_t) -> Option<i8> {
     if recv_info.is_null() {
         return None;
@@ -139,14 +159,26 @@ unsafe extern "C" fn raw_recv_cb(
     data_len: core::ffi::c_int,
 ) {
     if recv_info.is_null() || data.is_null() || data_len <= 0 {
+        log::warn!(
+            "ESP-NOW RX drop: invalid callback args recv_info_null={} data_null={} data_len={}",
+            recv_info.is_null(),
+            data.is_null(),
+            data_len
+        );
         return;
     }
     let len = data_len as usize;
     if len > ESPNOW_MAX_DATA_SIZE {
+        log::warn!("ESP-NOW RX drop: frame too large len={}", len);
         return;
     }
     let payload = unsafe { core::slice::from_raw_parts(data, len) };
     let Some(rssi_dbm) = recv_rssi_dbm(recv_info) else {
+        log::warn!(
+            "ESP-NOW RX drop: missing rx metadata msg_type={} len={}",
+            espnow_msg_type_label(payload),
+            len
+        );
         return;
     };
     if let Some(state) = RECV_STATE.get() {
@@ -166,12 +198,24 @@ unsafe extern "C" fn raw_recv_cb(
                 true
             } else {
                 guard.drop_count = guard.drop_count.saturating_add(1);
+                log::warn!(
+                    "ESP-NOW RX drop: ring full msg_type={} len={} rssi={}",
+                    espnow_msg_type_label(payload),
+                    len,
+                    rssi_dbm
+                );
                 false
             }
         };
         // Notify after releasing the lock to avoid waking the consumer
         // into immediate contention on the same mutex.
         if enqueued {
+            log::info!(
+                "ESP-NOW RX enqueue: msg_type={} len={} rssi={}",
+                espnow_msg_type_label(payload),
+                len,
+                rssi_dbm
+            );
             state.condvar.notify_one();
         }
     }
@@ -333,6 +377,12 @@ impl crate::traits::Transport for EspNowTransport {
                 if full_drops > 0 {
                     log::warn!("ESP-NOW recv ring: {} full drop(s)", full_drops);
                 }
+                log::info!(
+                    "ESP-NOW RX dequeue: msg_type={} len={} rssi={}",
+                    espnow_msg_type_label(&buf[..len]),
+                    len,
+                    rssi_dbm
+                );
                 return Ok(Some(ReceivedFrame {
                     data: buf[..len].to_vec(),
                     rssi_dbm: Some(rssi_dbm),
@@ -346,6 +396,7 @@ impl crate::traits::Transport for EspNowTransport {
                 if full_drops > 0 {
                     log::warn!("ESP-NOW recv ring: {} full drop(s)", full_drops);
                 }
+                log::info!("ESP-NOW RX wait timed out after {} ms", timeout_ms);
                 return Ok(None);
             }
             let remaining = deadline - now;

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -133,7 +133,10 @@ unsafe extern "C" fn raw_recv_cb(
         return;
     }
     let payload = unsafe { core::slice::from_raw_parts(data, len) };
-    let rssi_dbm = unsafe { (*(*recv_info).rx_ctrl).rssi() };
+    let rssi_dbm = match i8::try_from(unsafe { (*(*recv_info).rx_ctrl).rssi() }) {
+        Ok(rssi_dbm) => rssi_dbm,
+        Err(_) => return,
+    };
     if let Some(state) = RECV_STATE.get() {
         let enqueued = {
             // Match try_lock errors explicitly: recover on Poisoned so

--- a/crates/sonde-node/src/esp_transport.rs
+++ b/crates/sonde-node/src/esp_transport.rs
@@ -210,7 +210,7 @@ unsafe extern "C" fn raw_recv_cb(
         // Notify after releasing the lock to avoid waking the consumer
         // into immediate contention on the same mutex.
         if enqueued {
-            log::info!(
+            log::debug!(
                 "ESP-NOW RX enqueue: msg_type={} len={} rssi={:?}",
                 espnow_msg_type_label(payload),
                 len,
@@ -377,7 +377,7 @@ impl crate::traits::Transport for EspNowTransport {
                 if full_drops > 0 {
                     log::warn!("ESP-NOW recv ring: {} full drop(s)", full_drops);
                 }
-                log::info!(
+                log::debug!(
                     "ESP-NOW RX dequeue: msg_type={} len={} rssi={:?}",
                     espnow_msg_type_label(&buf[..len]),
                     len,
@@ -396,7 +396,7 @@ impl crate::traits::Transport for EspNowTransport {
                 if full_drops > 0 {
                     log::warn!("ESP-NOW recv ring: {} full drop(s)", full_drops);
                 }
-                log::info!("ESP-NOW RX wait timed out after {} ms", timeout_ms);
+                log::debug!("ESP-NOW RX wait timed out after {} ms", timeout_ms);
                 return Ok(None);
             }
             let remaining = deadline - now;

--- a/crates/sonde-node/src/traits.rs
+++ b/crates/sonde-node/src/traits.rs
@@ -2,7 +2,20 @@
 // Copyright (c) 2026 sonde contributors
 
 use crate::error::NodeResult;
-use sonde_protocol::BoardLayout;
+use sonde_protocol::{BoardLayout, TestResult};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReceivedFrame {
+    pub data: Vec<u8>,
+    pub rssi_dbm: Option<i8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagedTestCommand {
+    pub test_type: u64,
+    pub rf_channel: Option<u8>,
+    pub payload: Vec<u8>,
+}
 
 /// Radio transport for sending and receiving frames.
 pub trait Transport {
@@ -13,6 +26,16 @@ pub trait Transport {
     /// Returns `Ok(Some(data))` if a frame arrives within the timeout,
     /// `Ok(None)` if the timeout expires, or `Err` on transport failure.
     fn recv(&mut self, timeout_ms: u32) -> NodeResult<Option<Vec<u8>>>;
+
+    /// Wait for a frame together with optional receive metadata.
+    fn recv_with_metadata(&mut self, timeout_ms: u32) -> NodeResult<Option<ReceivedFrame>> {
+        self.recv(timeout_ms).map(|frame| {
+            frame.map(|data| ReceivedFrame {
+                data,
+                rssi_dbm: None,
+            })
+        })
+    }
 }
 
 /// Hardware random number generator.
@@ -183,6 +206,31 @@ pub trait PlatformStorage {
 
     /// Persist the current-cycle battery value for the next wake.
     fn write_last_battery_mv(&mut self, _battery_mv: u32) -> NodeResult<()> {
+        Ok(())
+    }
+
+    /// Read the staged pre-provisioning test command retained in RTC memory.
+    fn read_staged_test_command(&self) -> Option<StagedTestCommand> {
+        None
+    }
+
+    /// Persist a staged pre-provisioning test command in RTC memory.
+    fn write_staged_test_command(&mut self, _command: &StagedTestCommand) -> NodeResult<()> {
+        Ok(())
+    }
+
+    /// Clear any staged pre-provisioning test command.
+    fn clear_staged_test_command(&mut self) -> NodeResult<()> {
+        Ok(())
+    }
+
+    /// Read the latest retained pre-provisioning test result from RTC memory.
+    fn read_test_result(&self) -> Option<TestResult> {
+        None
+    }
+
+    /// Persist the latest retained pre-provisioning test result in RTC memory.
+    fn write_test_result(&mut self, _result: &TestResult) -> NodeResult<()> {
         Ok(())
     }
 }

--- a/crates/sonde-pair-ui/src-tauri/Cargo.toml
+++ b/crates/sonde-pair-ui/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_info"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+sonde-protocol = { path = "../../sonde-protocol" }
 
 # Desktop: use btleplug BLE transport and JSON file store
 [target.'cfg(not(target_os = "android"))'.dependencies.sonde-pair]

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use sonde_pair::discovery::{service_type, DeviceScanner, ServiceType};
 use sonde_pair::phase1::PairingProgress;
 use sonde_pair::rng::OsRng;
-use sonde_pair::types::{BoardLayout, ScannedDevice};
+use sonde_pair::types::{BoardLayout, DiagnosticResult, ScannedDevice};
 use sonde_pair::{phase1, phase2};
 
 #[cfg(not(target_os = "android"))]
@@ -77,6 +77,18 @@ struct DeviceInfo {
 struct PairingStatus {
     paired: bool,
     gateway_id: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticReview {
+    success: bool,
+    summary: String,
+    gateway_rssi_dbm: Option<i8>,
+    signal_quality: Option<String>,
+    node_reply_rssi_dbm: Option<i8>,
+    attempt_count: Option<u64>,
+    elapsed_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -176,6 +188,85 @@ fn device_to_info(d: &ScannedDevice) -> DeviceInfo {
             None => "Unknown".into(),
         },
     }
+}
+
+fn signal_quality_label(signal_quality: u8) -> String {
+    match signal_quality {
+        sonde_protocol::SIGNAL_QUALITY_GOOD => "Good".into(),
+        sonde_protocol::SIGNAL_QUALITY_MARGINAL => "Marginal".into(),
+        sonde_protocol::SIGNAL_QUALITY_BAD => "Bad".into(),
+        other => format!("Unknown ({other})"),
+    }
+}
+
+fn diagnostic_review_success(result: &DiagnosticResult) -> DiagnosticReview {
+    DiagnosticReview {
+        success: true,
+        summary: format!(
+            "Gateway RSSI {} dBm, node reply RSSI {} dBm, {} attempt(s), {} ms",
+            result.gateway_rssi_dbm,
+            result.node_reply_rssi_dbm,
+            result.attempt_count,
+            result.elapsed_ms
+        ),
+        gateway_rssi_dbm: Some(result.gateway_rssi_dbm),
+        signal_quality: Some(signal_quality_label(result.signal_quality)),
+        node_reply_rssi_dbm: Some(result.node_reply_rssi_dbm),
+        attempt_count: Some(result.attempt_count),
+        elapsed_ms: Some(result.elapsed_ms),
+    }
+}
+
+fn diagnostic_review_failure(message: String) -> DiagnosticReview {
+    DiagnosticReview {
+        success: false,
+        summary: message,
+        gateway_rssi_dbm: None,
+        signal_quality: None,
+        node_reply_rssi_dbm: None,
+        attempt_count: None,
+        elapsed_ms: None,
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn load_cached_artifacts(
+    state: &tauri::State<'_, AppState>,
+) -> Result<Arc<phase1::PairingArtifacts>, String> {
+    let mut guard = state.pairing_artifacts.lock().unwrap();
+    if guard.is_none() {
+        let store = FilePairingStore::new().map_err(|e| e.to_string())?;
+        match store.load_artifacts() {
+            Ok(Some(loaded)) => {
+                *guard = Some(Arc::new(loaded));
+            }
+            Ok(None) => {}
+            Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
+        }
+    }
+    guard
+        .clone()
+        .ok_or_else(|| "Not paired — run pair_gateway first".to_string())
+}
+
+#[cfg(target_os = "android")]
+fn load_cached_artifacts(
+    state: &tauri::State<'_, AppState>,
+) -> Result<Arc<phase1::PairingArtifacts>, String> {
+    let mut guard = state.pairing_artifacts.lock().unwrap();
+    if guard.is_none() {
+        let store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
+        match store.load_artifacts() {
+            Ok(Some(loaded)) => {
+                *guard = Some(Arc::new(loaded));
+            }
+            Ok(None) => {}
+            Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
+        }
+    }
+    guard
+        .clone()
+        .ok_or_else(|| "Not paired — run pair_gateway first".to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -329,22 +420,7 @@ async fn provision_node(
     let board_layout = resolve_board_layout(board_layout, i2c_sda, i2c_scl)?;
 
     // Load artifacts from in-memory cache, falling back to file store.
-    let artifacts = {
-        let mut guard = state.pairing_artifacts.lock().unwrap();
-        if guard.is_none() {
-            let store = FilePairingStore::new().map_err(|e| e.to_string())?;
-            match store.load_artifacts() {
-                Ok(Some(loaded)) => {
-                    *guard = Some(Arc::new(loaded));
-                }
-                Ok(None) => {}
-                Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
-            }
-        }
-        guard
-            .clone()
-            .ok_or_else(|| "Not paired — run pair_gateway first".to_string())?
-    };
+    let artifacts = load_cached_artifacts(&state)?;
 
     *state.phase.lock().unwrap() = "Provisioning".into();
 
@@ -376,6 +452,43 @@ async fn provision_node(
             let msg = e.to_string();
             *state.phase.lock().unwrap() = format!("Error: {msg}");
             Err(msg)
+        }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+#[tauri::command]
+async fn run_pre_provisioning_diagnostic(
+    state: tauri::State<'_, AppState>,
+    address: String,
+) -> Result<DiagnosticReview, String> {
+    let addr = match parse_address(&address) {
+        Ok(a) => a,
+        Err(e) => {
+            *state.phase.lock().unwrap() = format!("Error: {e}");
+            return Err(e);
+        }
+    };
+    let artifacts = load_cached_artifacts(&state)?;
+    *state.phase.lock().unwrap() = "Running diagnostic".into();
+
+    let result = tokio::task::spawn_blocking(move || {
+        tokio::runtime::Handle::current().block_on(async {
+            let mut transport = BtleplugTransport::new().await?;
+            phase2::check_rssi_with_artifacts(&mut transport, &artifacts, &addr).await
+        })
+    })
+    .await
+    .map_err(|e| format!("task panicked: {e}"))?;
+
+    match result {
+        Ok(result) => {
+            *state.phase.lock().unwrap() = "Diagnostic ready".into();
+            Ok(diagnostic_review_success(&result))
+        }
+        Err(e) => {
+            *state.phase.lock().unwrap() = "Diagnostic failed".into();
+            Ok(diagnostic_review_failure(e.to_string()))
         }
     }
 }
@@ -573,22 +686,7 @@ async fn provision_node(
     let board_layout = resolve_board_layout(board_layout, i2c_sda, i2c_scl)?;
 
     // Load artifacts from in-memory cache, falling back to Android secure storage.
-    let artifacts = {
-        let mut guard = state.pairing_artifacts.lock().unwrap();
-        if guard.is_none() {
-            let store = AndroidPairingStore::from_cached_vm().map_err(|e| e.to_string())?;
-            match store.load_artifacts() {
-                Ok(Some(loaded)) => {
-                    *guard = Some(Arc::new(loaded));
-                }
-                Ok(None) => {}
-                Err(e) => return Err(format!("failed to load pairing artifacts: {e}")),
-            }
-        }
-        guard
-            .clone()
-            .ok_or_else(|| "Not paired — run pair_gateway first".to_string())?
-    };
+    let artifacts = load_cached_artifacts(&state)?;
 
     *state.phase.lock().unwrap() = "Provisioning".into();
 
@@ -620,6 +718,43 @@ async fn provision_node(
             let msg = e.to_string();
             *state.phase.lock().unwrap() = format!("Error: {msg}");
             Err(msg)
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+#[tauri::command]
+async fn run_pre_provisioning_diagnostic(
+    state: tauri::State<'_, AppState>,
+    address: String,
+) -> Result<DiagnosticReview, String> {
+    let addr = match parse_address(&address) {
+        Ok(a) => a,
+        Err(e) => {
+            *state.phase.lock().unwrap() = format!("Error: {e}");
+            return Err(e);
+        }
+    };
+    let artifacts = load_cached_artifacts(&state)?;
+    *state.phase.lock().unwrap() = "Running diagnostic".into();
+
+    let result = tokio::task::spawn_blocking(move || {
+        tokio::runtime::Handle::current().block_on(async {
+            let mut transport = AndroidBleTransport::from_cached_vm()?;
+            phase2::check_rssi_with_artifacts(&mut transport, &artifacts, &addr).await
+        })
+    })
+    .await
+    .map_err(|e| format!("task panicked: {e}"))?;
+
+    match result {
+        Ok(result) => {
+            *state.phase.lock().unwrap() = "Diagnostic ready".into();
+            Ok(diagnostic_review_success(&result))
+        }
+        Err(e) => {
+            *state.phase.lock().unwrap() = "Diagnostic failed".into();
+            Ok(diagnostic_review_failure(e.to_string()))
         }
     }
 }
@@ -815,6 +950,7 @@ pub fn run() {
             stop_scan,
             get_devices,
             pair_gateway,
+            run_pre_provisioning_diagnostic,
             provision_node,
             get_phase,
             get_pairing_status,

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -200,18 +200,19 @@ fn signal_quality_label(signal_quality: u8) -> String {
 }
 
 fn diagnostic_review_success(result: &DiagnosticResult) -> DiagnosticReview {
+    let node_reply_summary = result
+        .node_reply_rssi_dbm
+        .map(|rssi| format!("{rssi} dBm"))
+        .unwrap_or_else(|| "unavailable".into());
     DiagnosticReview {
         success: true,
         summary: format!(
-            "Gateway RSSI {} dBm, node reply RSSI {} dBm, {} attempt(s), {} ms",
-            result.gateway_rssi_dbm,
-            result.node_reply_rssi_dbm,
-            result.attempt_count,
-            result.elapsed_ms
+            "Gateway RSSI {} dBm, node reply RSSI {}, {} attempt(s), {} ms",
+            result.gateway_rssi_dbm, node_reply_summary, result.attempt_count, result.elapsed_ms
         ),
         gateway_rssi_dbm: Some(result.gateway_rssi_dbm),
         signal_quality: Some(signal_quality_label(result.signal_quality)),
-        node_reply_rssi_dbm: Some(result.node_reply_rssi_dbm),
+        node_reply_rssi_dbm: result.node_reply_rssi_dbm,
         attempt_count: Some(result.attempt_count),
         elapsed_ms: Some(result.elapsed_ms),
     }

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -484,10 +484,12 @@ async fn run_pre_provisioning_diagnostic(
 
     match result {
         Ok(result) => {
+            tracing::info!("pre-provisioning diagnostic succeeded");
             *state.phase.lock().unwrap() = "Diagnostic ready".into();
             Ok(diagnostic_review_success(&result))
         }
         Err(e) => {
+            tracing::warn!("pre-provisioning diagnostic failed: {}", e);
             *state.phase.lock().unwrap() = "Diagnostic failed".into();
             Ok(diagnostic_review_failure(e.to_string()))
         }
@@ -750,10 +752,12 @@ async fn run_pre_provisioning_diagnostic(
 
     match result {
         Ok(result) => {
+            tracing::info!("pre-provisioning diagnostic succeeded");
             *state.phase.lock().unwrap() = "Diagnostic ready".into();
             Ok(diagnostic_review_success(&result))
         }
         Err(e) => {
+            tracing::warn!("pre-provisioning diagnostic failed: {}", e);
             *state.phase.lock().unwrap() = "Diagnostic failed".into();
             Ok(diagnostic_review_failure(e.to_string()))
         }

--- a/crates/sonde-pair-ui/src/index.html
+++ b/crates/sonde-pair-ui/src/index.html
@@ -144,7 +144,42 @@
       </div>
     </section>
 
-    <!-- Page 6: Done (PT-1217) -->
+    <!-- Page 6: Diagnostic Review -->
+    <section class="page" id="page-diagnostic-review">
+      <div class="card">
+        <h2>Diagnostic Review</h2>
+        <div id="diagnostic-summary" class="status-text"></div>
+        <div id="diagnostic-metrics" class="diagnostic-metrics hidden">
+          <div class="diagnostic-metric">
+            <span class="diagnostic-label">Gateway RSSI</span>
+            <span id="diagnostic-gateway-rssi" class="diagnostic-value">--</span>
+          </div>
+          <div class="diagnostic-metric">
+            <span class="diagnostic-label">Signal Quality</span>
+            <span id="diagnostic-signal-quality" class="diagnostic-value">--</span>
+          </div>
+          <div class="diagnostic-metric">
+            <span class="diagnostic-label">Node Reply RSSI</span>
+            <span id="diagnostic-node-rssi" class="diagnostic-value">--</span>
+          </div>
+          <div class="diagnostic-metric">
+            <span class="diagnostic-label">Attempts</span>
+            <span id="diagnostic-attempt-count" class="diagnostic-value">--</span>
+          </div>
+          <div class="diagnostic-metric">
+            <span class="diagnostic-label">Elapsed</span>
+            <span id="diagnostic-elapsed-ms" class="diagnostic-value">--</span>
+          </div>
+        </div>
+        <div id="diagnostic-action-status" class="status-text hidden"></div>
+        <div class="btn-row">
+          <button id="btn-diagnostic-continue">Continue</button>
+          <button id="btn-diagnostic-cancel" class="btn-danger">Cancel</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Page 7: Done (PT-1217) -->
     <section class="page" id="page-done">
       <div class="card">
         <h2>Provisioning Complete</h2>

--- a/crates/sonde-pair-ui/src/index.html
+++ b/crates/sonde-pair-ui/src/index.html
@@ -174,6 +174,7 @@
         <div id="diagnostic-action-status" class="status-text hidden"></div>
         <div class="btn-row">
           <button id="btn-diagnostic-continue">Continue</button>
+          <button id="btn-diagnostic-retry">Retry Diagnostic</button>
           <button id="btn-diagnostic-cancel" class="btn-danger">Cancel</button>
         </div>
       </div>

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -15,6 +15,7 @@ const pages = [
   document.getElementById("page-gateway-done"),
   document.getElementById("page-node-scan"),
   document.getElementById("page-node-provision"),
+  document.getElementById("page-diagnostic-review"),
   document.getElementById("page-done"),
 ];
 
@@ -66,6 +67,18 @@ const btnProvision = document.getElementById("btn-provision");
 const provisionStatus = document.getElementById("provision-status");
 
 // Page 6: Done
+const diagnosticSummary = document.getElementById("diagnostic-summary");
+const diagnosticMetrics = document.getElementById("diagnostic-metrics");
+const diagnosticGatewayRssi = document.getElementById("diagnostic-gateway-rssi");
+const diagnosticSignalQuality = document.getElementById("diagnostic-signal-quality");
+const diagnosticNodeRssi = document.getElementById("diagnostic-node-rssi");
+const diagnosticAttemptCount = document.getElementById("diagnostic-attempt-count");
+const diagnosticElapsedMs = document.getElementById("diagnostic-elapsed-ms");
+const diagnosticActionStatus = document.getElementById("diagnostic-action-status");
+const btnDiagnosticContinue = document.getElementById("btn-diagnostic-continue");
+const btnDiagnosticCancel = document.getElementById("btn-diagnostic-cancel");
+
+// Page 7: Done
 const provisionDetails = document.getElementById("provision-details");
 const btnProvisionAnother = document.getElementById("btn-provision-another");
 
@@ -86,6 +99,7 @@ let logTimer = null;
 let busy = false;
 let isPaired = false;
 let scanGeneration = 0;
+let pendingProvisionRequest = null;
 
 // ---------------------------------------------------------------------------
 // Board presets (PT-1216)
@@ -158,7 +172,7 @@ function resolveBoardLayout() {
 // ---------------------------------------------------------------------------
 
 // Maps page index → stepper phase index (0=Gateway, 1=Node, 2=Done)
-const PAGE_TO_PHASE = [0, 0, 0, 1, 1, 2];
+const PAGE_TO_PHASE = [0, 0, 0, 1, 1, 1, 2];
 const STORAGE_KEY = "sonde-pair-page";
 
 class Navigator {
@@ -233,7 +247,7 @@ class Navigator {
       target = 0;
     }
 
-    // Pages 5–6 require ephemeral state (selected node / provisioning-success context)
+    // Pages 5–7 require ephemeral state (selected node / diagnostic / provisioning context)
     // that cannot survive a restart — fall back to Node Scan when paired,
     // or Welcome when unpaired, consistent with the prerequisite check above (PT-1219 AC 4)
     if (target >= 4) {
@@ -265,7 +279,7 @@ class Navigator {
         el.classList.add("step--active");
       }
     });
-    // PT-1220 AC 6–7: show back button on pages 2–6, hide on page 1
+    // PT-1220 AC 6–7: show back button on pages 2–7, hide on page 1
     btnBack.classList.toggle("hidden", this.currentPage === 0);
   }
 
@@ -326,11 +340,43 @@ function setBusy(b) {
   // Disable action buttons on the current page while busy
   btnPair.disabled = b || !selectedAddressGw;
   btnProvision.disabled = b || !selectedAddressNode;
+  btnDiagnosticContinue.disabled = b || !pendingProvisionRequest;
+  btnDiagnosticCancel.disabled = b;
   btnScanStartGw.disabled = b || scanning;
   btnScanStopGw.disabled = b || !scanning;
   btnScanStartNode.disabled = b || scanning;
   btnScanStopNode.disabled = b || !scanning;
   btnToProvision.disabled = b || !selectedAddressNode;
+}
+
+function resetDiagnosticReview() {
+  pendingProvisionRequest = null;
+  diagnosticSummary.textContent = "";
+  diagnosticMetrics.classList.add("hidden");
+  diagnosticGatewayRssi.textContent = "--";
+  diagnosticSignalQuality.textContent = "--";
+  diagnosticNodeRssi.textContent = "--";
+  diagnosticAttemptCount.textContent = "--";
+  diagnosticElapsedMs.textContent = "--";
+  hideStatus(diagnosticActionStatus);
+  btnDiagnosticContinue.textContent = "Continue";
+}
+
+function renderDiagnosticReview(review) {
+  diagnosticSummary.textContent = review.summary;
+  const hasMetrics = review.success;
+  diagnosticMetrics.classList.toggle("hidden", !hasMetrics);
+  if (hasMetrics) {
+    diagnosticGatewayRssi.textContent = `${review.gatewayRssiDbm} dBm`;
+    diagnosticSignalQuality.textContent = review.signalQuality ?? "--";
+    diagnosticNodeRssi.textContent = `${review.nodeReplyRssiDbm} dBm`;
+    diagnosticAttemptCount.textContent = String(review.attemptCount ?? "--");
+    diagnosticElapsedMs.textContent = `${review.elapsedMs ?? "--"} ms`;
+    btnDiagnosticContinue.textContent = "Continue to Provisioning";
+  } else {
+    btnDiagnosticContinue.textContent = "Continue Anyway";
+  }
+  hideStatus(diagnosticActionStatus);
 }
 
 // ---------------------------------------------------------------------------
@@ -548,19 +594,41 @@ async function provisionNode() {
   clearError();
   if (scanning) await stopScan();
   setBusy(true);
-  showStatus(provisionStatus, "Connecting to node\u2026");
+  showStatus(provisionStatus, "Running diagnostic\u2026");
   try {
-    showStatus(provisionStatus, "Provisioning\u2026");
-    await invoke("provision_node", {
+    pendingProvisionRequest = {
       address: selectedAddressNode,
       nodeId: nid,
       boardLayout,
+    };
+    const review = await invoke("run_pre_provisioning_diagnostic", {
+      address: selectedAddressNode,
     });
     hideStatus(provisionStatus);
-    provisionDetails.textContent = "Node \"" + nid + "\" provisioned.";
+    renderDiagnosticReview(review);
     navigator_.next();
   } catch (e) {
+    pendingProvisionRequest = null;
     hideStatus(provisionStatus);
+    showError(e);
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function continueProvisioningAfterDiagnostic() {
+  if (!pendingProvisionRequest) return;
+  clearError();
+  setBusy(true);
+  showStatus(diagnosticActionStatus, "Provisioning\u2026");
+  try {
+    await invoke("provision_node", pendingProvisionRequest);
+    hideStatus(diagnosticActionStatus);
+    provisionDetails.textContent = `Node "${pendingProvisionRequest.nodeId}" provisioned.`;
+    resetDiagnosticReview();
+    navigator_.next();
+  } catch (e) {
+    hideStatus(diagnosticActionStatus);
     showError(e);
   } finally {
     setBusy(false);
@@ -597,6 +665,7 @@ async function clearPairing() {
   try {
     await invoke("clear_pairing");
     isPaired = false;
+    resetDiagnosticReview();
     await refreshPairingStatus();
     navigator_.goTo(0);
   } catch (e) {
@@ -665,13 +734,21 @@ boardSelect.addEventListener("change", () => {
   customPins.classList.toggle("hidden", boardSelect.value !== "custom");
 });
 
-// Page 6: Done
+// Page 6: Diagnostic Review
+btnDiagnosticContinue.addEventListener("click", continueProvisioningAfterDiagnostic);
+btnDiagnosticCancel.addEventListener("click", () => {
+  resetDiagnosticReview();
+  navigator_.goTo(4);
+});
+
+// Page 7: Done
 btnProvisionAnother.addEventListener("click", () => {
   nodeId.value = "";
   selectedAddressNode = null;
   rssiPanel.classList.add("hidden");
   btnToProvision.disabled = true;
   renderDevices(deviceListNode, [], false);
+  resetDiagnosticReview();
   navigator_.goTo(3);
 });
 
@@ -697,6 +774,7 @@ window.addEventListener("popstate", (e) => {
 // ---------------------------------------------------------------------------
 
 initBoardSelect();
+resetDiagnosticReview();
 refreshPairingStatus().then(() => {
   navigator_.restore();
 });

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -369,7 +369,7 @@ function renderDiagnosticReview(review) {
   if (hasMetrics) {
     diagnosticGatewayRssi.textContent = `${review.gatewayRssiDbm} dBm`;
     diagnosticSignalQuality.textContent = review.signalQuality ?? "--";
-    diagnosticNodeRssi.textContent = `${review.nodeReplyRssiDbm} dBm`;
+    diagnosticNodeRssi.textContent = review.nodeReplyRssiDbm == null ? "--" : `${review.nodeReplyRssiDbm} dBm`;
     diagnosticAttemptCount.textContent = String(review.attemptCount ?? "--");
     diagnosticElapsedMs.textContent = `${review.elapsedMs ?? "--"} ms`;
     btnDiagnosticContinue.textContent = "Continue to Provisioning";

--- a/crates/sonde-pair-ui/src/main.js
+++ b/crates/sonde-pair-ui/src/main.js
@@ -76,6 +76,7 @@ const diagnosticAttemptCount = document.getElementById("diagnostic-attempt-count
 const diagnosticElapsedMs = document.getElementById("diagnostic-elapsed-ms");
 const diagnosticActionStatus = document.getElementById("diagnostic-action-status");
 const btnDiagnosticContinue = document.getElementById("btn-diagnostic-continue");
+const btnDiagnosticRetry = document.getElementById("btn-diagnostic-retry");
 const btnDiagnosticCancel = document.getElementById("btn-diagnostic-cancel");
 
 // Page 7: Done
@@ -341,6 +342,7 @@ function setBusy(b) {
   btnPair.disabled = b || !selectedAddressGw;
   btnProvision.disabled = b || !selectedAddressNode;
   btnDiagnosticContinue.disabled = b || !pendingProvisionRequest;
+  btnDiagnosticRetry.disabled = b || !pendingProvisionRequest;
   btnDiagnosticCancel.disabled = b;
   btnScanStartGw.disabled = b || scanning;
   btnScanStopGw.disabled = b || !scanning;
@@ -377,6 +379,30 @@ function renderDiagnosticReview(review) {
     btnDiagnosticContinue.textContent = "Continue Anyway";
   }
   hideStatus(diagnosticActionStatus);
+}
+
+async function runDiagnosticForPendingProvision(showStatusMessage, pushToReviewPage) {
+  if (!pendingProvisionRequest) return;
+  clearError();
+  setBusy(true);
+  showStatus(diagnosticActionStatus, showStatusMessage);
+  try {
+    const review = await invoke("run_pre_provisioning_diagnostic", {
+      address: pendingProvisionRequest.address,
+    });
+    hideStatus(diagnosticActionStatus);
+    hideStatus(provisionStatus);
+    renderDiagnosticReview(review);
+    if (pushToReviewPage && navigator_.current !== 5) {
+      navigator_.goTo(5);
+    }
+  } catch (e) {
+    hideStatus(diagnosticActionStatus);
+    hideStatus(provisionStatus);
+    showError(e);
+  } finally {
+    setBusy(false);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -593,27 +619,13 @@ async function provisionNode() {
   if (!boardLayout) return;
   clearError();
   if (scanning) await stopScan();
-  setBusy(true);
+  pendingProvisionRequest = {
+    address: selectedAddressNode,
+    nodeId: nid,
+    boardLayout,
+  };
   showStatus(provisionStatus, "Running diagnostic\u2026");
-  try {
-    pendingProvisionRequest = {
-      address: selectedAddressNode,
-      nodeId: nid,
-      boardLayout,
-    };
-    const review = await invoke("run_pre_provisioning_diagnostic", {
-      address: selectedAddressNode,
-    });
-    hideStatus(provisionStatus);
-    renderDiagnosticReview(review);
-    navigator_.next();
-  } catch (e) {
-    pendingProvisionRequest = null;
-    hideStatus(provisionStatus);
-    showError(e);
-  } finally {
-    setBusy(false);
-  }
+  await runDiagnosticForPendingProvision("Running diagnostic\u2026", true);
 }
 
 async function continueProvisioningAfterDiagnostic() {
@@ -736,6 +748,9 @@ boardSelect.addEventListener("change", () => {
 
 // Page 6: Diagnostic Review
 btnDiagnosticContinue.addEventListener("click", continueProvisioningAfterDiagnostic);
+btnDiagnosticRetry.addEventListener("click", () => {
+  runDiagnosticForPendingProvision("Retrying diagnostic\u2026", false);
+});
 btnDiagnosticCancel.addEventListener("click", () => {
   resetDiagnosticReview();
   navigator_.goTo(4);

--- a/crates/sonde-pair-ui/src/styles.css
+++ b/crates/sonde-pair-ui/src/styles.css
@@ -316,6 +316,35 @@ label {
 
 .status-text.hidden { display: none; }
 
+.diagnostic-metrics {
+  display: grid;
+  gap: 8px;
+  margin: 8px 0 10px;
+}
+
+.diagnostic-metrics.hidden { display: none; }
+
+.diagnostic-metric {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+}
+
+.diagnostic-label {
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-size: 11px;
+}
+
+.diagnostic-value {
+  font-weight: 600;
+}
+
 /* Device list */
 .device-list {
   list-style: none;

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -302,10 +302,19 @@ fn parse_ble_response<'a>(
 /// Run one generic pre-provisioning test using existing Phase 1 artifacts.
 pub async fn run_pre_provisioning_test_with_artifacts(
     transport: &mut dyn BleTransport,
-    _artifacts: &crate::phase1::PairingArtifacts,
+    artifacts: &crate::phase1::PairingArtifacts,
     device_address: &[u8; 6],
     command: &PreProvisioningTestCommand,
 ) -> Result<sonde_protocol::TestResult, PairingError> {
+    if command.test_type == PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME
+        && command.rf_channel != Some(artifacts.rf_channel)
+    {
+        return Err(PairingError::DiagnosticFailed(format!(
+            "DIAG_FRAME test must use Phase 1 RF channel {}",
+            artifacts.rf_channel
+        )));
+    }
+
     connect_to_node(transport, device_address).await?;
 
     let run_test_body = sonde_protocol::encode_run_test_command(
@@ -1255,6 +1264,32 @@ mod tests {
         let (_, body) = sonde_protocol::parse_ble_envelope(written).unwrap();
         let decoded = sonde_protocol::decode_run_test_command(body).unwrap();
         assert_eq!(decoded.test_type, PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME);
+    }
+
+    #[tokio::test]
+    async fn run_pre_provisioning_test_rejects_diag_frame_with_wrong_phase1_channel() {
+        let artifacts = mock_artifacts();
+        let command = PreProvisioningTestCommand {
+            test_type: PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(artifacts.rf_channel + 1),
+            payload: vec![0xAA; 32],
+        };
+        let mut transport = MockBleTransport::new(247);
+
+        let result = run_pre_provisioning_test_with_artifacts(
+            &mut transport,
+            &artifacts,
+            &[0xAA; 6],
+            &command,
+        )
+        .await;
+        let err = result.unwrap_err().to_string();
+
+        assert!(
+            err.contains("Phase 1 RF channel"),
+            "unexpected error: {err}"
+        );
+        assert!(transport.written.is_empty(), "must fail before BLE writes");
     }
 
     /// Validates: PT-1214 AC2 — board layout CBOR deterministic encoding.

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -385,6 +385,16 @@ pub async fn run_pre_provisioning_test_with_artifacts(
         }
     })?;
 
+    if result.status != sonde_protocol::TEST_RESULT_NO_RESULT
+        && result.test_type != Some(command.test_type)
+    {
+        transport.disconnect().await.ok();
+        return Err(PairingError::DiagnosticFailed(format!(
+            "unexpected test result type: {:?}",
+            result.test_type
+        )));
+    }
+
     transport.disconnect().await.ok();
     Ok(result)
 }
@@ -1132,6 +1142,44 @@ mod tests {
             err.contains("unexpected test result type"),
             "unexpected error: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn run_pre_provisioning_test_rejects_stale_result_type() {
+        let artifacts = mock_artifacts();
+        let command = PreProvisioningTestCommand {
+            test_type: PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(artifacts.rf_channel),
+            payload: vec![0xAA; 32],
+        };
+        let mut transport = MockBleTransport::new(247);
+        transport.queue_response(Ok(encode_ack_response(sonde_protocol::RUN_TEST_ACK_OK)));
+        transport.queue_response(Ok(encode_test_result_response(
+            &sonde_protocol::TestResult {
+                status: sonde_protocol::TEST_RESULT_TIMEOUT,
+                test_type: Some(0x99),
+                reply_frame: None,
+                reply_rssi_dbm: None,
+                attempt_count: 4,
+                elapsed_ms: 8_600,
+            },
+        )));
+
+        let result = run_pre_provisioning_test_with_artifacts(
+            &mut transport,
+            &artifacts,
+            &[0xAA; 6],
+            &command,
+        )
+        .await;
+        let err = result.unwrap_err().to_string();
+
+        assert!(
+            err.contains("unexpected test result type"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(transport.written.len(), 2);
+        assert_eq!(transport.disconnect_count, 2);
     }
 
     #[tokio::test]

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -1128,7 +1128,10 @@ mod tests {
 
         let result = check_rssi(&mut transport, &store, &[0xAA; 6]).await;
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("unexpected test result type"), "unexpected error: {err}");
+        assert!(
+            err.contains("unexpected test result type"),
+            "unexpected error: {err}"
+        );
     }
 
     #[tokio::test]

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -424,16 +424,11 @@ pub async fn run_pre_provisioning_test(
 }
 
 /// Perform the rebooted pre-provisioning RSSI diagnostic.
-pub async fn check_rssi(
+pub async fn check_rssi_with_artifacts(
     transport: &mut dyn BleTransport,
-    store: &dyn PairingStore,
+    artifacts: &crate::phase1::PairingArtifacts,
     device_address: &[u8; 6],
 ) -> Result<DiagnosticResult, PairingError> {
-    let artifacts = store.load_artifacts()?.ok_or_else(|| {
-        PairingError::DiagnosticFailed(
-            "complete Phase 1 gateway pairing first to obtain a phone PSK".into(),
-        )
-    })?;
     let (diag_frame, request_nonce) =
         crate::crypto::build_diag_request_frame(&artifacts.phone_psk)?;
     let command = PreProvisioningTestCommand {
@@ -443,7 +438,7 @@ pub async fn check_rssi(
     };
 
     let result =
-        run_pre_provisioning_test_with_artifacts(transport, &artifacts, device_address, &command)
+        run_pre_provisioning_test_with_artifacts(transport, artifacts, device_address, &command)
             .await?;
 
     match result.status {
@@ -486,6 +481,20 @@ pub async fn check_rssi(
             "unknown TEST_RESULT status: 0x{other:02x}"
         ))),
     }
+}
+
+/// Perform the rebooted pre-provisioning RSSI diagnostic.
+pub async fn check_rssi(
+    transport: &mut dyn BleTransport,
+    store: &dyn PairingStore,
+    device_address: &[u8; 6],
+) -> Result<DiagnosticResult, PairingError> {
+    let artifacts = store.load_artifacts()?.ok_or_else(|| {
+        PairingError::DiagnosticFailed(
+            "complete Phase 1 gateway pairing first to obtain a phone PSK".into(),
+        )
+    })?;
+    check_rssi_with_artifacts(transport, &artifacts, device_address).await
 }
 
 #[cfg(test)]

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -429,6 +429,12 @@ pub async fn check_rssi(
 
     match result.status {
         sonde_protocol::TEST_RESULT_OK => {
+            if result.test_type != Some(PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME) {
+                return Err(PairingError::DiagnosticFailed(format!(
+                    "unexpected test result type: {:?}",
+                    result.test_type
+                )));
+            }
             let reply_frame = result.reply_frame.as_deref().ok_or_else(|| {
                 PairingError::DiagnosticFailed("missing raw DIAG_REPLY frame".into())
             })?;
@@ -1102,6 +1108,27 @@ mod tests {
         assert_eq!(result.node_reply_rssi_dbm, -67);
         assert_eq!(result.attempt_count, 2);
         assert_eq!(result.elapsed_ms, 4_300);
+    }
+
+    #[tokio::test]
+    async fn check_rssi_rejects_unexpected_test_result_type() {
+        let mut transport = MockBleTransport::new(247);
+        transport.queue_response(Ok(encode_ack_response(sonde_protocol::RUN_TEST_ACK_OK)));
+        transport.queue_response(Ok(encode_test_result_response(
+            &sonde_protocol::TestResult {
+                status: sonde_protocol::TEST_RESULT_OK,
+                test_type: Some(0x99),
+                reply_frame: Some(vec![0xAA; 32]),
+                reply_rssi_dbm: Some(-67),
+                attempt_count: 1,
+                elapsed_ms: 900,
+            },
+        )));
+        let store = mock_store();
+
+        let result = check_rssi(&mut transport, &store, &[0xAA; 6]).await;
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("unexpected test result type"), "unexpected error: {err}");
     }
 
     #[tokio::test]

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -452,9 +452,6 @@ pub async fn check_rssi_with_artifacts(
             let reply_frame = result.reply_frame.as_deref().ok_or_else(|| {
                 PairingError::DiagnosticFailed("missing raw DIAG_REPLY frame".into())
             })?;
-            let node_reply_rssi_dbm = result.reply_rssi_dbm.ok_or_else(|| {
-                PairingError::DiagnosticFailed("missing node-observed reply RSSI".into())
-            })?;
             let (gateway_rssi_dbm, signal_quality) = crate::crypto::decrypt_diag_reply(
                 reply_frame,
                 &artifacts.phone_psk,
@@ -463,7 +460,7 @@ pub async fn check_rssi_with_artifacts(
             Ok(DiagnosticResult {
                 gateway_rssi_dbm,
                 signal_quality,
-                node_reply_rssi_dbm,
+                node_reply_rssi_dbm: result.reply_rssi_dbm,
                 attempt_count: result.attempt_count,
                 elapsed_ms: result.elapsed_ms,
             })
@@ -1133,7 +1130,7 @@ mod tests {
         assert_eq!(transport.inner.disconnect_count, 2);
         assert_eq!(result.gateway_rssi_dbm, -58);
         assert_eq!(result.signal_quality, sonde_protocol::SIGNAL_QUALITY_GOOD);
-        assert_eq!(result.node_reply_rssi_dbm, -67);
+        assert_eq!(result.node_reply_rssi_dbm, Some(-67));
         assert_eq!(result.attempt_count, 2);
         assert_eq!(result.elapsed_ms, 4_300);
     }

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -11,6 +11,7 @@ use crate::transport::BleTransport;
 use crate::types::*;
 use crate::validation::{compute_key_hint, validate_node_id};
 use sonde_protocol::encode_board_layout_cbor;
+use std::time::{Duration, Instant};
 use tracing::{debug, info, trace};
 use zeroize::Zeroizing;
 
@@ -22,6 +23,18 @@ const RUN_TEST_ACK_TIMEOUT_MS: u64 = 5_000;
 
 /// `TEST_RESULT` indication timeout in milliseconds.
 const TEST_RESULT_TIMEOUT_MS: u64 = 5_000;
+
+#[cfg(not(test))]
+/// Total time budget for reconnecting after the node reboots into BLE pairing mode.
+const POST_REBOOT_RECONNECT_TIMEOUT_MS: u64 = 15_000;
+#[cfg(test)]
+const POST_REBOOT_RECONNECT_TIMEOUT_MS: u64 = 50;
+
+#[cfg(not(test))]
+/// Delay between reconnect attempts after the node reboots back into pairing mode.
+const POST_REBOOT_RECONNECT_BACKOFF_MS: u64 = 500;
+#[cfg(test)]
+const POST_REBOOT_RECONNECT_BACKOFF_MS: u64 = 0;
 
 /// Map a BLE provisioning message type byte to its spec name (PT-0702).
 fn msg_type_name(t: u8) -> &'static str {
@@ -277,6 +290,56 @@ async fn connect_to_node(
     Ok(())
 }
 
+async fn reconnect_to_node_after_test_reboot(
+    transport: &mut dyn BleTransport,
+    device_address: &[u8; 6],
+) -> Result<(), PairingError> {
+    let deadline = Instant::now() + Duration::from_millis(POST_REBOOT_RECONNECT_TIMEOUT_MS);
+    let mut attempt = 0u32;
+
+    loop {
+        attempt += 1;
+        match connect_to_node(transport, device_address).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                let err_text = err.to_string();
+                debug!(
+                    address = ?device_address,
+                    attempt,
+                    error = %err_text,
+                    "post-reboot reconnect attempt failed"
+                );
+                transport.disconnect().await.ok();
+                if Instant::now() >= deadline {
+                    return Err(PairingError::DiagnosticFailed(format!(
+                        "node did not reconnect after test reboot within {} ms: {}",
+                        POST_REBOOT_RECONNECT_TIMEOUT_MS, err_text
+                    )));
+                }
+
+                sleep_reconnect_backoff(Duration::from_millis(POST_REBOOT_RECONNECT_BACKOFF_MS))
+                    .await;
+            }
+        }
+    }
+}
+
+async fn sleep_reconnect_backoff(delay: Duration) {
+    if delay.is_zero() {
+        return;
+    }
+
+    #[cfg(any(feature = "btleplug", feature = "android", feature = "loopback-ble"))]
+    {
+        tokio::time::sleep(delay).await;
+    }
+
+    #[cfg(not(any(feature = "btleplug", feature = "android", feature = "loopback-ble")))]
+    {
+        std::thread::sleep(delay);
+    }
+}
+
 fn parse_ble_response<'a>(
     response: &'a [u8],
     expected_msg_type: u8,
@@ -317,95 +380,104 @@ pub async fn run_pre_provisioning_test_with_artifacts(
 
     connect_to_node(transport, device_address).await?;
 
-    let run_test_body = sonde_protocol::encode_run_test_command(
-        command.test_type,
-        command.rf_channel,
-        &command.payload,
-    )
-    .map_err(|e| PairingError::DiagnosticFailed(format!("RUN_TEST_COMMAND encode failed: {e}")))?;
-    let run_test_envelope =
-        sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_RUN_TEST_COMMAND, &run_test_body)
-            .ok_or_else(|| {
+    let result = async {
+        let run_test_body = sonde_protocol::encode_run_test_command(
+            command.test_type,
+            command.rf_channel,
+            &command.payload,
+        )
+        .map_err(|e| {
+            PairingError::DiagnosticFailed(format!("RUN_TEST_COMMAND encode failed: {e}"))
+        })?;
+        let run_test_envelope = sonde_protocol::encode_ble_envelope(
+            sonde_protocol::BLE_RUN_TEST_COMMAND,
+            &run_test_body,
+        )
+        .ok_or_else(|| {
             PairingError::DiagnosticFailed("RUN_TEST_COMMAND envelope too large".into())
         })?;
 
-    transport
-        .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &run_test_envelope)
-        .await?;
+        transport
+            .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &run_test_envelope)
+            .await?;
 
-    let ack_response = transport
-        .read_indication(
-            NODE_SERVICE_UUID,
-            NODE_COMMAND_UUID,
-            RUN_TEST_ACK_TIMEOUT_MS,
+        let ack_response = transport
+            .read_indication(
+                NODE_SERVICE_UUID,
+                NODE_COMMAND_UUID,
+                RUN_TEST_ACK_TIMEOUT_MS,
+            )
+            .await?;
+        let ack_body = parse_ble_response(
+            &ack_response,
+            sonde_protocol::BLE_RUN_TEST_ACK,
+            "RUN_TEST_ACK",
+        )?;
+        let ack_status = sonde_protocol::decode_run_test_ack(ack_body).map_err(|e| {
+            PairingError::InvalidResponse {
+                msg_type: sonde_protocol::BLE_RUN_TEST_ACK,
+                reason: format!("decode RUN_TEST_ACK: {e}"),
+            }
+        })?;
+        if ack_status != sonde_protocol::RUN_TEST_ACK_OK {
+            let reason = match ack_status {
+                sonde_protocol::RUN_TEST_ACK_INVALID => "node rejected test command as invalid",
+                sonde_protocol::RUN_TEST_ACK_UNSUPPORTED => {
+                    "node does not support the requested test type"
+                }
+                other => {
+                    return Err(PairingError::DiagnosticFailed(format!(
+                        "unknown RUN_TEST_ACK status: 0x{other:02x}"
+                    )))
+                }
+            };
+            return Err(PairingError::DiagnosticFailed(reason.into()));
+        }
+
+        transport.disconnect().await.ok();
+        reconnect_to_node_after_test_reboot(transport, device_address).await?;
+
+        let read_result_envelope = sonde_protocol::encode_ble_envelope(
+            sonde_protocol::BLE_READ_TEST_RESULT,
+            &sonde_protocol::encode_read_test_result(),
         )
-        .await?;
-    let ack_body = parse_ble_response(
-        &ack_response,
-        sonde_protocol::BLE_RUN_TEST_ACK,
-        "RUN_TEST_ACK",
-    )?;
-    let ack_status = sonde_protocol::decode_run_test_ack(ack_body).map_err(|e| {
-        PairingError::InvalidResponse {
-            msg_type: sonde_protocol::BLE_RUN_TEST_ACK,
-            reason: format!("decode RUN_TEST_ACK: {e}"),
+        .ok_or_else(|| {
+            PairingError::DiagnosticFailed("READ_TEST_RESULT envelope too large".into())
+        })?;
+        transport
+            .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &read_result_envelope)
+            .await?;
+
+        let result_response = transport
+            .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, TEST_RESULT_TIMEOUT_MS)
+            .await?;
+        let result_body = parse_ble_response(
+            &result_response,
+            sonde_protocol::BLE_TEST_RESULT,
+            "TEST_RESULT",
+        )?;
+        let result = sonde_protocol::decode_test_result(result_body).map_err(|e| {
+            PairingError::InvalidResponse {
+                msg_type: sonde_protocol::BLE_TEST_RESULT,
+                reason: format!("decode TEST_RESULT: {e}"),
+            }
+        })?;
+
+        if result.status != sonde_protocol::TEST_RESULT_NO_RESULT
+            && result.test_type != Some(command.test_type)
+        {
+            return Err(PairingError::DiagnosticFailed(format!(
+                "unexpected test result type: {:?}",
+                result.test_type
+            )));
         }
-    })?;
-    if ack_status != sonde_protocol::RUN_TEST_ACK_OK {
-        transport.disconnect().await.ok();
-        let reason = match ack_status {
-            sonde_protocol::RUN_TEST_ACK_INVALID => "node rejected test command as invalid",
-            sonde_protocol::RUN_TEST_ACK_UNSUPPORTED => {
-                "node does not support the requested test type"
-            }
-            other => {
-                return Err(PairingError::DiagnosticFailed(format!(
-                    "unknown RUN_TEST_ACK status: 0x{other:02x}"
-                )))
-            }
-        };
-        return Err(PairingError::DiagnosticFailed(reason.into()));
+
+        Ok(result)
     }
+    .await;
 
     transport.disconnect().await.ok();
-    connect_to_node(transport, device_address).await?;
-
-    let read_result_envelope = sonde_protocol::encode_ble_envelope(
-        sonde_protocol::BLE_READ_TEST_RESULT,
-        &sonde_protocol::encode_read_test_result(),
-    )
-    .ok_or_else(|| PairingError::DiagnosticFailed("READ_TEST_RESULT envelope too large".into()))?;
-    transport
-        .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &read_result_envelope)
-        .await?;
-
-    let result_response = transport
-        .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, TEST_RESULT_TIMEOUT_MS)
-        .await?;
-    let result_body = parse_ble_response(
-        &result_response,
-        sonde_protocol::BLE_TEST_RESULT,
-        "TEST_RESULT",
-    )?;
-    let result = sonde_protocol::decode_test_result(result_body).map_err(|e| {
-        PairingError::InvalidResponse {
-            msg_type: sonde_protocol::BLE_TEST_RESULT,
-            reason: format!("decode TEST_RESULT: {e}"),
-        }
-    })?;
-
-    if result.status != sonde_protocol::TEST_RESULT_NO_RESULT
-        && result.test_type != Some(command.test_type)
-    {
-        transport.disconnect().await.ok();
-        return Err(PairingError::DiagnosticFailed(format!(
-            "unexpected test result type: {:?}",
-            result.test_type
-        )));
-    }
-
-    transport.disconnect().await.ok();
-    Ok(result)
+    result
 }
 
 /// Run one generic pre-provisioning test, loading Phase 1 artifacts from storage.
@@ -975,6 +1047,128 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn check_rssi_retries_reconnect_after_test_reboot() {
+        struct FlakyReconnectTransport {
+            inner: MockBleTransport,
+            reconnect_failures_remaining: usize,
+        }
+
+        impl crate::transport::BleTransport for FlakyReconnectTransport {
+            fn start_scan(
+                &mut self,
+                service_uuids: &[u128],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), PairingError>> + '_>>
+            {
+                self.inner.start_scan(service_uuids)
+            }
+
+            fn stop_scan(
+                &mut self,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), PairingError>> + '_>>
+            {
+                self.inner.stop_scan()
+            }
+
+            fn get_discovered_devices(
+                &self,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = Result<Vec<ScannedDevice>, PairingError>> + '_,
+                >,
+            > {
+                self.inner.get_discovered_devices()
+            }
+
+            fn connect(
+                &mut self,
+                address: &[u8; 6],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<u16, PairingError>> + '_>>
+            {
+                if self.inner.connect_count >= 1 && self.reconnect_failures_remaining > 0 {
+                    self.inner.connect_count += 1;
+                    self.reconnect_failures_remaining -= 1;
+                    self.inner.connected = false;
+                    self.inner.connected_address = None;
+                    let device = crate::error::format_device_address(address);
+                    return Box::pin(async move {
+                        Err(PairingError::ConnectionFailed {
+                            device: Some(device),
+                            reason: "node rebooting".into(),
+                        })
+                    });
+                }
+                self.inner.connect(address)
+            }
+
+            fn disconnect(
+                &mut self,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), PairingError>> + '_>>
+            {
+                self.inner.disconnect()
+            }
+
+            fn write_characteristic(
+                &mut self,
+                service: u128,
+                characteristic: u128,
+                data: &[u8],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), PairingError>> + '_>>
+            {
+                self.inner
+                    .write_characteristic(service, characteristic, data)
+            }
+
+            fn read_indication(
+                &mut self,
+                service: u128,
+                characteristic: u128,
+                timeout_ms: u64,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<Vec<u8>, PairingError>> + '_>,
+            > {
+                self.inner
+                    .read_indication(service, characteristic, timeout_ms)
+            }
+
+            fn pairing_method(&self) -> Option<PairingMethod> {
+                self.inner.pairing_method()
+            }
+
+            fn set_defer_bonding(&mut self, defer: bool) {
+                self.inner.set_defer_bonding(defer);
+            }
+        }
+
+        let mut transport = FlakyReconnectTransport {
+            inner: MockBleTransport::new(247),
+            reconnect_failures_remaining: 1,
+        };
+        transport
+            .inner
+            .queue_response(Ok(encode_ack_response(sonde_protocol::RUN_TEST_ACK_OK)));
+        transport
+            .inner
+            .queue_response(Ok(encode_test_result_response(
+                &sonde_protocol::TestResult {
+                    status: sonde_protocol::TEST_RESULT_TIMEOUT,
+                    test_type: Some(sonde_protocol::TEST_TYPE_DIAG_FRAME),
+                    reply_frame: None,
+                    reply_rssi_dbm: None,
+                    attempt_count: 4,
+                    elapsed_ms: 8_600,
+                },
+            )));
+        let store = mock_store();
+
+        let result = check_rssi(&mut transport, &store, &[0xAA; 6]).await;
+
+        assert!(matches!(result, Err(PairingError::DiagnosticFailed(_))));
+        assert_eq!(transport.inner.connect_count, 3);
+        assert_eq!(transport.inner.disconnect_count, 3);
+        assert_eq!(transport.inner.written.len(), 2);
+    }
+
+    #[tokio::test]
     async fn check_rssi_ack_failure_surfaces_error() {
         let mut transport = MockBleTransport::new(247);
         transport.queue_response(Ok(encode_ack_response(
@@ -1195,6 +1389,34 @@ mod tests {
         );
         assert_eq!(transport.written.len(), 2);
         assert_eq!(transport.disconnect_count, 2);
+    }
+
+    #[tokio::test]
+    async fn run_pre_provisioning_test_disconnects_on_write_error() {
+        let artifacts = mock_artifacts();
+        let command = PreProvisioningTestCommand {
+            test_type: PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(artifacts.rf_channel),
+            payload: vec![0xAA; 32],
+        };
+        let mut transport = MockBleTransport::new(247);
+        transport.write_error = Some(PairingError::GattWriteFailed {
+            device: Some(crate::error::format_device_address(&[0xAA; 6])),
+            reason: "injected write failure".into(),
+        });
+
+        let result = run_pre_provisioning_test_with_artifacts(
+            &mut transport,
+            &artifacts,
+            &[0xAA; 6],
+            &command,
+        )
+        .await;
+
+        assert!(matches!(result, Err(PairingError::GattWriteFailed { .. })));
+        assert_eq!(transport.connect_count, 1);
+        assert_eq!(transport.disconnect_count, 1);
+        assert_eq!(transport.read_call_count, 0);
     }
 
     #[tokio::test]

--- a/crates/sonde-pair/src/phase2.rs
+++ b/crates/sonde-pair/src/phase2.rs
@@ -6,6 +6,7 @@ use crate::crypto;
 use crate::envelope::{build_envelope, parse_envelope, parse_error_body, parse_node_ack};
 use crate::error::{format_device_address, PairingError};
 use crate::rng::RngProvider;
+use crate::store::PairingStore;
 use crate::transport::BleTransport;
 use crate::types::*;
 use crate::validation::{compute_key_hint, validate_node_id};
@@ -16,8 +17,11 @@ use zeroize::Zeroizing;
 /// NODE_ACK indication timeout in milliseconds (PT-1002).
 const NODE_ACK_TIMEOUT_MS: u64 = 5_000;
 
-/// DIAG_RELAY_RESPONSE indication timeout in milliseconds (PT-1303).
-const DIAG_RELAY_TIMEOUT_MS: u64 = 10_000;
+/// `RUN_TEST_ACK` indication timeout in milliseconds.
+const RUN_TEST_ACK_TIMEOUT_MS: u64 = 5_000;
+
+/// `TEST_RESULT` indication timeout in milliseconds.
+const TEST_RESULT_TIMEOUT_MS: u64 = 5_000;
 
 /// Map a BLE provisioning message type byte to its spec name (PT-0702).
 fn msg_type_name(t: u8) -> &'static str {
@@ -254,89 +258,207 @@ async fn do_provision_node(
     Ok(NodeProvisionResult { status })
 }
 
-/// Result of an RSSI diagnostic check.
-#[derive(Debug, Clone, PartialEq)]
-pub struct DiagnosticResult {
-    /// Measured RSSI in dBm (typically −30 to −90).
-    pub rssi_dbm: i8,
-    /// Signal quality: 0=good, 1=marginal, 2=bad.
-    pub signal_quality: u8,
+async fn connect_to_node(
+    transport: &mut dyn BleTransport,
+    device_address: &[u8; 6],
+) -> Result<(), PairingError> {
+    transport.set_defer_bonding(true);
+    let mtu_result = transport.connect(device_address).await;
+    transport.set_defer_bonding(false);
+    let mtu = mtu_result?;
+    if mtu < BLE_MTU_MIN {
+        transport.disconnect().await.ok();
+        return Err(PairingError::MtuTooLow {
+            device: format_device_address(device_address),
+            negotiated: mtu,
+            required: BLE_MTU_MIN,
+        });
+    }
+    Ok(())
 }
 
-/// Perform an RSSI diagnostic using the node as a radio relay (PT-1300).
-///
-/// The node must already be connected via BLE. This function can be called
-/// multiple times (diagnostic is repeatable, PT-1306) and does not modify
-/// any pairing state (PT-1308).
-pub async fn check_rssi(
-    transport: &mut dyn BleTransport,
-    artifacts: &crate::phase1::PairingArtifacts,
-) -> Result<DiagnosticResult, PairingError> {
-    // 1. Build DIAG_REQUEST frame (PT-1301).
-    let (diag_frame, request_nonce) =
-        crate::crypto::build_diag_request_frame(&artifacts.phone_psk)?;
-
-    // 2. Wrap in DIAG_RELAY_REQUEST BLE envelope (PT-1302).
-    let relay_body = sonde_protocol::encode_diag_relay_request(artifacts.rf_channel, &diag_frame)
-        .map_err(|e| PairingError::DiagnosticFailed(format!("relay encode: {}", e)))?;
-    let envelope =
-        sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_DIAG_RELAY_REQUEST, &relay_body)
-            .ok_or_else(|| PairingError::DiagnosticFailed("BLE envelope too large".into()))?;
-
-    // 3. Write to node BLE characteristic.
-    transport
-        .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &envelope)
-        .await?;
-
-    // 4. Wait for DIAG_RELAY_RESPONSE (timeout per PT-1303).
-    let response = transport
-        .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, DIAG_RELAY_TIMEOUT_MS)
-        .await?;
-
-    // 5. Parse BLE envelope.
-    let (msg_type, body) = sonde_protocol::parse_ble_envelope(&response).ok_or_else(|| {
+fn parse_ble_response<'a>(
+    response: &'a [u8],
+    expected_msg_type: u8,
+    expected_name: &str,
+) -> Result<&'a [u8], PairingError> {
+    let (msg_type, body) = sonde_protocol::parse_ble_envelope(response).ok_or_else(|| {
         PairingError::InvalidResponse {
             msg_type: 0,
             reason: "malformed BLE envelope".into(),
         }
     })?;
-    if msg_type != sonde_protocol::BLE_DIAG_RELAY_RESPONSE {
+    if msg_type != expected_msg_type {
         return Err(PairingError::InvalidResponse {
             msg_type,
             reason: format!(
-                "expected DIAG_RELAY_RESPONSE (0x82), got 0x{:02x}",
-                msg_type
+                "expected {expected_name} (0x{expected_msg_type:02x}), got 0x{msg_type:02x}"
             ),
         });
     }
+    Ok(body)
+}
 
-    // 6. Parse relay response status.
-    let (status, payload) = sonde_protocol::decode_diag_relay_response(body).map_err(|e| {
+/// Run one generic pre-provisioning test using existing Phase 1 artifacts.
+pub async fn run_pre_provisioning_test_with_artifacts(
+    transport: &mut dyn BleTransport,
+    _artifacts: &crate::phase1::PairingArtifacts,
+    device_address: &[u8; 6],
+    command: &PreProvisioningTestCommand,
+) -> Result<sonde_protocol::TestResult, PairingError> {
+    connect_to_node(transport, device_address).await?;
+
+    let run_test_body = sonde_protocol::encode_run_test_command(
+        command.test_type,
+        command.rf_channel,
+        &command.payload,
+    )
+    .map_err(|e| PairingError::DiagnosticFailed(format!("RUN_TEST_COMMAND encode failed: {e}")))?;
+    let run_test_envelope =
+        sonde_protocol::encode_ble_envelope(sonde_protocol::BLE_RUN_TEST_COMMAND, &run_test_body)
+            .ok_or_else(|| {
+            PairingError::DiagnosticFailed("RUN_TEST_COMMAND envelope too large".into())
+        })?;
+
+    transport
+        .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &run_test_envelope)
+        .await?;
+
+    let ack_response = transport
+        .read_indication(
+            NODE_SERVICE_UUID,
+            NODE_COMMAND_UUID,
+            RUN_TEST_ACK_TIMEOUT_MS,
+        )
+        .await?;
+    let ack_body = parse_ble_response(
+        &ack_response,
+        sonde_protocol::BLE_RUN_TEST_ACK,
+        "RUN_TEST_ACK",
+    )?;
+    let ack_status = sonde_protocol::decode_run_test_ack(ack_body).map_err(|e| {
         PairingError::InvalidResponse {
-            msg_type,
-            reason: format!("decode relay response: {}", e),
+            msg_type: sonde_protocol::BLE_RUN_TEST_ACK,
+            reason: format!("decode RUN_TEST_ACK: {e}"),
+        }
+    })?;
+    if ack_status != sonde_protocol::RUN_TEST_ACK_OK {
+        transport.disconnect().await.ok();
+        let reason = match ack_status {
+            sonde_protocol::RUN_TEST_ACK_INVALID => "node rejected test command as invalid",
+            sonde_protocol::RUN_TEST_ACK_UNSUPPORTED => {
+                "node does not support the requested test type"
+            }
+            other => {
+                return Err(PairingError::DiagnosticFailed(format!(
+                    "unknown RUN_TEST_ACK status: 0x{other:02x}"
+                )))
+            }
+        };
+        return Err(PairingError::DiagnosticFailed(reason.into()));
+    }
+
+    transport.disconnect().await.ok();
+    connect_to_node(transport, device_address).await?;
+
+    let read_result_envelope = sonde_protocol::encode_ble_envelope(
+        sonde_protocol::BLE_READ_TEST_RESULT,
+        &sonde_protocol::encode_read_test_result(),
+    )
+    .ok_or_else(|| PairingError::DiagnosticFailed("READ_TEST_RESULT envelope too large".into()))?;
+    transport
+        .write_characteristic(NODE_SERVICE_UUID, NODE_COMMAND_UUID, &read_result_envelope)
+        .await?;
+
+    let result_response = transport
+        .read_indication(NODE_SERVICE_UUID, NODE_COMMAND_UUID, TEST_RESULT_TIMEOUT_MS)
+        .await?;
+    let result_body = parse_ble_response(
+        &result_response,
+        sonde_protocol::BLE_TEST_RESULT,
+        "TEST_RESULT",
+    )?;
+    let result = sonde_protocol::decode_test_result(result_body).map_err(|e| {
+        PairingError::InvalidResponse {
+            msg_type: sonde_protocol::BLE_TEST_RESULT,
+            reason: format!("decode TEST_RESULT: {e}"),
         }
     })?;
 
-    match status {
-        sonde_protocol::DIAG_RELAY_STATUS_OK => {
-            // 7. Decrypt DIAG_REPLY (PT-1303 AC-2).
-            let (rssi_dbm, signal_quality) =
-                crate::crypto::decrypt_diag_reply(payload, &artifacts.phone_psk, request_nonce)?;
+    transport.disconnect().await.ok();
+    Ok(result)
+}
+
+/// Run one generic pre-provisioning test, loading Phase 1 artifacts from storage.
+pub async fn run_pre_provisioning_test(
+    transport: &mut dyn BleTransport,
+    store: &dyn PairingStore,
+    device_address: &[u8; 6],
+    command: &PreProvisioningTestCommand,
+) -> Result<sonde_protocol::TestResult, PairingError> {
+    let artifacts = store.load_artifacts()?.ok_or_else(|| {
+        PairingError::DiagnosticFailed(
+            "complete Phase 1 gateway pairing first to obtain a phone PSK".into(),
+        )
+    })?;
+    run_pre_provisioning_test_with_artifacts(transport, &artifacts, device_address, command).await
+}
+
+/// Perform the rebooted pre-provisioning RSSI diagnostic.
+pub async fn check_rssi(
+    transport: &mut dyn BleTransport,
+    store: &dyn PairingStore,
+    device_address: &[u8; 6],
+) -> Result<DiagnosticResult, PairingError> {
+    let artifacts = store.load_artifacts()?.ok_or_else(|| {
+        PairingError::DiagnosticFailed(
+            "complete Phase 1 gateway pairing first to obtain a phone PSK".into(),
+        )
+    })?;
+    let (diag_frame, request_nonce) =
+        crate::crypto::build_diag_request_frame(&artifacts.phone_psk)?;
+    let command = PreProvisioningTestCommand {
+        test_type: PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME,
+        rf_channel: Some(artifacts.rf_channel),
+        payload: diag_frame,
+    };
+
+    let result =
+        run_pre_provisioning_test_with_artifacts(transport, &artifacts, device_address, &command)
+            .await?;
+
+    match result.status {
+        sonde_protocol::TEST_RESULT_OK => {
+            let reply_frame = result.reply_frame.as_deref().ok_or_else(|| {
+                PairingError::DiagnosticFailed("missing raw DIAG_REPLY frame".into())
+            })?;
+            let node_reply_rssi_dbm = result.reply_rssi_dbm.ok_or_else(|| {
+                PairingError::DiagnosticFailed("missing node-observed reply RSSI".into())
+            })?;
+            let (gateway_rssi_dbm, signal_quality) = crate::crypto::decrypt_diag_reply(
+                reply_frame,
+                &artifacts.phone_psk,
+                request_nonce,
+            )?;
             Ok(DiagnosticResult {
-                rssi_dbm,
+                gateway_rssi_dbm,
                 signal_quality,
+                node_reply_rssi_dbm,
+                attempt_count: result.attempt_count,
+                elapsed_ms: result.elapsed_ms,
             })
         }
-        sonde_protocol::DIAG_RELAY_STATUS_TIMEOUT => Err(PairingError::DiagnosticFailed(
-            "no response from gateway — verify gateway is running and modem is connected".into(),
+        sonde_protocol::TEST_RESULT_TIMEOUT => Err(PairingError::DiagnosticFailed(
+            "diagnostic timed out — verify gateway is running and modem is connected".into(),
         )),
-        sonde_protocol::DIAG_RELAY_STATUS_CHANNEL_ERROR => Err(PairingError::DiagnosticFailed(
-            "channel error — verify RF channel configuration".into(),
+        sonde_protocol::TEST_RESULT_NO_RESULT => Err(PairingError::DiagnosticFailed(
+            "node reported no retained test result; retry the diagnostic run".into(),
+        )),
+        sonde_protocol::TEST_RESULT_EXECUTION_ERROR => Err(PairingError::DiagnosticFailed(
+            "node failed to execute the staged diagnostic command".into(),
         )),
         other => Err(PairingError::DiagnosticFailed(format!(
-            "unknown relay status: 0x{:02x}",
-            other
+            "unknown TEST_RESULT status: 0x{other:02x}"
         ))),
     }
 }
@@ -345,6 +467,7 @@ pub async fn check_rssi(
 mod tests {
     use super::*;
     use crate::rng::MockRng;
+    use crate::store::MockPairingStore;
     use crate::transport::MockBleTransport;
 
     #[tokio::test]
@@ -759,49 +882,301 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn check_rssi_timeout_status() {
-        let artifacts = mock_artifacts();
+    fn mock_store() -> MockPairingStore {
+        MockPairingStore::with_artifacts(mock_artifacts())
+    }
 
-        let relay_body = sonde_protocol::encode_diag_relay_response(
-            sonde_protocol::DIAG_RELAY_STATUS_TIMEOUT,
-            &[],
+    fn encode_ack_response(status: u8) -> Vec<u8> {
+        sonde_protocol::encode_ble_envelope(
+            sonde_protocol::BLE_RUN_TEST_ACK,
+            &sonde_protocol::encode_run_test_ack(status).unwrap(),
         )
-        .unwrap();
-        let ble_response = sonde_protocol::encode_ble_envelope(
-            sonde_protocol::BLE_DIAG_RELAY_RESPONSE,
-            &relay_body,
+        .unwrap()
+    }
+
+    fn encode_test_result_response(result: &sonde_protocol::TestResult) -> Vec<u8> {
+        sonde_protocol::encode_ble_envelope(
+            sonde_protocol::BLE_TEST_RESULT,
+            &sonde_protocol::encode_test_result(result).unwrap(),
         )
-        .unwrap();
-
-        let mut transport = MockBleTransport::new(247);
-        transport.queue_response(Ok(ble_response));
-
-        let result = check_rssi(&mut transport, &artifacts).await;
-        assert!(matches!(result, Err(PairingError::DiagnosticFailed(_))));
-        assert_eq!(transport.written.len(), 1);
+        .unwrap()
     }
 
     #[tokio::test]
-    async fn check_rssi_channel_error_status() {
-        let artifacts = mock_artifacts();
-
-        let relay_body = sonde_protocol::encode_diag_relay_response(
-            sonde_protocol::DIAG_RELAY_STATUS_CHANNEL_ERROR,
-            &[],
-        )
-        .unwrap();
-        let ble_response = sonde_protocol::encode_ble_envelope(
-            sonde_protocol::BLE_DIAG_RELAY_RESPONSE,
-            &relay_body,
-        )
-        .unwrap();
-
+    async fn check_rssi_requires_phase1_artifacts() {
         let mut transport = MockBleTransport::new(247);
-        transport.queue_response(Ok(ble_response));
+        let store = MockPairingStore::new();
 
-        let result = check_rssi(&mut transport, &artifacts).await;
+        let result = check_rssi(&mut transport, &store, &[0xAA; 6]).await;
+        let message = result.unwrap_err().to_string();
+        assert!(message.contains("Phase 1"), "unexpected error: {message}");
+        assert!(transport.written.is_empty(), "must fail before BLE writes");
+    }
+
+    #[tokio::test]
+    async fn check_rssi_happy_path_reconnects_and_reads_result() {
+        let mut transport = MockBleTransport::new(247);
+        transport.queue_response(Ok(encode_ack_response(sonde_protocol::RUN_TEST_ACK_OK)));
+        transport.queue_response(Ok(encode_test_result_response(
+            &sonde_protocol::TestResult {
+                status: sonde_protocol::TEST_RESULT_TIMEOUT,
+                test_type: Some(sonde_protocol::TEST_TYPE_DIAG_FRAME),
+                reply_frame: None,
+                reply_rssi_dbm: None,
+                attempt_count: 4,
+                elapsed_ms: 8_600,
+            },
+        )));
+        let store = mock_store();
+
+        let result = check_rssi(&mut transport, &store, &[0xAA; 6]).await;
         assert!(matches!(result, Err(PairingError::DiagnosticFailed(_))));
+        assert_eq!(transport.written.len(), 2);
+        assert_eq!(
+            transport.written[0].2[0],
+            sonde_protocol::BLE_RUN_TEST_COMMAND
+        );
+        assert_eq!(
+            transport.written[1].2[0],
+            sonde_protocol::BLE_READ_TEST_RESULT
+        );
+        assert_eq!(transport.disconnect_count, 2);
+    }
+
+    #[tokio::test]
+    async fn check_rssi_ack_failure_surfaces_error() {
+        let mut transport = MockBleTransport::new(247);
+        transport.queue_response(Ok(encode_ack_response(
+            sonde_protocol::RUN_TEST_ACK_INVALID,
+        )));
+        let store = mock_store();
+
+        let result = check_rssi(&mut transport, &store, &[0xAA; 6]).await;
+        assert!(matches!(result, Err(PairingError::DiagnosticFailed(_))));
+        assert_eq!(transport.written.len(), 1);
+        assert_eq!(
+            transport.written[0].2[0],
+            sonde_protocol::BLE_RUN_TEST_COMMAND
+        );
+    }
+
+    #[tokio::test]
+    async fn check_rssi_success_combines_gateway_and_node_metadata() {
+        struct SuccessDiagnosticTransport {
+            inner: MockBleTransport,
+            psk: [u8; 32],
+        }
+
+        impl crate::transport::BleTransport for SuccessDiagnosticTransport {
+            fn start_scan(
+                &mut self,
+                service_uuids: &[u128],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), PairingError>> + '_>>
+            {
+                self.inner.start_scan(service_uuids)
+            }
+
+            fn stop_scan(
+                &mut self,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), PairingError>> + '_>>
+            {
+                self.inner.stop_scan()
+            }
+
+            fn get_discovered_devices(
+                &self,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<Output = Result<Vec<ScannedDevice>, PairingError>> + '_,
+                >,
+            > {
+                self.inner.get_discovered_devices()
+            }
+
+            fn connect(
+                &mut self,
+                address: &[u8; 6],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<u16, PairingError>> + '_>>
+            {
+                self.inner.connect(address)
+            }
+
+            fn disconnect(
+                &mut self,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), PairingError>> + '_>>
+            {
+                self.inner.disconnect()
+            }
+
+            fn write_characteristic(
+                &mut self,
+                service: u128,
+                characteristic: u128,
+                data: &[u8],
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), PairingError>> + '_>>
+            {
+                self.inner
+                    .write_characteristic(service, characteristic, data)
+            }
+
+            fn read_indication(
+                &mut self,
+                service: u128,
+                characteristic: u128,
+                timeout_ms: u64,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<Vec<u8>, PairingError>> + '_>,
+            > {
+                if self.inner.read_call_count == 1 {
+                    let written = self.inner.written[0].2.clone();
+                    let psk = self.psk;
+                    let sha = crate::crypto::PairSha256;
+                    let aead = crate::crypto::PairAead;
+                    let (_, body) = sonde_protocol::parse_ble_envelope(&written).unwrap();
+                    let decoded = sonde_protocol::decode_run_test_command(body).unwrap();
+                    let request = sonde_protocol::decode_frame(&decoded.payload).unwrap();
+                    let reply_payload = sonde_protocol::GatewayMessage::DiagReply {
+                        diagnostic_type: sonde_protocol::DIAG_TYPE_RSSI,
+                        rssi_dbm: -58,
+                        signal_quality: sonde_protocol::SIGNAL_QUALITY_GOOD,
+                    }
+                    .encode()
+                    .unwrap();
+                    let header = sonde_protocol::FrameHeader {
+                        key_hint: sonde_protocol::key_hint_from_psk(&psk, &sha),
+                        msg_type: sonde_protocol::MSG_DIAG_REPLY,
+                        nonce: request.header.nonce,
+                    };
+                    let raw_reply =
+                        sonde_protocol::encode_frame(&header, &reply_payload, &psk, &aead, &sha)
+                            .unwrap();
+                    self.inner.queue_response(Ok(encode_test_result_response(
+                        &sonde_protocol::TestResult {
+                            status: sonde_protocol::TEST_RESULT_OK,
+                            test_type: Some(sonde_protocol::TEST_TYPE_DIAG_FRAME),
+                            reply_frame: Some(raw_reply),
+                            reply_rssi_dbm: Some(-67),
+                            attempt_count: 2,
+                            elapsed_ms: 4_300,
+                        },
+                    )));
+                }
+                self.inner
+                    .read_indication(service, characteristic, timeout_ms)
+            }
+
+            fn pairing_method(&self) -> Option<PairingMethod> {
+                self.inner.pairing_method()
+            }
+
+            fn set_defer_bonding(&mut self, defer: bool) {
+                self.inner.set_defer_bonding(defer);
+            }
+        }
+
+        let artifacts = mock_artifacts();
+        let store = MockPairingStore::with_artifacts(artifacts.clone());
+        let mut transport = SuccessDiagnosticTransport {
+            inner: MockBleTransport::new(247),
+            psk: *artifacts.phone_psk,
+        };
+        transport
+            .inner
+            .queue_response(Ok(encode_ack_response(sonde_protocol::RUN_TEST_ACK_OK)));
+
+        let result = check_rssi(&mut transport, &store, &[0xAA; 6])
+            .await
+            .unwrap();
+        assert_eq!(transport.inner.written.len(), 2);
+        assert_eq!(
+            transport.inner.written[0].2[0],
+            sonde_protocol::BLE_RUN_TEST_COMMAND
+        );
+        assert_eq!(
+            transport.inner.written[1].2[0],
+            sonde_protocol::BLE_READ_TEST_RESULT
+        );
+        assert_eq!(transport.inner.disconnect_count, 2);
+        assert_eq!(result.gateway_rssi_dbm, -58);
+        assert_eq!(result.signal_quality, sonde_protocol::SIGNAL_QUALITY_GOOD);
+        assert_eq!(result.node_reply_rssi_dbm, -67);
+        assert_eq!(result.attempt_count, 2);
+        assert_eq!(result.elapsed_ms, 4_300);
+    }
+
+    #[tokio::test]
+    async fn repeated_sampling_requires_separate_runs() {
+        let store = mock_store();
+        let mut transport = MockBleTransport::new(247);
+        transport.queue_response(Ok(encode_ack_response(sonde_protocol::RUN_TEST_ACK_OK)));
+        transport.queue_response(Ok(encode_test_result_response(
+            &sonde_protocol::TestResult {
+                status: sonde_protocol::TEST_RESULT_TIMEOUT,
+                test_type: Some(sonde_protocol::TEST_TYPE_DIAG_FRAME),
+                reply_frame: None,
+                reply_rssi_dbm: None,
+                attempt_count: 4,
+                elapsed_ms: 8_600,
+            },
+        )));
+        let _ = check_rssi(&mut transport, &store, &[0xAA; 6]).await;
+        assert_eq!(
+            transport
+                .written
+                .iter()
+                .filter(|(_, _, data)| data[0] == sonde_protocol::BLE_RUN_TEST_COMMAND)
+                .count(),
+            1
+        );
+
+        transport.queue_response(Ok(encode_ack_response(sonde_protocol::RUN_TEST_ACK_OK)));
+        transport.queue_response(Ok(encode_test_result_response(
+            &sonde_protocol::TestResult {
+                status: sonde_protocol::TEST_RESULT_TIMEOUT,
+                test_type: Some(sonde_protocol::TEST_TYPE_DIAG_FRAME),
+                reply_frame: None,
+                reply_rssi_dbm: None,
+                attempt_count: 4,
+                elapsed_ms: 8_600,
+            },
+        )));
+        let _ = check_rssi(&mut transport, &store, &[0xAA; 6]).await;
+        assert_eq!(
+            transport
+                .written
+                .iter()
+                .filter(|(_, _, data)| data[0] == sonde_protocol::BLE_RUN_TEST_COMMAND)
+                .count(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn run_pre_provisioning_test_uses_explicit_test_discriminator() {
+        let store = mock_store();
+        let command = PreProvisioningTestCommand {
+            test_type: PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME,
+            rf_channel: Some(6),
+            payload: vec![0xAA; 32],
+        };
+        let mut transport = MockBleTransport::new(247);
+        transport.queue_response(Ok(encode_ack_response(sonde_protocol::RUN_TEST_ACK_OK)));
+        transport.queue_response(Ok(encode_test_result_response(
+            &sonde_protocol::TestResult {
+                status: sonde_protocol::TEST_RESULT_TIMEOUT,
+                test_type: Some(PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME),
+                reply_frame: None,
+                reply_rssi_dbm: None,
+                attempt_count: 4,
+                elapsed_ms: 8_600,
+            },
+        )));
+
+        let _ = run_pre_provisioning_test(&mut transport, &store, &[0xAA; 6], &command).await;
+        let (_, _, written) = &transport.written[0];
+        let (_, body) = sonde_protocol::parse_ble_envelope(written).unwrap();
+        let decoded = sonde_protocol::decode_run_test_command(body).unwrap();
+        assert_eq!(decoded.test_type, PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME);
     }
 
     /// Validates: PT-1214 AC2 — board layout CBOR deterministic encoding.

--- a/crates/sonde-pair/src/transport.rs
+++ b/crates/sonde-pair/src/transport.rs
@@ -87,6 +87,8 @@ pub struct MockBleTransport {
     pub connect_error: Option<PairingError>,
     /// If `Some`, the next `write_characteristic()` call takes and returns this error.
     pub write_error: Option<PairingError>,
+    /// Count of `connect()` calls for reconnect verification.
+    pub connect_count: usize,
     /// Count of `disconnect()` calls for resource-leak verification.
     pub disconnect_count: usize,
     /// Count of `read_indication()` calls for retry verification.
@@ -110,6 +112,7 @@ impl MockBleTransport {
             connected: false,
             connect_error: None,
             write_error: None,
+            connect_count: 0,
             disconnect_count: 0,
             read_call_count: 0,
             pairing_method: None,
@@ -152,6 +155,7 @@ impl BleTransport for MockBleTransport {
         address: &[u8; 6],
     ) -> Pin<Box<dyn Future<Output = Result<u16, PairingError>> + '_>> {
         let device_str = format_device_address(address);
+        self.connect_count += 1;
         if let Some(err) = self.connect_error.take() {
             self.connected = false;
             self.connected_address = None;

--- a/crates/sonde-pair/src/types.rs
+++ b/crates/sonde-pair/src/types.rs
@@ -65,8 +65,9 @@ pub struct DiagnosticResult {
     pub gateway_rssi_dbm: i8,
     /// Gateway-reported signal-quality assessment.
     pub signal_quality: u8,
-    /// Node-observed RSSI of the received reply frame.
-    pub node_reply_rssi_dbm: i8,
+    /// Node-observed RSSI of the received reply frame, when the platform
+    /// exposes receive metadata for the reply.
+    pub node_reply_rssi_dbm: Option<i8>,
     /// Number of send/listen attempts used by the node.
     pub attempt_count: u64,
     /// Total node-side execution time for the test run.

--- a/crates/sonde-pair/src/types.rs
+++ b/crates/sonde-pair/src/types.rs
@@ -50,6 +50,29 @@ pub struct NodeProvisionResult {
     pub status: NodeAckStatus,
 }
 
+/// Generic pre-provisioning test command staged over BLE before the node reboots.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreProvisioningTestCommand {
+    pub test_type: u64,
+    pub rf_channel: Option<u8>,
+    pub payload: Vec<u8>,
+}
+
+/// Result of a successful pre-provisioning RSSI diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticResult {
+    /// Gateway-observed RSSI from the decrypted `DIAG_REPLY`.
+    pub gateway_rssi_dbm: i8,
+    /// Gateway-reported signal-quality assessment.
+    pub signal_quality: u8,
+    /// Node-observed RSSI of the received reply frame.
+    pub node_reply_rssi_dbm: i8,
+    /// Number of send/listen attempts used by the node.
+    pub attempt_count: u64,
+    /// Total node-side execution time for the test run.
+    pub elapsed_ms: u64,
+}
+
 /// Status codes from node provisioning acknowledgement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeAckStatus {
@@ -89,6 +112,8 @@ impl std::fmt::Display for NodeAckStatus {
         }
     }
 }
+
+pub const PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME: u64 = sonde_protocol::TEST_TYPE_DIAG_FRAME;
 
 /// BLE pairing method negotiated during connection (PT-0904).
 ///

--- a/crates/sonde-protocol/src/ble_envelope.rs
+++ b/crates/sonde-protocol/src/ble_envelope.rs
@@ -184,6 +184,10 @@ pub fn encode_run_test_command(
     rf_channel: Option<u8>,
     payload: &[u8],
 ) -> Result<Vec<u8>, EncodeError> {
+    if payload.len() > MAX_FRAME_SIZE {
+        return Err(EncodeError::FrameTooLarge);
+    }
+
     if test_type == TEST_TYPE_DIAG_FRAME {
         let rf_channel = rf_channel.ok_or_else(|| {
             EncodeError::InvalidParameter("DIAG_FRAME requires rf_channel".into())
@@ -198,9 +202,6 @@ pub fn encode_run_test_command(
             return Err(EncodeError::InvalidParameter(
                 "DIAG_FRAME payload must not be empty".into(),
             ));
-        }
-        if payload.len() > MAX_FRAME_SIZE {
-            return Err(EncodeError::FrameTooLarge);
         }
     }
 
@@ -222,6 +223,13 @@ pub fn decode_run_test_command(body: &[u8]) -> Result<RunTestCommand, DecodeErro
     let fields = cbor_decode_map(body)?;
     let test_type = get_uint(&fields, TEST_CMD_KEY_TEST_TYPE)?;
     let payload = get_bytes(&fields, TEST_CMD_KEY_PAYLOAD)?;
+    if payload.len() > MAX_FRAME_SIZE {
+        return Err(DecodeError::InvalidParameter(format!(
+            "test payload too large: {} > {}",
+            payload.len(),
+            MAX_FRAME_SIZE
+        )));
+    }
     let rf_channel = match get_optional_uint(&fields, TEST_CMD_KEY_RF_CHANNEL)? {
         None => None,
         Some(channel) => Some(
@@ -468,6 +476,15 @@ mod tests {
     }
 
     #[test]
+    fn run_test_command_large_payload_rejected_for_all_test_types() {
+        let payload = vec![0x42u8; MAX_FRAME_SIZE + 1];
+        assert!(matches!(
+            encode_run_test_command(0x99, None, &payload),
+            Err(EncodeError::FrameTooLarge)
+        ));
+    }
+
+    #[test]
     fn run_test_ack_round_trip() {
         let body = encode_run_test_ack(RUN_TEST_ACK_OK).unwrap();
         let envelope = encode_ble_envelope(BLE_RUN_TEST_ACK, &body).unwrap();
@@ -591,6 +608,23 @@ mod tests {
         assert!(matches!(
             decode_run_test_command(&body),
             Err(DecodeError::MissingField(TEST_CMD_KEY_RF_CHANNEL))
+        ));
+    }
+
+    #[test]
+    fn decode_run_test_command_rejects_large_payload_for_all_test_types() {
+        let body = cbor_encode_map(&[
+            (TEST_CMD_KEY_TEST_TYPE, Value::Integer(0x99u64.into())),
+            (
+                TEST_CMD_KEY_PAYLOAD,
+                Value::Bytes(vec![0x42; MAX_FRAME_SIZE + 1]),
+            ),
+        ])
+        .unwrap();
+
+        assert!(matches!(
+            decode_run_test_command(&body),
+            Err(DecodeError::InvalidParameter(_))
         ));
     }
 

--- a/crates/sonde-protocol/src/ble_envelope.rs
+++ b/crates/sonde-protocol/src/ble_envelope.rs
@@ -103,6 +103,12 @@ fn cbor_decode_map(data: &[u8]) -> Result<Vec<(u64, Value)>, DecodeError> {
                 "BLE test message key must be unsigned integer".into(),
             ));
         };
+        if decoded.iter().any(|(existing_key, _)| *existing_key == key) {
+            return Err(DecodeError::InvalidParameter(format!(
+                "duplicate BLE test message key: {}",
+                key
+            )));
+        }
         decoded.push((key, value.clone()));
     }
     Ok(decoded)

--- a/crates/sonde-protocol/src/ble_envelope.rs
+++ b/crates/sonde-protocol/src/ble_envelope.rs
@@ -108,7 +108,7 @@ fn cbor_decode_map(data: &[u8]) -> Result<Vec<(u64, Value)>, DecodeError> {
     Ok(decoded)
 }
 
-fn get_field<'a>(fields: &'a [(u64, Value)], key: u64) -> Result<&'a Value, DecodeError> {
+fn get_field(fields: &[(u64, Value)], key: u64) -> Result<&Value, DecodeError> {
     fields
         .iter()
         .find(|(candidate, _)| *candidate == key)

--- a/crates/sonde-protocol/src/ble_envelope.rs
+++ b/crates/sonde-protocol/src/ble_envelope.rs
@@ -288,8 +288,8 @@ pub fn decode_read_test_result(body: &[u8]) -> Result<(), DecodeError> {
     }
 }
 
-/// Encode a `TEST_RESULT` BLE body.
-pub fn encode_test_result(result: &TestResult) -> Result<Vec<u8>, EncodeError> {
+/// Validate `TEST_RESULT` field combinations before encoding or storing.
+pub fn validate_test_result(result: &TestResult) -> Result<(), EncodeError> {
     if result.status == TEST_RESULT_OK {
         if result.reply_frame.is_none() || result.reply_rssi_dbm.is_none() {
             return Err(EncodeError::InvalidParameter(
@@ -318,6 +318,13 @@ pub fn encode_test_result(result: &TestResult) -> Result<Vec<u8>, EncodeError> {
             return Err(EncodeError::FrameTooLarge);
         }
     }
+
+    Ok(())
+}
+
+/// Encode a `TEST_RESULT` BLE body.
+pub fn encode_test_result(result: &TestResult) -> Result<Vec<u8>, EncodeError> {
+    validate_test_result(result)?;
 
     let mut pairs = vec![(TEST_RESULT_KEY_STATUS, Value::Integer(result.status.into()))];
     if let Some(test_type) = result.test_type {

--- a/crates/sonde-protocol/src/ble_envelope.rs
+++ b/crates/sonde-protocol/src/ble_envelope.rs
@@ -12,16 +12,40 @@
 //! Used by both the node (BLE pairing provisioning) and the gateway
 //! (phone registration over BLE relay).
 
+use alloc::format;
+use alloc::vec;
 use alloc::vec::Vec;
 
-use crate::constants::MAX_FRAME_SIZE;
+use ciborium::Value;
+
+use crate::constants::{
+    MAX_FRAME_SIZE, TEST_CMD_KEY_PAYLOAD, TEST_CMD_KEY_RF_CHANNEL, TEST_CMD_KEY_TEST_TYPE,
+    TEST_RESULT_KEY_ATTEMPT_COUNT, TEST_RESULT_KEY_ELAPSED_MS, TEST_RESULT_KEY_REPLY_FRAME,
+    TEST_RESULT_KEY_REPLY_RSSI_DBM, TEST_RESULT_KEY_STATUS, TEST_RESULT_KEY_TEST_TYPE,
+    TEST_RESULT_NO_RESULT, TEST_RESULT_OK, TEST_TYPE_DIAG_FRAME,
+};
 use crate::error::{DecodeError, EncodeError};
 
+/// Parsed `RUN_TEST_COMMAND` body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunTestCommand {
+    pub test_type: u64,
+    pub rf_channel: Option<u8>,
+    pub payload: Vec<u8>,
+}
+
+/// Parsed `TEST_RESULT` body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestResult {
+    pub status: u8,
+    pub test_type: Option<u64>,
+    pub reply_frame: Option<Vec<u8>>,
+    pub reply_rssi_dbm: Option<i8>,
+    pub attempt_count: u64,
+    pub elapsed_ms: u64,
+}
+
 /// Parse a BLE message envelope.
-///
-/// Returns `(msg_type, body_slice)` on success, or `None` if the buffer is
-/// shorter than the 3-byte header, shorter than `3 + LEN`, or contains
-/// trailing bytes after the envelope.
 pub fn parse_ble_envelope(data: &[u8]) -> Option<(u8, &[u8])> {
     if data.len() < 3 {
         return None;
@@ -35,9 +59,6 @@ pub fn parse_ble_envelope(data: &[u8]) -> Option<(u8, &[u8])> {
 }
 
 /// Encode a BLE message envelope.
-///
-/// Returns `None` if `body.len()` exceeds `u16::MAX` (65535 bytes), since the
-/// 2-byte LEN field cannot represent larger sizes.
 pub fn encode_ble_envelope(msg_type: u8, body: &[u8]) -> Option<Vec<u8>> {
     if body.len() > u16::MAX as usize {
         return None;
@@ -50,126 +71,337 @@ pub fn encode_ble_envelope(msg_type: u8, body: &[u8]) -> Option<Vec<u8>> {
     Some(out)
 }
 
-/// Encode a DIAG_RELAY_REQUEST BLE body.
-///
-/// Body format: `rf_channel (1B) | payload_len (2B BE) | payload`.
-/// Returns `Err` if `rf_channel` is outside 1–13, `payload` is empty,
-/// or `payload` exceeds `MAX_FRAME_SIZE`.
-pub fn encode_diag_relay_request(rf_channel: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError> {
-    if !(1..=13).contains(&rf_channel) {
-        return Err(EncodeError::InvalidParameter(alloc::format!(
-            "DIAG_RELAY_REQUEST rf_channel {} out of range 1-13",
-            rf_channel
-        )));
-    }
-    if payload.is_empty() {
-        return Err(EncodeError::InvalidParameter(
-            "DIAG_RELAY_REQUEST payload must not be empty".into(),
-        ));
-    }
-    if payload.len() > MAX_FRAME_SIZE {
-        return Err(EncodeError::FrameTooLarge);
-    }
-    let payload_len = payload.len() as u16;
-    let mut body = Vec::with_capacity(3 + payload.len());
-    body.push(rf_channel);
-    body.extend_from_slice(&payload_len.to_be_bytes());
-    body.extend_from_slice(payload);
-    Ok(body)
+fn cbor_encode_map(pairs: &[(u64, Value)]) -> Result<Vec<u8>, EncodeError> {
+    let value = Value::Map(
+        pairs
+            .iter()
+            .map(|(key, value)| (Value::Integer((*key).into()), value.clone()))
+            .collect(),
+    );
+    let mut buf = Vec::new();
+    ciborium::into_writer(&value, &mut buf).map_err(|e| EncodeError::CborError(format!("{e}")))?;
+    Ok(buf)
 }
 
-/// Decode a DIAG_RELAY_REQUEST BLE body.
-///
-/// Returns `(rf_channel, payload)` on success. Rejects truncated bodies,
-/// bodies with trailing bytes, out-of-range channels, empty payloads,
-/// and oversized payloads.
-pub fn decode_diag_relay_request(body: &[u8]) -> Result<(u8, &[u8]), DecodeError> {
-    if body.len() < 3 {
-        return Err(DecodeError::TooShort);
-    }
-    let rf_channel = body[0];
-    if !(1..=13).contains(&rf_channel) {
-        return Err(DecodeError::InvalidParameter(alloc::format!(
-            "rf_channel {} out of range 1-13",
-            rf_channel
-        )));
-    }
-    let payload_len = u16::from_be_bytes([body[1], body[2]]) as usize;
-    if payload_len == 0 || payload_len > MAX_FRAME_SIZE {
-        return Err(DecodeError::InvalidParameter(alloc::format!(
-            "payload_len {} out of range 1-{}",
-            payload_len,
-            MAX_FRAME_SIZE
-        )));
-    }
-    if body.len() < 3 + payload_len {
-        return Err(DecodeError::TooShort);
-    }
-    if body.len() > 3 + payload_len {
+fn cbor_decode_map(data: &[u8]) -> Result<Vec<(u64, Value)>, DecodeError> {
+    let mut remaining = data;
+    let value: Value = ciborium::from_reader(&mut remaining)
+        .map_err(|e| DecodeError::CborError(format!("{e}")))?;
+    if !remaining.is_empty() {
         return Err(DecodeError::TooLong);
     }
-    Ok((rf_channel, &body[3..3 + payload_len]))
+    let map = value
+        .as_map()
+        .ok_or_else(|| DecodeError::CborError("expected CBOR map".into()))?;
+    let mut decoded = Vec::with_capacity(map.len());
+    for (key, value) in map {
+        let Some(key) = key
+            .as_integer()
+            .and_then(|integer| u64::try_from(integer).ok())
+        else {
+            return Err(DecodeError::InvalidParameter(
+                "BLE test message key must be unsigned integer".into(),
+            ));
+        };
+        decoded.push((key, value.clone()));
+    }
+    Ok(decoded)
 }
 
-/// Encode a DIAG_RELAY_RESPONSE BLE body.
-///
-/// Body format: `status (1B) | payload_len (2B BE) | payload`.
-/// When `status` ≠ `DIAG_RELAY_STATUS_OK`, `payload` must be empty.
-pub fn encode_diag_relay_response(status: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError> {
-    if status != crate::constants::DIAG_RELAY_STATUS_OK && !payload.is_empty() {
+fn get_field<'a>(fields: &'a [(u64, Value)], key: u64) -> Result<&'a Value, DecodeError> {
+    fields
+        .iter()
+        .find(|(candidate, _)| *candidate == key)
+        .map(|(_, value)| value)
+        .ok_or(DecodeError::MissingField(key))
+}
+
+fn get_uint(fields: &[(u64, Value)], key: u64) -> Result<u64, DecodeError> {
+    get_field(fields, key)?
+        .as_integer()
+        .and_then(|value| u64::try_from(value).ok())
+        .ok_or(DecodeError::InvalidFieldType(key))
+}
+
+fn get_u8(fields: &[(u64, Value)], key: u64) -> Result<u8, DecodeError> {
+    u8::try_from(get_uint(fields, key)?).map_err(|_| DecodeError::InvalidFieldType(key))
+}
+
+fn get_bytes(fields: &[(u64, Value)], key: u64) -> Result<Vec<u8>, DecodeError> {
+    get_field(fields, key)?
+        .as_bytes()
+        .map(|bytes| bytes.to_vec())
+        .ok_or(DecodeError::InvalidFieldType(key))
+}
+
+fn get_optional_uint(fields: &[(u64, Value)], key: u64) -> Result<Option<u64>, DecodeError> {
+    match fields.iter().find(|(candidate, _)| *candidate == key) {
+        None => Ok(None),
+        Some((_, value)) => value
+            .as_integer()
+            .and_then(|integer| u64::try_from(integer).ok())
+            .map(Some)
+            .ok_or(DecodeError::InvalidFieldType(key)),
+    }
+}
+
+fn get_optional_i8(fields: &[(u64, Value)], key: u64) -> Result<Option<i8>, DecodeError> {
+    match fields.iter().find(|(candidate, _)| *candidate == key) {
+        None => Ok(None),
+        Some((_, value)) => {
+            let integer = value
+                .as_integer()
+                .ok_or(DecodeError::InvalidFieldType(key))?;
+            let value = i64::try_from(integer).map_err(|_| DecodeError::InvalidFieldType(key))?;
+            i8::try_from(value)
+                .map(Some)
+                .map_err(|_| DecodeError::InvalidFieldType(key))
+        }
+    }
+}
+
+fn get_optional_bytes(fields: &[(u64, Value)], key: u64) -> Result<Option<Vec<u8>>, DecodeError> {
+    match fields.iter().find(|(candidate, _)| *candidate == key) {
+        None => Ok(None),
+        Some((_, value)) => value
+            .as_bytes()
+            .map(|bytes| Some(bytes.to_vec()))
+            .ok_or(DecodeError::InvalidFieldType(key)),
+    }
+}
+
+/// Encode a `RUN_TEST_COMMAND` BLE body.
+pub fn encode_run_test_command(
+    test_type: u64,
+    rf_channel: Option<u8>,
+    payload: &[u8],
+) -> Result<Vec<u8>, EncodeError> {
+    if test_type == TEST_TYPE_DIAG_FRAME {
+        let rf_channel = rf_channel.ok_or_else(|| {
+            EncodeError::InvalidParameter("DIAG_FRAME requires rf_channel".into())
+        })?;
+        if !(1..=13).contains(&rf_channel) {
+            return Err(EncodeError::InvalidParameter(format!(
+                "DIAG_FRAME rf_channel {} out of range 1-13",
+                rf_channel
+            )));
+        }
+        if payload.is_empty() {
+            return Err(EncodeError::InvalidParameter(
+                "DIAG_FRAME payload must not be empty".into(),
+            ));
+        }
+        if payload.len() > MAX_FRAME_SIZE {
+            return Err(EncodeError::FrameTooLarge);
+        }
+    }
+
+    let mut pairs = vec![
+        (TEST_CMD_KEY_TEST_TYPE, Value::Integer(test_type.into())),
+        (TEST_CMD_KEY_PAYLOAD, Value::Bytes(payload.to_vec())),
+    ];
+    if let Some(rf_channel) = rf_channel {
+        pairs.insert(
+            1,
+            (TEST_CMD_KEY_RF_CHANNEL, Value::Integer(rf_channel.into())),
+        );
+    }
+    cbor_encode_map(&pairs)
+}
+
+/// Decode a `RUN_TEST_COMMAND` BLE body.
+pub fn decode_run_test_command(body: &[u8]) -> Result<RunTestCommand, DecodeError> {
+    let fields = cbor_decode_map(body)?;
+    let test_type = get_uint(&fields, TEST_CMD_KEY_TEST_TYPE)?;
+    let payload = get_bytes(&fields, TEST_CMD_KEY_PAYLOAD)?;
+    let rf_channel = match get_optional_uint(&fields, TEST_CMD_KEY_RF_CHANNEL)? {
+        None => None,
+        Some(channel) => Some(
+            u8::try_from(channel)
+                .map_err(|_| DecodeError::InvalidFieldType(TEST_CMD_KEY_RF_CHANNEL))?,
+        ),
+    };
+
+    if test_type == TEST_TYPE_DIAG_FRAME {
+        let rf_channel = rf_channel.ok_or(DecodeError::MissingField(TEST_CMD_KEY_RF_CHANNEL))?;
+        if !(1..=13).contains(&rf_channel) {
+            return Err(DecodeError::InvalidParameter(format!(
+                "DIAG_FRAME rf_channel {} out of range 1-13",
+                rf_channel
+            )));
+        }
+        if payload.is_empty() {
+            return Err(DecodeError::InvalidParameter(
+                "DIAG_FRAME payload must not be empty".into(),
+            ));
+        }
+        if payload.len() > MAX_FRAME_SIZE {
+            return Err(DecodeError::InvalidParameter(format!(
+                "DIAG_FRAME payload too large: {} > {}",
+                payload.len(),
+                MAX_FRAME_SIZE
+            )));
+        }
+    }
+
+    Ok(RunTestCommand {
+        test_type,
+        rf_channel,
+        payload,
+    })
+}
+
+/// Encode a `RUN_TEST_ACK` BLE body.
+pub fn encode_run_test_ack(status: u8) -> Result<Vec<u8>, EncodeError> {
+    Ok(vec![status])
+}
+
+/// Decode a `RUN_TEST_ACK` BLE body.
+pub fn decode_run_test_ack(body: &[u8]) -> Result<u8, DecodeError> {
+    if body.len() != 1 {
+        return if body.is_empty() {
+            Err(DecodeError::TooShort)
+        } else {
+            Err(DecodeError::TooLong)
+        };
+    }
+    Ok(body[0])
+}
+
+/// Encode an empty `READ_TEST_RESULT` BLE body.
+pub fn encode_read_test_result() -> Vec<u8> {
+    Vec::new()
+}
+
+/// Decode a `READ_TEST_RESULT` BLE body.
+pub fn decode_read_test_result(body: &[u8]) -> Result<(), DecodeError> {
+    if body.is_empty() {
+        Ok(())
+    } else {
+        Err(DecodeError::TooLong)
+    }
+}
+
+/// Encode a `TEST_RESULT` BLE body.
+pub fn encode_test_result(result: &TestResult) -> Result<Vec<u8>, EncodeError> {
+    if result.status == TEST_RESULT_OK {
+        if result.reply_frame.is_none() || result.reply_rssi_dbm.is_none() {
+            return Err(EncodeError::InvalidParameter(
+                "successful TEST_RESULT requires reply_frame and reply_rssi_dbm".into(),
+            ));
+        }
+    } else if result.reply_frame.is_some() || result.reply_rssi_dbm.is_some() {
         return Err(EncodeError::InvalidParameter(
-            "DIAG_RELAY_RESPONSE payload must be empty for non-OK status".into(),
+            "non-success TEST_RESULT must not include reply fields".into(),
         ));
     }
-    if payload.len() > MAX_FRAME_SIZE {
-        return Err(EncodeError::FrameTooLarge);
+
+    if result.status != TEST_RESULT_NO_RESULT && result.test_type.is_none() {
+        return Err(EncodeError::InvalidParameter(
+            "TEST_RESULT missing test_type".into(),
+        ));
     }
-    let payload_len = payload.len() as u16;
-    let mut body = Vec::with_capacity(3 + payload.len());
-    body.push(status);
-    body.extend_from_slice(&payload_len.to_be_bytes());
-    body.extend_from_slice(payload);
-    Ok(body)
+
+    if let Some(reply_frame) = &result.reply_frame {
+        if reply_frame.is_empty() {
+            return Err(EncodeError::InvalidParameter(
+                "reply_frame must not be empty when present".into(),
+            ));
+        }
+        if reply_frame.len() > MAX_FRAME_SIZE {
+            return Err(EncodeError::FrameTooLarge);
+        }
+    }
+
+    let mut pairs = vec![(TEST_RESULT_KEY_STATUS, Value::Integer(result.status.into()))];
+    if let Some(test_type) = result.test_type {
+        pairs.push((TEST_RESULT_KEY_TEST_TYPE, Value::Integer(test_type.into())));
+    }
+    if let Some(reply_frame) = &result.reply_frame {
+        pairs.push((
+            TEST_RESULT_KEY_REPLY_FRAME,
+            Value::Bytes(reply_frame.clone()),
+        ));
+    }
+    if let Some(reply_rssi_dbm) = result.reply_rssi_dbm {
+        pairs.push((
+            TEST_RESULT_KEY_REPLY_RSSI_DBM,
+            Value::Integer(reply_rssi_dbm.into()),
+        ));
+    }
+    pairs.push((
+        TEST_RESULT_KEY_ATTEMPT_COUNT,
+        Value::Integer(result.attempt_count.into()),
+    ));
+    pairs.push((
+        TEST_RESULT_KEY_ELAPSED_MS,
+        Value::Integer(result.elapsed_ms.into()),
+    ));
+
+    cbor_encode_map(&pairs)
 }
 
-/// Decode a DIAG_RELAY_RESPONSE BLE body.
-///
-/// Returns `(status, payload)` on success. Rejects truncated bodies,
-/// bodies with trailing bytes, and payloads exceeding `MAX_FRAME_SIZE`.
-pub fn decode_diag_relay_response(body: &[u8]) -> Result<(u8, &[u8]), DecodeError> {
-    if body.len() < 3 {
-        return Err(DecodeError::TooShort);
-    }
-    let status = body[0];
-    let payload_len = u16::from_be_bytes([body[1], body[2]]) as usize;
-    if payload_len > MAX_FRAME_SIZE {
-        return Err(DecodeError::InvalidParameter(alloc::format!(
-            "DIAG_RELAY_RESPONSE payload_len {} exceeds MAX_FRAME_SIZE {}",
-            payload_len,
-            MAX_FRAME_SIZE
-        )));
-    }
-    if body.len() < 3 + payload_len {
-        return Err(DecodeError::TooShort);
-    }
-    if body.len() > 3 + payload_len {
-        return Err(DecodeError::TooLong);
-    }
-    if status != crate::DIAG_RELAY_STATUS_OK && payload_len != 0 {
+/// Decode a `TEST_RESULT` BLE body.
+pub fn decode_test_result(body: &[u8]) -> Result<TestResult, DecodeError> {
+    let fields = cbor_decode_map(body)?;
+    let status = get_u8(&fields, TEST_RESULT_KEY_STATUS)?;
+    let test_type = get_optional_uint(&fields, TEST_RESULT_KEY_TEST_TYPE)?;
+    let reply_frame = get_optional_bytes(&fields, TEST_RESULT_KEY_REPLY_FRAME)?;
+    let reply_rssi_dbm = get_optional_i8(&fields, TEST_RESULT_KEY_REPLY_RSSI_DBM)?;
+    let attempt_count = get_uint(&fields, TEST_RESULT_KEY_ATTEMPT_COUNT)?;
+    let elapsed_ms = get_uint(&fields, TEST_RESULT_KEY_ELAPSED_MS)?;
+
+    if status == TEST_RESULT_OK {
+        if reply_frame.is_none() || reply_rssi_dbm.is_none() {
+            return Err(DecodeError::InvalidParameter(
+                "successful TEST_RESULT missing reply fields".into(),
+            ));
+        }
+    } else if reply_frame.is_some() || reply_rssi_dbm.is_some() {
         return Err(DecodeError::InvalidParameter(
-            "non-OK DIAG_RELAY_RESPONSE must have empty payload".into(),
+            "non-success TEST_RESULT must not include reply fields".into(),
         ));
     }
-    Ok((status, &body[3..3 + payload_len]))
+
+    if status != TEST_RESULT_NO_RESULT && test_type.is_none() {
+        return Err(DecodeError::MissingField(TEST_RESULT_KEY_TEST_TYPE));
+    }
+
+    if let Some(reply_frame) = &reply_frame {
+        if reply_frame.is_empty() {
+            return Err(DecodeError::InvalidParameter(
+                "reply_frame must not be empty when present".into(),
+            ));
+        }
+        if reply_frame.len() > MAX_FRAME_SIZE {
+            return Err(DecodeError::InvalidParameter(format!(
+                "reply_frame too large: {} > {}",
+                reply_frame.len(),
+                MAX_FRAME_SIZE
+            )));
+        }
+    }
+
+    Ok(TestResult {
+        status,
+        test_type,
+        reply_frame,
+        reply_rssi_dbm,
+        attempt_count,
+        elapsed_ms,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constants::{BLE_DIAG_RELAY_REQUEST, BLE_DIAG_RELAY_RESPONSE};
-    use alloc::vec;
+    use crate::constants::{
+        BLE_READ_TEST_RESULT, BLE_RUN_TEST_ACK, BLE_RUN_TEST_COMMAND, BLE_TEST_RESULT,
+        RUN_TEST_ACK_INVALID, RUN_TEST_ACK_OK, RUN_TEST_ACK_UNSUPPORTED,
+        TEST_RESULT_EXECUTION_ERROR, TEST_RESULT_TIMEOUT,
+    };
 
-    #[test] // T-P100: BLE envelope round-trip
+    #[test]
     fn round_trip() {
         let body = [0x42u8; 10];
         let encoded = encode_ble_envelope(0x01, &body).unwrap();
@@ -178,7 +410,7 @@ mod tests {
         assert_eq!(decoded, &body);
     }
 
-    #[test] // T-P101: BLE envelope with empty body
+    #[test]
     fn empty_body() {
         let encoded = encode_ble_envelope(0x81, &[]).unwrap();
         let (msg_type, body) = parse_ble_envelope(&encoded).unwrap();
@@ -186,120 +418,201 @@ mod tests {
         assert!(body.is_empty());
     }
 
-    #[test] // T-P102: BLE envelope too short rejected
+    #[test]
     fn too_short() {
         assert!(parse_ble_envelope(&[0x01, 0x00]).is_none());
     }
 
-    #[test] // T-P103: BLE envelope truncated body rejected
+    #[test]
     fn truncated() {
         assert!(parse_ble_envelope(&[0x01, 0x00, 0x04, 0xAA, 0xBB]).is_none());
     }
 
-    #[test] // T-P104: BLE envelope trailing bytes rejected
+    #[test]
     fn trailing_bytes() {
         assert!(parse_ble_envelope(&[0x01, 0x00, 0x02, 0xAA, 0xBB, 0xCC]).is_none());
     }
 
-    // T-P114: DIAG_RELAY_REQUEST round-trip
     #[test]
-    fn diag_relay_request_round_trip() {
+    fn run_test_command_round_trip() {
         let payload = [0x42u8; 50];
-        let body = encode_diag_relay_request(6, &payload).unwrap();
-        let envelope = encode_ble_envelope(BLE_DIAG_RELAY_REQUEST, &body).unwrap();
+        let body = encode_run_test_command(TEST_TYPE_DIAG_FRAME, Some(6), &payload).unwrap();
+        let envelope = encode_ble_envelope(BLE_RUN_TEST_COMMAND, &body).unwrap();
         let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
-        assert_eq!(msg_type, BLE_DIAG_RELAY_REQUEST);
-        let (rf_channel, decoded_payload) = decode_diag_relay_request(decoded_body).unwrap();
-        assert_eq!(rf_channel, 6);
-        assert_eq!(decoded_payload, &payload);
+        assert_eq!(msg_type, BLE_RUN_TEST_COMMAND);
+        let decoded = decode_run_test_command(decoded_body).unwrap();
+        assert_eq!(decoded.test_type, TEST_TYPE_DIAG_FRAME);
+        assert_eq!(decoded.rf_channel, Some(6));
+        assert_eq!(decoded.payload, &payload);
     }
 
-    // T-P115: DIAG_RELAY_REQUEST invalid channel rejected
     #[test]
-    fn diag_relay_request_invalid_channel() {
+    fn run_test_command_invalid_channel_rejected() {
         let payload = [0x42u8; 50];
-        assert!(encode_diag_relay_request(0, &payload).is_err());
-        assert!(encode_diag_relay_request(14, &payload).is_err());
-        assert!(encode_diag_relay_request(1, &payload).is_ok());
-        assert!(encode_diag_relay_request(13, &payload).is_ok());
+        assert!(encode_run_test_command(TEST_TYPE_DIAG_FRAME, Some(14), &payload).is_err());
     }
 
-    // T-P116: DIAG_RELAY_RESPONSE round-trip (success, timeout, channel_error)
     #[test]
-    fn diag_relay_response_round_trip() {
-        // status=0x00 with payload
-        let payload = [0xAA; 30];
-        let body = encode_diag_relay_response(0x00, &payload).unwrap();
-        let envelope = encode_ble_envelope(BLE_DIAG_RELAY_RESPONSE, &body).unwrap();
+    fn run_test_ack_round_trip() {
+        let body = encode_run_test_ack(RUN_TEST_ACK_OK).unwrap();
+        let envelope = encode_ble_envelope(BLE_RUN_TEST_ACK, &body).unwrap();
         let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
-        assert_eq!(msg_type, BLE_DIAG_RELAY_RESPONSE);
-        let (status, decoded_payload) = decode_diag_relay_response(decoded_body).unwrap();
-        assert_eq!(status, 0x00);
-        assert_eq!(decoded_payload, &payload);
-
-        // status=0x01 (timeout), empty payload
-        let body = encode_diag_relay_response(0x01, &[]).unwrap();
-        let (status, decoded_payload) = decode_diag_relay_response(&body).unwrap();
-        assert_eq!(status, 0x01);
-        assert!(decoded_payload.is_empty());
-
-        // status=0x02 (channel_error), empty payload
-        let body = encode_diag_relay_response(0x02, &[]).unwrap();
-        let (status, decoded_payload) = decode_diag_relay_response(&body).unwrap();
-        assert_eq!(status, 0x02);
-        assert!(decoded_payload.is_empty());
-    }
-
-    // T-P115 additional: empty payload rejected
-    #[test]
-    fn diag_relay_request_empty_payload_rejected() {
-        assert!(encode_diag_relay_request(6, &[]).is_err());
+        assert_eq!(msg_type, BLE_RUN_TEST_ACK);
+        assert_eq!(decode_run_test_ack(decoded_body).unwrap(), RUN_TEST_ACK_OK);
     }
 
     #[test]
-    fn diag_relay_request_decode_out_of_range_channel() {
-        let body = [14, 0, 1, 0xAA]; // rf_channel=14
-        assert!(decode_diag_relay_request(&body).is_err());
+    fn read_test_result_round_trip() {
+        let body = encode_read_test_result();
+        let envelope = encode_ble_envelope(BLE_READ_TEST_RESULT, &body).unwrap();
+        let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
+        assert_eq!(msg_type, BLE_READ_TEST_RESULT);
+        decode_read_test_result(decoded_body).unwrap();
     }
 
     #[test]
-    fn diag_relay_request_decode_zero_payload_len() {
-        let body = [6, 0, 0]; // payload_len=0
-        assert!(decode_diag_relay_request(&body).is_err());
+    fn test_result_round_trip_success_and_timeout() {
+        let success = TestResult {
+            status: TEST_RESULT_OK,
+            test_type: Some(TEST_TYPE_DIAG_FRAME),
+            reply_frame: Some(vec![0xAA; 30]),
+            reply_rssi_dbm: Some(-64),
+            attempt_count: 2,
+            elapsed_ms: 4_100,
+        };
+        let body = encode_test_result(&success).unwrap();
+        let envelope = encode_ble_envelope(BLE_TEST_RESULT, &body).unwrap();
+        let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
+        assert_eq!(msg_type, BLE_TEST_RESULT);
+        assert_eq!(decode_test_result(decoded_body).unwrap(), success);
+
+        let timeout = TestResult {
+            status: TEST_RESULT_TIMEOUT,
+            test_type: Some(TEST_TYPE_DIAG_FRAME),
+            reply_frame: None,
+            reply_rssi_dbm: None,
+            attempt_count: 4,
+            elapsed_ms: 8_600,
+        };
+        assert_eq!(
+            decode_test_result(&encode_test_result(&timeout).unwrap()).unwrap(),
+            timeout
+        );
     }
 
     #[test]
-    fn diag_relay_request_decode_trailing_bytes() {
-        let body = [6, 0, 1, 0xAA, 0xBB]; // payload_len=1 but 2 data bytes
-        assert!(decode_diag_relay_request(&body).is_err());
+    fn test_result_no_result_allows_missing_test_type() {
+        let no_result = TestResult {
+            status: TEST_RESULT_NO_RESULT,
+            test_type: None,
+            reply_frame: None,
+            reply_rssi_dbm: None,
+            attempt_count: 0,
+            elapsed_ms: 0,
+        };
+        assert_eq!(
+            decode_test_result(&encode_test_result(&no_result).unwrap()).unwrap(),
+            no_result
+        );
     }
 
     #[test]
-    fn diag_relay_request_decode_truncated() {
-        let body = [6, 0, 5, 0xAA, 0xBB]; // payload_len=5 but only 2 data bytes
-        assert!(decode_diag_relay_request(&body).is_err());
+    fn test_result_reply_fields_required_on_success() {
+        let result = TestResult {
+            status: TEST_RESULT_OK,
+            test_type: Some(TEST_TYPE_DIAG_FRAME),
+            reply_frame: None,
+            reply_rssi_dbm: Some(-55),
+            attempt_count: 1,
+            elapsed_ms: 1,
+        };
+        assert!(encode_test_result(&result).is_err());
     }
 
     #[test]
-    fn diag_relay_response_non_ok_with_payload_rejected() {
-        assert!(encode_diag_relay_response(0x01, &[0xAA]).is_err());
-        assert!(encode_diag_relay_response(0x02, &[0xBB]).is_err());
+    fn test_result_reply_fields_rejected_on_non_success() {
+        let result = TestResult {
+            status: TEST_RESULT_EXECUTION_ERROR,
+            test_type: Some(TEST_TYPE_DIAG_FRAME),
+            reply_frame: Some(vec![0xAA]),
+            reply_rssi_dbm: Some(-55),
+            attempt_count: 1,
+            elapsed_ms: 1,
+        };
+        assert!(encode_test_result(&result).is_err());
     }
 
     #[test]
-    fn diag_relay_response_decode_trailing_bytes() {
-        let body = [0x00, 0, 1, 0xAA, 0xBB]; // payload_len=1 but 2 data bytes
-        assert!(decode_diag_relay_response(&body).is_err());
+    fn run_test_command_rejects_empty_diag_payload() {
+        assert!(encode_run_test_command(TEST_TYPE_DIAG_FRAME, Some(6), &[]).is_err());
     }
 
     #[test]
-    fn diag_relay_response_decode_oversized_payload_rejected() {
-        // payload_len > MAX_FRAME_SIZE should be rejected
-        let oversized_len = (MAX_FRAME_SIZE as u16) + 1;
-        let mut body = vec![0x00]; // status OK
-        body.extend_from_slice(&oversized_len.to_be_bytes());
-        // Don't need to provide actual payload bytes — the length check
-        // should reject before reaching the slice bounds check.
-        assert!(decode_diag_relay_response(&body).is_err());
+    fn decode_run_test_command_missing_rf_channel_for_diag() {
+        let body = cbor_encode_map(&[
+            (
+                TEST_CMD_KEY_TEST_TYPE,
+                Value::Integer(TEST_TYPE_DIAG_FRAME.into()),
+            ),
+            (TEST_CMD_KEY_PAYLOAD, Value::Bytes(vec![0x42; 5])),
+        ])
+        .unwrap();
+        assert!(matches!(
+            decode_run_test_command(&body),
+            Err(DecodeError::MissingField(TEST_CMD_KEY_RF_CHANNEL))
+        ));
+    }
+
+    #[test]
+    fn decode_run_test_ack_wrong_length() {
+        assert!(matches!(
+            decode_run_test_ack(&[]),
+            Err(DecodeError::TooShort)
+        ));
+        assert!(matches!(
+            decode_run_test_ack(&[RUN_TEST_ACK_INVALID, RUN_TEST_ACK_UNSUPPORTED]),
+            Err(DecodeError::TooLong)
+        ));
+    }
+
+    #[test]
+    fn decode_read_test_result_rejects_non_empty_body() {
+        assert!(decode_read_test_result(&[0xAA]).is_err());
+    }
+
+    #[test]
+    fn decode_test_result_rejects_success_without_reply_fields() {
+        let body = cbor_encode_map(&[
+            (
+                TEST_RESULT_KEY_STATUS,
+                Value::Integer(TEST_RESULT_OK.into()),
+            ),
+            (
+                TEST_RESULT_KEY_TEST_TYPE,
+                Value::Integer(TEST_TYPE_DIAG_FRAME.into()),
+            ),
+            (TEST_RESULT_KEY_ATTEMPT_COUNT, Value::Integer(1.into())),
+            (TEST_RESULT_KEY_ELAPSED_MS, Value::Integer(10.into())),
+        ])
+        .unwrap();
+        assert!(decode_test_result(&body).is_err());
+    }
+
+    #[test]
+    fn decode_test_result_rejects_trailing_bytes() {
+        let mut body = encode_test_result(&TestResult {
+            status: TEST_RESULT_TIMEOUT,
+            test_type: Some(TEST_TYPE_DIAG_FRAME),
+            reply_frame: None,
+            reply_rssi_dbm: None,
+            attempt_count: 4,
+            elapsed_ms: 8_600,
+        })
+        .unwrap();
+        body.push(0x00);
+        assert!(matches!(
+            decode_test_result(&body),
+            Err(DecodeError::TooLong)
+        ));
     }
 }

--- a/crates/sonde-protocol/src/ble_envelope.rs
+++ b/crates/sonde-protocol/src/ble_envelope.rs
@@ -291,9 +291,9 @@ pub fn decode_read_test_result(body: &[u8]) -> Result<(), DecodeError> {
 /// Validate `TEST_RESULT` field combinations before encoding or storing.
 pub fn validate_test_result(result: &TestResult) -> Result<(), EncodeError> {
     if result.status == TEST_RESULT_OK {
-        if result.reply_frame.is_none() || result.reply_rssi_dbm.is_none() {
+        if result.reply_frame.is_none() {
             return Err(EncodeError::InvalidParameter(
-                "successful TEST_RESULT requires reply_frame and reply_rssi_dbm".into(),
+                "successful TEST_RESULT requires reply_frame".into(),
             ));
         }
     } else if result.reply_frame.is_some() || result.reply_rssi_dbm.is_some() {
@@ -365,9 +365,9 @@ pub fn decode_test_result(body: &[u8]) -> Result<TestResult, DecodeError> {
     let elapsed_ms = get_uint(&fields, TEST_RESULT_KEY_ELAPSED_MS)?;
 
     if status == TEST_RESULT_OK {
-        if reply_frame.is_none() || reply_rssi_dbm.is_none() {
+        if reply_frame.is_none() {
             return Err(DecodeError::InvalidParameter(
-                "successful TEST_RESULT missing reply fields".into(),
+                "successful TEST_RESULT missing reply_frame".into(),
             ));
         }
     } else if reply_frame.is_some() || reply_rssi_dbm.is_some() {
@@ -540,6 +540,22 @@ mod tests {
             elapsed_ms: 1,
         };
         assert!(encode_test_result(&result).is_err());
+    }
+
+    #[test]
+    fn test_result_success_allows_missing_reply_rssi() {
+        let result = TestResult {
+            status: TEST_RESULT_OK,
+            test_type: Some(TEST_TYPE_DIAG_FRAME),
+            reply_frame: Some(vec![0xAA; 30]),
+            reply_rssi_dbm: None,
+            attempt_count: 1,
+            elapsed_ms: 10,
+        };
+        assert_eq!(
+            decode_test_result(&encode_test_result(&result).unwrap()).unwrap(),
+            result
+        );
     }
 
     #[test]

--- a/crates/sonde-protocol/src/ble_envelope.rs
+++ b/crates/sonde-protocol/src/ble_envelope.rs
@@ -72,8 +72,10 @@ pub fn encode_ble_envelope(msg_type: u8, body: &[u8]) -> Option<Vec<u8>> {
 }
 
 fn cbor_encode_map(pairs: &[(u64, Value)]) -> Result<Vec<u8>, EncodeError> {
+    let mut sorted_pairs = pairs.to_vec();
+    sorted_pairs.sort_unstable_by_key(|(key, _)| *key);
     let value = Value::Map(
-        pairs
+        sorted_pairs
             .iter()
             .map(|(key, value)| (Value::Integer((*key).into()), value.clone()))
             .collect(),
@@ -590,6 +592,30 @@ mod tests {
             decode_run_test_command(&body),
             Err(DecodeError::MissingField(TEST_CMD_KEY_RF_CHANNEL))
         ));
+    }
+
+    #[test]
+    fn cbor_encode_map_sorts_keys_canonically() {
+        let unsorted = cbor_encode_map(&[
+            (TEST_CMD_KEY_PAYLOAD, Value::Bytes(vec![0x42; 2])),
+            (
+                TEST_CMD_KEY_TEST_TYPE,
+                Value::Integer(TEST_TYPE_DIAG_FRAME.into()),
+            ),
+            (TEST_CMD_KEY_RF_CHANNEL, Value::Integer(6.into())),
+        ])
+        .unwrap();
+        let sorted = cbor_encode_map(&[
+            (
+                TEST_CMD_KEY_TEST_TYPE,
+                Value::Integer(TEST_TYPE_DIAG_FRAME.into()),
+            ),
+            (TEST_CMD_KEY_RF_CHANNEL, Value::Integer(6.into())),
+            (TEST_CMD_KEY_PAYLOAD, Value::Bytes(vec![0x42; 2])),
+        ])
+        .unwrap();
+
+        assert_eq!(unsorted, sorted);
     }
 
     #[test]

--- a/crates/sonde-protocol/src/constants.rs
+++ b/crates/sonde-protocol/src/constants.rs
@@ -108,12 +108,35 @@ pub const SIGNAL_QUALITY_BAD: u8 = 2;
 
 // BLE envelope message types (Node Command characteristic)
 pub const BLE_NODE_PROVISION: u8 = 0x01;
-pub const BLE_DIAG_RELAY_REQUEST: u8 = 0x02;
+pub const BLE_RUN_TEST_COMMAND: u8 = 0x02;
+pub const BLE_READ_TEST_RESULT: u8 = 0x03;
 pub const BLE_NODE_ACK: u8 = 0x81;
-pub const BLE_DIAG_RELAY_RESPONSE: u8 = 0x82;
+pub const BLE_RUN_TEST_ACK: u8 = 0x82;
+pub const BLE_TEST_RESULT: u8 = 0x83;
 pub const BLE_ERROR: u8 = 0xFF;
 
-// DIAG_RELAY_RESPONSE status codes
-pub const DIAG_RELAY_STATUS_OK: u8 = 0x00;
-pub const DIAG_RELAY_STATUS_TIMEOUT: u8 = 0x01;
-pub const DIAG_RELAY_STATUS_CHANNEL_ERROR: u8 = 0x02;
+// Pre-provisioning test CBOR keys (separate keyspace)
+pub const TEST_CMD_KEY_TEST_TYPE: u64 = 1;
+pub const TEST_CMD_KEY_RF_CHANNEL: u64 = 2;
+pub const TEST_CMD_KEY_PAYLOAD: u64 = 3;
+
+pub const TEST_RESULT_KEY_STATUS: u64 = 1;
+pub const TEST_RESULT_KEY_TEST_TYPE: u64 = 2;
+pub const TEST_RESULT_KEY_REPLY_FRAME: u64 = 3;
+pub const TEST_RESULT_KEY_REPLY_RSSI_DBM: u64 = 4;
+pub const TEST_RESULT_KEY_ATTEMPT_COUNT: u64 = 5;
+pub const TEST_RESULT_KEY_ELAPSED_MS: u64 = 6;
+
+// Pre-provisioning test types
+pub const TEST_TYPE_DIAG_FRAME: u64 = 0x01;
+
+// RUN_TEST_ACK status codes
+pub const RUN_TEST_ACK_OK: u8 = 0x00;
+pub const RUN_TEST_ACK_INVALID: u8 = 0x01;
+pub const RUN_TEST_ACK_UNSUPPORTED: u8 = 0x02;
+
+// TEST_RESULT status codes
+pub const TEST_RESULT_OK: u8 = 0x00;
+pub const TEST_RESULT_TIMEOUT: u8 = 0x01;
+pub const TEST_RESULT_NO_RESULT: u8 = 0x02;
+pub const TEST_RESULT_EXECUTION_ERROR: u8 = 0x03;

--- a/crates/sonde-protocol/src/lib.rs
+++ b/crates/sonde-protocol/src/lib.rs
@@ -21,7 +21,7 @@ pub use aead_codec::{build_gcm_nonce, decode_frame, encode_frame, open_frame, De
 pub use ble_envelope::{
     decode_read_test_result, decode_run_test_ack, decode_run_test_command, decode_test_result,
     encode_ble_envelope, encode_read_test_result, encode_run_test_ack, encode_run_test_command,
-    encode_test_result, parse_ble_envelope, RunTestCommand, TestResult,
+    encode_test_result, parse_ble_envelope, validate_test_result, RunTestCommand, TestResult,
 };
 pub use board_layout::{
     decode_board_layout_cbor, encode_board_layout_cbor, BoardLayout, BOARD_LAYOUT_KEY_BATTERY_ADC,

--- a/crates/sonde-protocol/src/lib.rs
+++ b/crates/sonde-protocol/src/lib.rs
@@ -19,8 +19,9 @@ pub mod traits;
 
 pub use aead_codec::{build_gcm_nonce, decode_frame, encode_frame, open_frame, DecodedFrame};
 pub use ble_envelope::{
-    decode_diag_relay_request, decode_diag_relay_response, encode_ble_envelope,
-    encode_diag_relay_request, encode_diag_relay_response, parse_ble_envelope,
+    decode_read_test_result, decode_run_test_ack, decode_run_test_command, decode_test_result,
+    encode_ble_envelope, encode_read_test_result, encode_run_test_ack, encode_run_test_command,
+    encode_test_result, parse_ble_envelope, RunTestCommand, TestResult,
 };
 pub use board_layout::{
     decode_board_layout_cbor, encode_board_layout_cbor, BoardLayout, BOARD_LAYOUT_KEY_BATTERY_ADC,

--- a/crates/sonde-protocol/tests/validation.rs
+++ b/crates/sonde-protocol/tests/validation.rs
@@ -2833,6 +2833,36 @@ fn test_p115_run_test_command_invalid_channel_rejected() {
     );
 }
 
+#[test]
+fn test_p115b_run_test_command_duplicate_key_rejected() {
+    let map = vec![
+        (
+            ciborium::Value::Integer(TEST_CMD_KEY_TEST_TYPE.into()),
+            ciborium::Value::Integer(TEST_TYPE_DIAG_FRAME.into()),
+        ),
+        (
+            ciborium::Value::Integer(TEST_CMD_KEY_TEST_TYPE.into()),
+            ciborium::Value::Integer(0x99.into()),
+        ),
+        (
+            ciborium::Value::Integer(TEST_CMD_KEY_RF_CHANNEL.into()),
+            ciborium::Value::Integer(6.into()),
+        ),
+        (
+            ciborium::Value::Integer(TEST_CMD_KEY_PAYLOAD.into()),
+            ciborium::Value::Bytes(vec![0x42; 8]),
+        ),
+    ];
+    let mut body = Vec::new();
+    ciborium::ser::into_writer(&ciborium::Value::Map(map), &mut body).unwrap();
+
+    let err = decode_run_test_command(&body).unwrap_err();
+    assert!(
+        matches!(err, DecodeError::InvalidParameter(ref msg) if msg.contains("duplicate")),
+        "expected duplicate-key rejection, got {err:?}"
+    );
+}
+
 /// T-P116: RUN_TEST_ACK and TEST_RESULT round-trip
 #[test]
 fn test_p116_run_test_ack_and_test_result_round_trip() {

--- a/crates/sonde-protocol/tests/validation.rs
+++ b/crates/sonde-protocol/tests/validation.rs
@@ -2794,67 +2794,74 @@ fn test_p104_ble_envelope_trailing_bytes_rejected() {
 }
 
 // ---------------------------------------------------------------------------
-// 10  DIAG relay integration tests (T-P114 – T-P116)
+// 10  Pre-provisioning test BLE integration tests (T-P114 – T-P116)
 // ---------------------------------------------------------------------------
 
-/// T-P114: DIAG_RELAY_REQUEST encode → BLE envelope → decode round-trip
+/// T-P114: RUN_TEST_COMMAND encode → BLE envelope → decode round-trip
 #[test]
-fn test_p114_diag_relay_request_round_trip() {
+fn test_p114_run_test_command_round_trip() {
     let payload = [0x42u8; 50];
-    let body = encode_diag_relay_request(6, &payload).unwrap();
-    let envelope = encode_ble_envelope(BLE_DIAG_RELAY_REQUEST, &body).unwrap();
+    let body = encode_run_test_command(TEST_TYPE_DIAG_FRAME, Some(6), &payload).unwrap();
+    let envelope = encode_ble_envelope(BLE_RUN_TEST_COMMAND, &body).unwrap();
     let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
-    assert_eq!(msg_type, BLE_DIAG_RELAY_REQUEST);
-    let (rf_channel, decoded_payload) = decode_diag_relay_request(decoded_body).unwrap();
-    assert_eq!(rf_channel, 6);
-    assert_eq!(decoded_payload, &payload);
+    assert_eq!(msg_type, BLE_RUN_TEST_COMMAND);
+    let decoded = decode_run_test_command(decoded_body).unwrap();
+    assert_eq!(decoded.test_type, TEST_TYPE_DIAG_FRAME);
+    assert_eq!(decoded.rf_channel, Some(6));
+    assert_eq!(decoded.payload, &payload);
 }
 
-/// T-P115: DIAG_RELAY_REQUEST rejects channels outside 1–13 (boundary-inclusive check)
+/// T-P115: RUN_TEST_COMMAND rejects channels outside 1–13 (boundary-inclusive check)
 #[test]
-fn test_p115_diag_relay_request_invalid_channel_rejected() {
+fn test_p115_run_test_command_invalid_channel_rejected() {
     let payload = [0x42u8; 10];
     assert!(
-        encode_diag_relay_request(0, &payload).is_err(),
+        encode_run_test_command(TEST_TYPE_DIAG_FRAME, Some(0), &payload).is_err(),
         "channel 0 must be rejected"
     );
     assert!(
-        encode_diag_relay_request(14, &payload).is_err(),
+        encode_run_test_command(TEST_TYPE_DIAG_FRAME, Some(14), &payload).is_err(),
         "channel 14 must be rejected"
     );
-    // Boundary values: channels 1 and 13 are the valid extremes
     assert!(
-        encode_diag_relay_request(1, &payload).is_ok(),
+        encode_run_test_command(TEST_TYPE_DIAG_FRAME, Some(1), &payload).is_ok(),
         "channel 1 (lower boundary) must succeed"
     );
     assert!(
-        encode_diag_relay_request(13, &payload).is_ok(),
+        encode_run_test_command(TEST_TYPE_DIAG_FRAME, Some(13), &payload).is_ok(),
         "channel 13 (upper boundary) must succeed"
     );
 }
 
-/// T-P116: DIAG_RELAY_RESPONSE — OK with payload, non-OK statuses require empty payload
+/// T-P116: RUN_TEST_ACK and TEST_RESULT round-trip
 #[test]
-fn test_p116_diag_relay_response_round_trip() {
-    // status=OK with non-empty payload
-    let payload = [0xABu8; 30];
-    let body = encode_diag_relay_response(DIAG_RELAY_STATUS_OK, &payload).unwrap();
-    let envelope = encode_ble_envelope(BLE_DIAG_RELAY_RESPONSE, &body).unwrap();
-    let (msg_type, decoded_body) = parse_ble_envelope(&envelope).unwrap();
-    assert_eq!(msg_type, BLE_DIAG_RELAY_RESPONSE);
-    let (status, decoded_payload) = decode_diag_relay_response(decoded_body).unwrap();
-    assert_eq!(status, DIAG_RELAY_STATUS_OK);
-    assert_eq!(decoded_payload, &payload);
+fn test_p116_run_test_ack_and_test_result_round_trip() {
+    let ack = encode_run_test_ack(RUN_TEST_ACK_OK).unwrap();
+    assert_eq!(decode_run_test_ack(&ack).unwrap(), RUN_TEST_ACK_OK);
 
-    // status=TIMEOUT, empty payload
-    let body_timeout = encode_diag_relay_response(DIAG_RELAY_STATUS_TIMEOUT, &[]).unwrap();
-    let (status_t, payload_t) = decode_diag_relay_response(&body_timeout).unwrap();
-    assert_eq!(status_t, DIAG_RELAY_STATUS_TIMEOUT);
-    assert!(payload_t.is_empty());
+    let success = TestResult {
+        status: TEST_RESULT_OK,
+        test_type: Some(TEST_TYPE_DIAG_FRAME),
+        reply_frame: Some(vec![0xABu8; 30]),
+        reply_rssi_dbm: Some(-64),
+        attempt_count: 2,
+        elapsed_ms: 4_100,
+    };
+    assert_eq!(
+        decode_test_result(&encode_test_result(&success).unwrap()).unwrap(),
+        success
+    );
 
-    // status=CHANNEL_ERROR, empty payload
-    let body_chan = encode_diag_relay_response(DIAG_RELAY_STATUS_CHANNEL_ERROR, &[]).unwrap();
-    let (status_c, payload_c) = decode_diag_relay_response(&body_chan).unwrap();
-    assert_eq!(status_c, DIAG_RELAY_STATUS_CHANNEL_ERROR);
-    assert!(payload_c.is_empty());
+    let timeout = TestResult {
+        status: TEST_RESULT_TIMEOUT,
+        test_type: Some(TEST_TYPE_DIAG_FRAME),
+        reply_frame: None,
+        reply_rssi_dbm: None,
+        attempt_count: 4,
+        elapsed_ms: 8_600,
+    };
+    assert_eq!(
+        decode_test_result(&encode_test_result(&timeout).unwrap()).unwrap(),
+        timeout
+    );
 }

--- a/docs/ble-pairing-protocol.md
+++ b/docs/ble-pairing-protocol.md
@@ -459,7 +459,7 @@ The body is a deterministic CBOR map:
 | 1 | `status` | uint | `0x00` = success, `0x01` = timeout, `0x02` = no result available, `0x03` = execution error. |
 | 2 | `test_type` | uint | Echoes the executed test type. |
 | 3 | `reply_frame` | bstr | Raw gateway reply frame, present on success. |
-| 4 | `reply_rssi_dbm` | int | Node-observed RSSI of the received reply frame, present on success. |
+| 4 | `reply_rssi_dbm` | int | Node-observed RSSI of the received reply frame, present on success when the platform receive path provides RSSI metadata. |
 | 5 | `attempt_count` | uint | Number of send/listen attempts used during execution. |
 | 6 | `elapsed_ms` | uint | Total execution time in milliseconds. |
 
@@ -487,7 +487,7 @@ The node identifies reply frames by inspecting the `msg_type` byte at header off
 4. Tool waits up to **5 seconds** for `RUN_TEST_ACK`.
 5. On `RUN_TEST_ACK(status=0x00)`, the tool expects the node to reboot and later reconnects to the BLE pairing service.
 6. Tool sends `READ_TEST_RESULT` and waits up to **5 seconds** for `TEST_RESULT`.
-7. On `TEST_RESULT(status=0x00)`, the tool decrypts the raw `DIAG_REPLY` frame using `phone_psk`, combines the gateway-reported diagnostic fields with the node-reported reply RSSI and timing metadata, and displays the result.
+7. On `TEST_RESULT(status=0x00)`, the tool decrypts the raw `DIAG_REPLY` frame using `phone_psk`, combines the gateway-reported diagnostic fields with timing metadata and any available node-reported reply RSSI, and displays the result.
 8. On `TEST_RESULT(status=0x01)` (timeout) or `TEST_RESULT(status=0x03)` (execution error), the tool displays an error message with guidance.
 9. If the decrypted gateway `signal_quality` is `2` (bad), the tool displays a warning and requires installer confirmation before allowing provisioning to proceed.
 

--- a/docs/ble-pairing-protocol.md
+++ b/docs/ble-pairing-protocol.md
@@ -158,9 +158,11 @@ Total envelope overhead: 3 bytes.
 | Type | Direction | Name | Description |
 |------|-----------|------|-------------|
 | 0x01 | Phone → Node | `NODE_PROVISION` | Provision PSK + encrypted payload. |
-| 0x02 | Phone → Node | `DIAG_RELAY_REQUEST` | Diagnostic relay request. See §6a. |
+| 0x02 | Phone → Node | `RUN_TEST_COMMAND` | Stage a pre-provisioning test command. See §6a. |
+| 0x03 | Phone → Node | `READ_TEST_RESULT` | Read the latest retained pre-provisioning test result. See §6a. |
 | 0x81 | Node → Phone | `NODE_ACK` | Provision acknowledgement. |
-| 0x82 | Node → Phone | `DIAG_RELAY_RESPONSE` | Diagnostic relay response. See §6a. |
+| 0x82 | Node → Phone | `RUN_TEST_ACK` | Acknowledges staging of `RUN_TEST_COMMAND`. See §6a. |
+| 0x83 | Node → Phone | `TEST_RESULT` | Latest retained pre-provisioning test result. See §6a. |
 | 0xFF | Either | `ERROR` | Error response. |
 
 ---
@@ -388,77 +390,113 @@ Offset  Size  Field
 
 ---
 
-## 6a  Pairing-time RSSI diagnostic
+## 6a  Pre-provisioning test mode
 
 ### 6a.1  Overview
 
-Before provisioning, the pairing tool may request an RF link quality check by using the node as a **dumb radio relay**. The node does not decrypt or interpret the diagnostic payload — it relays an opaque ESP-NOW frame to the gateway and forwards the reply back.
+Before provisioning, the pairing tool may request a **rebooted pre-provisioning test run**. The node does not keep BLE and ESP-NOW active at the same time. Instead, it stages a single generic test command over BLE, acknowledges receipt, reboots into a dedicated pre-provisioning test mode, executes the command, stores the latest result in RTC-retained memory, reboots back into BLE pairing mode, and then returns the retained result when the pairing tool asks for it.
 
-This step is **optional** (the installer may skip it) and **repeatable** (the installer may run it multiple times to test different node positions).
+This step is **optional** (the installer may skip it) and **repeatable** (the installer may run it multiple times to test different node positions by submitting another command).
 
 ### 6a.2  BLE message formats
 
-#### DIAG_RELAY_REQUEST (0x02, Phone → Node)
+#### RUN_TEST_COMMAND (0x02, Phone → Node)
 
-```
-┌──────────────┬──────────────┬───────────────────────────┐
-│ rf_channel   │ payload_len  │ payload                   │
-│ (1 byte)     │ (2 bytes BE) │ (payload_len bytes)       │
-└──────────────┴──────────────┴───────────────────────────┘
-```
+The body is a deterministic CBOR map:
 
-| Field | Size | Description |
-|---|---|---|
-| `rf_channel` | 1 byte | WiFi channel (1–13) to broadcast on. From Phase 1 `PHONE_REGISTERED`. |
-| `payload_len` | 2 bytes, BE | Length of the opaque ESP-NOW frame. |
-| `payload` | variable | Complete `DIAG_REQUEST` ESP-NOW frame (header + ciphertext + GCM tag), built by the pairing tool. |
-
-#### DIAG_RELAY_RESPONSE (0x82, Node → Phone)
-
-```
-┌──────────────┬──────────────┬───────────────────────────┐
-│ status       │ payload_len  │ payload                   │
-│ (1 byte)     │ (2 bytes BE) │ (payload_len bytes)       │
-└──────────────┴──────────────┴───────────────────────────┘
+```cbor
+{
+  1: test_type,      ; uint
+  2: rf_channel,     ; uint (optional; required for DIAG_FRAME)
+  3: payload         ; bstr
+}
 ```
 
-| Field | Size | Description |
-|---|---|---|
-| `status` | 1 byte | `0x00` = success (payload contains `DIAG_REPLY`), `0x01` = timeout (no reply after retries), `0x02` = channel error. |
-| `payload_len` | 2 bytes, BE | Length of the opaque ESP-NOW reply frame. Zero if `status` ≠ `0x00`. |
-| `payload` | variable | Raw `DIAG_REPLY` ESP-NOW frame from gateway (if status is `0x00`). |
+| Key | Field | Type | Description |
+|---|---|---|---|
+| 1 | `test_type` | uint | Test discriminator. Initial value: `0x01` = `DIAG_FRAME`. |
+| 2 | `rf_channel` | uint | WiFi channel (1–13). Required for `DIAG_FRAME`. |
+| 3 | `payload` | bstr | Test-specific opaque payload. For `DIAG_FRAME`, this is a complete `DIAG_REQUEST` ESP-NOW frame built by the pairing tool. |
 
-### 6a.3  Node relay behavior
+#### RUN_TEST_ACK (0x82, Node → Phone)
 
-1. Node receives `DIAG_RELAY_REQUEST` on the Node Command BLE characteristic.
-2. Node temporarily tunes the ESP-NOW radio to `rf_channel`.
-3. Node broadcasts `payload` as a raw ESP-NOW frame (broadcast MAC `FF:FF:FF:FF:FF:FF`).
-4. Node listens for an inbound ESP-NOW frame with `msg_type` = `0x85` (`DIAG_REPLY`) in the header (byte offset 2).
-5. **Retry behavior**: up to **3 retransmissions** with **200 ms** backoff between attempts, **2-second** listen window per attempt.
-6. If a valid `DIAG_REPLY` frame is received, node sends `DIAG_RELAY_RESPONSE(status=0x00, payload=<raw frame>)` via BLE indication.
-7. If all retries are exhausted without receiving a reply, node sends `DIAG_RELAY_RESPONSE(status=0x01, payload_len=0)`.
-8. Node restores its previous radio state after the diagnostic completes.
+```
+┌──────────────┐
+│ status       │
+│ (1 byte)     │
+└──────────────┘
+```
 
-The node identifies reply frames by inspecting the `msg_type` byte at header offset 2 — this field is plaintext (part of the AAD, not the ciphertext). The node does not decrypt or validate the reply payload.
+**Status codes:**
+
+| Code | Meaning |
+|---|---|
+| `0x00` | Command accepted and staged |
+| `0x01` | Invalid request |
+| `0x02` | Unsupported `test_type` |
+
+#### READ_TEST_RESULT (0x03, Phone → Node)
+
+**Body:** empty.
+
+#### TEST_RESULT (0x83, Node → Phone)
+
+The body is a deterministic CBOR map:
+
+```cbor
+{
+  1: status,         ; uint
+  2: test_type,      ; uint
+  3: reply_frame,    ; bstr (optional)
+  4: reply_rssi_dbm, ; int  (optional)
+  5: attempt_count,  ; uint
+  6: elapsed_ms      ; uint
+}
+```
+
+| Key | Field | Type | Description |
+|---|---|---|---|
+| 1 | `status` | uint | `0x00` = success, `0x01` = timeout, `0x02` = no result available, `0x03` = execution error. |
+| 2 | `test_type` | uint | Echoes the executed test type. |
+| 3 | `reply_frame` | bstr | Raw gateway reply frame, present on success. |
+| 4 | `reply_rssi_dbm` | int | Node-observed RSSI of the received reply frame, present on success. |
+| 5 | `attempt_count` | uint | Number of send/listen attempts used during execution. |
+| 6 | `elapsed_ms` | uint | Total execution time in milliseconds. |
+
+### 6a.3  Node behavior
+
+1. While in BLE pairing mode, the node receives `RUN_TEST_COMMAND` on the Node Command characteristic.
+2. The node validates the generic command body. For `DIAG_FRAME`, validation requires `rf_channel` ∈ 1–13 and `0 < payload.len() ≤ 250`.
+3. On success, the node stages the command in RTC-retained memory and sends `RUN_TEST_ACK(status=0x00)`.
+4. The node disconnects BLE and reboots into pre-provisioning test mode.
+5. In test mode, the node executes the staged command without BLE active. For `DIAG_FRAME`, it tunes ESP-NOW to `rf_channel`, broadcasts `payload` as a raw ESP-NOW frame, and listens for an inbound frame with `msg_type = 0x85` (`DIAG_REPLY`) in the header.
+6. **Retry behavior:** up to **3 retransmissions** with **200 ms** backoff between attempts, **2-second** listen window per attempt.
+7. The node stores the latest result in RTC-retained memory, clears the staged command, and reboots back into BLE pairing mode.
+8. Later, when the phone sends `READ_TEST_RESULT`, the node returns the retained result as `TEST_RESULT`.
+
+The node identifies reply frames by inspecting the `msg_type` byte at header offset 2 — this field is plaintext (part of the AAD, not the ciphertext). For `DIAG_FRAME`, the node does not decrypt or validate the reply payload.
 
 ### 6a.4  Pairing tool behavior
 
 1. Tool connects to the node's BLE Node Provisioning Service (same service used for Phase 2).
 2. Tool constructs a `DIAG_REQUEST` ESP-NOW frame authenticated with `phone_psk`:
-   - Header: `[phone_key_hint (2B) | msg_type=0x06 (1B) | random_nonce (8B)]`
-   - CBOR payload: `{ 1: 0x01 }` (diagnostic_type = DIAG_RSSI)
-   - AES-256-GCM encryption using `phone_psk`, AAD = 11-byte header
-3. Tool sends `DIAG_RELAY_REQUEST(rf_channel, payload=<frame>)` via BLE write.
-4. Tool waits up to **10 seconds** for `DIAG_RELAY_RESPONSE`.
-5. On `status=0x00`: tool decrypts the `DIAG_REPLY` payload using `phone_psk`, displays RSSI and signal quality assessment.
-6. On `status=0x01` (timeout) or `status=0x02` (channel error): tool displays an error message with guidance.
-7. If signal quality is `2` (bad): tool displays a warning and requires installer confirmation before allowing provisioning to proceed.
+    - Header: `[phone_key_hint (2B) | msg_type=0x06 (1B) | random_nonce (8B)]`
+    - CBOR payload: `{ 1: 0x01 }` (diagnostic_type = DIAG_RSSI)
+    - AES-256-GCM encryption using `phone_psk`, AAD = 11-byte header
+3. Tool sends `RUN_TEST_COMMAND({1: 0x01, 2: rf_channel, 3: payload})` via BLE write.
+4. Tool waits up to **5 seconds** for `RUN_TEST_ACK`.
+5. On `RUN_TEST_ACK(status=0x00)`, the tool expects the node to reboot and later reconnects to the BLE pairing service.
+6. Tool sends `READ_TEST_RESULT` and waits up to **5 seconds** for `TEST_RESULT`.
+7. On `TEST_RESULT(status=0x00)`, the tool decrypts the raw `DIAG_REPLY` frame using `phone_psk`, combines the gateway-reported diagnostic fields with the node-reported reply RSSI and timing metadata, and displays the result.
+8. On `TEST_RESULT(status=0x01)` (timeout) or `TEST_RESULT(status=0x03)` (execution error), the tool displays an error message with guidance.
+9. If the decrypted gateway `signal_quality` is `2` (bad), the tool displays a warning and requires installer confirmation before allowing provisioning to proceed.
 
 ### 6a.5  Timing
 
 | Parameter | Value |
 |-----------|-------|
-| BLE diagnostic timeout (pairing tool) | 10 seconds |
+| BLE `RUN_TEST_ACK` timeout (pairing tool) | 5 seconds |
+| BLE `TEST_RESULT` timeout (pairing tool) | 5 seconds |
 | ESP-NOW listen window (node, per attempt) | 2 seconds |
 | ESP-NOW retry backoff (node) | 200 ms |
 | ESP-NOW max retries (node) | 3 |
@@ -468,11 +506,12 @@ The node identifies reply frames by inspecting the `msg_type` byte at header off
 
 | Condition | Behavior |
 |-----------|----------|
-| `rf_channel` outside 1–13 | Node sends `DIAG_RELAY_RESPONSE(status=0x02)`. |
-| `payload_len` = 0 or exceeds MAX_FRAME_SIZE (250) | Node sends `DIAG_RELAY_RESPONSE(status=0x02)`. |
-| No `DIAG_REPLY` received after 3 retries | Node sends `DIAG_RELAY_RESPONSE(status=0x01)`. |
-| BLE disconnect during diagnostic | Node aborts relay, restores radio state. |
-| Gateway cannot decrypt (wrong PSK / revoked) | Gateway silently discards. Node times out. |
+| `rf_channel` outside 1–13 for `DIAG_FRAME` | Node sends `RUN_TEST_ACK(status=0x01)`. |
+| `payload` empty or exceeds MAX_FRAME_SIZE (250) | Node sends `RUN_TEST_ACK(status=0x01)`. |
+| Unsupported `test_type` | Node sends `RUN_TEST_ACK(status=0x02)`. |
+| No `DIAG_REPLY` received after 3 retries | Node stores `TEST_RESULT(status=0x01)` and reboots back to BLE pairing mode. |
+| `READ_TEST_RESULT` requested before any run completes | Node returns `TEST_RESULT(status=0x02)`. |
+| Gateway cannot decrypt (wrong PSK / revoked) | Gateway silently discards. Node stores a timeout result. |
 
 ---
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -54,6 +54,7 @@ crates/sonde-pair/
     ├── discovery.rs            # BLE scan logic, device filtering, scan lifecycle
     ├── phase1.rs               # Phase 1 state machine (gateway pairing)
     ├── phase2.rs               # Phase 2 state machine (node provisioning)
+    ├── preprovision_test.rs    # Rebooted pre-provisioning test flow
     ├── crypto.rs               # AES-256-GCM, SHA-256, pairing AEAD codec
     ├── envelope.rs             # BLE message envelope (TYPE + LEN + BODY) encode/decode
     ├── cbor.rs                 # PairingRequest CBOR construction (deterministic encoding)
@@ -206,6 +207,60 @@ The Phase 2 state machine implements the node provisioning flow from [ble-pairin
 - All validation and payload construction happen *before* the BLE write.  The tool rejects invalid inputs (empty `node_id`, `rf_channel` out of range, payload > 202 bytes) without touching BLE (PT-0403, PT-0406).
 - `node_psk` is never persisted to disk.  It exists only in memory during provisioning and is zeroed via `Zeroizing` after the `NODE_PROVISION` write succeeds (PT-0408, PT-0804).
 - The pairing request payload is encrypted with `phone_psk` (AES-256-GCM, AAD = `"sonde-pairing-v2"`) and wrapped in a complete ESP-NOW `PEER_REQUEST` frame (PT-0402).
+
+### 4.4  Pre-provisioning test state machine
+
+The pre-provisioning test flow is implemented as a separate async state machine in `preprovision_test.rs`. It takes a `BleTransport`, `PairingArtifacts` (from Phase 1), a device address, and a generic `PreprovisionTestCommand`, and returns a structured retained-result value. The initial concrete command is `PreprovisionTestCommand::DiagFrame`.
+
+```text
+┌─────────────┐
+│ Prerequisite│──── no phone_psk ──► Error("complete Phase 1 first")
+│ Check       │
+└────┬────────┘
+     │ phone_psk present
+     ▼
+┌──────────────────┐
+│ Build test cmd   │──── invalid ─────► Error (before BLE)
+│ 1. Create        │
+│    DIAG_REQUEST  │
+│ 2. Wrap generic  │
+│    RUN_TEST_CMD  │
+└────┬─────────────┘
+     ▼
+┌──────────────────┐
+│ Stage command    │
+│ write RUN_TEST   │
+│ wait RUN_TEST_ACK│──── timeout 5s ──► Error("no response")
+│                  │──── ACK !0x00 ───► Error("test rejected")
+└────┬─────────────┘
+     │ ACK(0x00)
+     ▼
+┌──────────────────┐
+│ Reconnect later  │
+│ node reboots     │
+│ connect again    │
+└────┬─────────────┘
+     ▼
+┌──────────────────┐
+│ Read result      │
+│ write READ_TEST  │
+│ wait TEST_RESULT │──── timeout 5s ──► Error("result unavailable")
+└────┬─────────────┘
+     │ TEST_RESULT
+     ▼
+┌──────────────────┐
+│ Interpret        │
+│ decrypt reply    │
+│ present gateway  │
+│ + node RSSI/meta │
+└──────────────────┘
+```
+
+**Key design decisions:**
+
+- The flow is explicitly split into **stage** and **read** phases so the tool never assumes the original BLE connection will survive test execution.
+- The outer BLE workflow is generic over `test_type`; only the test-specific payload builder changes when new test kinds are added later.
+- For `DiagFrame`, the tool combines the decrypted gateway reply (`rssi_dbm`, `signal_quality`) with the node-reported reply RSSI and elapsed-time metadata from `TEST_RESULT`.
 
 ### 4.1  NODE_PROVISION body wire format
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -211,6 +211,8 @@ The Phase 2 state machine implements the node provisioning flow from [ble-pairin
 
 The pre-provisioning test flow is implemented in `phase2.rs` alongside the rest of the node-facing Phase 2 logic. It takes a `BleTransport`, `PairingArtifacts` (from Phase 1), a device address, and a generic `PreProvisioningTestCommand`, and returns a structured retained-result value. The initial concrete command uses `test_type = PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME`.
 
+In the Tauri pairing tool, this diagnostic is part of the normal node-provisioning flow on both desktop and Android. After the operator selects a node and enters provisioning inputs, the UI first runs the automatic `DIAG_FRAME` pre-provisioning test, then presents the result in an interstitial confirmation step before allowing `NODE_PROVISION` to proceed.
+
 ```text
 ┌─────────────┐
 │ Prerequisite│──── no phone_psk ──► Error("complete Phase 1 first")
@@ -252,6 +254,21 @@ The pre-provisioning test flow is implemented in `phase2.rs` alongside the rest 
 │ decrypt reply    │
 │ present gateway  │
 │ + node RSSI/meta │
+└────┬─────────────┘
+     │ result shown to operator
+     ▼
+┌──────────────────┐
+│ Confirm next step│──── diag failed + cancel ─► Stop, no provisioning
+│ success: Continue│──── diag failed + continue ► Proceed anyway
+│ failure: Continue│
+│ anyway / Cancel  │
+└────┬─────────────┘
+     │ explicit operator confirmation
+     ▼
+┌──────────────────┐
+│ Provision node   │
+│ send NODE_PROV   │
+│ wait NODE_ACK    │
 └──────────────────┘
 ```
 
@@ -260,6 +277,8 @@ The pre-provisioning test flow is implemented in `phase2.rs` alongside the rest 
 - The flow is explicitly split into **stage** and **read** phases so the tool never assumes the original BLE connection will survive test execution.
 - The outer BLE workflow is generic over `test_type`; only the test-specific payload builder changes when new test kinds are added later.
 - For `DiagFrame`, the tool combines the decrypted gateway reply (`rssi_dbm`, `signal_quality`) with the node-reported reply RSSI and elapsed-time metadata from `TEST_RESULT`.
+- The automatic diagnostic is advisory rather than a hard gate: the operator may continue provisioning after a failure, but only by taking an explicit **continue anyway** action.
+- Success also requires explicit confirmation so the operator can review the measured result before provisioning continues.
 
 ### 4.1  NODE_PROVISION body wire format
 
@@ -945,8 +964,9 @@ Each wizard page is a `<section class="page">` element in `index.html` with a pa
 | 2 | `page-gateway-scan` | Scan controls, device list, phone label, pair button | Gateway |
 | 3 | `page-gateway-done` | Pairing success, channel/key hint info | Gateway |
 | 4 | `page-node-scan` | Scan controls, device list, RSSI indicator | Node |
-| 5 | `page-node-provision` | Node ID, board selector, provision button | Node |
-| 6 | `page-done` | Success summary, "Provision Another" button | Done |
+| 5 | `page-node-provision` | Node ID, board selector, automatic diagnostic start | Node |
+| 6 | `page-diagnostic-review` | Diagnostic result or failure, continue / continue-anyway / cancel | Node |
+| 7 | `page-done` | Success summary, "Provision Another" button | Done |
 
 ### Navigator class
 
@@ -967,7 +987,7 @@ class Navigator {
 
 **Page transitions:** `goTo()` applies CSS classes (`slide-in-right` for forward, `slide-in-left` for back) to animate the transition.  Transitions are ≤ 300 ms.  The previous page gets `slide-out-left` or `slide-out-right` respectively.
 
-**Persistence:** `goTo()` saves `currentPage` (0-based) to `localStorage` key `sonde-pair-page`.  `restore()` reads this key on startup, validates prerequisites (pairing artifacts for pages 3–6; non-ephemeral context for pages 5–6), and navigates to the saved page or the earliest valid page if prerequisites are missing.  Pages 5–6 (Node Provision, Done) require ephemeral state (selected node address and provisioning-success context respectively) that cannot survive a restart; if the saved page is 5 or 6, `restore()` falls back to page 4 (Node Scan).  Invalid or out-of-range values default to the earliest valid page (page 1 if unpaired, page 4 if paired).  After determining the target page N, `restore()` pushes all intermediate states (pages 1 through N) into the history stack so that back navigation traverses each page in sequence.
+**Persistence:** `goTo()` saves `currentPage` (0-based) to `localStorage` key `sonde-pair-page`.  `restore()` reads this key on startup, validates prerequisites (pairing artifacts for pages 3–7; non-ephemeral context for pages 5–7), and navigates to the saved page or the earliest valid page if prerequisites are missing.  Pages 5–7 (Node Provision, Diagnostic Review, Done) require ephemeral state (selected node address, diagnostic result/failure context, and provisioning-success context respectively) that cannot survive a restart; if the saved page is 5, 6, or 7, `restore()` falls back to page 4 (Node Scan).  Invalid or out-of-range values default to the earliest valid page (page 1 if unpaired, page 4 if paired).  After determining the target page N, `restore()` pushes all intermediate states (pages 1 through N) into the history stack so that back navigation traverses each page in sequence.
 
 ### Stepper bar
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -54,7 +54,6 @@ crates/sonde-pair/
     ├── discovery.rs            # BLE scan logic, device filtering, scan lifecycle
     ├── phase1.rs               # Phase 1 state machine (gateway pairing)
     ├── phase2.rs               # Phase 2 state machine (node provisioning)
-    ├── preprovision_test.rs    # Rebooted pre-provisioning test flow
     ├── crypto.rs               # AES-256-GCM, SHA-256, pairing AEAD codec
     ├── envelope.rs             # BLE message envelope (TYPE + LEN + BODY) encode/decode
     ├── cbor.rs                 # PairingRequest CBOR construction (deterministic encoding)
@@ -210,7 +209,7 @@ The Phase 2 state machine implements the node provisioning flow from [ble-pairin
 
 ### 4.4  Pre-provisioning test state machine
 
-The pre-provisioning test flow is implemented as a separate async state machine in `preprovision_test.rs`. It takes a `BleTransport`, `PairingArtifacts` (from Phase 1), a device address, and a generic `PreprovisionTestCommand`, and returns a structured retained-result value. The initial concrete command is `PreprovisionTestCommand::DiagFrame`.
+The pre-provisioning test flow is implemented in `phase2.rs` alongside the rest of the node-facing Phase 2 logic. It takes a `BleTransport`, `PairingArtifacts` (from Phase 1), a device address, and a generic `PreProvisioningTestCommand`, and returns a structured retained-result value. The initial concrete command uses `test_type = PRE_PROVISIONING_TEST_TYPE_DIAG_FRAME`.
 
 ```text
 ┌─────────────┐

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -570,6 +570,38 @@ The pairing tool's core API MUST model pre-provisioning tests as a generic comma
 
 ---
 
+### PT-0416  Automatic diagnostic step before provisioning
+
+**Priority:** Must  
+**Source:** USER-REQUEST (actual pairing-tool validation flow)
+
+**Description:**  
+When the tool is about to provision an unpaired node and valid Phase 1 artifacts are available, it MUST automatically run the initial `DIAG_FRAME` pre-provisioning test before sending `NODE_PROVISION`. This automatic diagnostic step applies to both desktop and Android pairing-tool flows; the operator must not need a separate hidden or developer-only action to trigger it.
+
+**Acceptance criteria:**
+
+1. After the operator starts node provisioning, the tool automatically starts the `DIAG_FRAME` pre-provisioning test before any `NODE_PROVISION` write.
+2. The same automatic diagnostic step is part of both desktop and Android pairing-tool flows.
+3. If the automatic diagnostic step cannot start because Phase 1 artifacts are unavailable, the tool fails with the existing Phase 1 prerequisite error instead of silently skipping the test.
+
+---
+
+### PT-0417  Operator confirmation after automatic diagnostic
+
+**Priority:** Must  
+**Source:** USER-REQUEST (automatic but skippable with explicit continue)
+
+**Description:**  
+After an automatic pre-provisioning diagnostic completes, the tool MUST pause the provisioning flow and require an explicit operator decision before proceeding. On success, the tool presents the diagnostic result and waits for confirmation to continue. On failure, the tool presents the failure and offers an explicit **continue anyway** path; diagnostic failure does not permanently block provisioning, but provisioning MUST NOT continue automatically after either success or failure.
+
+**Acceptance criteria:**
+
+1. A successful automatic diagnostic displays the result and requires explicit operator confirmation before the tool sends `NODE_PROVISION`.
+2. A failed automatic diagnostic displays the failure and requires an explicit **continue anyway** action before the tool sends `NODE_PROVISION`.
+3. The tool does not proceed from the diagnostic step to provisioning automatically, regardless of whether the diagnostic succeeded or failed.
+
+---
+
 ## 7  Error handling
 
 ### PT-0500  Error classification
@@ -1459,6 +1491,8 @@ The UI SHOULD use CSS transitions for page changes.  Forward navigation slides t
 | PT-0413 | Diagnostic result interpretation | Active |
 | PT-0414 | One-command-per-run semantics | Active |
 | PT-0415 | Generic pre-provisioning test-command model | Active |
+| PT-0416 | Automatic diagnostic step before provisioning | Active |
+| PT-0417 | Operator confirmation after automatic diagnostic | Active |
 | PT-0500 | Error classification | Active |
 | PT-0501 | Actionable error messages | Active |
 | PT-0502 | No partial state on failure | Active |

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -471,6 +471,105 @@ Before provisioning, the tool MUST validate any board layout supplied by the ope
 
 ---
 
+### PT-0410  Phase 1 prerequisite for pre-provisioning tests
+
+**Priority:** Must  
+**Source:** ble-pairing-protocol.md §6a, security.md §1.1
+
+**Description:**  
+Before starting a pre-provisioning test on an unpaired node, the tool MUST verify that it holds a valid phone PSK from Phase 1 gateway pairing. If no valid phone PSK is available, the tool MUST refuse to run the test and instruct the operator to complete Phase 1 first.
+
+**Acceptance criteria:**
+
+1. If no `phone_psk` is available, the tool refuses to start the pre-provisioning test.
+2. The error message clearly instructs the operator to complete gateway pairing first.
+3. If a valid `phone_psk` is present, the tool may construct and send the test command.
+
+---
+
+### PT-0411  RUN_TEST_COMMAND construction and acknowledgement
+
+**Priority:** Must  
+**Source:** ble-pairing-protocol.md §6a, protocol.md §5.8
+
+**Description:**  
+The tool MUST support a generic pre-provisioning `RUN_TEST_COMMAND` write (BLE envelope type `0x02`) and wait for an immediate `RUN_TEST_ACK` indication (BLE envelope type `0x82`). For the initial concrete test type, `DIAG_FRAME`, the tool constructs a complete ESP-NOW `DIAG_REQUEST` frame authenticated with `phone_psk`, wraps it in a generic CBOR command containing `test_type`, `rf_channel`, and `payload`, writes the command to the Node Command characteristic, and waits up to 5 seconds for acknowledgement.
+
+**Acceptance criteria:**
+
+1. The generic command body includes an explicit `test_type`.
+2. For `DIAG_FRAME`, the tool includes the RF channel from Phase 1 and a complete authenticated `DIAG_REQUEST` ESP-NOW frame.
+3. `RUN_TEST_ACK(status=0x00)` is treated as successful staging of the command.
+4. A non-success acknowledgement or 5-second timeout is surfaced as an operator-visible error.
+
+---
+
+### PT-0412  Explicit pre-provisioning test-result readback
+
+**Priority:** Must  
+**Source:** ble-pairing-protocol.md §6a
+
+**Description:**  
+After the node reboots back into BLE pairing mode, the tool MUST explicitly request the latest retained result by sending `READ_TEST_RESULT` (BLE envelope type `0x03`) and waiting for `TEST_RESULT` (BLE envelope type `0x83`). The tool MUST treat result retrieval as a separate step from command submission rather than expecting the original BLE connection to remain active across test execution.
+
+**Acceptance criteria:**
+
+1. The tool reconnects to the node after the rebooted test session instead of waiting for an in-session response.
+2. The tool sends `READ_TEST_RESULT` explicitly to fetch the latest retained result.
+3. Repeated reads of the same retained result are supported until the node runs another test.
+4. A missing result or read timeout is surfaced as an operator-visible error.
+
+---
+
+### PT-0413  Diagnostic result interpretation
+
+**Priority:** Must  
+**Source:** protocol.md §5.9, ble-pairing-protocol.md §6a
+
+**Description:**  
+For a successful `DIAG_FRAME` result, the tool MUST decrypt the raw `DIAG_REPLY` frame using `phone_psk`, extract the gateway-reported diagnostic fields, and present them together with the node-reported reply RSSI and timing metadata. The displayed result MUST distinguish between the gateway-observed RSSI contained in the decrypted `DIAG_REPLY` payload and the node-observed RSSI recorded when the reply was received.
+
+**Acceptance criteria:**
+
+1. The tool decrypts a successful raw `DIAG_REPLY` using the stored `phone_psk`.
+2. The displayed result includes the gateway-observed RSSI and signal-quality fields from `DIAG_REPLY`.
+3. The displayed result includes the node-observed reply RSSI and timing metadata from `TEST_RESULT`.
+4. Timeout results are displayed without attempting to decrypt a missing reply frame.
+
+---
+
+### PT-0414  One-command-per-run semantics
+
+**Priority:** Must  
+**Source:** USER-REQUEST (repeat by sending again)
+
+**Description:**  
+Each pre-provisioning test run MUST contain exactly one generic test command. If the operator wants additional samples, the tool MUST initiate another full run by sending a new `RUN_TEST_COMMAND`; it MUST NOT silently queue multiple diagnostic requests for a single reboot cycle.
+
+**Acceptance criteria:**
+
+1. Each `RUN_TEST_COMMAND` corresponds to at most one rebooted test execution on the node.
+2. The tool does not batch multiple diagnostic requests into a single run.
+3. Repeated sampling is initiated only by explicit operator action to start another run.
+
+---
+
+### PT-0415  Generic pre-provisioning test-command model
+
+**Priority:** Must  
+**Source:** USER-REQUEST (future BPF diagnostic mode)
+
+**Description:**  
+The pairing tool's core API MUST model pre-provisioning tests as a generic command type rather than hard-coding the current diagnostic request as the only supported operation. The initial implementation only needs to support `DIAG_FRAME`, but the API and wire-building logic MUST be structured so a future BPF-based test command can be added without replacing the outer run/read workflow.
+
+**Acceptance criteria:**
+
+1. The core API represents the requested test with an explicit test-type discriminator.
+2. The initial implementation supports `DIAG_FRAME` as the only concrete test type.
+3. Adding a future test type does not require changing the outer run/ack/read/result workflow.
+
+---
+
 ## 7  Error handling
 
 ### PT-0500  Error classification
@@ -1354,6 +1453,12 @@ The UI SHOULD use CSS transitions for page changes.  Forward navigation slides t
 | PT-0407 | NODE_PROVISION transmission and acknowledgement | Active |
 | PT-0408 | Node PSK zeroing | Active |
 | PT-0409 | Pin configuration validation | Active |
+| PT-0410 | Phase 1 prerequisite for pre-provisioning tests | Active |
+| PT-0411 | RUN_TEST_COMMAND construction and acknowledgement | Active |
+| PT-0412 | Explicit pre-provisioning test-result readback | Active |
+| PT-0413 | Diagnostic result interpretation | Active |
+| PT-0414 | One-command-per-run semantics | Active |
+| PT-0415 | Generic pre-provisioning test-command model | Active |
 | PT-0500 | Error classification | Active |
 | PT-0501 | Actionable error messages | Active |
 | PT-0502 | No partial state on failure | Active |

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -739,6 +739,42 @@ TestNode {
 
 ---
 
+### T-PT-322  Automatic diagnostic runs before provisioning
+
+**Validates:** PT-0416
+
+**Procedure:**
+1. Pre-load the pairing tool with valid Phase 1 artifacts and select a node in the Tauri UI flow.
+2. Enter valid node-provisioning inputs and press the provision action once.
+3. Assert: the tool starts the automatic `DIAG_FRAME` pre-provisioning test before any `NODE_PROVISION` write.
+4. Assert: the same sequencing is present in both desktop and Android pairing-tool backends.
+
+---
+
+### T-PT-323  Successful automatic diagnostic requires explicit continue
+
+**Validates:** PT-0417
+
+**Procedure:**
+1. Configure the mock node to return a successful automatic diagnostic result.
+2. Start the node-provisioning flow in the Tauri UI.
+3. Assert: the tool displays the successful diagnostic result on the diagnostic review step.
+4. Assert: no `NODE_PROVISION` write is sent until the operator explicitly selects **Continue**.
+
+---
+
+### T-PT-324  Failed automatic diagnostic requires explicit continue-anyway
+
+**Validates:** PT-0417
+
+**Procedure:**
+1. Configure the mock node to return a failed automatic diagnostic result.
+2. Start the node-provisioning flow in the Tauri UI.
+3. Assert: the tool displays the failure on the diagnostic review step and does not send `NODE_PROVISION` automatically.
+4. Assert: provisioning proceeds only after the operator explicitly selects **Continue Anyway**.
+
+---
+
 ## 6  Error handling tests
 
 ### T-PT-400  Error classification (device/transport/protocol)
@@ -1731,6 +1767,9 @@ TestNode {
 | T-PT-319 | PT-0413 | Successful diagnostic result combines gateway and node metadata |
 | T-PT-320 | PT-0414 | Repeated sampling requires separate runs |
 | T-PT-321 | PT-0415 | Generic pre-provisioning test command uses explicit discriminator |
+| T-PT-322 | PT-0416 | Automatic diagnostic runs before provisioning |
+| T-PT-323 | PT-0417 | Successful automatic diagnostic requires explicit continue |
+| T-PT-324 | PT-0417 | Failed automatic diagnostic requires explicit continue-anyway |
 | T-PT-400 | PT-0500 | Error classification |
 | T-PT-401 | PT-0501 | Actionable error messages |
 | T-PT-402 | PT-0502 | No partial state persisted on failure |

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -663,6 +663,82 @@ TestNode {
 
 ---
 
+### T-PT-316  Pre-provisioning test requires Phase 1 artifacts
+
+**Validates:** PT-0410
+
+**Procedure:**
+1. Start with an empty pairing store.
+2. Attempt to run a pre-provisioning test against a mock node.
+3. Assert: the call fails before any BLE write is made.
+4. Assert: the error instructs the operator to complete Phase 1 first.
+
+---
+
+### T-PT-317  RUN_TEST_COMMAND happy path and explicit result readback
+
+**Validates:** PT-0411, PT-0412
+
+**Procedure:**
+1. Pre-load the pairing store with valid Phase 1 artifacts.
+2. Configure the mock node to return `RUN_TEST_ACK(status=0x00)` on the first connection and a successful `TEST_RESULT` after reconnection.
+3. Start a `DIAG_FRAME` pre-provisioning test run.
+4. Assert: the tool writes `RUN_TEST_COMMAND` first, then reconnects and writes `READ_TEST_RESULT`.
+5. Assert: the run completes successfully after the explicit readback step.
+
+---
+
+### T-PT-318  RUN_TEST_COMMAND acknowledgement failure surfaces error
+
+**Validates:** PT-0411
+
+**Procedure:**
+1. Pre-load the pairing store with valid Phase 1 artifacts.
+2. Configure the mock node to return `RUN_TEST_ACK(status=0x01)` or to time out waiting for the acknowledgement.
+3. Start a pre-provisioning test run.
+4. Assert: the tool surfaces an operator-visible error.
+5. Assert: the tool does not proceed to the result-read step.
+
+---
+
+### T-PT-319  Successful diagnostic result combines gateway and node metadata
+
+**Validates:** PT-0413
+
+**Procedure:**
+1. Pre-load the pairing store with a known `phone_psk`.
+2. Configure the mock node to return a successful `TEST_RESULT` containing a raw `DIAG_REPLY` frame, `reply_rssi_dbm=-67`, `attempt_count=2`, and `elapsed_ms=4300`.
+3. Run the pre-provisioning test flow.
+4. Assert: the tool decrypts the raw `DIAG_REPLY`.
+5. Assert: the reported result includes the gateway-observed RSSI/signal-quality values from the decrypted payload and the node-observed reply RSSI/timing metadata from `TEST_RESULT`.
+
+---
+
+### T-PT-320  Repeated sampling requires separate runs
+
+**Validates:** PT-0414
+
+**Procedure:**
+1. Pre-load the pairing store with valid Phase 1 artifacts.
+2. Start one pre-provisioning test run.
+3. Assert: exactly one `RUN_TEST_COMMAND` write is issued for that run.
+4. Start a second run explicitly.
+5. Assert: the second sample is obtained only after a second `RUN_TEST_COMMAND` write.
+
+---
+
+### T-PT-321  Generic pre-provisioning test command uses explicit discriminator
+
+**Validates:** PT-0415
+
+**Procedure:**
+1. Build the initial `DIAG_FRAME` pre-provisioning test command.
+2. Capture the encoded `RUN_TEST_COMMAND` payload written to the mock BLE transport.
+3. Decode the payload as CBOR.
+4. Assert: it contains an explicit `test_type` discriminator rather than inferring the command kind from the BLE verb alone.
+
+---
+
 ## 6  Error handling tests
 
 ### T-PT-400  Error classification (device/transport/protocol)
@@ -1649,6 +1725,12 @@ TestNode {
 | T-PT-313 | PT-0407 | NODE_ACK(0x02) — storage error |
 | T-PT-314 | PT-0407 | NODE_ACK timeout (5 s) |
 | T-PT-315 | PT-0408 | Node PSK zeroing after success |
+| T-PT-316 | PT-0410 | Pre-provisioning test requires Phase 1 artifacts |
+| T-PT-317 | PT-0411, PT-0412 | RUN_TEST_COMMAND happy path and explicit result readback |
+| T-PT-318 | PT-0411 | RUN_TEST_COMMAND acknowledgement failure surfaces error |
+| T-PT-319 | PT-0413 | Successful diagnostic result combines gateway and node metadata |
+| T-PT-320 | PT-0414 | Repeated sampling requires separate runs |
+| T-PT-321 | PT-0415 | Generic pre-provisioning test command uses explicit discriminator |
 | T-PT-400 | PT-0500 | Error classification |
 | T-PT-401 | PT-0501 | Actionable error messages |
 | T-PT-402 | PT-0502 | No partial state persisted on failure |

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -88,7 +88,7 @@ The wake cycle engine is the central state machine. It runs once per wake and th
 
 ### 4.1  State machine
 
-The state machine has five main states plus two alternate boot paths. Starting from BOOT, the node reads credentials from the `key` flash partition (§6.1) and the `reg_complete` flag from NVS (§6.1a) to determine the boot path (ND-0900): (1) no PSK in key partition or pairing button held ≥ 500 ms → enter BLE pairing mode (§15); (2) PSK present but `reg_complete` not set → enter PEER_REQUEST registration (§15.7); (3) PSK present and `reg_complete` set → enter WAKE SEND. WAKE SEND transmits a WAKE frame and waits for a COMMAND response (retrying up to 3 times); if all retries fail it goes directly to SLEEP. On receiving a COMMAND, the node enters DISPATCH COMMAND, which branches on the command type: NOP proceeds to BPF execution; UPDATE_PROGRAM or RUN_EPHEMERAL initiates chunked transfer before BPF execution; UPDATE_SCHEDULE stores the new interval and proceeds to BPF execution; REBOOT restarts the firmware. After BPF execution — which may perform APP_DATA exchanges with the gateway — the node enters SLEEP.
+The state machine has five main states plus three alternate boot paths. Starting from BOOT, the node checks RTC-retained pre-provisioning test state, then reads credentials from the `key` flash partition (§6.1) and the `reg_complete` flag from NVS (§6.1a) to determine the boot path (ND-0900): (1) staged pre-provisioning test command present → enter pre-provisioning test mode (§15.8); (2) no PSK in key partition or pairing button held ≥ 500 ms → enter BLE pairing mode (§15); (3) PSK present but `reg_complete` not set → enter PEER_REQUEST registration (§15.7); (4) PSK present and `reg_complete` set → enter WAKE SEND. WAKE SEND transmits a WAKE frame and waits for a COMMAND response (retrying up to 3 times); if all retries fail it goes directly to SLEEP. On receiving a COMMAND, the node enters DISPATCH COMMAND, which branches on the command type: NOP proceeds to BPF execution; UPDATE_PROGRAM or RUN_EPHEMERAL initiates chunked transfer before BPF execution; UPDATE_SCHEDULE stores the new interval and proceeds to BPF execution; REBOOT restarts the firmware. After BPF execution — which may perform APP_DATA exchanges with the gateway — the node enters SLEEP.
 
 ```
 ┌─────────┐
@@ -96,6 +96,7 @@ The state machine has five main states plus two alternate boot paths. Starting f
 └────┬────┘
      │ check PSK + reg_complete (ND-0900)
      │
+     ├── staged test command  → pre-provisioning test mode (§15.8)
      ├── no PSK OR button held → BLE pairing mode (§15)
      ├── PSK + no reg_complete → PEER_REQUEST (§15.7)
      │
@@ -129,7 +130,7 @@ The state machine has five main states plus two alternate boot paths. Starting f
 
 ### 4.2  Wake sequence (detailed)
 
-1. **Boot/wake**: Initialize hardware. Determine boot path per ND-0900: (1) no PSK or button held → BLE pairing mode, (2) PSK + no `reg_complete` → PEER_REQUEST registration, (3) PSK + `reg_complete` → proceed to step 2.
+1. **Boot/wake**: Initialize hardware. Determine boot path per ND-0900: (1) staged test command → pre-provisioning test mode, (2) no PSK or button held → BLE pairing mode, (3) PSK + no `reg_complete` → PEER_REQUEST registration, (4) PSK + `reg_complete` → proceed to step 2.
 2. **Generate nonce**: Hardware RNG produces a 64-bit random nonce.
 3. **Drain async queue**: Check the async queue (§8.6) from the previous cycle. If exactly 1 message is queued and it fits in the WAKE payload budget, include it as `blob` (CBOR key 10) in the WAKE message. Otherwise, `blob` is omitted and the queue is left intact for overflow drain in step 7 (NOP only).
 4. **Send WAKE**: Construct WAKE frame (`firmware_abi_version`, `program_hash`, `battery_mv`, `firmware_version`, and optionally `blob`). The `firmware_version` string is derived from `CARGO_PKG_VERSION` at compile time. `battery_mv` comes from the RTC-retained reading captured on the previous wake; if no value has been captured yet, it is `0`. AEAD-encrypt with PSK. Transmit via ESP-NOW.
@@ -641,7 +642,7 @@ The Node Provisioning Service exposes a single characteristic:
 | UUID | Property | Purpose |
 |---|---|---|
 | `0xFE50` (service) | — | Node Provisioning Service |
-| `0xFE51` (characteristic) | Write + Indicate | NODE_PROVISION (write) / NODE_ACK (indicate) |
+| `0xFE51` (characteristic) | Write + Indicate | `NODE_PROVISION`, `RUN_TEST_COMMAND`, `READ_TEST_RESULT` (write) / `NODE_ACK`, `RUN_TEST_ACK`, `TEST_RESULT` (indicate) |
 
 GATT writes received before LESC pairing completes are accepted at the ATT level but not processed immediately: the implementation buffers at most one pre-auth write in `pending_write` and defers it until authentication succeeds and the negotiated ATT MTU is ≥ 247 bytes (ND-0904). Writes that cannot be buffered (for example because a pending write is already present or the payload is invalid/too large) are rejected/ignored according to normal ATT error handling. If authentication fails, or if the post-pairing MTU negotiation results in MTU < 247, any buffered write is discarded and the connection is dropped.
 
@@ -666,20 +667,20 @@ boot → NimBLE init → GATT service register → start advertising
     ↓
 phone connects → server calls ble_gap_security_initiate() → LESC pairing → MTU exchange → auth complete
     ↓
-buffered GATT write flushed (if any) → handle_node_provision() → NODE_ACK indicate
+buffered GATT write flushed (if any) → handle_pairing_command() → NODE_ACK / RUN_TEST_ACK / TEST_RESULT indicate
     ↓
-phone disconnects → return → reboot (ND-0907)
+phone disconnects → return → reboot (ND-0907, ND-1106)
 ```
 
-The main loop polls for pending GATT writes and disconnection events at 100 ms intervals. On disconnect, the function returns and the caller reboots into normal wake-cycle mode with the newly provisioned credentials.
+The main loop polls for pending GATT writes and disconnection events at 100 ms intervals. On disconnect, the function returns and the caller reboots. Depending on retained state, the next boot may enter pre-provisioning test mode, BLE pairing mode, or the normal wake-cycle path.
 
 ### 15.6  Platform-independent handler
 
-The GATT write payload is parsed and handled by `handle_node_provision()` in the platform-independent `ble_pairing` module (ND-0905, ND-0906, ND-0908). The handler parses the five NODE_PROVISION fields (`node_key_hint`, `node_psk`, `rf_channel`, `payload_len`, `encrypted_payload`), validates `payload_len` before reading `encrypted_payload`, and persists credentials: PSK and key_hint to the `key` flash partition (§6.1), and `channel`, `peer_payload`, `reg_complete` to NVS (§6.1a, ND-0916). The `reg_complete` flag is cleared on successful provision. If any write fails, the handler responds with NODE_ACK(0x02) (ND-0908). This keeps provisioning logic testable on the host (see T-N904–T-N907). The ESP-specific `esp_ble_pairing` module handles only NimBLE initialization, GATT plumbing, and the event loop.
+The GATT write payload is parsed and handled by a platform-independent pairing-command handler in the `ble_pairing` module. `NODE_PROVISION` handling remains responsible for parsing the five provisioning fields (`node_key_hint`, `node_psk`, `rf_channel`, `payload_len`, `encrypted_payload`), validating `payload_len` before reading `encrypted_payload`, and persisting credentials: PSK and key hint to the `key` flash partition (§6.1), and `channel`, `peer_payload`, `reg_complete` to NVS (§6.1a, ND-0916). `RUN_TEST_COMMAND` handling validates and stages one pending pre-provisioning test command in RTC-retained state and returns `RUN_TEST_ACK`. `READ_TEST_RESULT` handling returns the latest retained result as `TEST_RESULT` without clearing it. This keeps provisioning and pre-provisioning test logic testable on the host. The ESP-specific `esp_ble_pairing` module handles only NimBLE initialization, GATT plumbing, and the event loop.
 
 ### 15.7  Post-provisioning registration (PEER_REQUEST / PEER_ACK)
 
-When the node boots with a PSK stored but the `reg_complete` flag not set (boot path 2, ND-0900), it enters the PEER_REQUEST registration sub-protocol. This completes the pairing handshake by registering the node with the gateway via the modem.
+When the node boots with a PSK stored but the `reg_complete` flag not set (boot path 3, ND-0900), it enters the PEER_REQUEST registration sub-protocol. This completes the pairing handshake by registering the node with the gateway via the modem.
 
 **Frame construction (ND-0909):**
 
@@ -720,44 +721,32 @@ After the first successful WAKE/COMMAND exchange (the gateway responds with a va
 
 If WAKE fails (no response or AEAD decryption failure) after `reg_complete` is set, the node clears the `reg_complete` flag and reverts to sending PEER_REQUEST on the next boot. This allows the node to re-register if the gateway lost its registration state.
 
-### 15.8  Diagnostic relay (pre-provisioning)
+### 15.8  Pre-provisioning test mode
 
-> **Requirements:** ND-1100 (BLE diagnostic relay command), ND-1101 (diagnostic ESP-NOW broadcast), ND-1102 (diagnostic reply reception), ND-1103 (diagnostic retry behavior), ND-1104 (diagnostic timeout handling), ND-1105 (diagnostic BLE response forwarding), ND-1106 (diagnostic radio state restoration).
+> **Requirements:** ND-1100 (generic BLE pre-provisioning test command), ND-1101 (test-command acknowledgement and staging), ND-1102 (pre-provisioning test-mode execution), ND-1103 (diagnostic retry behavior in test mode), ND-1104 (latest-result retention and explicit readback), ND-1105 (diagnostic result contents), ND-1106 (reboot back to BLE pairing mode after test execution), ND-1107 (test-command format extensibility).
 
-While in BLE pairing mode (before `NODE_PROVISION` is received), the node can act as a **dumb radio relay** for pairing-time diagnostics. The pairing tool uses this to measure the node→gateway RF link quality before committing to provisioning.
+The pre-provisioning test flow is split across two boots so the ESP32-C3 never needs BLE and ESP-NOW active concurrently.
 
-**BLE command handling (ND-1100):**
+**BLE-side staging (ND-1100, ND-1101, ND-1107):**
 
-The node's BLE GATT handler processes `DIAG_RELAY_REQUEST` (envelope type `0x02`) on the Node Command characteristic:
+1. While in BLE pairing mode, the GATT handler accepts `RUN_TEST_COMMAND` (envelope type `0x02`) and parses its CBOR body.
+2. The generic command format identifies the requested test by `test_type` and carries a test-specific payload as an opaque byte string.
+3. For the initial `DIAG_FRAME` test type, the handler validates `rf_channel` and payload length, stages the RF channel and payload in RTC-retained memory, and sends `RUN_TEST_ACK(status=0x00)`.
+4. Unsupported or malformed commands are rejected before reboot with a non-success acknowledgement.
 
-1. Parse the envelope body: `rf_channel` (1 byte), `payload_len` (2 bytes BE), `payload` (variable).
-2. Validate: `rf_channel` ∈ 1–13 and 0 < `payload_len` ≤ 250. On validation failure → respond with `DIAG_RELAY_RESPONSE(status=0x02)`.
+**Execution boot (ND-1102, ND-1103):**
 
-**ESP-NOW relay (ND-1101, ND-1102):**
+1. On the next boot, the firmware sees the staged command and enters pre-provisioning test mode before BLE pairing mode.
+2. For `DIAG_FRAME`, the node initializes ESP-NOW on the staged channel, broadcasts the staged `DIAG_REQUEST` frame, and listens for `DIAG_REPLY`.
+3. Retry parameters match the diagnostic specification: up to 3 retransmissions, 200 ms backoff, 2-second listen window per attempt.
+4. The node records the first successful reply frame, the receive RSSI reported by the ESP-NOW stack, the number of attempts used, and the total elapsed time.
 
-1. Save the current ESP-NOW channel (if any).
-2. Tune the ESP-NOW radio to `rf_channel`.
-3. Broadcast `payload` as a raw ESP-NOW frame to `FF:FF:FF:FF:FF:FF`.
-4. Listen for inbound ESP-NOW frames.
-5. Accept the first frame whose `msg_type` byte (header offset 2) = `0x85` (`DIAG_REPLY`).
-6. Ignore frames with any other `msg_type`.
+**Result retention and return (ND-1104, ND-1105, ND-1106):**
 
-**Retry behavior (ND-1103):**
-
-Matches the WAKE cycle retry parameters:
-- Up to 3 retransmissions.
-- 200 ms backoff between attempts.
-- 2-second listen window per attempt.
-- A reply received during any attempt terminates the loop.
-
-**Response (ND-1104, ND-1105):**
-
-- On reply received: send `DIAG_RELAY_RESPONSE(status=0x00, payload=<raw DIAG_REPLY frame>)` via BLE indication.
-- On timeout after all retries: send `DIAG_RELAY_RESPONSE(status=0x01, payload_len=0)`.
-
-**Radio state restoration (ND-1106):**
-
-After the relay completes, restore the ESP-NOW channel to its previous value. The node remains in BLE pairing mode and can accept further diagnostic relay requests or proceed to `NODE_PROVISION`.
+1. After execution completes, the node writes a single latest-result record to RTC-retained memory, clears the staged command, and reboots back into BLE pairing mode.
+2. The latest-result record is overwritten by the next accepted test run.
+3. While back in BLE pairing mode, the node serves `READ_TEST_RESULT` (envelope type `0x03`) by returning `TEST_RESULT` (envelope type `0x83`) without clearing the retained result.
+4. The node can then accept another test run or proceed to `NODE_PROVISION`.
 
 ---
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -853,13 +853,14 @@ During chunked transfer, if the node receives a CHUNK response with a `chunk_ind
 **Source:** ble-pairing-protocol.md §8.1
 
 **Description:**  
-On boot the node MUST check, in order: (1) no PSK in NVS OR pairing button held ≥ 500 ms → enter BLE pairing mode, (2) PSK stored and `reg_complete` flag NOT set → send PEER_REQUEST, (3) PSK stored and `reg_complete` flag set → normal WAKE cycle.  (The `reg_complete` NVS key is defined in ND-0916.)
+On boot the node MUST check, in order: (1) a pending pre-provisioning test command is staged in RTC-retained state → enter pre-provisioning test mode, (2) no PSK in NVS OR pairing button held ≥ 500 ms → enter BLE pairing mode, (3) PSK stored and `reg_complete` flag NOT set → send PEER_REQUEST, (4) PSK stored and `reg_complete` flag set → normal WAKE cycle. The pre-provisioning test-mode path is only used for unpaired nodes and is entered before BLE pairing mode so the node never attempts to keep BLE and ESP-NOW active concurrently. (The `reg_complete` NVS key is defined in ND-0916.)
 
 **Acceptance criteria:**
 
-1. BLE pairing mode is entered when no PSK exists or the pairing button is held.
-2. PEER_REQUEST path is taken when PSK is stored but registration is incomplete.
-3. Normal WAKE cycle is entered only when PSK is stored and registration is complete.
+1. If a pending pre-provisioning test command is present at boot, the node enters pre-provisioning test mode before evaluating the BLE pairing and normal wake paths.
+2. BLE pairing mode is entered when no PSK exists or the pairing button is held and no pending pre-provisioning test command is present.
+3. PEER_REQUEST path is taken when PSK is stored but registration is incomplete and no pending pre-provisioning test command is present.
+4. Normal WAKE cycle is entered only when PSK is stored, registration is complete, and no pending pre-provisioning test command is present.
 
 ---
 
@@ -1444,64 +1445,67 @@ The node MUST log the WiFi / ESP-NOW channel number at boot using `warn!()` leve
 
 ---
 
-## 12  Diagnostic relay
+## 12  Pre-provisioning test mode
 
-### ND-1100  BLE diagnostic relay command
+### ND-1100  Generic BLE pre-provisioning test command
 
 **Priority:** Must  
 **Source:** ble-pairing-protocol.md §6a, protocol.md §5.8
 
 **Description:**  
-In BLE pairing mode, the node MUST accept `DIAG_RELAY_REQUEST` (BLE envelope type `0x02`) on the Node Command characteristic. The node MUST NOT require provisioning to have completed — the diagnostic relay is available as soon as BLE pairing mode is active.
+In BLE pairing mode, the unpaired node MUST accept a generic `RUN_TEST_COMMAND` request (BLE envelope type `0x02`) on the Node Command characteristic. The command body MUST be encoded as a CBOR map with integer keys so that the BLE verb remains stable while the payload schema can grow in future. The command map MUST include `test_type` (key 1) and `payload` (key 3); it MAY include `rf_channel` (key 2) for test types that require a radio channel. The initial concrete test type is `0x01` (`DIAG_FRAME`), whose payload is a complete ESP-NOW `DIAG_REQUEST` frame built and authenticated by the pairing tool using the phone PSK obtained in Phase 1. The node MUST NOT require node provisioning to have completed before accepting the command.
 
 **Acceptance criteria:**
 
-1. `DIAG_RELAY_REQUEST` messages are accepted on the Node Command characteristic while in BLE pairing mode.
-2. The node parses `rf_channel` (1 byte), `payload_len` (2 bytes BE), and `payload` (variable) from the BLE envelope body.
-3. The node rejects requests with `rf_channel` outside 1–13 by sending `DIAG_RELAY_RESPONSE(status=0x02)`.
-4. The node rejects requests with `payload_len` = 0 or `payload_len` > 250 by sending `DIAG_RELAY_RESPONSE(status=0x02)`.
+1. `RUN_TEST_COMMAND` messages are accepted on the Node Command characteristic while the node is unpaired and in BLE pairing mode.
+2. The node parses a CBOR map containing integer key 1 = `test_type`, optional key 2 = `rf_channel`, and key 3 = `payload`.
+3. For `DIAG_FRAME` (`test_type = 0x01`), the node rejects requests with `rf_channel` outside 1–13.
+4. For `DIAG_FRAME`, the node rejects requests whose payload is empty or exceeds 250 bytes.
+5. The node rejects unsupported or malformed test commands without staging them for execution.
 
 ---
 
-### ND-1101  Diagnostic ESP-NOW broadcast
+### ND-1101  Test-command acknowledgement and staging
 
 **Priority:** Must  
-**Source:** ble-pairing-protocol.md §6a.3, protocol.md §6.6
+**Source:** ble-pairing-protocol.md §6a
 
 **Description:**  
-Upon receiving a valid `DIAG_RELAY_REQUEST`, the node MUST temporarily tune the ESP-NOW radio to the specified `rf_channel` and broadcast the `payload` as a raw ESP-NOW frame using the broadcast MAC address (`FF:FF:FF:FF:FF:FF`). The node MUST NOT decrypt or interpret the payload.
+Upon receiving a valid `RUN_TEST_COMMAND`, the node MUST stage exactly one pending pre-provisioning test command in RTC-retained state, replacing any previously staged command that has not yet been executed. Before rebooting, the node MUST send `RUN_TEST_ACK` (BLE envelope type `0x82`) to confirm whether the command was accepted for execution. For the initial `DIAG_FRAME` test type, the node stores the raw ESP-NOW frame and RF channel verbatim and MUST NOT decrypt or interpret the payload.
 
 **Acceptance criteria:**
 
-1. The node tunes to the specified `rf_channel` before transmitting.
-2. The payload is transmitted verbatim as a broadcast ESP-NOW frame.
-3. The node does not attempt to decrypt, parse, or validate the payload contents.
+1. A valid `RUN_TEST_COMMAND` is staged in RTC-retained state before the node reboots.
+2. The node sends `RUN_TEST_ACK(status=0x00)` only after the command has been staged successfully.
+3. Invalid or unsupported requests are rejected with a non-success `RUN_TEST_ACK` status and are not staged.
+4. For `DIAG_FRAME`, the node stores the RF channel and payload verbatim and does not decrypt the payload.
 
 ---
 
-### ND-1102  Diagnostic reply reception
+### ND-1102  Pre-provisioning test-mode execution
 
 **Priority:** Must  
-**Source:** ble-pairing-protocol.md §6a.3, protocol.md §5.9
+**Source:** ble-pairing-protocol.md §6a.3, protocol.md §5.8, protocol.md §5.9
 
 **Description:**  
-After broadcasting the diagnostic payload, the node MUST listen for an inbound ESP-NOW frame whose `msg_type` byte (header offset 2) is `0x85` (`DIAG_REPLY`). The node identifies reply frames by inspecting the plaintext `msg_type` byte in the frame header — no decryption is required.
+When the node boots with a staged pre-provisioning test command, it MUST enter pre-provisioning test mode instead of BLE pairing mode or the normal wake-cycle path. For the initial `DIAG_FRAME` test type, the node MUST tune ESP-NOW to the staged `rf_channel`, transmit the staged diagnostic request as a raw broadcast frame to `FF:FF:FF:FF:FF:FF`, and then listen for an inbound ESP-NOW frame whose plaintext `msg_type` byte (header offset 2) is `0x85` (`DIAG_REPLY`). The node MUST NOT keep BLE active during this execution phase.
 
 **Acceptance criteria:**
 
-1. The node accepts inbound ESP-NOW frames with `msg_type` = `0x85` as diagnostic replies.
-2. The node ignores inbound frames with any other `msg_type` during the listen window.
-3. The node does not decrypt or validate the reply payload.
+1. A staged command causes the node to boot into pre-provisioning test mode rather than BLE pairing mode.
+2. For `DIAG_FRAME`, the node transmits the staged payload as a broadcast ESP-NOW frame on the staged RF channel.
+3. The node accepts inbound ESP-NOW frames with `msg_type = 0x85` as diagnostic replies and ignores other message types during the listen window.
+4. BLE is not active during pre-provisioning test execution.
 
 ---
 
-### ND-1103  Diagnostic retry behavior
+### ND-1103  Diagnostic retry behavior in test mode
 
 **Priority:** Must  
 **Source:** ble-pairing-protocol.md §6a.5, protocol.md §6.6
 
 **Description:**  
-The node MUST retry the ESP-NOW broadcast up to **3 times** with a **200 ms** backoff between attempts, listening for up to **2 seconds** per attempt for a `DIAG_REPLY`. This matches the retry behavior of the WAKE cycle.
+For the `DIAG_FRAME` test type, the node MUST retry the ESP-NOW diagnostic transmission up to **3 times** with a **200 ms** backoff between attempts, listening for up to **2 seconds** per attempt for a `DIAG_REPLY`. A reply received during any attempt terminates the retry loop.
 
 **Acceptance criteria:**
 
@@ -1512,50 +1516,69 @@ The node MUST retry the ESP-NOW broadcast up to **3 times** with a **200 ms** ba
 
 ---
 
-### ND-1104  Diagnostic timeout handling
+### ND-1104  Latest-result retention and explicit readback
 
 **Priority:** Must  
-**Source:** ble-pairing-protocol.md §6a.6
+**Source:** ble-pairing-protocol.md §6a
 
 **Description:**  
-If no `DIAG_REPLY` is received after all retry attempts, the node MUST send `DIAG_RELAY_RESPONSE(status=0x01, payload_len=0)` to the pairing tool via BLE indication.
+After pre-provisioning test execution completes, the node MUST store exactly one latest test result in RTC-retained state and make it available after reboot via an explicit `READ_TEST_RESULT` request (BLE envelope type `0x03`). The node MUST return the retained result in a `TEST_RESULT` response (BLE envelope type `0x83`) while back in BLE pairing mode. The retained result MUST remain available for repeated reads until the next successful `RUN_TEST_COMMAND` overwrites it.
 
 **Acceptance criteria:**
 
-1. After 3 failed retry attempts, the node sends `DIAG_RELAY_RESPONSE` with status `0x01` (timeout).
-2. The `payload_len` is 0 and no payload is included in the timeout response.
+1. The node stores only the most recent pre-provisioning test result.
+2. `READ_TEST_RESULT` returns the retained latest result after the node has rebooted back into BLE pairing mode.
+3. Repeated `READ_TEST_RESULT` requests return the same retained result until a later test run overwrites it.
+4. If no prior test result is available, the node returns a non-success `TEST_RESULT` status indicating that no result is present.
 
 ---
 
-### ND-1105  Diagnostic BLE response forwarding
+### ND-1105  Diagnostic result contents
 
 **Priority:** Must  
-**Source:** ble-pairing-protocol.md §6a.3
+**Source:** ble-pairing-protocol.md §6a, protocol.md §5.9
 
 **Description:**  
-When a `DIAG_REPLY` frame is received, the node MUST forward the raw frame to the pairing tool as `DIAG_RELAY_RESPONSE(status=0x00, payload=<raw frame>)` via a BLE indication on the Node Command characteristic.
+For the initial `DIAG_FRAME` test type, the retained and reported test result MUST contain: the execution status, the `test_type`, the raw `DIAG_REPLY` frame when one was received, the node-observed RSSI of the received `DIAG_REPLY`, and timing metadata for the run. Timing metadata MUST include at least the number of attempts used and the total elapsed execution time in milliseconds. On timeout, no raw reply frame is included.
 
 **Acceptance criteria:**
 
-1. The raw `DIAG_REPLY` ESP-NOW frame is forwarded verbatim in the `DIAG_RELAY_RESPONSE` payload.
-2. The BLE indication uses envelope type `0x82`.
-3. The response status is `0x00` (success).
+1. On success, the retained result includes the raw `DIAG_REPLY` frame verbatim.
+2. The retained result includes the node-observed reply RSSI in dBm.
+3. The retained result includes timing metadata containing at least `attempt_count` and `elapsed_ms`.
+4. On timeout, the retained result records a timeout status and omits the raw reply frame.
 
 ---
 
-### ND-1106  Diagnostic radio state restoration
+### ND-1106  Reboot back to BLE pairing mode after test execution
 
 **Priority:** Must  
-**Source:** ble-pairing-protocol.md §6a.3
+**Source:** ble-pairing-protocol.md §6a
 
 **Description:**  
-After a diagnostic relay completes (whether by receiving a reply or exhausting retries), the node MUST restore the ESP-NOW radio to its previous state. The diagnostic MUST NOT leave the radio on a different channel or in an unexpected state.
+After pre-provisioning test execution completes, the node MUST clear the staged pending command, reboot, and return to BLE pairing mode rather than proceeding to PEER_REQUEST or the normal wake cycle. Once back in BLE pairing mode, the node MUST be able to accept another `RUN_TEST_COMMAND`, a `READ_TEST_RESULT` request, or `NODE_PROVISION`.
 
 **Acceptance criteria:**
 
-1. The radio channel is restored to its pre-diagnostic value after the relay completes.
-2. BLE connectivity is maintained throughout the diagnostic relay operation.
-3. The node remains in BLE pairing mode after the diagnostic completes and can accept further `DIAG_RELAY_REQUEST` or `NODE_PROVISION` commands.
+1. The node reboots after test execution completes.
+2. On the next boot after test execution, the node returns to BLE pairing mode.
+3. The node can accept another `RUN_TEST_COMMAND`, `READ_TEST_RESULT`, or `NODE_PROVISION` after it has returned to BLE pairing mode.
+
+---
+
+### ND-1107  Test-command format extensibility
+
+**Priority:** Must  
+**Source:** USER-REQUEST (future BPF diagnostic mode)
+
+**Description:**  
+The BLE pre-provisioning test framework MUST support adding new test types without redefining the outer BLE verbs or the retained-result mechanism. The generic `RUN_TEST_COMMAND` and `TEST_RESULT` formats MUST therefore identify the requested test via an explicit `test_type` field and treat the test-specific payload as opaque to the outer BLE command layer.
+
+**Acceptance criteria:**
+
+1. The outer BLE verbs for run/ack/read/result do not need to change when a new test type is added.
+2. The generic command and result formats include an explicit `test_type`.
+3. Unsupported future test types are rejected explicitly rather than misinterpreted as the initial diagnostic type.
 
 ---
 
@@ -1645,10 +1668,11 @@ After a diagnostic relay completes (whether by receiving a reply or exhausting r
 | ND-1014 | Error diagnostic observability | Must |
 | ND-1015 | Boot version visibility | Must |
 | ND-1016 | ESP-NOW channel logging at boot | Must |
-| ND-1100 | BLE diagnostic relay command | Must |
-| ND-1101 | Diagnostic ESP-NOW broadcast | Must |
-| ND-1102 | Diagnostic reply reception | Must |
-| ND-1103 | Diagnostic retry behavior | Must |
-| ND-1104 | Diagnostic timeout handling | Must |
-| ND-1105 | Diagnostic BLE response forwarding | Must |
-| ND-1106 | Diagnostic radio state restoration | Must |
+| ND-1100 | Generic BLE pre-provisioning test command | Must |
+| ND-1101 | Test-command acknowledgement and staging | Must |
+| ND-1102 | Pre-provisioning test-mode execution | Must |
+| ND-1103 | Diagnostic retry behavior in test mode | Must |
+| ND-1104 | Latest-result retention and explicit readback | Must |
+| ND-1105 | Diagnostic result contents | Must |
+| ND-1106 | Reboot back to BLE pairing mode after test execution | Must |
+| ND-1107 | Test-command format extensibility | Must |

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -1539,12 +1539,12 @@ After pre-provisioning test execution completes, the node MUST store exactly one
 **Source:** ble-pairing-protocol.md §6a, protocol.md §5.9
 
 **Description:**  
-For the initial `DIAG_FRAME` test type, the retained and reported test result MUST contain: the execution status, the `test_type`, the raw `DIAG_REPLY` frame when one was received, the node-observed RSSI of the received `DIAG_REPLY`, and timing metadata for the run. Timing metadata MUST include at least the number of attempts used and the total elapsed execution time in milliseconds. On timeout, no raw reply frame is included.
+For the initial `DIAG_FRAME` test type, the retained and reported test result MUST contain: the execution status, the `test_type`, the raw `DIAG_REPLY` frame when one was received, timing metadata for the run, and the node-observed RSSI of the received `DIAG_REPLY` when that metadata is available from the platform receive path. Timing metadata MUST include at least the number of attempts used and the total elapsed execution time in milliseconds. On timeout, no raw reply frame is included.
 
 **Acceptance criteria:**
 
 1. On success, the retained result includes the raw `DIAG_REPLY` frame verbatim.
-2. The retained result includes the node-observed reply RSSI in dBm.
+2. When the platform provides receive metadata for the successful `DIAG_REPLY`, the retained result includes the node-observed reply RSSI in dBm; otherwise the result remains successful with the RSSI field omitted.
 3. The retained result includes timing metadata containing at least `attempt_count` and `elapsed_ms`.
 4. On timeout, the retained result records a timeout status and omits the raw reply frame.
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1998,79 +1998,81 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
-## 12  Diagnostic relay tests
+## 12  Pre-provisioning test mode tests
 
-### T-N1100  DIAG_RELAY_REQUEST accepted in pairing mode
+### T-N1100  RUN_TEST_COMMAND accepted and acknowledged in pairing mode
 
 **Validates:** ND-1100
 
 **Procedure:**
 1. Boot node into BLE pairing mode (no PSK stored).
-2. Connect via BLE and send a `DIAG_RELAY_REQUEST` (envelope type 0x02) with `rf_channel=6` and a valid 50-byte payload.
-3. Assert: the node processes the request (does not reject or ignore it).
-4. Assert: a `DIAG_RELAY_RESPONSE` (envelope type 0x82) is received via BLE indication.
+2. Connect via BLE and send a `RUN_TEST_COMMAND` (envelope type 0x02) containing `test_type=DIAG_FRAME`, `rf_channel=6`, and a valid 50-byte payload.
+3. Assert: the node accepts the command and stages it for execution.
+4. Assert: a `RUN_TEST_ACK(status=0x00)` (envelope type 0x82) is received via BLE indication.
 
 ---
 
-### T-N1101  DIAG_RELAY_REQUEST invalid channel rejected
+### T-N1101  Invalid DIAG_FRAME request rejected
 
 **Validates:** ND-1100
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with `rf_channel=14` (out of range).
-3. Assert: node responds with `DIAG_RELAY_RESPONSE(status=0x02)`.
-4. Assert: no ESP-NOW frame is broadcast.
+2. Send `RUN_TEST_COMMAND` with `test_type=DIAG_FRAME` and `rf_channel=14` (out of range).
+3. Assert: node responds with `RUN_TEST_ACK(status=0x01)`.
+4. Assert: no pending test command is staged.
 
 ---
 
-### T-N1102  DIAG_RELAY_REQUEST empty payload rejected
+### T-N1102  Accepted test command triggers reboot into test mode
 
-**Validates:** ND-1100
+**Validates:** ND-1101, ND-1102
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with `rf_channel=6` and `payload_len=0`.
-3. Assert: node responds with `DIAG_RELAY_RESPONSE(status=0x02)`.
+2. Send a valid `RUN_TEST_COMMAND` and receive `RUN_TEST_ACK(status=0x00)`.
+3. Disconnect BLE or allow the node to disconnect after the acknowledgement.
+4. Assert: the next boot enters pre-provisioning test mode instead of BLE pairing mode.
 
 ---
 
-### T-N1103  Diagnostic ESP-NOW broadcast
-
-**Validates:** ND-1101
-
-**Procedure:**
-1. Boot node into BLE pairing mode.
-2. Set up an ESP-NOW receiver on channel 6.
-3. Send `DIAG_RELAY_REQUEST` with `rf_channel=6` and a known payload.
-4. Assert: the ESP-NOW receiver captures a broadcast frame matching the payload exactly.
-5. Assert: the destination MAC is `FF:FF:FF:FF:FF:FF`.
-
----
-
-### T-N1104  Diagnostic reply reception and forwarding
-
-**Validates:** ND-1102, ND-1105
-
-**Procedure:**
-1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with a valid payload.
-3. From a test ESP-NOW transmitter, send a frame with `msg_type=0x85` at header offset 2 to the node.
-4. Assert: node forwards the frame in a `DIAG_RELAY_RESPONSE(status=0x00, payload=<frame>)` BLE indication.
-5. Assert: the forwarded payload is byte-identical to the ESP-NOW frame sent.
-
----
-
-### T-N1105  Non-diagnostic ESP-NOW frames ignored during listen
+### T-N1103  Diagnostic ESP-NOW broadcast in test mode
 
 **Validates:** ND-1102
 
 **Procedure:**
-1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST`.
-3. During the listen window, send ESP-NOW frames with `msg_type=0x81` (COMMAND) and `msg_type=0x04` (APP_DATA).
-4. Assert: node does not forward these frames to the pairing tool.
-5. After the listen window expires (no `msg_type=0x85` received), assert `DIAG_RELAY_RESPONSE(status=0x01)`.
+1. Boot node into BLE pairing mode and stage a valid `RUN_TEST_COMMAND` for `DIAG_FRAME`.
+2. Allow the node to reboot into test mode and set up an ESP-NOW receiver on channel 6.
+3. Assert: the ESP-NOW receiver captures a broadcast frame matching the staged payload exactly.
+4. Assert: the destination MAC is `FF:FF:FF:FF:FF:FF`.
+
+---
+
+### T-N1104  Diagnostic reply stored with RSSI and timing metadata
+
+**Validates:** ND-1102, ND-1104, ND-1105
+
+**Procedure:**
+1. Boot node into BLE pairing mode and stage a valid `RUN_TEST_COMMAND`.
+2. During the rebooted test-mode listen window, send a frame with `msg_type=0x85` at header offset 2 to the node.
+3. Allow the node to reboot back into BLE pairing mode.
+4. Send `READ_TEST_RESULT`.
+5. Assert: `TEST_RESULT(status=0x00)` includes the raw reply frame byte-identically.
+6. Assert: the returned result includes a reply RSSI value and non-zero timing metadata.
+
+---
+
+### T-N1105  Timeout result stored after all retries
+
+**Validates:** ND-1103, ND-1104, ND-1105
+
+**Procedure:**
+1. Boot node into BLE pairing mode and stage a valid `RUN_TEST_COMMAND` with no gateway or modem available.
+2. Allow the node to execute the test mode retry loop without receiving any `DIAG_REPLY`.
+3. Reconnect after the node reboots back into BLE pairing mode.
+4. Send `READ_TEST_RESULT`.
+5. Assert: `TEST_RESULT(status=0x01)` is returned.
+6. Assert: no raw reply frame is present.
 
 ---
 
@@ -2079,63 +2081,63 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Validates:** ND-1103
 
 **Procedure:**
-1. Boot node into BLE pairing mode.
+1. Boot node into BLE pairing mode and stage a valid `RUN_TEST_COMMAND`.
 2. Set up an ESP-NOW receiver that counts broadcasts but does NOT send a reply.
-3. Send `DIAG_RELAY_REQUEST`.
+3. Allow the node to reboot into test mode and execute the command.
 4. Assert: the receiver counts exactly 4 broadcasts (1 initial + 3 retries).
-5. Assert: the time between consecutive broadcasts is approximately 2.2 seconds (2s listen + 200ms backoff).
-6. Assert: node sends `DIAG_RELAY_RESPONSE(status=0x01)` after all retries.
+5. Assert: the time between consecutive broadcasts is approximately 2.2 seconds (2 s listen + 200 ms backoff).
+6. After the node reboots back into BLE pairing mode, assert the retained result reports a timeout.
 
 ---
 
-### T-N1107  Diagnostic timeout after all retries
+### T-N1107  READ_TEST_RESULT returns latest retained result after reboot
 
 **Validates:** ND-1104
 
 **Procedure:**
-1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with no gateway or modem available (no ESP-NOW reply will arrive).
-3. Assert: node sends `DIAG_RELAY_RESPONSE(status=0x01, payload_len=0)` within approximately 9 seconds.
+1. Boot node into BLE pairing mode and stage a successful `RUN_TEST_COMMAND`.
+2. Let the node execute the test and reboot back into BLE pairing mode.
+3. Send `READ_TEST_RESULT`.
+4. Assert: the node returns `TEST_RESULT` over BLE.
+5. Assert: the returned `test_type` matches the staged command.
 
 ---
 
-### T-N1108  Radio state restored after diagnostic
+### T-N1108  Retained result remains readable until overwritten
 
-**Validates:** ND-1106
+**Validates:** ND-1104
 
 **Procedure:**
-1. Boot node into BLE pairing mode. Record the initial ESP-NOW channel (or lack thereof).
-2. Send `DIAG_RELAY_REQUEST` with `rf_channel=11`.
-3. Wait for `DIAG_RELAY_RESPONSE`.
-4. Assert: the ESP-NOW radio is restored to its pre-diagnostic state.
-5. Assert: BLE remains connected and functional (send a second `DIAG_RELAY_REQUEST` successfully).
+1. Complete one successful pre-provisioning test run.
+2. Send `READ_TEST_RESULT` twice after the node has rebooted back into BLE pairing mode.
+3. Assert: both reads return identical `TEST_RESULT` payloads.
+4. Start a second test run with a different expected result.
+5. Assert: a later `READ_TEST_RESULT` returns only the new latest result.
 
 ---
 
-### T-N1109  Diagnostic followed by provisioning
+### T-N1109  Test execution followed by provisioning
 
-**Validates:** ND-1106, ND-1100
+**Validates:** ND-1100, ND-1106
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Run a complete diagnostic relay (send `DIAG_RELAY_REQUEST`, receive response).
+2. Run a complete pre-provisioning test cycle (stage command, execute, reboot back, read result).
 3. Send `NODE_PROVISION` with valid provisioning data.
 4. Assert: provisioning succeeds (`NODE_ACK` status=0x00).
 5. Assert: NVS contains the expected PSK and channel.
 
 ---
 
-### T-N1110  Multiple diagnostics in sequence
+### T-N1110  Unsupported future test type rejected explicitly
 
-**Validates:** ND-1100, ND-1106
+**Validates:** ND-1100, ND-1107
 
 **Procedure:**
 1. Boot node into BLE pairing mode.
-2. Send `DIAG_RELAY_REQUEST` with `rf_channel=1`. Wait for response.
-3. Send `DIAG_RELAY_REQUEST` with `rf_channel=6`. Wait for response.
-4. Send `DIAG_RELAY_REQUEST` with `rf_channel=11`. Wait for response.
-5. Assert: all three diagnostics complete successfully.
-6. Assert: BLE remains connected and functional after all three.
+2. Send `RUN_TEST_COMMAND` with an unsupported `test_type`.
+3. Assert: node responds with `RUN_TEST_ACK(status=0x02)`.
+4. Assert: no command is staged and no reboot into test mode occurs.
 
 ---
 
@@ -2225,13 +2227,14 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-1014 | T-N1021 |
 | ND-1015 | T-N1022 |
 | ND-1016 | T-N1023 |
-| ND-1100 | T-N1100, T-N1101, T-N1102, T-N1109, T-N1110 |
-| ND-1101 | T-N1103 |
-| ND-1102 | T-N1104, T-N1105 |
-| ND-1103 | T-N1106 |
-| ND-1104 | T-N1107 |
-| ND-1105 | T-N1104 |
-| ND-1106 | T-N1108, T-N1109, T-N1110 |
+| ND-1100 | T-N1100, T-N1101, T-N1109, T-N1110 |
+| ND-1101 | T-N1100, T-N1102 |
+| ND-1102 | T-N1102, T-N1103, T-N1104 |
+| ND-1103 | T-N1105, T-N1106 |
+| ND-1104 | T-N1104, T-N1105, T-N1107, T-N1108 |
+| ND-1105 | T-N1104, T-N1105, T-N1106 |
+| ND-1106 | T-N1107, T-N1109 |
+| ND-1107 | T-N1110 |
 
 ---
 

--- a/docs/protocol-crate-design.md
+++ b/docs/protocol-crate-design.md
@@ -111,15 +111,23 @@ pub const SIGNAL_QUALITY_BAD: u8 = 2;
 
 // BLE envelope message types (Node Command characteristic — separate from ESP-NOW msg_types)
 pub const BLE_NODE_PROVISION: u8 = 0x01;
-pub const BLE_DIAG_RELAY_REQUEST: u8 = 0x02;
+pub const BLE_RUN_TEST_COMMAND: u8 = 0x02;
+pub const BLE_READ_TEST_RESULT: u8 = 0x03;
 pub const BLE_NODE_ACK: u8 = 0x81;
-pub const BLE_DIAG_RELAY_RESPONSE: u8 = 0x82;
+pub const BLE_RUN_TEST_ACK: u8 = 0x82;
+pub const BLE_TEST_RESULT: u8 = 0x83;
 pub const BLE_ERROR: u8 = 0xFF;
 
-// DIAG_RELAY_RESPONSE status codes
-pub const DIAG_RELAY_STATUS_OK: u8 = 0x00;
-pub const DIAG_RELAY_STATUS_TIMEOUT: u8 = 0x01;
-pub const DIAG_RELAY_STATUS_CHANNEL_ERROR: u8 = 0x02;
+// RUN_TEST_ACK status codes
+pub const RUN_TEST_ACK_OK: u8 = 0x00;
+pub const RUN_TEST_ACK_INVALID: u8 = 0x01;
+pub const RUN_TEST_ACK_UNSUPPORTED: u8 = 0x02;
+
+// TEST_RESULT status codes
+pub const TEST_RESULT_OK: u8 = 0x00;
+pub const TEST_RESULT_TIMEOUT: u8 = 0x01;
+pub const TEST_RESULT_NO_RESULT: u8 = 0x02;
+pub const TEST_RESULT_EXECUTION_ERROR: u8 = 0x03;
 
 // CBOR integer keys (program image — separate keyspace)
 pub const IMG_KEY_BYTECODE: u64 = 1;
@@ -547,7 +555,7 @@ Implements a minimal Type-Length-Value envelope used for BLE GATT messages in th
 
 ## 12  Diagnostic message codec
 
-Implements encoding and decoding for `DIAG_REQUEST` (`msg_type` 0x06) and `DIAG_REPLY` (`msg_type` 0x85) messages, and for the BLE `DIAG_RELAY_REQUEST` / `DIAG_RELAY_RESPONSE` envelopes.
+Implements encoding and decoding for `DIAG_REQUEST` (`msg_type` 0x06) and `DIAG_REPLY` (`msg_type` 0x85) messages, and for the BLE `RUN_TEST_COMMAND` / `RUN_TEST_ACK` / `READ_TEST_RESULT` / `TEST_RESULT` envelopes.
 
 > **Requirements:** ND-1100 (BLE diagnostic relay command), GW-1700 (DIAG_REQUEST reception), GW-1704 (DIAG_REPLY construction), PT-1301 (diagnostic request construction), PT-1302 (BLE diagnostic relay).
 
@@ -557,29 +565,54 @@ Implements encoding and decoding for `DIAG_REQUEST` (`msg_type` 0x06) and `DIAG_
 
 Encoding and decoding are handled by the existing `NodeMessage::encode/decode` and `GatewayMessage::encode/decode` methods, which dispatch on `msg_type`.
 
-### 12.2  BLE diagnostic relay messages
+### 12.2  BLE pre-provisioning test messages
 
-The BLE envelope for diagnostic relay uses the same `TYPE | LEN | BODY` format as other BLE messages (§11). The body formats are:
+The BLE envelope for pre-provisioning tests uses the same `TYPE | LEN | BODY` format as other BLE messages (§11). The body formats are:
 
-**DIAG_RELAY_REQUEST (type 0x02):**
+**RUN_TEST_COMMAND (type 0x02):**
+
+Deterministic CBOR map:
+
+```cbor
+{
+  1: test_type,  // uint
+  2: rf_channel, // uint (optional)
+  3: payload     // bstr
+}
+```
+
+**RUN_TEST_ACK (type 0x82):**
 
 ```
-rf_channel: u8      // WiFi channel 1–13
-payload_len: u16 BE // Length of ESP-NOW frame
-payload: [u8]       // Complete DIAG_REQUEST ESP-NOW frame
+status: u8 // 0x00=ok, 0x01=invalid, 0x02=unsupported
 ```
 
-**DIAG_RELAY_RESPONSE (type 0x82):**
+**READ_TEST_RESULT (type 0x03):**
 
-```
-status: u8          // 0x00=ok, 0x01=timeout, 0x02=channel_error
-payload_len: u16 BE // Length of ESP-NOW reply (0 if status ≠ 0x00)
-payload: [u8]       // Raw DIAG_REPLY ESP-NOW frame (if status=0x00)
+Empty body.
+
+**TEST_RESULT (type 0x83):**
+
+Deterministic CBOR map:
+
+```cbor
+{
+  1: status,         // uint
+  2: test_type,      // uint
+  3: reply_frame,    // bstr (optional)
+  4: reply_rssi_dbm, // int  (optional)
+  5: attempt_count,  // uint
+  6: elapsed_ms      // uint
+}
 ```
 
 **Public API:**
 
-- `encode_diag_relay_request(rf_channel: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError>` — encode a `DIAG_RELAY_REQUEST` body. Validates `rf_channel` ∈ 1–13 and `payload.len()` ≤ `MAX_FRAME_SIZE`. Wrap the returned body with `encode_ble_envelope(...)` to produce the full BLE `TYPE | LEN | BODY` message.
-- `decode_diag_relay_request(body: &[u8]) -> Result<(u8, &[u8]), DecodeError>` — decode a `DIAG_RELAY_REQUEST` body, returning `(rf_channel, payload)`. Validates channel range, payload size, and rejects trailing bytes.
-- `encode_diag_relay_response(status: u8, payload: &[u8]) -> Result<Vec<u8>, EncodeError>` — encode a `DIAG_RELAY_RESPONSE` body. Enforces payload must be empty for non-OK status. Wrap the returned body with `encode_ble_envelope(...)` to produce the full BLE message.
-- `decode_diag_relay_response(body: &[u8]) -> Result<(u8, &[u8]), DecodeError>` — decode a `DIAG_RELAY_RESPONSE` body, returning `(status, payload)`. Rejects truncated and trailing-byte inputs.
+- `encode_run_test_command(test_type: u64, rf_channel: Option<u8>, payload: &[u8]) -> Result<Vec<u8>, EncodeError>` — encode a `RUN_TEST_COMMAND` body. For the initial `DIAG_FRAME` test type, validates `rf_channel` ∈ 1–13 and `payload.len()` ≤ `MAX_FRAME_SIZE`. Wrap the returned body with `encode_ble_envelope(...)` to produce the full BLE `TYPE | LEN | BODY` message.
+- `decode_run_test_command(body: &[u8]) -> Result<RunTestCommand<'_>, DecodeError>` — decode a `RUN_TEST_COMMAND` body, validating required fields, channel range for `DIAG_FRAME`, payload size, and rejecting trailing bytes.
+- `encode_run_test_ack(status: u8) -> Result<Vec<u8>, EncodeError>` — encode a `RUN_TEST_ACK` body.
+- `decode_run_test_ack(body: &[u8]) -> Result<u8, DecodeError>` — decode a `RUN_TEST_ACK` body.
+- `encode_read_test_result() -> Vec<u8>` — encode an empty `READ_TEST_RESULT` body.
+- `decode_read_test_result(body: &[u8]) -> Result<(), DecodeError>` — decode a `READ_TEST_RESULT` body, rejecting non-empty bodies.
+- `encode_test_result(result: &TestResult) -> Result<Vec<u8>, EncodeError>` — encode a `TEST_RESULT` body.
+- `decode_test_result(body: &[u8]) -> Result<TestResult, DecodeError>` — decode a `TEST_RESULT` body, validating optional-field combinations and rejecting trailing bytes.

--- a/docs/protocol-crate-design.md
+++ b/docs/protocol-crate-design.md
@@ -557,7 +557,7 @@ Implements a minimal Type-Length-Value envelope used for BLE GATT messages in th
 
 Implements encoding and decoding for `DIAG_REQUEST` (`msg_type` 0x06) and `DIAG_REPLY` (`msg_type` 0x85) messages, and for the BLE `RUN_TEST_COMMAND` / `RUN_TEST_ACK` / `READ_TEST_RESULT` / `TEST_RESULT` envelopes.
 
-> **Requirements:** ND-1100 (BLE diagnostic relay command), GW-1700 (DIAG_REQUEST reception), GW-1704 (DIAG_REPLY construction), PT-1301 (diagnostic request construction), PT-1302 (BLE diagnostic relay).
+> **Requirements:** ND-1100 (Generic BLE pre-provisioning test command), ND-1101 (Test-command acknowledgement and staging), ND-1104 (Latest-result retention and explicit readback), ND-1105 (Diagnostic result contents), ND-1107 (Test-command format extensibility), GW-1700 (DIAG_REQUEST reception), GW-1704 (DIAG_REPLY construction), PT-0411 (RUN_TEST_COMMAND construction and acknowledgement), PT-0412 (Explicit pre-provisioning test-result readback), PT-0413 (Diagnostic result interpretation), PT-0415 (Generic pre-provisioning test-command model).
 
 ### 12.1  ESP-NOW diagnostic messages
 
@@ -608,8 +608,8 @@ Deterministic CBOR map:
 
 **Public API:**
 
-- `encode_run_test_command(test_type: u64, rf_channel: Option<u8>, payload: &[u8]) -> Result<Vec<u8>, EncodeError>` — encode a `RUN_TEST_COMMAND` body. For the initial `DIAG_FRAME` test type, validates `rf_channel` ∈ 1–13 and `payload.len()` ≤ `MAX_FRAME_SIZE`. Wrap the returned body with `encode_ble_envelope(...)` to produce the full BLE `TYPE | LEN | BODY` message.
-- `decode_run_test_command(body: &[u8]) -> Result<RunTestCommand<'_>, DecodeError>` — decode a `RUN_TEST_COMMAND` body, validating required fields, channel range for `DIAG_FRAME`, payload size, and rejecting trailing bytes.
+- `encode_run_test_command(test_type: u64, rf_channel: Option<u8>, payload: &[u8]) -> Result<Vec<u8>, EncodeError>` — encode a `RUN_TEST_COMMAND` body. For the initial `DIAG_FRAME` test type, validates that `rf_channel` is present and in 1–13, `payload` is non-empty, and `payload.len()` ≤ `MAX_FRAME_SIZE`. Wrap the returned body with `encode_ble_envelope(...)` to produce the full BLE `TYPE | LEN | BODY` message.
+- `decode_run_test_command(body: &[u8]) -> Result<RunTestCommand, DecodeError>` — decode a `RUN_TEST_COMMAND` body into an owned `RunTestCommand`, validating required fields, channel range for `DIAG_FRAME`, non-empty `payload`, payload size, and rejecting trailing bytes.
 - `encode_run_test_ack(status: u8) -> Result<Vec<u8>, EncodeError>` — encode a `RUN_TEST_ACK` body.
 - `decode_run_test_ack(body: &[u8]) -> Result<u8, DecodeError>` — decode a `RUN_TEST_ACK` body.
 - `encode_read_test_result() -> Vec<u8>` — encode an empty `READ_TEST_RESULT` body.

--- a/docs/protocol-crate-validation.md
+++ b/docs/protocol-crate-validation.md
@@ -1049,40 +1049,40 @@ impl Sha256Provider for SoftwareSha256 { /* RustCrypto sha2 */ }
 
 ---
 
-### T-P114  DIAG_RELAY_REQUEST round-trip
+### T-P114  RUN_TEST_COMMAND round-trip
 
 **Validates:** protocol-crate-design.md §12.2
 
 **Procedure:**
-1. Call `encode_diag_relay_request(rf_channel=6, payload=&[0x42; 50])`.
-2. Wrap in BLE envelope with type `BLE_DIAG_RELAY_REQUEST`.
+1. Call `encode_run_test_command(test_type=0x01, rf_channel=Some(6), payload=&[0x42; 50])`.
+2. Wrap in BLE envelope with type `BLE_RUN_TEST_COMMAND`.
 3. Parse the BLE envelope.
-4. Call `decode_diag_relay_request(body)`.
-5. Assert: `rf_channel` = 6, `payload` = `[0x42; 50]`.
+4. Call `decode_run_test_command(body)`.
+5. Assert: `test_type` = `0x01`, `rf_channel` = `Some(6)`, `payload` = `[0x42; 50]`.
 
 ---
 
-### T-P115  DIAG_RELAY_REQUEST invalid channel rejected
+### T-P115  RUN_TEST_COMMAND invalid channel rejected
 
 **Validates:** protocol-crate-design.md §12.2, ND-1100
 
 **Procedure:**
-1. Call `encode_diag_relay_request(rf_channel=14, payload=&[0x42; 50])`.
+1. Call `encode_run_test_command(test_type=0x01, rf_channel=Some(14), payload=&[0x42; 50])`.
 2. Assert: returns `Err(EncodeError)` — channel 14 is out of range (valid: 1–13).
 
 ---
 
-### T-P116  DIAG_RELAY_RESPONSE round-trip (success and timeout)
+### T-P116  RUN_TEST_ACK and TEST_RESULT round-trip
 
 **Validates:** protocol-crate-design.md §12.2
 
 **Procedure:**
-1. Encode `DIAG_RELAY_RESPONSE` with `status=0x00` and a non-empty payload.
-2. Decode and assert: `status` = 0x00, payload matches.
-3. Encode `DIAG_RELAY_RESPONSE` with `status=0x01` and empty payload.
-4. Decode and assert: `status` = 0x01, `payload_len` = 0.
-5. Encode `DIAG_RELAY_RESPONSE` with `status=0x02` and empty payload.
-6. Decode and assert: `status` = 0x02, `payload_len` = 0.
+1. Encode `RUN_TEST_ACK(status=0x00)` and decode it back.
+2. Assert: decoded acknowledgement status = `0x00`.
+3. Encode a successful `TEST_RESULT` containing `test_type=0x01`, a non-empty `reply_frame`, `reply_rssi_dbm=-64`, `attempt_count=2`, and `elapsed_ms=4100`.
+4. Decode and assert: all fields round-trip exactly.
+5. Encode a timeout `TEST_RESULT` with no `reply_frame`.
+6. Decode and assert: `status` = `0x01` and the optional reply fields are absent.
 
 ---
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -379,7 +379,7 @@ If a `send_recv()` call on the node times out waiting for `APP_DATA_REPLY`, the 
 
 ### 5.8  DIAG_REQUEST (Node → Gateway)
 
-Sent by a **pre-provisioning node acting as a dumb radio relay** on behalf of the pairing tool. The pairing tool constructs the complete frame (authenticated with `phone_psk`) and hands it to the node over BLE. The node broadcasts it on the specified RF channel without decrypting or interpreting the payload.
+Sent by an unpaired node during a **pre-provisioning test-mode boot** on behalf of the pairing tool. The pairing tool constructs the complete frame (authenticated with `phone_psk`) and stages it on the node over BLE before the node reboots into test mode. The node then broadcasts it on the specified RF channel without decrypting or interpreting the payload.
 
 | Field | CBOR type | Required | Description |
 |---|---|---|---|
@@ -389,7 +389,7 @@ The `key_hint` in the frame header identifies a phone PSK — the gateway perfor
 
 ### 5.9  DIAG_REPLY (Gateway → Node)
 
-Sent by the gateway in response to a valid `DIAG_REQUEST`. Authenticated with the same `phone_psk` used to decrypt the request. The node forwards the raw frame back to the pairing tool over BLE without decrypting it.
+Sent by the gateway in response to a valid `DIAG_REQUEST`. Authenticated with the same `phone_psk` used to decrypt the request. The node stores the raw frame in its retained pre-provisioning test result without decrypting it; the pairing tool later reads that result over BLE and performs the decryption itself.
 
 | Field | CBOR type | Required | Description |
 |---|---|---|---|
@@ -545,29 +545,31 @@ The number of exchanges per wake cycle is determined by the BPF program. The pro
 
 ### 6.6  Pairing-time RSSI diagnostic
 
-The pairing tool uses the node as a **dumb radio relay** to measure the node→gateway RF link quality **before provisioning**. The node is not yet authenticated with the gateway — all authentication uses the pairing tool's `phone_psk`.
+The pairing tool uses a rebooted **pre-provisioning test mode** to measure node→gateway RF link quality **before provisioning**. The node is not yet authenticated with the gateway — all authentication uses the pairing tool's `phone_psk`.
 
 ```
-    Pairing Tool      Node (BLE relay)      Modem         Gateway
+    Pairing Tool          Node              Modem         Gateway
          │                  │                  │              │
-         │── DIAG_RELAY ───►│                  │              │
-         │   REQUEST (BLE)  │                  │              │
+         │─ RUN_TEST_CMD ──►│                  │              │
+         │   (BLE)          │                  │              │
+         │◄─ RUN_TEST_ACK ──│                  │              │
+         │                  │                  │              │
+         │        [node reboots into test mode]              │
          │                  │── DIAG_REQUEST ─►│              │
          │                  │   (ESP-NOW       │── RECV ─────►│
          │                  │    broadcast)    │   FRAME      │
-         │                  │                  │              │  (decrypt with
-         │                  │                  │              │   phone_psk,
-         │                  │                  │              │   measure RSSI)
-         │                  │                  │◄─ SEND ──────│
-         │                  │◄─ DIAG_REPLY ────│   FRAME      │
-         │                  │   (ESP-NOW)      │              │
-         │◄─ DIAG_RELAY ───│                  │              │
-         │   RESPONSE (BLE) │                  │              │
+         │                  │                  │              │
+         │                  │◄─ DIAG_REPLY ────│◄─ SEND ──────│
+         │                  │   (ESP-NOW)      │   FRAME      │
+         │        [node stores latest result, reboots]       │
+         │                  │                  │              │
+         │─ READ_RESULT ───►│                  │              │
+         │◄─ TEST_RESULT ───│                  │              │
 ```
 
-The node retries the ESP-NOW broadcast up to **3 retries** with **200 ms** backoff between attempts, **2-second** listen window per attempt. If no `DIAG_REPLY` is received after all retries, the node returns a timeout status to the pairing tool. Total worst-case node-side duration is approximately **8.6 seconds** (4 broadcasts × 2 s listen + 3 × 200 ms backoff). The pairing tool applies a **10-second** overall timeout.
+The node retries the ESP-NOW broadcast up to **3 retries** with **200 ms** backoff between attempts and a **2-second** listen window per attempt. If no `DIAG_REPLY` is received after all retries, the node stores a timeout result and returns it later when the pairing tool reads back the latest result. Total worst-case node-side duration is approximately **8.6 seconds** (4 broadcasts × 2 s listen + 3 × 200 ms backoff). The pairing tool applies **5-second** BLE timeouts for the initial acknowledgement and later result-read operations.
 
-The diagnostic step is **optional** and **repeatable** — the installer may run it multiple times to test different node positions before committing to provisioning.
+The diagnostic step is **optional** and **repeatable** — the installer may run it multiple times to test different node positions before committing to provisioning by submitting another test command.
 
 ### 6.7  Store-and-forward data flow
 


### PR DESCRIPTION
## Summary
- replace the old synchronous BLE diagnostic relay with a rebooted pre-provisioning test flow for unpaired nodes
- add generic BLE run/ack/read/result codecs plus RTC-retained staged-command and latest-result storage on the node
- update the pairing tool to stage a test, reconnect after reboot, read back the retained result, and interpret diagnostic metadata

## Traceability
- Requirements: updated node, BLE pairing-tool, and protocol requirements for rebooted test mode
- Design: updated node, BLE pairing-tool, protocol, and BLE pairing protocol design/docs for the staged reboot flow
- Implementation: `sonde-protocol`, `sonde-node`, and `sonde-pair` now implement the generic run/read/result workflow
- Audit: implementation audit passed after adding missing validation coverage for boot-mode priority, retained-result overwrite/readback, post-test provisioning, and explicit successful readback sequencing

## Validation
- cargo test -p sonde-protocol --quiet
- cargo test -p sonde-node --quiet
- cargo test -p sonde-pair --quiet