### PR TITLE
Make battery telemetry runtime-only

### DIFF
--- a/crates/sonde-admin/tests/integration.rs
+++ b/crates/sonde-admin/tests/integration.rs
@@ -125,6 +125,37 @@ async fn start_server_with_storage(test_name: &str) -> (String, Arc<InMemoryStor
     }
 }
 
+/// Start an admin gRPC server backed by caller-owned storage and runtime state.
+async fn start_server_with_runtime(
+    test_name: &str,
+) -> (String, Arc<InMemoryStorage>, Arc<SessionManager>) {
+    let storage = Arc::new(InMemoryStorage::new());
+    let pending: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
+        Arc::new(RwLock::new(HashMap::new()));
+    let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+    let admin = AdminService::new(storage.clone(), pending, Arc::clone(&session_manager));
+
+    let endpoint = unique_endpoint(test_name);
+    let server_endpoint = endpoint.clone();
+
+    tokio::spawn(async move {
+        if let Err(e) = sonde_gateway::admin::serve_admin(admin, &server_endpoint).await {
+            eprintln!("admin server ended: {e}");
+        }
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        match AdminClient::connect(&endpoint).await {
+            Ok(_) => return (endpoint, storage, session_manager),
+            Err(_) if tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => panic!("failed to connect to admin server: {e}"),
+        }
+    }
+}
+
 async fn seed_node_with_programs(
     storage: &Arc<InMemoryStorage>,
     node_id: &str,
@@ -421,6 +452,29 @@ async fn grpc_get_node_status_without_session() {
     assert_eq!(status.node_id, "status-node");
     assert!(!status.has_active_session);
     assert_eq!(status.battery_mv, None);
+}
+
+/// Test: list/get/status surface runtime battery observations without durable persistence.
+#[tokio::test]
+async fn grpc_runtime_battery_is_visible_in_status_surfaces() {
+    let (endpoint, _storage, session_manager) =
+        start_server_with_runtime("runtime_battery_status").await;
+    let mut client = AdminClient::connect(&endpoint).await.unwrap();
+    client
+        .register_node("status-node", 0x5555, vec![0xBC; 32])
+        .await
+        .unwrap();
+
+    session_manager.record_battery_mv("status-node", 3300).await;
+
+    let nodes = client.list_nodes().await.unwrap();
+    assert_eq!(nodes[0].last_battery_mv, Some(3300));
+
+    let node = client.get_node("status-node").await.unwrap();
+    assert_eq!(node.last_battery_mv, Some(3300));
+
+    let status = client.get_node_status("status-node").await.unwrap();
+    assert_eq!(status.battery_mv, Some(3300));
 }
 
 // ── BLE pairing tests ───────────────────────────────────────────────────────

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -90,9 +90,9 @@ async fn t_e2e_001_nop_wake_cycle() {
         "AEAD wake cycle must receive at least one response (COMMAND)"
     );
 
-    // Verify gateway updated node telemetry.
+    // Verify gateway updated durable firmware metadata and runtime observations.
     let record = env.storage.get_node("aead-nop").await.unwrap().unwrap();
-    assert_eq!(record.last_battery_mv, Some(0));
+    assert_eq!(record.last_battery_mv, None);
     assert!(env
         .gateway
         .session_manager()
@@ -108,8 +108,8 @@ async fn t_e2e_001_nop_wake_cycle() {
 /// T-E2E-002b — Consecutive AEAD wake cycles (state persistence).
 ///
 /// Runs two AEAD wake cycles on the same `NodeProxy` to verify that
-/// persistent storage, battery telemetry propagation, and monotonic RNG
-/// state work correctly across multiple AES-256-GCM exchanges.
+/// persistent storage, runtime battery telemetry propagation, and monotonic
+/// RNG state work correctly across multiple AES-256-GCM exchanges.
 ///
 /// This harness uses `BoardLayout::LEGACY_COMPAT`, so no battery ADC is
 /// provisioned. The node therefore persists the explicit failure value
@@ -127,13 +127,13 @@ async fn t_e2e_002b_consecutive_wake_cycles() {
     assert_eq!(stats1.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(stats1.response_count > 0);
     let record_after_first = env.storage.get_node("aead-multi").await.unwrap().unwrap();
-    assert_eq!(record_after_first.last_battery_mv, Some(0));
+    assert_eq!(record_after_first.last_battery_mv, None);
 
     let stats2 = node.run_wake_cycle(&env);
     assert_eq!(stats2.outcome, WakeCycleOutcome::Sleep { seconds: 60 });
     assert!(stats2.response_count > 0);
     let record_after_second = env.storage.get_node("aead-multi").await.unwrap().unwrap();
-    assert_eq!(record_after_second.last_battery_mv, Some(0));
+    assert_eq!(record_after_second.last_battery_mv, None);
 
     // Verify nonce uniqueness across cycles.
     assert!(
@@ -726,7 +726,7 @@ async fn t_e2e_002_aead_authentication_round_trip() {
         "gateway must respond to valid AEAD frame"
     );
     let rec = env.storage.get_node("aead-002").await.unwrap().unwrap();
-    assert_eq!(rec.last_battery_mv, Some(0));
+    assert_eq!(rec.last_battery_mv, None);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -181,14 +181,18 @@ pub(crate) fn system_time_to_millis(t: std::time::SystemTime) -> Option<u64> {
         .map(|d| d.as_millis() as u64)
 }
 
-fn node_to_info(n: &NodeRecord, last_seen: Option<std::time::SystemTime>) -> NodeInfo {
+fn node_to_info(
+    n: &NodeRecord,
+    last_seen: Option<std::time::SystemTime>,
+    last_battery_mv: Option<u32>,
+) -> NodeInfo {
     let last_seen_ms = last_seen.and_then(system_time_to_millis);
     NodeInfo {
         node_id: n.node_id.clone(),
         key_hint: n.key_hint as u32,
         assigned_program_hash: n.assigned_program_hash.clone().unwrap_or_default(),
         current_program_hash: n.current_program_hash.clone().unwrap_or_default(),
-        last_battery_mv: n.last_battery_mv,
+        last_battery_mv,
         last_firmware_abi_version: n.firmware_abi_version,
         last_seen_ms,
         schedule_interval_s: Some(n.schedule_interval_s),
@@ -415,10 +419,11 @@ pub(crate) async fn get_node_status_impl(
         .get_last_seen(node_id)
         .await
         .and_then(system_time_to_millis);
+    let battery_mv = session_manager.get_battery_mv(node_id).await;
     Ok(NodeStatusSnapshot {
         node_id: node.node_id,
         current_program_hash: node.current_program_hash.unwrap_or_default(),
-        battery_mv: node.last_battery_mv,
+        battery_mv,
         firmware_abi_version: node.firmware_abi_version,
         last_seen_ms,
         has_active_session,
@@ -507,9 +512,16 @@ impl GatewayAdmin for AdminService {
     ) -> Result<Response<ListNodesResponse>, Status> {
         let nodes = list_nodes_impl(&self.storage).await?;
         let last_seen = self.session_manager.snapshot_last_seen().await;
+        let battery_mv = self.session_manager.snapshot_battery_mv().await;
         let mut nodes: Vec<_> = nodes
             .iter()
-            .map(|node| node_to_info(node, last_seen.get(&node.node_id).copied()))
+            .map(|node| {
+                node_to_info(
+                    node,
+                    last_seen.get(&node.node_id).copied(),
+                    battery_mv.get(&node.node_id).copied(),
+                )
+            })
             .collect();
         nodes.sort_by(|a, b| a.node_id.cmp(&b.node_id));
         Ok(Response::new(ListNodesResponse { nodes }))
@@ -522,7 +534,8 @@ impl GatewayAdmin for AdminService {
         let node_id = &request.get_ref().node_id;
         let node = get_node_impl(&self.storage, node_id).await?;
         let last_seen = self.session_manager.get_last_seen(node_id).await;
-        Ok(Response::new(node_to_info(&node, last_seen)))
+        let battery_mv = self.session_manager.get_battery_mv(node_id).await;
+        Ok(Response::new(node_to_info(&node, last_seen, battery_mv)))
     }
 
     async fn register_node(
@@ -603,6 +616,7 @@ impl GatewayAdmin for AdminService {
         // continue communicating after removal.
         self.session_manager.remove_session(node_id).await;
         self.session_manager.clear_last_seen(node_id).await;
+        self.session_manager.clear_battery_mv(node_id).await;
 
         Ok(Response::new(Empty {}))
     }
@@ -646,6 +660,7 @@ impl GatewayAdmin for AdminService {
         // immediately treated as unknown (GW-0705 AC1).
         self.session_manager.remove_session(node_id).await;
         self.session_manager.clear_last_seen(node_id).await;
+        self.session_manager.clear_battery_mv(node_id).await;
 
         // Clear any pending commands for the removed node.
         self.pending_commands.write().await.remove(node_id);
@@ -1079,6 +1094,7 @@ impl GatewayAdmin for AdminService {
         // Clear any pending commands queued for the old node set.
         self.pending_commands.write().await.clear();
         self.session_manager.clear_all_last_seen().await;
+        self.session_manager.clear_all_battery_mv().await;
 
         Ok(Response::new(Empty {}))
     }

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -224,8 +224,25 @@ fn build_node_status_lines(
     lines
 }
 
+async fn node_status_nodes(
+    storage: &Arc<dyn Storage>,
+    session_manager: Option<&Arc<SessionManager>>,
+) -> Result<Vec<NodeRecord>, sonde_gateway::storage::StorageError> {
+    let mut nodes = storage.list_nodes().await?;
+    if let Some(session_manager) = session_manager {
+        let last_seen = session_manager.snapshot_last_seen().await;
+        let battery_mv = session_manager.snapshot_battery_mv().await;
+        for node in &mut nodes {
+            node.last_seen = last_seen.get(&node.node_id).copied();
+            node.last_battery_mv = battery_mv.get(&node.node_id).copied();
+        }
+    }
+    Ok(nodes)
+}
+
 async fn render_status_page(
     storage: &Arc<dyn Storage>,
+    session_manager: Option<&Arc<SessionManager>>,
     default_channel: u8,
     page: StatusPage,
 ) -> RenderedStatusPage {
@@ -242,7 +259,7 @@ async fn render_status_page(
             let line_refs = [lines[0].as_str(), lines[1].as_str()];
             RenderedStatusPage::Static(Box::new(render_display_message(&line_refs)))
         }
-        StatusPage::Nodes => match storage.list_nodes().await {
+        StatusPage::Nodes => match node_status_nodes(storage, session_manager).await {
             Ok(nodes) => {
                 if nodes.is_empty() {
                     return RenderedStatusPage::Scrollable(render_status_text_page(
@@ -550,10 +567,12 @@ async fn complete_button_pairing_success(
     schedule_button_pairing_banner_restore(transport, controller, display_generation);
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_idle_button_short_event(
     transport: &Arc<UsbEspNowTransport>,
     controller: &Arc<sonde_gateway::ble_pairing::BlePairingController>,
     storage: &Arc<dyn Storage>,
+    session_manager: &Arc<SessionManager>,
     default_channel: u8,
     display_generation: &Arc<AtomicU64>,
     status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
@@ -571,7 +590,8 @@ async fn handle_idle_button_short_event(
         cycle.next_page_index = (cycle.next_page_index + 1) % StatusPage::ALL.len();
         page
     };
-    let rendered_page = render_status_page(storage, default_channel, page).await;
+    let rendered_page =
+        render_status_page(storage, Some(session_manager), default_channel, page).await;
     let initial_frame = rendered_page.initial_frame();
     let initial_send_ok = match transport.send_display_frame(initial_frame).await {
         Ok(()) => true,
@@ -1162,6 +1182,7 @@ async fn run_gateway(
         // rather than capturing the CLI startup value.
         let ble_channel = channel_for_transport;
         let ble_ctrl = Arc::clone(&ble_controller);
+        let ble_session_manager = Arc::clone(&session_manager);
         let mut ble_loop = tokio::spawn(async move {
             use sonde_gateway::ble_pairing::{handle_ble_recv, PairingOrigin};
             use sonde_gateway::modem::BleEvent;
@@ -1398,6 +1419,7 @@ async fn run_gateway(
                                     &ble_transport,
                                     &ble_ctrl,
                                     &ble_storage,
+                                    &ble_session_manager,
                                     ble_channel,
                                     &display_generation,
                                     &status_page_cycle,
@@ -2050,6 +2072,19 @@ mod tests {
         node
     }
 
+    async fn seed_runtime_observation(session_manager: &Arc<SessionManager>, node: &NodeRecord) {
+        if let Some(last_seen) = node.last_seen {
+            session_manager
+                .record_last_seen(&node.node_id, last_seen)
+                .await;
+        }
+        if let Some(battery_mv) = node.last_battery_mv {
+            session_manager
+                .record_battery_mv(&node.node_id, battery_mv)
+                .await;
+        }
+    }
+
     fn make_program_record(hash_fill: u8, source_filename: Option<&str>) -> ProgramRecord {
         ProgramRecord {
             hash: vec![hash_fill; 32],
@@ -2181,15 +2216,18 @@ mod tests {
     #[tokio::test]
     async fn render_status_page_nodes_prefers_program_source_filename() {
         let storage = Arc::new(InMemoryStorage::new());
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(60)));
         let node = make_rich_node("named", 1, 0x31, 1_700_000_000);
         let assigned_program = make_program_record(0x31, Some("C:\\captures\\a.o"));
         let current_program = make_program_record(0x32, Some("/tmp/b.o"));
         storage.store_program(&assigned_program).await.unwrap();
         storage.store_program(&current_program).await.unwrap();
         storage.upsert_node(&node).await.unwrap();
+        seed_runtime_observation(&session_manager, &node).await;
         let storage: Arc<dyn Storage> = storage;
 
-        let rendered = render_status_page(&storage, 6, StatusPage::Nodes).await;
+        let rendered =
+            render_status_page(&storage, Some(&session_manager), 6, StatusPage::Nodes).await;
         let expected = render_status_text_page(&build_node_status_lines(
             &[node],
             &build_program_name_map(&[
@@ -2203,6 +2241,37 @@ mod tests {
                 },
             ]),
         ));
+
+        match rendered {
+            RenderedStatusPage::Scrollable(framebuffer) => {
+                assert_eq!(framebuffer.visible_window(0), expected.visible_window(0));
+            }
+            RenderedStatusPage::Static(_) => panic!("nodes page should be scrollable"),
+        }
+    }
+
+    #[tokio::test]
+    async fn render_status_page_nodes_uses_runtime_observations() {
+        let storage = Arc::new(InMemoryStorage::new());
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(60)));
+        let mut node = NodeRecord::new("runtime".to_string(), 1, [0x11; 32]);
+        node.schedule_interval_s = 120;
+        storage.upsert_node(&node).await.unwrap();
+        let storage: Arc<dyn Storage> = storage;
+
+        let observed_at = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        session_manager
+            .record_last_seen("runtime", observed_at)
+            .await;
+        session_manager.record_battery_mv("runtime", 3300).await;
+
+        let rendered =
+            render_status_page(&storage, Some(&session_manager), 6, StatusPage::Nodes).await;
+        let mut expected_node = node.clone();
+        expected_node.last_seen = Some(observed_at);
+        expected_node.last_battery_mv = Some(3300);
+        let expected =
+            render_status_text_page(&build_node_status_lines(&[expected_node], &HashMap::new()));
 
         match rendered {
             RenderedStatusPage::Scrollable(framebuffer) => {
@@ -2630,6 +2699,7 @@ mod tests {
         let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
         let storage = Arc::new(InMemoryStorage::new());
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(60)));
         storage.set_config("espnow_channel", "11").await.unwrap();
         let storage: Arc<dyn Storage> = storage;
         let mut decoder = FrameDecoder::new();
@@ -2640,6 +2710,7 @@ mod tests {
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
             let storage = Arc::clone(&storage);
+            let session_manager = Arc::clone(&session_manager);
             let display_generation = Arc::clone(&display_generation);
             let status_page_cycle = Arc::clone(&status_page_cycle);
             let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
@@ -2648,6 +2719,7 @@ mod tests {
                     &transport,
                     &controller,
                     &storage,
+                    &session_manager,
                     6,
                     &display_generation,
                     &status_page_cycle,
@@ -2672,6 +2744,7 @@ mod tests {
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
             let storage = Arc::clone(&storage);
+            let session_manager = Arc::clone(&session_manager);
             let display_generation = Arc::clone(&display_generation);
             let status_page_cycle = Arc::clone(&status_page_cycle);
             let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
@@ -2680,6 +2753,7 @@ mod tests {
                     &transport,
                     &controller,
                     &storage,
+                    &session_manager,
                     6,
                     &display_generation,
                     &status_page_cycle,
@@ -2720,11 +2794,14 @@ mod tests {
         let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
         let storage = Arc::new(InMemoryStorage::new());
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(60)));
         storage.set_config("espnow_channel", "11").await.unwrap();
         let node_a = make_rich_node("node-a", 0x1001, 0x41, 1_700_000_000);
         let node_b = make_rich_node("node-b", 0x1002, 0x52, 1_700_000_060);
         storage.upsert_node(&node_a).await.unwrap();
         storage.upsert_node(&node_b).await.unwrap();
+        seed_runtime_observation(&session_manager, &node_a).await;
+        seed_runtime_observation(&session_manager, &node_b).await;
         let storage: Arc<dyn Storage> = storage;
         let mut decoder = FrameDecoder::new();
         let mut buf = [0u8; 2048];
@@ -2744,6 +2821,7 @@ mod tests {
                 let transport = Arc::clone(&transport);
                 let controller = Arc::clone(&controller);
                 let storage = Arc::clone(&storage);
+                let session_manager = Arc::clone(&session_manager);
                 let display_generation = Arc::clone(&display_generation);
                 let status_page_cycle = Arc::clone(&status_page_cycle);
                 let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
@@ -2752,6 +2830,7 @@ mod tests {
                         &transport,
                         &controller,
                         &storage,
+                        &session_manager,
                         6,
                         &display_generation,
                         &status_page_cycle,
@@ -2787,11 +2866,14 @@ mod tests {
         let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
         let storage = Arc::new(InMemoryStorage::new());
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(60)));
         storage.set_config("espnow_channel", "11").await.unwrap();
         let node_a = make_rich_node("node-a", 0x1001, 0x41, 1_700_000_000);
         let node_b = make_rich_node("node-b", 0x1002, 0x52, 1_700_000_060);
         storage.upsert_node(&node_a).await.unwrap();
         storage.upsert_node(&node_b).await.unwrap();
+        seed_runtime_observation(&session_manager, &node_a).await;
+        seed_runtime_observation(&session_manager, &node_b).await;
         let storage: Arc<dyn Storage> = storage;
         let mut decoder = FrameDecoder::new();
         let mut buf = [0u8; 2048];
@@ -2807,6 +2889,7 @@ mod tests {
                 let transport = Arc::clone(&transport);
                 let controller = Arc::clone(&controller);
                 let storage = Arc::clone(&storage);
+                let session_manager = Arc::clone(&session_manager);
                 let display_generation = Arc::clone(&display_generation);
                 let status_page_cycle = Arc::clone(&status_page_cycle);
                 let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
@@ -2815,6 +2898,7 @@ mod tests {
                         &transport,
                         &controller,
                         &storage,
+                        &session_manager,
                         6,
                         &display_generation,
                         &status_page_cycle,
@@ -2842,6 +2926,7 @@ mod tests {
                 let transport = Arc::clone(&transport);
                 let controller = Arc::clone(&controller);
                 let storage = Arc::clone(&storage);
+                let session_manager = Arc::clone(&session_manager);
                 let display_generation = Arc::clone(&display_generation);
                 let status_page_cycle = Arc::clone(&status_page_cycle);
                 let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
@@ -2850,6 +2935,7 @@ mod tests {
                         &transport,
                         &controller,
                         &storage,
+                        &session_manager,
                         6,
                         &display_generation,
                         &status_page_cycle,
@@ -2872,6 +2958,7 @@ mod tests {
         let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
         let storage = Arc::new(InMemoryStorage::new());
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(60)));
         storage.set_config("espnow_channel", "11").await.unwrap();
         let storage: Arc<dyn Storage> = storage;
         let mut decoder = FrameDecoder::new();
@@ -2895,6 +2982,7 @@ mod tests {
                 let transport = Arc::clone(&transport);
                 let controller = Arc::clone(&controller);
                 let storage = Arc::clone(&storage);
+                let session_manager = Arc::clone(&session_manager);
                 let display_generation = Arc::clone(&display_generation);
                 let status_page_cycle = Arc::clone(&status_page_cycle);
                 let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
@@ -2903,6 +2991,7 @@ mod tests {
                         &transport,
                         &controller,
                         &storage,
+                        &session_manager,
                         6,
                         &display_generation,
                         &status_page_cycle,
@@ -2934,6 +3023,7 @@ mod tests {
         let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
         let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
         let storage = Arc::new(InMemoryStorage::new());
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(60)));
         storage.set_config("espnow_channel", "11").await.unwrap();
         let storage: Arc<dyn Storage> = storage;
         let mut decoder = FrameDecoder::new();
@@ -2944,6 +3034,7 @@ mod tests {
             let transport = Arc::clone(&transport);
             let controller = Arc::clone(&controller);
             let storage = Arc::clone(&storage);
+            let session_manager = Arc::clone(&session_manager);
             let display_generation = Arc::clone(&display_generation);
             let status_page_cycle = Arc::clone(&status_page_cycle);
             let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
@@ -2952,6 +3043,7 @@ mod tests {
                     &transport,
                     &controller,
                     &storage,
+                    &session_manager,
                     6,
                     &display_generation,
                     &status_page_cycle,

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -875,10 +875,13 @@ impl Gateway {
             _ => {}
         }
 
-        // 4. Update durable registry metadata and runtime observations.
+        // 4. Update durable firmware metadata and runtime observations.
+        let _ = self
+            .storage
+            .update_node_wake_metadata(&node.node_id, firmware_abi_version, &firmware_version)
+            .await;
         let mut updated_node = node.clone();
         updated_node.update_telemetry(battery_mv, firmware_abi_version, firmware_version);
-        let _ = self.storage.upsert_node(&updated_node).await;
         let observed_at = SystemTime::now();
         self.session_manager
             .record_last_seen(&node.node_id, observed_at)

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -876,19 +876,41 @@ impl Gateway {
         }
 
         // 4. Update durable firmware metadata and runtime observations.
-        let _ = self
+        let metadata_persisted = match self
             .storage
             .update_node_wake_metadata(&node.node_id, firmware_abi_version, &firmware_version)
-            .await;
+            .await
+        {
+            Ok(()) => true,
+            Err(crate::storage::StorageError::NotFound(_)) => {
+                warn!(
+                    node_id = %node.node_id,
+                    "dropping WAKE runtime observation because node disappeared before metadata update",
+                );
+                self.session_manager.clear_last_seen(&node.node_id).await;
+                self.session_manager.clear_battery_mv(&node.node_id).await;
+                false
+            }
+            Err(e) => {
+                warn!(
+                    node_id = %node.node_id,
+                    error = %e,
+                    "failed to persist WAKE firmware metadata",
+                );
+                false
+            }
+        };
         let mut updated_node = node.clone();
         updated_node.update_telemetry(battery_mv, firmware_abi_version, firmware_version);
-        let observed_at = SystemTime::now();
-        self.session_manager
-            .record_last_seen(&node.node_id, observed_at)
-            .await;
-        self.session_manager
-            .record_battery_mv(&node.node_id, battery_mv)
-            .await;
+        if metadata_persisted {
+            let observed_at = SystemTime::now();
+            self.session_manager
+                .record_last_seen(&node.node_id, observed_at)
+                .await;
+            self.session_manager
+                .record_battery_mv(&node.node_id, battery_mv)
+                .await;
+        }
 
         self.connector_event_hub.emit_actual_state_for_node(
             node.node_id.clone(),

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -875,12 +875,16 @@ impl Gateway {
             _ => {}
         }
 
-        // 4. Update registry (battery_mv, firmware_abi_version, firmware_version)
+        // 4. Update durable registry metadata and runtime observations.
         let mut updated_node = node.clone();
         updated_node.update_telemetry(battery_mv, firmware_abi_version, firmware_version);
         let _ = self.storage.upsert_node(&updated_node).await;
+        let observed_at = SystemTime::now();
         self.session_manager
-            .record_last_seen(&node.node_id, SystemTime::now())
+            .record_last_seen(&node.node_id, observed_at)
+            .await;
+        self.session_manager
+            .record_battery_mv(&node.node_id, battery_mv)
             .await;
 
         self.connector_event_hub.emit_actual_state_for_node(

--- a/crates/sonde-gateway/src/registry.rs
+++ b/crates/sonde-gateway/src/registry.rs
@@ -51,8 +51,9 @@ pub struct NodeRecord {
     pub sensors: Vec<SensorDescriptor>,
     /// Phone ID that registered this node (audit trail). Set during BLE pairing.
     pub registered_by_phone_id: Option<u32>,
-    /// Historical battery voltage readings retained only for backward-compatible
-    /// decoding of legacy state. New gateway code does not append to this list.
+    /// Historical battery voltage readings retained only for struct/schema
+    /// compatibility with legacy battery-persistence code paths. New gateway
+    /// code does not populate or append to this list.
     pub battery_history: Vec<BatteryReading>,
 }
 
@@ -78,7 +79,7 @@ impl NodeRecord {
         }
     }
 
-    /// Update runtime battery, ABI, and firmware version fields (called on each WAKE).
+    /// Update runtime battery plus durable firmware metadata from a WAKE.
     pub fn update_telemetry(
         &mut self,
         battery_mv: u32,

--- a/crates/sonde-gateway/src/registry.rs
+++ b/crates/sonde-gateway/src/registry.rs
@@ -3,9 +3,6 @@
 
 use std::time::SystemTime;
 
-/// Maximum number of battery readings to retain per node (GW-0702 AC2).
-const MAX_BATTERY_HISTORY: usize = 100;
-
 /// A timestamped battery voltage reading.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BatteryReading {
@@ -54,7 +51,8 @@ pub struct NodeRecord {
     pub sensors: Vec<SensorDescriptor>,
     /// Phone ID that registered this node (audit trail). Set during BLE pairing.
     pub registered_by_phone_id: Option<u32>,
-    /// Historical battery voltage readings (GW-0702 AC2). Most recent last.
+    /// Historical battery voltage readings retained only for backward-compatible
+    /// decoding of legacy state. New gateway code does not append to this list.
     pub battery_history: Vec<BatteryReading>,
 }
 
@@ -80,7 +78,7 @@ impl NodeRecord {
         }
     }
 
-    /// Update battery, ABI, and firmware version fields (called on each WAKE).
+    /// Update runtime battery, ABI, and firmware version fields (called on each WAKE).
     pub fn update_telemetry(
         &mut self,
         battery_mv: u32,
@@ -90,17 +88,6 @@ impl NodeRecord {
         self.last_battery_mv = Some(battery_mv);
         self.firmware_abi_version = Some(firmware_abi_version);
         self.firmware_version = Some(firmware_version);
-        let now = SystemTime::now();
-
-        // GW-0702 AC2: maintain battery history, capped at MAX_BATTERY_HISTORY.
-        self.battery_history.push(BatteryReading {
-            timestamp: now,
-            battery_mv,
-        });
-        if self.battery_history.len() > MAX_BATTERY_HISTORY {
-            let excess = self.battery_history.len() - MAX_BATTERY_HISTORY;
-            self.battery_history.drain(..excess);
-        }
     }
 
     /// Mark the node's current program hash (called on PROGRAM_ACK).

--- a/crates/sonde-gateway/src/registry.rs
+++ b/crates/sonde-gateway/src/registry.rs
@@ -27,8 +27,9 @@ pub struct SensorDescriptor {
 }
 
 /// Node record. The `node_id` is an admin-assigned opaque identifier used to
-/// correlate a node across sessions and handler API calls. The `last_seen`
-/// field is runtime-only and is not persisted by durable storage backends.
+/// correlate a node across sessions and handler API calls. The `last_seen` and
+/// `last_battery_mv` fields are runtime-only overlays and are not persisted by
+/// durable storage backends.
 #[derive(Debug, Clone)]
 pub struct NodeRecord {
     pub node_id: String,
@@ -43,6 +44,8 @@ pub struct NodeRecord {
     pub schedule_interval_s: u32,
     pub firmware_abi_version: Option<u32>,
     pub firmware_version: Option<String>,
+    /// Most recent WAKE battery reading observed by the current gateway process.
+    /// Durable storage backends intentionally do not persist this field.
     pub last_battery_mv: Option<u32>,
     pub last_seen: Option<SystemTime>,
     /// RF channel the node operates on (1–13). Set during BLE pairing.
@@ -79,7 +82,11 @@ impl NodeRecord {
         }
     }
 
-    /// Update runtime battery plus durable firmware metadata from a WAKE.
+    /// Update the in-memory WAKE overlay on a `NodeRecord`.
+    ///
+    /// This caches the runtime-only battery reading plus the latest firmware
+    /// metadata in a cloned record used by admin/connector shaping. Durable
+    /// persistence of firmware metadata is handled separately by storage.
     pub fn update_telemetry(
         &mut self,
         battery_mv: u32,

--- a/crates/sonde-gateway/src/session.rs
+++ b/crates/sonde-gateway/src/session.rs
@@ -72,6 +72,7 @@ pub struct Session {
 pub struct SessionManager {
     sessions: RwLock<HashMap<String, Session>>,
     last_seen: RwLock<HashMap<String, SystemTime>>,
+    last_battery_mv: RwLock<HashMap<String, u32>>,
     timeout: Duration,
     /// Held as a write-lock during state import to prevent new sessions
     /// from being created while the storage is being replaced.  Normal
@@ -85,6 +86,7 @@ impl SessionManager {
         Self {
             sessions: RwLock::new(HashMap::new()),
             last_seen: RwLock::new(HashMap::new()),
+            last_battery_mv: RwLock::new(HashMap::new()),
             timeout,
             import_lock: RwLock::new(()),
         }
@@ -174,9 +176,27 @@ impl SessionManager {
         self.last_seen.read().await.get(node_id).copied()
     }
 
+    /// Record the most recent battery reading observed during WAKE handling.
+    pub async fn record_battery_mv(&self, node_id: &str, battery_mv: u32) {
+        self.last_battery_mv
+            .write()
+            .await
+            .insert(node_id.to_string(), battery_mv);
+    }
+
+    /// Get the runtime battery reading for a node, if any.
+    pub async fn get_battery_mv(&self, node_id: &str) -> Option<u32> {
+        self.last_battery_mv.read().await.get(node_id).copied()
+    }
+
     /// Return a snapshot of runtime last-seen timestamps keyed by node ID.
     pub async fn snapshot_last_seen(&self) -> HashMap<String, SystemTime> {
         self.last_seen.read().await.clone()
+    }
+
+    /// Return a snapshot of runtime battery readings keyed by node ID.
+    pub async fn snapshot_battery_mv(&self) -> HashMap<String, u32> {
+        self.last_battery_mv.read().await.clone()
     }
 
     /// Remove the runtime last-seen timestamp for a node.
@@ -184,9 +204,19 @@ impl SessionManager {
         self.last_seen.write().await.remove(node_id);
     }
 
+    /// Remove the runtime battery reading for a node.
+    pub async fn clear_battery_mv(&self, node_id: &str) {
+        self.last_battery_mv.write().await.remove(node_id);
+    }
+
     /// Remove all runtime last-seen timestamps.
     pub async fn clear_all_last_seen(&self) {
         self.last_seen.write().await.clear();
+    }
+
+    /// Remove all runtime battery readings.
+    pub async fn clear_all_battery_mv(&self) {
+        self.last_battery_mv.write().await.clear();
     }
 
     /// Remove all sessions that have exceeded the configured timeout.

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -942,6 +942,45 @@ impl Storage for SqliteStorage {
         .await
     }
 
+    async fn update_node_wake_metadata(
+        &self,
+        node_id: &str,
+        firmware_abi_version: u32,
+        firmware_version: &str,
+    ) -> Result<(), StorageError> {
+        let node_id = node_id.to_string();
+        let firmware_version = firmware_version.to_string();
+        self.with_conn(move |conn| {
+            let rows = conn
+                .execute(
+                    "UPDATE nodes
+                     SET firmware_abi_version = ?1,
+                         firmware_version = ?2
+                     WHERE node_id = ?3
+                       AND (firmware_abi_version IS NOT ?1 OR firmware_version IS NOT ?2)",
+                    params![firmware_abi_version, firmware_version, node_id],
+                )
+                .map_err(map_err)?;
+            if rows > 0 {
+                return Ok(());
+            }
+            let exists = conn
+                .query_row(
+                    "SELECT 1 FROM nodes WHERE node_id = ?1",
+                    params![node_id],
+                    |_row| Ok(()),
+                )
+                .optional()
+                .map_err(map_err)?;
+            if exists.is_some() {
+                Ok(())
+            } else {
+                Err(StorageError::NotFound(format!("node `{node_id}`")))
+            }
+        })
+        .await
+    }
+
     async fn insert_node_if_not_exists(&self, record: &NodeRecord) -> Result<bool, StorageError> {
         let record = record.clone();
         let mk = self.master_key.clone();
@@ -2525,6 +2564,63 @@ mod tests {
             .unwrap();
         assert_eq!(stored_battery, Some(3300));
         assert_eq!(stored_history_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_update_node_wake_metadata_preserves_psk_ciphertext() {
+        let store = SqliteStorage::in_memory(test_key()).unwrap();
+        let node = make_node("wake-meta", 0xBC);
+        store.upsert_node(&node).await.unwrap();
+
+        let initial_psk: Vec<u8> = store
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT psk FROM nodes WHERE node_id = 'wake-meta'",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)
+            })
+            .await
+            .unwrap();
+
+        store
+            .update_node_wake_metadata("wake-meta", 7, "1.2.3")
+            .await
+            .unwrap();
+
+        let after_first: (Vec<u8>, Option<u32>, Option<String>) = store
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT psk, firmware_abi_version, firmware_version FROM nodes WHERE node_id = 'wake-meta'",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .map_err(map_err)
+            })
+            .await
+            .unwrap();
+        assert_eq!(after_first.0, initial_psk);
+        assert_eq!(after_first.1, Some(7));
+        assert_eq!(after_first.2.as_deref(), Some("1.2.3"));
+
+        store
+            .update_node_wake_metadata("wake-meta", 7, "1.2.3")
+            .await
+            .unwrap();
+
+        let after_second: (Vec<u8>, Option<u32>, Option<String>) = store
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT psk, firmware_abi_version, firmware_version FROM nodes WHERE node_id = 'wake-meta'",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .map_err(map_err)
+            })
+            .await
+            .unwrap();
+        assert_eq!(after_second, after_first);
     }
 
     // ── Gateway config (GW-0808) ───────────────────────────────

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -15,7 +15,7 @@ use zeroize::Zeroizing;
 use crate::gateway_identity::GatewayIdentity;
 use crate::phone_trust::{PhonePskRecord, PhonePskStatus};
 use crate::program::{ProgramRecord, VerificationProfile};
-use crate::registry::{BatteryReading, NodeRecord, SensorDescriptor};
+use crate::registry::{NodeRecord, SensorDescriptor};
 use crate::storage::{ProgramDisplayRecord, ProgramSummaryRecord, Storage, StorageError};
 
 /// Encrypted PSK blob length: 12-byte nonce + 32-byte ciphertext + 16-byte GCM tag = 60 bytes.
@@ -809,105 +809,15 @@ fn row_to_node(row: &rusqlite::Row<'_>, master_key: &[u8; 32]) -> rusqlite::Resu
         schedule_interval_s,
         firmware_abi_version: row.get(7)?,
         firmware_version,
-        last_battery_mv: row.get(8)?,
+        last_battery_mv: None,
         last_seen: None,
         rf_channel,
         sensors: sensors_json
             .map(|j| sensors_from_json(&j))
             .unwrap_or_default(),
         registered_by_phone_id,
-        // Battery history is loaded separately from the battery_readings table.
         battery_history: Vec::new(),
     })
-}
-
-/// Load battery history for a node from the `battery_readings` table,
-/// ordered oldest-first, capped to the most recent 100 entries.
-fn load_battery_history(conn: &Connection, node_id: &str) -> rusqlite::Result<Vec<BatteryReading>> {
-    // Fetch only the most recent MAX entries in SQL to avoid loading the
-    // entire table into memory. The subquery selects rows newest-first with
-    // a LIMIT, then the outer query re-orders oldest-first.
-    const MAX: usize = 100;
-    let mut stmt = conn.prepare(
-        "SELECT timestamp_epoch_s, battery_mv FROM ( \
-             SELECT timestamp_epoch_s, battery_mv FROM battery_readings \
-             WHERE node_id = ?1 ORDER BY timestamp_epoch_s DESC LIMIT ?2 \
-         ) ORDER BY timestamp_epoch_s ASC",
-    )?;
-    let rows = stmt.query_map(params![node_id, MAX as i64], |row| {
-        let ts: i64 = row.get(0)?;
-        let mv: u32 = row.get(1)?;
-        Ok(BatteryReading {
-            timestamp: epoch_s_to_system_time(ts),
-            battery_mv: mv,
-        })
-    })?;
-    let mut history = Vec::new();
-    for r in rows {
-        history.push(r?);
-    }
-    Ok(history)
-}
-
-/// Persist battery readings for a node incrementally, pruning to the most
-/// recent 100. Only new readings (those with a timestamp newer than the
-/// latest stored entry) are inserted, and excess older rows are pruned
-/// afterwards. This avoids a full delete-and-rewrite on every upsert.
-fn save_battery_history(
-    conn: &Connection,
-    node_id: &str,
-    history: &[BatteryReading],
-) -> Result<(), StorageError> {
-    // Determine the latest timestamp already stored so we can skip duplicates.
-    let max_ts: Option<i64> = conn
-        .query_row(
-            "SELECT MAX(timestamp_epoch_s) FROM battery_readings WHERE node_id = ?1",
-            params![node_id],
-            |row| row.get(0),
-        )
-        .optional()
-        .map_err(map_err)?
-        // `optional()` returns `None` when no rows match; `row.get(0)` may
-        // return `Ok(None)` when the MAX is NULL (no rows), so flatten.
-        .flatten();
-
-    let mut stmt = conn
-        .prepare(
-            "INSERT INTO battery_readings (node_id, timestamp_epoch_s, battery_mv) \
-             VALUES (?1, ?2, ?3)",
-        )
-        .map_err(map_err)?;
-
-    // Only persist the most recent 100 readings from the in-memory history,
-    // and skip any that are already stored.
-    const MAX: usize = 100;
-    let start = history.len().saturating_sub(MAX);
-    for reading in &history[start..] {
-        let ts = system_time_to_epoch_s(&reading.timestamp);
-        if max_ts.is_none_or(|max| ts > max) {
-            stmt.execute(params![node_id, ts, reading.battery_mv])
-                .map_err(map_err)?;
-        }
-    }
-
-    // Prune older rows so that at most 100 readings remain for this node.
-    conn.execute(
-        "DELETE FROM battery_readings \
-          WHERE node_id = ?1 \
-            AND timestamp_epoch_s < ( \
-              SELECT MIN(timestamp_epoch_s) FROM ( \
-                SELECT timestamp_epoch_s \
-                  FROM battery_readings \
-                 WHERE node_id = ?1 \
-                 ORDER BY timestamp_epoch_s DESC \
-                 LIMIT 100 \
-              ) \
-            )",
-        params![node_id],
-    )
-    .map_err(map_err)?;
-
-    Ok(())
 }
 
 #[async_trait]
@@ -930,10 +840,7 @@ impl Storage for SqliteStorage {
                 .map_err(map_err)?;
             let mut nodes = Vec::new();
             for row in rows {
-                let mut node = row.map_err(map_err)?;
-                node.battery_history =
-                    load_battery_history(conn, &node.node_id).map_err(map_err)?;
-                nodes.push(node);
+                nodes.push(row.map_err(map_err)?);
             }
             Ok(nodes)
         })
@@ -956,13 +863,7 @@ impl Storage for SqliteStorage {
                 )
                 .optional()
                 .map_err(map_err)?;
-            if let Some(mut node) = maybe_node {
-                node.battery_history =
-                    load_battery_history(conn, &node.node_id).map_err(map_err)?;
-                Ok(Some(node))
-            } else {
-                Ok(None)
-            }
+            Ok(maybe_node)
         })
         .await
     }
@@ -984,10 +885,7 @@ impl Storage for SqliteStorage {
                 .map_err(map_err)?;
             let mut nodes = Vec::new();
             for row in rows {
-                let mut node = row.map_err(map_err)?;
-                node.battery_history =
-                    load_battery_history(conn, &node.node_id).map_err(map_err)?;
-                nodes.push(node);
+                nodes.push(row.map_err(map_err)?);
             }
             Ok(nodes)
         })
@@ -1015,7 +913,6 @@ impl Storage for SqliteStorage {
                  desired_schedule_interval_s = excluded.desired_schedule_interval_s, \
                  schedule_interval_s = excluded.schedule_interval_s, \
                  firmware_abi_version = excluded.firmware_abi_version, \
-                 last_battery_mv = excluded.last_battery_mv, \
                  last_seen_epoch_s = excluded.last_seen_epoch_s, \
                  rf_channel = excluded.rf_channel, \
                  sensors_json = excluded.sensors_json, \
@@ -1030,7 +927,7 @@ impl Storage for SqliteStorage {
                     record.desired_schedule_interval_s,
                     record.schedule_interval_s,
                     record.firmware_abi_version,
-                    record.last_battery_mv,
+                    Option::<u32>::None,
                     Option::<i64>::None,
                     record.rf_channel.map(|c| c as u32),
                     sensors_json,
@@ -1039,7 +936,6 @@ impl Storage for SqliteStorage {
                 ],
             )
             .map_err(map_err)?;
-            save_battery_history(&tx, &record.node_id, &record.battery_history)?;
             tx.commit().map_err(map_err)?;
             Ok(())
         })
@@ -1068,7 +964,7 @@ impl Storage for SqliteStorage {
                         record.desired_schedule_interval_s,
                         record.schedule_interval_s,
                         record.firmware_abi_version,
-                        record.last_battery_mv,
+                        Option::<u32>::None,
                         Option::<i64>::None,
                         record.rf_channel.map(|c| c as u32),
                         sensors_json,
@@ -1315,19 +1211,12 @@ impl Storage for SqliteStorage {
                             record.desired_schedule_interval_s,
                             record.schedule_interval_s,
                             record.firmware_abi_version,
-                            record.last_battery_mv,
+                            Option::<u32>::None,
                             Option::<i64>::None,
                             record.firmware_version,
                         ],
                     )
                     .map_err(map_err)?;
-
-                    // Repopulate battery history (cascade-deleted with the
-                    // old nodes row above). Without this, imported bundles
-                    // silently lose battery readings.
-                    if !record.battery_history.is_empty() {
-                        save_battery_history(conn, &record.node_id, &record.battery_history)?;
-                    }
                 }
                 Ok(())
             })();
@@ -2093,7 +1982,7 @@ mod tests {
         assert_eq!(fetched.desired_schedule_interval_s, Some(120));
         assert_eq!(fetched.schedule_interval_s, 120);
         assert_eq!(fetched.key_hint, 2);
-        assert_eq!(fetched.last_battery_mv, Some(3300));
+        assert_eq!(fetched.last_battery_mv, None);
     }
 
     /// GW-0601a migration: existing databases with plaintext 32-byte PSK blobs
@@ -2583,56 +2472,59 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_battery_history_roundtrip_and_pruning() {
+    async fn test_legacy_battery_storage_is_ignored_and_preserved() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
-
-        let mut node = make_node("batt1", 0xBB);
-
-        // Populate history with 3 readings.
-        let ts_base = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
-        node.battery_history = vec![
-            BatteryReading {
-                timestamp: ts_base,
-                battery_mv: 3300,
-            },
-            BatteryReading {
-                timestamp: ts_base + Duration::from_secs(60),
-                battery_mv: 3250,
-            },
-            BatteryReading {
-                timestamp: ts_base + Duration::from_secs(120),
-                battery_mv: 3200,
-            },
-        ];
-
+        let node = make_node("batt1", 0xBB);
         store.upsert_node(&node).await.unwrap();
 
-        // Reload and verify round-trip.
-        let loaded = store.get_node("batt1").await.unwrap().unwrap();
-        assert_eq!(loaded.battery_history.len(), 3);
-        assert_eq!(loaded.battery_history[0].battery_mv, 3300);
-        assert_eq!(loaded.battery_history[2].battery_mv, 3200);
-        // Ordering must be ascending by timestamp.
-        assert!(loaded.battery_history[0].timestamp < loaded.battery_history[1].timestamp);
-        assert!(loaded.battery_history[1].timestamp < loaded.battery_history[2].timestamp);
-
-        // Now verify pruning: insert 105 readings, only the most recent 100
-        // should survive.
-        node.battery_history = (0..105)
-            .map(|i| BatteryReading {
-                timestamp: ts_base + Duration::from_secs(200 + i * 10),
-                battery_mv: 3000 + i as u32,
+        store
+            .with_conn(|conn| {
+                conn.execute(
+                    "UPDATE nodes SET last_battery_mv = 3300 WHERE node_id = 'batt1'",
+                    [],
+                )
+                .map_err(map_err)?;
+                conn.execute(
+                    "INSERT INTO battery_readings (node_id, timestamp_epoch_s, battery_mv) \
+                     VALUES ('batt1', 1700000000, 3300)",
+                    [],
+                )
+                .map_err(map_err)?;
+                Ok(())
             })
-            .collect();
-
-        store.upsert_node(&node).await.unwrap();
+            .await
+            .unwrap();
 
         let loaded = store.get_node("batt1").await.unwrap().unwrap();
-        assert_eq!(loaded.battery_history.len(), 100);
-        // The first reading should correspond to index 5 of the original 105
-        // (the oldest 5 were pruned).
-        assert_eq!(loaded.battery_history[0].battery_mv, 3005);
-        assert_eq!(loaded.battery_history[99].battery_mv, 3104);
+        assert_eq!(loaded.last_battery_mv, None);
+        assert!(loaded.battery_history.is_empty());
+
+        let mut updated = loaded.clone();
+        updated.schedule_interval_s = 120;
+        store.upsert_node(&updated).await.unwrap();
+
+        let (stored_battery, stored_history_count): (Option<u32>, i64) = store
+            .with_conn(|conn| {
+                let stored_battery = conn
+                    .query_row(
+                        "SELECT last_battery_mv FROM nodes WHERE node_id = 'batt1'",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .map_err(map_err)?;
+                let stored_history_count = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM battery_readings WHERE node_id = 'batt1'",
+                        [],
+                        |row| row.get(0),
+                    )
+                    .map_err(map_err)?;
+                Ok((stored_battery, stored_history_count))
+            })
+            .await
+            .unwrap();
+        assert_eq!(stored_battery, Some(3300));
+        assert_eq!(stored_history_count, 1);
     }
 
     // ── Gateway config (GW-0808) ───────────────────────────────

--- a/crates/sonde-gateway/src/state_bundle.rs
+++ b/crates/sonde-gateway/src/state_bundle.rs
@@ -42,7 +42,7 @@ use crate::gateway_identity::GatewayIdentity;
 use crate::handler::{HandlerConfig, ProgramMatcher};
 use crate::phone_trust::{PhonePskRecord, PhonePskStatus};
 use crate::program::{ProgramRecord, VerificationProfile};
-use crate::registry::{BatteryReading, NodeRecord, SensorDescriptor};
+use crate::registry::{NodeRecord, SensorDescriptor};
 
 // ── Bundle constants ─────────────────────────────────────────────────────────
 
@@ -390,10 +390,6 @@ fn node_to_cbor(n: &NodeRecord) -> ciborium::value::Value {
             opt_u32_val(n.firmware_abi_version),
         ),
         (
-            Value::Integer(NODE_KEY_BATTERY.into()),
-            opt_u32_val(n.last_battery_mv),
-        ),
-        (
             Value::Integer(NODE_KEY_RF_CHANNEL.into()),
             match n.rf_channel {
                 Some(ch) => Value::Integer(ch.into()),
@@ -431,30 +427,6 @@ fn node_to_cbor(n: &NodeRecord) -> ciborium::value::Value {
             match n.registered_by_phone_id {
                 Some(id) => Value::Integer(id.into()),
                 None => Value::Null,
-            },
-        ),
-        (
-            Value::Integer(NODE_KEY_BATTERY_HISTORY.into()),
-            if n.battery_history.is_empty() {
-                Value::Null
-            } else {
-                Value::Array(
-                    n.battery_history
-                        .iter()
-                        .map(|r| {
-                            let ts: i64 = r
-                                .timestamp
-                                .duration_since(UNIX_EPOCH)
-                                .ok()
-                                .and_then(|d| i64::try_from(d.as_secs()).ok())
-                                .unwrap_or(0);
-                            Value::Array(vec![
-                                Value::Integer(ts.into()),
-                                Value::Integer(r.battery_mv.into()),
-                            ])
-                        })
-                        .collect(),
-                )
             },
         ),
         (
@@ -766,11 +738,9 @@ fn node_from_cbor(v: ciborium::value::Value) -> Result<NodeRecord, BundleError> 
     let mut desired_schedule_interval_s: Option<Option<u32>> = None;
     let mut schedule_interval_s: Option<u32> = None;
     let mut firmware_abi_version: Option<Option<u32>> = None;
-    let mut last_battery_mv: Option<Option<u32>> = None;
     let mut rf_channel: Option<u8> = None;
     let mut sensors: Vec<SensorDescriptor> = Vec::new();
     let mut registered_by_phone_id: Option<u32> = None;
-    let mut battery_history: Vec<BatteryReading> = Vec::new();
     let mut firmware_version: Option<String> = None;
 
     for (k, v) in map {
@@ -830,9 +800,7 @@ fn node_from_cbor(v: ciborium::value::Value) -> Result<NodeRecord, BundleError> 
                 Some(NODE_KEY_FW_ABI) => {
                     firmware_abi_version = Some(opt_u32_from_cbor(v, "firmware_abi_version")?);
                 }
-                Some(NODE_KEY_BATTERY) => {
-                    last_battery_mv = Some(opt_u32_from_cbor(v, "last_battery_mv")?);
-                }
+                Some(NODE_KEY_BATTERY) => {}
                 Some(NODE_KEY_LAST_SEEN) => {
                     let _ = opt_i64_from_cbor(v, "last_seen_epoch_s")?;
                 }
@@ -902,38 +870,7 @@ fn node_from_cbor(v: ciborium::value::Value) -> Result<NodeRecord, BundleError> 
                         ))
                     }
                 },
-                Some(NODE_KEY_BATTERY_HISTORY) => {
-                    if let Value::Array(arr) = v {
-                        // Cap imported history to the same limit used at runtime
-                        // to avoid excessive memory usage from large/modified bundles.
-                        const MAX_BATTERY_HISTORY: usize = 100;
-                        let start = arr.len().saturating_sub(MAX_BATTERY_HISTORY);
-                        for item in &arr[start..] {
-                            if let Value::Array(pair) = item {
-                                if pair.len() == 2 {
-                                    if let (Value::Integer(ts_int), Value::Integer(mv_int)) =
-                                        (&pair[0], &pair[1])
-                                    {
-                                        if let (Ok(ts), Ok(mv)) =
-                                            (i64::try_from(*ts_int), u32::try_from(*mv_int))
-                                        {
-                                            if ts >= 0 {
-                                                if let Some(t) = UNIX_EPOCH
-                                                    .checked_add(Duration::from_secs(ts as u64))
-                                                {
-                                                    battery_history.push(BatteryReading {
-                                                        timestamp: t,
-                                                        battery_mv: mv,
-                                                    });
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                Some(NODE_KEY_BATTERY_HISTORY) => {}
                 Some(NODE_KEY_FW_VERSION) => match v {
                     Value::Text(s) => firmware_version = Some(s),
                     Value::Null => {}
@@ -986,12 +923,12 @@ fn node_from_cbor(v: ciborium::value::Value) -> Result<NodeRecord, BundleError> 
         schedule_interval_s,
         firmware_abi_version: firmware_abi_version.flatten(),
         firmware_version,
-        last_battery_mv: last_battery_mv.flatten(),
+        last_battery_mv: None,
         last_seen: None,
         rf_channel,
         sensors,
         registered_by_phone_id,
-        battery_history,
+        battery_history: Vec::new(),
     })
 }
 
@@ -1505,7 +1442,7 @@ mod tests {
         assert_eq!(na.psk[0], 0x34);
         assert_eq!(na.desired_schedule_interval_s, None);
         assert_eq!(na.schedule_interval_s, 120);
-        assert_eq!(na.last_battery_mv, Some(3700));
+        assert_eq!(na.last_battery_mv, None);
 
         let nb = out_nodes.iter().find(|n| n.node_id == "node-b").unwrap();
         assert_eq!(nb.key_hint, 0x5678);
@@ -1789,11 +1726,12 @@ mod tests {
     }
 
     #[test]
-    fn roundtrip_battery_history() {
+    fn roundtrip_omits_battery_telemetry() {
         use crate::registry::BatteryReading;
         use std::time::{Duration, UNIX_EPOCH};
 
         let mut node = make_node("batt-node", 0xAAAA);
+        node.last_battery_mv = Some(3300);
         node.battery_history = vec![
             BatteryReading {
                 timestamp: UNIX_EPOCH + Duration::from_secs(1700000000),
@@ -1809,8 +1747,7 @@ mod tests {
         let (nodes, _) = decrypt_state(&bundle, "batt-pass").unwrap();
 
         assert_eq!(nodes.len(), 1);
-        assert_eq!(nodes[0].battery_history.len(), 2);
-        assert_eq!(nodes[0].battery_history[0].battery_mv, 3300);
-        assert_eq!(nodes[0].battery_history[1].battery_mv, 3250);
+        assert_eq!(nodes[0].last_battery_mv, None);
+        assert!(nodes[0].battery_history.is_empty());
     }
 }

--- a/crates/sonde-gateway/src/storage.rs
+++ b/crates/sonde-gateway/src/storage.rs
@@ -72,6 +72,16 @@ pub trait Storage: Send + Sync {
     async fn get_node(&self, node_id: &str) -> Result<Option<NodeRecord>, StorageError>;
     async fn get_nodes_by_key_hint(&self, key_hint: u16) -> Result<Vec<NodeRecord>, StorageError>;
     async fn upsert_node(&self, record: &NodeRecord) -> Result<(), StorageError>;
+    /// Persist only the durable metadata reported in a WAKE.
+    ///
+    /// Implementations must not rewrite unrelated fields such as the encrypted
+    /// PSK when only firmware metadata is being refreshed.
+    async fn update_node_wake_metadata(
+        &self,
+        node_id: &str,
+        firmware_abi_version: u32,
+        firmware_version: &str,
+    ) -> Result<(), StorageError>;
     /// Insert a node only if no node with the same `node_id` exists.
     ///
     /// Returns `true` if the node was inserted, `false` if it already existed.
@@ -274,6 +284,26 @@ impl Storage for InMemoryStorage {
     async fn upsert_node(&self, record: &NodeRecord) -> Result<(), StorageError> {
         let mut nodes = self.nodes.write().await;
         nodes.insert(record.node_id.clone(), Self::stored_node_record(record));
+        Ok(())
+    }
+
+    async fn update_node_wake_metadata(
+        &self,
+        node_id: &str,
+        firmware_abi_version: u32,
+        firmware_version: &str,
+    ) -> Result<(), StorageError> {
+        let mut nodes = self.nodes.write().await;
+        let node = nodes
+            .get_mut(node_id)
+            .ok_or_else(|| StorageError::NotFound(format!("node `{node_id}`")))?;
+        if node.firmware_abi_version == Some(firmware_abi_version)
+            && node.firmware_version.as_deref() == Some(firmware_version)
+        {
+            return Ok(());
+        }
+        node.firmware_abi_version = Some(firmware_abi_version);
+        node.firmware_version = Some(firmware_version.to_string());
         Ok(())
     }
 

--- a/crates/sonde-gateway/src/storage.rs
+++ b/crates/sonde-gateway/src/storage.rs
@@ -232,6 +232,14 @@ impl InMemoryStorage {
             handlers: RwLock::new(Vec::new()),
         }
     }
+
+    fn stored_node_record(record: &NodeRecord) -> NodeRecord {
+        let mut stored = record.clone();
+        stored.last_battery_mv = None;
+        stored.last_seen = None;
+        stored.battery_history.clear();
+        stored
+    }
 }
 
 impl Default for InMemoryStorage {
@@ -265,7 +273,7 @@ impl Storage for InMemoryStorage {
 
     async fn upsert_node(&self, record: &NodeRecord) -> Result<(), StorageError> {
         let mut nodes = self.nodes.write().await;
-        nodes.insert(record.node_id.clone(), record.clone());
+        nodes.insert(record.node_id.clone(), Self::stored_node_record(record));
         Ok(())
     }
 
@@ -275,7 +283,7 @@ impl Storage for InMemoryStorage {
         match nodes.entry(record.node_id.clone()) {
             Entry::Occupied(_) => Ok(false),
             Entry::Vacant(e) => {
-                e.insert(record.clone());
+                e.insert(Self::stored_node_record(record));
                 Ok(true)
             }
         }

--- a/crates/sonde-gateway/tests/behavioral_gaps.rs
+++ b/crates/sonde-gateway/tests/behavioral_gaps.rs
@@ -1235,9 +1235,9 @@ async fn t0504_many_to_one_handler_routing() {
 
 /// After registration + WAKE, the durable node record must contain all
 /// specified persisted fields with correct values: node_id, key_hint, psk,
-/// assigned_program_hash, schedule_interval_s, firmware_abi_version,
-/// last_battery_mv, and current_program_hash (None, since it is only set via
-/// PROGRAM_ACK). Runtime `last_seen` is tracked separately.
+/// assigned_program_hash, schedule_interval_s, firmware_abi_version, and
+/// current_program_hash (None, since it is only set via PROGRAM_ACK). Battery
+/// and `last_seen` are tracked separately as runtime observations.
 #[tokio::test]
 async fn t0700_registry_entry_all_fields_present() {
     let storage = Arc::new(InMemoryStorage::new());
@@ -1285,9 +1285,8 @@ async fn t0700_registry_entry_all_fields_present() {
         "firmware_abi_version must be updated by WAKE"
     );
     assert_eq!(
-        stored.last_battery_mv,
-        Some(3700),
-        "last_battery_mv must be updated by WAKE"
+        stored.last_battery_mv, None,
+        "battery must not be durably persisted"
     );
     assert!(
         gw.session_manager()
@@ -1295,6 +1294,11 @@ async fn t0700_registry_entry_all_fields_present() {
             .await
             .is_some(),
         "runtime last_seen must be set after WAKE"
+    );
+    assert_eq!(
+        gw.session_manager().get_battery_mv("node-fields").await,
+        Some(3700),
+        "runtime battery must be updated by WAKE"
     );
     // `current_program_hash` is only set via PROGRAM_ACK, not WAKE.
     assert_eq!(

--- a/crates/sonde-gateway/tests/phase2a.rs
+++ b/crates/sonde-gateway/tests/phase2a.rs
@@ -69,7 +69,7 @@ async fn t0700_node_registry_persistence() {
     assert!(gone.is_none(), "node must not exist after deletion");
 }
 
-/// T-0702: Battery level tracking — update via WAKE telemetry data.
+/// T-0702: Battery telemetry is runtime-only and not durably persisted.
 #[tokio::test]
 async fn t0702_battery_level_tracking() {
     let storage = InMemoryStorage::new();
@@ -82,22 +82,22 @@ async fn t0702_battery_level_tracking() {
 
     // First WAKE: battery at 3300 mV.
     node.update_telemetry(3300, 1, "0.6.0".into());
+    assert_eq!(node.last_battery_mv, Some(3300));
     storage.upsert_node(&node).await.unwrap();
 
     let fetched = storage.get_node("node-bat").await.unwrap().unwrap();
-    assert_eq!(fetched.last_battery_mv, Some(3300));
+    assert_eq!(fetched.last_battery_mv, None);
 
     // Second WAKE: battery drops to 2900 mV.
     node.update_telemetry(2900, 1, "0.6.0".into());
+    assert_eq!(node.last_battery_mv, Some(2900));
     storage.upsert_node(&node).await.unwrap();
 
     let fetched = storage.get_node("node-bat").await.unwrap().unwrap();
-    assert_eq!(fetched.last_battery_mv, Some(2900));
+    assert_eq!(fetched.last_battery_mv, None);
 }
 
-/// T-0702b: Battery historical data retention and cap at 100 readings.
-/// Validates GW-0702 AC2: historical battery data is available for trend
-/// analysis, capped at 100 readings per node.
+/// T-0702b: Local battery history is no longer accumulated or persisted.
 #[tokio::test]
 async fn t0702b_battery_history_retention_and_cap() {
     let storage = InMemoryStorage::new();
@@ -109,35 +109,19 @@ async fn t0702b_battery_history_retention_and_cap() {
         "initial battery history must be empty"
     );
 
-    // Send 105 readings (exceeds the 100-reading cap).
+    // Send many readings; runtime history should remain empty.
     for i in 0u32..105 {
         node.update_telemetry(3000 + i, 1, "0.6.0".into());
     }
+    assert!(
+        node.battery_history.is_empty(),
+        "battery history must stay empty"
+    );
     storage.upsert_node(&node).await.unwrap();
 
     let fetched = storage.get_node("node-bat-hist").await.unwrap().unwrap();
-
-    // History must be capped at 100 readings.
-    assert_eq!(
-        fetched.battery_history.len(),
-        100,
-        "battery history must be capped at 100 readings"
-    );
-
-    // Oldest retained reading should be the 6th (index 5) since first 5 were evicted.
-    assert_eq!(
-        fetched.battery_history[0].battery_mv, 3005,
-        "oldest retained reading must be 3005 mV (first 5 evicted)"
-    );
-
-    // Most recent reading must be the last one sent.
-    assert_eq!(
-        fetched.battery_history[99].battery_mv, 3104,
-        "most recent reading must be 3104 mV"
-    );
-
-    // last_battery_mv must reflect the most recent reading.
-    assert_eq!(fetched.last_battery_mv, Some(3104));
+    assert!(fetched.battery_history.is_empty());
+    assert_eq!(fetched.last_battery_mv, None);
 }
 
 /// T-0703: Firmware ABI version tracking.

--- a/crates/sonde-gateway/tests/phase2b.rs
+++ b/crates/sonde-gateway/tests/phase2b.rs
@@ -284,11 +284,15 @@ async fn t0103_wake_reception_and_field_extraction() {
         "must respond with COMMAND"
     );
 
-    // Verify the registry was updated
+    // Verify durable metadata was updated and battery stayed runtime-only.
     let updated = storage.get_node("node-03").await.unwrap().unwrap();
     assert_eq!(updated.firmware_abi_version, Some(1));
-    assert_eq!(updated.last_battery_mv, Some(3300));
+    assert_eq!(updated.last_battery_mv, None);
     assert_eq!(updated.firmware_version, Some(TEST_FIRMWARE_VERSION.into()));
+    assert_eq!(
+        gw.session_manager().get_battery_mv("node-03").await,
+        Some(3300)
+    );
 }
 
 /// T-0104: WAKE with missing `battery_mv` rejected.
@@ -1027,14 +1031,18 @@ async fn t0603_key_hint_collision() {
     let (_, msg_a) = decode_response(&resp_a, &node_a.psk);
     assert!(matches!(msg_a, GatewayMessage::Command { .. }));
 
-    // Registry must show node A was updated, not node B
+    // Runtime observations must show node A was updated, not node B
     let updated_a = storage.get_node("node-603a").await.unwrap().unwrap();
-    assert!(updated_a.last_battery_mv.is_some());
+    assert!(updated_a.last_battery_mv.is_none());
     assert!(gw
         .session_manager()
         .get_last_seen("node-603a")
         .await
         .is_some());
+    assert_eq!(
+        gw.session_manager().get_battery_mv("node-603a").await,
+        Some(3300)
+    );
 
     // Send WAKE from node B — also must succeed
     let frame_b = node_b.build_wake(2, 1, &[0u8; 32], 3200);
@@ -1046,7 +1054,11 @@ async fn t0603_key_hint_collision() {
     assert!(matches!(msg_b, GatewayMessage::Command { .. }));
 
     let updated_b = storage.get_node("node-603b").await.unwrap().unwrap();
-    assert_eq!(updated_b.last_battery_mv, Some(3200));
+    assert_eq!(updated_b.last_battery_mv, None);
+    assert_eq!(
+        gw.session_manager().get_battery_mv("node-603b").await,
+        Some(3200)
+    );
 }
 
 /// T-0609: Unknown node — silent discard.

--- a/docs/admin-design.md
+++ b/docs/admin-design.md
@@ -195,8 +195,11 @@ program identifiers, battery (mV), last seen (formatted), and schedule
 interval. For human-readable output, assigned/current program identifiers are
 resolved from stored program metadata: use the program's `source_filename`
 basename when available, otherwise display the hash. In `--verbose` mode, show
-the hash alongside any displayed filename. Optional fields are omitted when
-absent. JSON output remains hash-based.
+the hash alongside any displayed filename. Battery and last seen come from
+runtime node-status data rather than durable node storage, so they are omitted
+until the node completes a WAKE in the current gateway process and disappear
+again after gateway restart until the next WAKE. Optional fields are omitted
+when absent. JSON output remains hash-based.
 
 To preserve the existing hash-based admin API, human-readable node-status
 commands resolve filenames client-side. The CLI fetches the node-oriented RPC

--- a/docs/admin-requirements.md
+++ b/docs/admin-requirements.md
@@ -215,13 +215,15 @@ rather than crashing.
 **Source:** GW-0801
 
 **Description:**
-`sonde-admin node list` MUST list all registered nodes. Text output shows
-node ID, key hint, assigned/current program identifiers, battery, last seen
-when known, and schedule. For assigned/current programs, the default
-human-readable identifier is the stored `source_filename` basename when
-available; otherwise the hash is shown. In `--verbose` mode, human-readable
-output also shows the corresponding hash. JSON output remains hash-based. An
-empty registry displays "No nodes registered."
+`sonde-admin node list` MUST list all registered nodes. Text output shows node
+ID, key hint, assigned/current program identifiers, battery, last seen when
+known, and schedule. Battery and last seen are runtime-only observation fields:
+they are absent until the node completes a `WAKE` in the current gateway
+process and disappear again after gateway restart until the next `WAKE`. For
+assigned/current programs, the default human-readable identifier is the stored
+`source_filename` basename when available; otherwise the hash is shown. In
+`--verbose` mode, human-readable output also shows the corresponding hash. JSON
+output remains hash-based. An empty registry displays "No nodes registered."
 
 **Acceptance criteria:**
 
@@ -246,8 +248,11 @@ empty registry displays "No nodes registered."
 `sonde-admin node get <node-id>` MUST display details for a single node. In
 human-readable output, assigned/current programs use the stored
 `source_filename` basename when available and fall back to the hash when no
-filename metadata exists. `--verbose` also shows the corresponding hash. JSON
-output remains hash-based.
+filename metadata exists. Battery and last seen are runtime-only observation
+fields: they are absent until the node completes a `WAKE` in the current
+gateway process and disappear again after gateway restart until the next
+`WAKE`. `--verbose` also shows the corresponding hash. JSON output remains
+hash-based.
 
 **Acceptance criteria:**
 
@@ -441,8 +446,9 @@ ABI version, runtime last seen timestamp (formatted per ADMIN-0107), and
 active session indicator. In default human-readable output, the current
 program identifier is the stored `source_filename` basename when available,
 otherwise the hash. `--verbose` also shows the current program hash. JSON
-output remains hash-based. `last seen` is absent until the node completes a
-WAKE in the current gateway process.
+output remains hash-based. Battery and `last seen` are absent until the node
+completes a WAKE in the current gateway process and are absent again after a
+gateway restart until the next WAKE.
 
 **Acceptance criteria:**
 

--- a/docs/admin-validation.md
+++ b/docs/admin-validation.md
@@ -262,6 +262,23 @@ to avoid collisions when tests run in parallel.
 
 ---
 
+### T-0201b  `node list` and `node get` show runtime-only battery
+
+**Validates:** ADMIN-0200, ADMIN-0201
+**Category:** New automated (CLI process test)
+
+**Procedure:**
+1. Start an admin server with a registered node and process a valid WAKE carrying `battery_mv = 3300`.
+2. Invoke `sonde-admin node list`.
+3. Assert: the node entry includes `3300 mV`.
+4. Invoke `sonde-admin node get <node-id>`.
+5. Assert: the node detail output includes `3300 mV`.
+6. Restart the gateway against the same database without another WAKE.
+7. Invoke `sonde-admin node list` and `node get <node-id>` again.
+8. Assert: battery is omitted until the node completes another WAKE.
+
+---
+
 ### T-0202  Register node — invalid PSK length
 
 **Validates:** ADMIN-0202
@@ -388,6 +405,21 @@ to avoid collisions when tests run in parallel.
 2. Call `get_node_status(node_id)`.
 3. Assert: returned status contains the node ID.
 4. Assert: `has_active_session` is `false` (no WAKE has occurred).
+
+---
+
+### T-0403a  `status` shows runtime-only battery
+
+**Validates:** ADMIN-0403
+**Category:** New automated (CLI process test)
+
+**Procedure:**
+1. Start an admin server with a registered node and process a valid WAKE carrying `battery_mv = 3300`.
+2. Invoke `sonde-admin status <node-id>`.
+3. Assert: the text output includes `3300 mV`.
+4. Restart the gateway against the same database without another WAKE.
+5. Invoke `sonde-admin status <node-id>` again.
+6. Assert: battery is omitted until the node completes another WAKE.
 
 ---
 

--- a/docs/admin-validation.md
+++ b/docs/admin-validation.md
@@ -423,7 +423,7 @@ to avoid collisions when tests run in parallel.
 
 ---
 
-### T-0403a  Human-readable `status` prefers `source_filename` and falls back to hash
+### T-0403b  Human-readable `status` prefers `source_filename` and falls back to hash
 
 **Validates:** ADMIN-0403
 **Category:** New automated (CLI process test)

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -307,8 +307,8 @@ recv frame
   │     │     └── include deferred data as `blob` (key 10) in COMMAND, clear store
    │     ├── encode COMMAND response
    │     ├── send response (echoing wake nonce)
-   │     ├── update node registry (battery_mv, firmware_abi_version, firmware_version)
-   │     ├── update runtime node observations (`last_seen`)
+   │     ├── update node registry (firmware_abi_version, firmware_version)
+   │     ├── update runtime node observations (`last_seen`, `last_battery_mv`)
    │     ├── if WAKE contains `blob`:
   │     │     ├── route to handler as DATA message (§9.4)
   │     │     └── store handler reply as deferred data (§6.3a)
@@ -365,12 +365,15 @@ pub struct NodeRecord {
     pub schedule_interval_s: u32,
     pub firmware_abi_version: Option<u32>,
     pub firmware_version: Option<String>,
-    pub last_battery_mv: Option<u32>,
     pub admin_node_id: String,  // opaque human-readable ID for handler API
 }
 ```
 
-`NodeRecord` is used primarily for durable registry state. The Rust struct currently retains a `last_seen` field for in-memory compatibility, but it is not storage-backed, is initialized as `None` on reads/imports, and is not used as the source of truth for admin status or timeout detection. The runtime `last_seen` data lives in the separate in-memory observation map below.
+`NodeRecord` is used primarily for durable registry state. Battery telemetry is
+not part of the durable node record. The Rust implementation may retain
+in-memory compatibility fields, but neither `last_seen` nor battery telemetry
+is storage-backed or imported/exported as durable node metadata. Runtime
+observation data lives in the separate in-memory observation map below.
 
 ### 7.1a  Runtime node observations
 
@@ -379,10 +382,16 @@ The gateway maintains a separate in-memory map for per-node runtime observations
 ```rust
 pub struct RuntimeNodeState {
     pub last_seen: Option<SystemTime>,
+    pub last_battery_mv: Option<u32>,
 }
 ```
 
-The runtime state is keyed by `NodeId` and updated only after a valid `WAKE` is processed. It is cleared on gateway restart and is excluded from SQLite persistence and state export/import. Admin read paths and timeout detection merge durable `NodeRecord` data with this runtime map.
+The runtime state is keyed by `NodeId` and updated only after a valid `WAKE` is
+processed. It is cleared on gateway restart and is excluded from SQLite
+persistence and state export/import. Admin read paths, modem status-page
+rendering, and timeout detection merge durable `NodeRecord` data with this
+runtime map. The connector actual-state path emits `battery_mv` from the WAKE
+handling path directly and does not depend on durable battery storage.
 
 ### 7.2  Key lookup
 
@@ -1082,6 +1091,10 @@ For a `WAKE` carrying a piggybacked `blob`, the gateway emits the actual-state
 update first and the application-data message second. Application-data egress is
 informational only; it does not replace the existing handler reply path used for
 node `send_recv()` responses.
+
+The node actual-state payload continues to include `battery_mv` from the just-
+processed WAKE even though battery telemetry is runtime-only locally and is not
+written to durable gateway storage.
 
 ### 13A.4  External transport boundary and loss signaling
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -757,12 +757,22 @@ On receiving a `WAKE` message, the gateway MUST compare the node's reported `pro
 **Source:** README § Wake handshake
 
 **Description:**  
-The gateway SHOULD record the `battery_mv` value from each `WAKE` message for monitoring and operational visibility.
+The gateway SHOULD treat the `battery_mv` value from each `WAKE` message as
+runtime telemetry for operator visibility and upstream monitoring. To reduce
+durable-storage churn on microSD-backed gateways, the gateway MUST NOT persist
+new `battery_mv` readings or local battery-history series in durable storage.
+Instead, the latest battery reading remains available only in runtime state
+during the current gateway process and is exported upstream through the
+connector actual-state path (GW-0812) for long-term monitoring/storage.
 
 **Acceptance criteria:**
 
-1. The most recent `battery_mv` reading is stored per node.
-2. Historical battery data is available for trend analysis.
+1. After a valid `WAKE`, the latest `battery_mv` reading is available from
+   runtime state for local status surfaces in the current gateway process.
+2. Processing `WAKE` messages does not write new `battery_mv` readings or local
+   battery-history samples into durable gateway storage.
+3. After a gateway restart, battery is absent from local status until the node
+   completes another `WAKE`.
 
 ---
 
@@ -1042,7 +1052,16 @@ The connector API MUST accept control-plane desired-state messages addressed to 
 **Source:** User-requested gateway/control-plane reconciliation model
 
 **Description:**  
-The gateway MUST emit upstream control-plane messages that describe actual gateway and node state changes relevant to reconciliation. For nodes, this includes the state learned when the gateway accepts and processes an authenticated `WAKE`, such as `node_id`, current and assigned program hashes when known, `battery_mv`, firmware ABI/version data, and a reception timestamp encoded as Unix time in milliseconds. These upstream messages are produced only after the gateway has updated its latest-known actual state for the affected entity.
+The gateway MUST emit upstream control-plane messages that describe actual
+gateway and node state changes relevant to reconciliation. For nodes, this
+includes the state learned when the gateway accepts and processes an
+authenticated `WAKE`, such as `node_id`, current and assigned program hashes
+when known, `battery_mv`, firmware ABI/version data, and a reception timestamp
+encoded as Unix time in milliseconds. `battery_mv` remains part of the emitted
+actual-state record even though battery telemetry is runtime-only locally and is
+not durably persisted under GW-0702. These upstream messages are produced only
+after the gateway has updated its latest-known actual state for the affected
+entity.
 
 **Acceptance criteria:**
 
@@ -1260,7 +1279,25 @@ Whenever the gateway re-initializes the modem after a serial reconnect or warm r
 **Source:** Issue #798
 
 **Description:**
-While no BLE pairing session is active, the gateway SHOULD interpret `EVENT_BUTTON(BUTTON_SHORT)` as a request to advance the modem display to the next gateway-owned status page. The gateway owns status-page selection and framebuffer rendering; the modem continues to render only the received framebuffer bytes. The default status-page sequence consists of a `Channel` page and a `Nodes` page. The `Nodes` page text output MUST show the key operational node details in `node_id` order: `node_id`, assigned/current program identifiers, battery, last seen, and schedule, with optional fields omitted when absent. For assigned/current programs, the default display identifier is the stored `source_filename` basename when available; otherwise the hash is shown. `key_hint` MUST NOT be shown on the display page. The `last seen` value MUST be rendered in local time using the host locale's date/time presentation rather than fixed UTC text. On the display, each field is rendered as a left-aligned property line followed by a left-aligned `- value` line so properties and values are visually distinct. An empty node registry MUST display `No nodes registered.`
+While no BLE pairing session is active, the gateway SHOULD interpret
+`EVENT_BUTTON(BUTTON_SHORT)` as a request to advance the modem display to the
+next gateway-owned status page. The gateway owns status-page selection and
+framebuffer rendering; the modem continues to render only the received
+framebuffer bytes. The default status-page sequence consists of a `Channel`
+page and a `Nodes` page. The `Nodes` page text output MUST show the key
+operational node details in `node_id` order: `node_id`, assigned/current
+program identifiers, battery, last seen, and schedule, with optional fields
+omitted when absent. Battery and last seen are runtime-only observation fields:
+they are absent until the node completes a `WAKE` in the current gateway
+process and disappear again after gateway restart until the next `WAKE`. For
+assigned/current programs, the default display identifier is the stored
+`source_filename` basename when available; otherwise the hash is shown.
+`key_hint` MUST NOT be shown on the display page. The `last seen` value MUST be
+rendered in local time using the host locale's date/time presentation rather
+than fixed UTC text. On the display, each field is rendered as a left-aligned
+property line followed by a left-aligned `- value` line so properties and
+values are visually distinct. An empty node registry MUST display `No nodes
+registered.`
 
 **Acceptance criteria:**
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -105,7 +105,8 @@ A configurable stub handler process (or in-process mock) that:
 **Procedure:**
 1. Send a WAKE with `firmware_abi_version=1`, `program_hash=<known_hash>`, `battery_mv=3300`, `firmware_version="0.6.0"`.
 2. Assert: gateway responds with a COMMAND.
-3. Assert: the node's registry entry is updated with the received `firmware_abi_version`, `battery_mv`, and `firmware_version`.
+3. Assert: the node's durable registry entry is updated with the received `firmware_abi_version` and `firmware_version`.
+4. Assert: the gateway's runtime node-observation state records `battery_mv = 3300`.
 
 ---
 
@@ -1178,9 +1179,10 @@ A configurable stub handler process (or in-process mock) that:
 
 **Procedure:**
 1. Send WAKE with `battery_mv = 3300`.
-2. Assert: node registry entry `last_battery_mv = 3300`.
-3. Send WAKE with `battery_mv = 2900`.
-4. Assert: updated to `2900`.
+2. Assert: the gateway's runtime node-observation state reports `last_battery_mv = 3300`.
+3. Assert: local node-status surfaces in the same gateway process can display `3300 mV`.
+4. Restart the gateway against the same database without sending another WAKE.
+5. Assert: battery is absent from local node-status surfaces until the next WAKE.
 
 ---
 
@@ -1206,7 +1208,7 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
-### T-0705  Battery historical data
+### T-0705  Battery telemetry is not durably persisted
 
 **Validates:** GW-0702
 
@@ -1214,8 +1216,9 @@ A configurable stub handler process (or in-process mock) that:
 1. Send WAKE with `battery_mv = 3300`.
 2. Send WAKE with `battery_mv = 3100`.
 3. Send WAKE with `battery_mv = 2900`.
-4. Assert: storage retains all three readings (not just the latest).
-5. Assert: readings can be queried in chronological order for trend analysis.
+4. Restart the gateway against the same database.
+5. Assert: the reloaded durable node record does not restore a battery value or local battery history.
+6. Assert: battery becomes available again only after a new WAKE is processed.
 
 ---
 


### PR DESCRIPTION
## Summary
- stop durably persisting node battery telemetry on the gateway and ignore legacy stored battery values on read
- source local admin and modem node status battery display from runtime observations while keeping connector actual-state battery export intact
- update gateway, admin, and e2e tests plus the gateway/admin spec stack for the runtime-only battery model

Closes #831