### PR TITLE
Add on-demand Azure live CI workflow

### DIFF
--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -151,7 +151,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: azure-live-ci-artifacts
-          path: .azure-live-state
+          path: |
+            .azure-live-state/deployment.json
+            .azure-live-state/service-principal.json
+            .azure-live-state/service-bus.json
+            .azure-live-state/cert.pem
           retention-days: 7
           if-no-files-found: error
 

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -63,7 +63,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
           python3 -m pip install --upgrade pip
-          python3 -m pip install azure-identity azure-servicebus
+          python3 -m pip install azure-identity==1.25.3 azure-servicebus==7.14.3
 
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
@@ -88,7 +88,7 @@ jobs:
               echo "::error::refusing to delete resource group $SONDE_AZURE_CI_RESOURCE_GROUP without tags.sonde-ci-owner=azure-live-ci"
               exit 1
             fi
-            az group delete --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --yes
+            az group delete --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --yes --no-wait
           fi
           for _ in $(seq 1 90); do
             if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "false" ]; then
@@ -104,6 +104,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .azure-live-state
+          az group create \
+            --name "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+            --location "$SONDE_AZURE_CI_LOCATION" \
+            --tags sonde-ci-owner=azure-live-ci project="$SONDE_AZURE_CI_PROJECT_NAME" > /dev/null
           openssl ecparam -name prime256v1 -genkey -noout -out .azure-live-state/key.pem
           chmod 600 .azure-live-state/key.pem
           openssl req -new -x509 \
@@ -118,16 +122,9 @@ jobs:
             --parameters location="$SONDE_AZURE_CI_LOCATION" \
             --parameters resource_group_name="$SONDE_AZURE_CI_RESOURCE_GROUP" \
             --parameters project_name="$SONDE_AZURE_CI_PROJECT_NAME" \
+            --parameters resourceGroupOwnerTag='azure-live-ci' \
             --parameters companionCertificateBase64="$CERT_BASE64" \
             --output json > .azure-live-state/deployment.json
-
-      - name: Tag disposable resource group
-        shell: bash
-        run: |
-          set -euo pipefail
-          az group update \
-            --name "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-            --set tags.sonde-ci-owner=azure-live-ci > /dev/null
 
       - name: Write Azure companion runtime state
         shell: bash
@@ -169,6 +166,7 @@ jobs:
             --companion-bin ./target/debug/sonde-azure-companion \
             --state-dir ./.azure-live-state \
             --connector-socket /tmp/sonde-azure-live-ci.sock \
+            --message-timeout-secs 180 \
             --namespace "$(python3 -c "import json; print(json.load(open('.azure-live-state/service-bus.json'))['namespace'])")" \
             --upstream-queue "$(python3 -c "import json; print(json.load(open('.azure-live-state/service-bus.json'))['upstream_queue'])")" \
             --downstream-queue "$(python3 -c "import json; print(json.load(open('.azure-live-state/service-bus.json'))['downstream_queue'])")"
@@ -201,7 +199,7 @@ jobs:
               echo "::error::refusing to delete resource group $SONDE_AZURE_CI_RESOURCE_GROUP without tags.sonde-ci-owner=azure-live-ci"
               exit 1
             fi
-            az group delete --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --yes
+            az group delete --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --yes --no-wait
           fi
           for _ in $(seq 1 90); do
             if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "false" ]; then

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -24,6 +24,7 @@ jobs:
       AZURE_TENANT_ID: ${{ vars.SONDE_AZURE_CI_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.SONDE_AZURE_CI_SUBSCRIPTION_ID }}
       SONDE_AZURE_CI_RESOURCE_GROUP: ${{ vars.SONDE_AZURE_CI_RESOURCE_GROUP }}
+      SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX: ${{ vars.SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX }}
       SONDE_AZURE_CI_LOCATION: ${{ vars.SONDE_AZURE_CI_LOCATION }}
       SONDE_AZURE_CI_PROJECT_NAME: ${{ vars.SONDE_AZURE_CI_PROJECT_NAME }}
     steps:
@@ -34,14 +35,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          project_name="${SONDE_AZURE_CI_PROJECT_NAME:-sonde-ci}"
+          resource_group_prefix="${SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX:-${project_name}-ci-}"
           for name in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID SONDE_AZURE_CI_RESOURCE_GROUP; do
             if [ -z "${!name:-}" ]; then
               echo "::error::$name must be configured as a repository or environment variable"
               exit 1
             fi
           done
+          echo "SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX=$resource_group_prefix" >> "$GITHUB_ENV"
           echo "SONDE_AZURE_CI_LOCATION=${SONDE_AZURE_CI_LOCATION:-eastus}" >> "$GITHUB_ENV"
-          echo "SONDE_AZURE_CI_PROJECT_NAME=${SONDE_AZURE_CI_PROJECT_NAME:-sonde-ci}" >> "$GITHUB_ENV"
+          echo "SONDE_AZURE_CI_PROJECT_NAME=$project_name" >> "$GITHUB_ENV"
 
       - name: Azure login (OIDC)
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
@@ -74,7 +78,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "$SONDE_AZURE_CI_RESOURCE_GROUP" != "${SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX}"* ]]; then
+            echo "::error::resource group $SONDE_AZURE_CI_RESOURCE_GROUP must start with CI prefix $SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX"
+            exit 1
+          fi
           if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "true" ]; then
+            ci_owner_tag="$(az group show --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --query "tags.sonde-ci-owner" --output tsv)"
+            if [ "$ci_owner_tag" != "azure-live-ci" ]; then
+              echo "::error::refusing to delete resource group $SONDE_AZURE_CI_RESOURCE_GROUP without tags.sonde-ci-owner=azure-live-ci"
+              exit 1
+            fi
             az group delete --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --yes
           fi
           for _ in $(seq 1 90); do
@@ -107,6 +120,14 @@ jobs:
             --parameters project_name="$SONDE_AZURE_CI_PROJECT_NAME" \
             --parameters companionCertificateBase64="$CERT_BASE64" \
             --output json > .azure-live-state/deployment.json
+
+      - name: Tag disposable resource group
+        shell: bash
+        run: |
+          set -euo pipefail
+          az group update \
+            --name "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+            --set tags.sonde-ci-owner=azure-live-ci > /dev/null
 
       - name: Write Azure companion runtime state
         shell: bash
@@ -170,7 +191,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "$SONDE_AZURE_CI_RESOURCE_GROUP" != "${SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX}"* ]]; then
+            echo "::error::resource group $SONDE_AZURE_CI_RESOURCE_GROUP must start with CI prefix $SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX"
+            exit 1
+          fi
           if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "true" ]; then
+            ci_owner_tag="$(az group show --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --query "tags.sonde-ci-owner" --output tsv)"
+            if [ "$ci_owner_tag" != "azure-live-ci" ]; then
+              echo "::error::refusing to delete resource group $SONDE_AZURE_CI_RESOURCE_GROUP without tags.sonde-ci-owner=azure-live-ci"
+              exit 1
+            fi
             az group delete --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --yes
           fi
           for _ in $(seq 1 90); do

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+
+name: Azure Live CI
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: azure-live-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  azure-live:
+    name: Provision and validate Azure companion
+    runs-on: ubuntu-latest
+    env:
+      AZURE_CLIENT_ID: ${{ vars.SONDE_AZURE_CI_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.SONDE_AZURE_CI_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.SONDE_AZURE_CI_SUBSCRIPTION_ID }}
+      SONDE_AZURE_CI_RESOURCE_GROUP: ${{ vars.SONDE_AZURE_CI_RESOURCE_GROUP }}
+      SONDE_AZURE_CI_LOCATION: ${{ vars.SONDE_AZURE_CI_LOCATION }}
+      SONDE_AZURE_CI_PROJECT_NAME: ${{ vars.SONDE_AZURE_CI_PROJECT_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate required Azure CI variables
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID SONDE_AZURE_CI_RESOURCE_GROUP; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::$name must be configured as a repository or environment variable"
+              exit 1
+            fi
+          done
+          echo "SONDE_AZURE_CI_LOCATION=${SONDE_AZURE_CI_LOCATION:-eastus}" >> "$GITHUB_ENV"
+          echo "SONDE_AZURE_CI_PROJECT_NAME=${SONDE_AZURE_CI_PROJECT_NAME:-sonde-ci}" >> "$GITHUB_ENV"
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Install build and validation dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+          python3 -m pip install --upgrade pip
+          python3 -m pip install azure-identity azure-servicebus
+
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          key: azure-live-ci
+
+      - name: Build Azure companion
+        run: cargo build --locked -p sonde-azure-companion
+
+      - name: Preflight-delete disposable resource group
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "true" ]; then
+            az group delete --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --yes
+          fi
+          for _ in $(seq 1 90); do
+            if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "false" ]; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::resource group $SONDE_AZURE_CI_RESOURCE_GROUP was not deleted before provisioning"
+          exit 1
+
+      - name: Generate runtime certificate and deploy disposable stack
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .azure-live-state
+          openssl ecparam -name prime256v1 -genkey -noout -out .azure-live-state/key.pem
+          chmod 600 .azure-live-state/key.pem
+          openssl req -new -x509 \
+            -key .azure-live-state/key.pem \
+            -out .azure-live-state/cert.pem \
+            -days 730 \
+            -subj "/CN=sonde-azure-live-ci"
+          CERT_BASE64="$(openssl x509 -in .azure-live-state/cert.pem -outform der | base64 -w0)"
+          az deployment sub create \
+            --location "$SONDE_AZURE_CI_LOCATION" \
+            --template-file ./deploy/bicep/main.bicep \
+            --parameters resource_group_name="$SONDE_AZURE_CI_RESOURCE_GROUP" \
+            --parameters project_name="$SONDE_AZURE_CI_PROJECT_NAME" \
+            --parameters companionCertificateBase64="$CERT_BASE64" \
+            --output json > .azure-live-state/deployment.json
+
+      - name: Write Azure companion runtime state
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          state_dir = Path(".azure-live-state")
+          deployment = json.loads((state_dir / "deployment.json").read_text(encoding="utf-8"))
+          outputs = deployment["properties"]["outputs"]
+          bootstrap = outputs["companionBootstrapValues"]["value"]
+          namespace = bootstrap["serviceBusNamespace"]
+          if not namespace.endswith(".servicebus.windows.net"):
+              namespace = f"{namespace}.servicebus.windows.net"
+          service_principal = {
+              "tenant_id": bootstrap["tenantId"],
+              "client_id": bootstrap["clientId"],
+              "certificate_path": "cert.pem",
+              "private_key_path": "key.pem",
+          }
+          service_bus = {
+              "namespace": namespace,
+              "upstream_queue": bootstrap["upstreamQueue"],
+              "downstream_queue": bootstrap["downstreamQueue"],
+          }
+          (state_dir / "service-principal.json").write_text(
+              json.dumps(service_principal), encoding="utf-8"
+          )
+          (state_dir / "service-bus.json").write_text(
+              json.dumps(service_bus), encoding="utf-8"
+          )
+          PY
+
+      - name: Run live Azure companion validation
+        run: |
+          python3 ./deploy/azure-companion/live_ci.py \
+            --companion-bin ./target/debug/sonde-azure-companion \
+            --state-dir ./.azure-live-state \
+            --connector-socket /tmp/sonde-azure-live-ci.sock \
+            --namespace "$(python3 -c "import json; print(json.load(open('.azure-live-state/service-bus.json'))['namespace'])")" \
+            --upstream-queue "$(python3 -c "import json; print(json.load(open('.azure-live-state/service-bus.json'))['upstream_queue'])")" \
+            --downstream-queue "$(python3 -c "import json; print(json.load(open('.azure-live-state/service-bus.json'))['downstream_queue'])")"
+
+      - name: Upload Azure live artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: azure-live-ci-artifacts
+          path: .azure-live-state
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Teardown disposable resource group
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "true" ]; then
+            az group delete --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --yes
+          fi
+          for _ in $(seq 1 90); do
+            if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "false" ]; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::resource group $SONDE_AZURE_CI_RESOURCE_GROUP still exists after teardown"
+          exit 1

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -20,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: azure-live-ci
     env:
+      SONDE_AZURE_CI_CLIENT_ID: ${{ vars.SONDE_AZURE_CI_CLIENT_ID }}
+      SONDE_AZURE_CI_TENANT_ID: ${{ vars.SONDE_AZURE_CI_TENANT_ID }}
+      SONDE_AZURE_CI_SUBSCRIPTION_ID: ${{ vars.SONDE_AZURE_CI_SUBSCRIPTION_ID }}
       AZURE_CLIENT_ID: ${{ vars.SONDE_AZURE_CI_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.SONDE_AZURE_CI_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.SONDE_AZURE_CI_SUBSCRIPTION_ID }}
@@ -35,9 +38,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          project_name="${SONDE_AZURE_CI_PROJECT_NAME:-sonde-ci}"
+          project_name="${SONDE_AZURE_CI_PROJECT_NAME:-sonde}"
           resource_group_prefix="${SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX:-${project_name}-ci-}"
-          for name in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID SONDE_AZURE_CI_RESOURCE_GROUP; do
+          for name in SONDE_AZURE_CI_CLIENT_ID SONDE_AZURE_CI_TENANT_ID SONDE_AZURE_CI_SUBSCRIPTION_ID SONDE_AZURE_CI_RESOURCE_GROUP; do
             if [ -z "${!name:-}" ]; then
               echo "::error::$name must be configured as a repository or environment variable"
               exit 1
@@ -166,6 +169,7 @@ jobs:
             --companion-bin ./target/debug/sonde-azure-companion \
             --state-dir ./.azure-live-state \
             --connector-socket /tmp/sonde-azure-live-ci.sock \
+            --connect-timeout-secs 180 \
             --message-timeout-secs 180 \
             --namespace "$(python3 -c "import json; print(json.load(open('.azure-live-state/service-bus.json'))['namespace'])")" \
             --upstream-queue "$(python3 -c "import json; print(json.load(open('.azure-live-state/service-bus.json'))['upstream_queue'])")" \

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: azure-live-ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -43,7 +43,7 @@ jobs:
           echo "SONDE_AZURE_CI_PROJECT_NAME=${SONDE_AZURE_CI_PROJECT_NAME:-sonde-ci}" >> "$GITHUB_ENV"
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: azure-live-ci-${{ github.ref }}
+  group: azure-live-ci
   cancel-in-progress: false
 
 permissions:
@@ -18,6 +18,7 @@ jobs:
   azure-live:
     name: Provision and validate Azure companion
     runs-on: ubuntu-latest
+    environment: azure-live-ci
     env:
       AZURE_CLIENT_ID: ${{ vars.SONDE_AZURE_CI_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.SONDE_AZURE_CI_TENANT_ID }}
@@ -48,6 +49,10 @@ jobs:
           client-id: ${{ env.AZURE_CLIENT_ID }}
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
 
       - name: Install build and validation dependencies
         run: |
@@ -97,6 +102,7 @@ jobs:
           az deployment sub create \
             --location "$SONDE_AZURE_CI_LOCATION" \
             --template-file ./deploy/bicep/main.bicep \
+            --parameters location="$SONDE_AZURE_CI_LOCATION" \
             --parameters resource_group_name="$SONDE_AZURE_CI_RESOURCE_GROUP" \
             --parameters project_name="$SONDE_AZURE_CI_PROJECT_NAME" \
             --parameters companionCertificateBase64="$CERT_BASE64" \

--- a/deploy/azure-companion/live_ci.py
+++ b/deploy/azure-companion/live_ci.py
@@ -78,6 +78,7 @@ class ConnectorHarness:
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._downstream_payloads: asyncio.Queue[bytes] = asyncio.Queue()
+        self._abort_next_downstream_write = False
 
     async def start(self) -> None:
         if self.socket_path.exists():
@@ -92,6 +93,16 @@ class ConnectorHarness:
         self.connected.set()
         try:
             while True:
+                if self._abort_next_downstream_write:
+                    self._abort_next_downstream_write = False
+                    try:
+                        await reader.readexactly(4)
+                    except asyncio.IncompleteReadError as exc:
+                        if exc.partial:
+                            raise RuntimeError("truncated connector frame length prefix") from exc
+                        break
+                    writer.transport.abort()
+                    return
                 payload = await read_framed(reader)
                 if payload is None:
                     break
@@ -112,11 +123,10 @@ class ConnectorHarness:
     async def wait_downstream(self, timeout_secs: int) -> bytes:
         return await asyncio.wait_for(self._downstream_payloads.get(), timeout=timeout_secs)
 
-    async def close_peer(self) -> None:
-        if self._writer is not None:
-            self._writer.close()
-            with contextlib.suppress(Exception):
-                await self._writer.wait_closed()
+    def abort_next_downstream_write(self) -> None:
+        if self._writer is None:
+            raise RuntimeError("connector harness has no connected writer")
+        self._abort_next_downstream_write = True
 
     async def stop(self) -> None:
         if self._server is not None:
@@ -210,8 +220,8 @@ async def run_failure_path(
     companion: asyncio.subprocess.Process,
     message_timeout_secs: int,
 ) -> None:
-    failed_handoff_payload = b"ci-live-downstream-write-failure"
-    await harness.close_peer()
+    failed_handoff_payload = b"x" * (240 * 1024)
+    harness.abort_next_downstream_write()
     async with client.get_queue_sender(queue_name=downstream_queue) as sender:
         await sender.send_messages(ServiceBusMessage(failed_handoff_payload))
 

--- a/deploy/azure-companion/live_ci.py
+++ b/deploy/azure-companion/live_ci.py
@@ -239,12 +239,13 @@ async def async_main() -> int:
     companion: asyncio.subprocess.Process | None = None
     stdout_task: asyncio.Task[None] | None = None
     stderr_task: asyncio.Task[None] | None = None
-
-    await harness.start()
-    credential = AzureCliCredential()
-    client = ServiceBusClient(namespace, credential=credential, logging_enable=False)
+    credential: AzureCliCredential | None = None
+    client: ServiceBusClient | None = None
 
     try:
+        await harness.start()
+        credential = AzureCliCredential()
+        client = ServiceBusClient(namespace, credential=credential, logging_enable=False)
         companion = await asyncio.create_subprocess_exec(
             args.companion_bin,
             "--connector-socket",
@@ -285,7 +286,8 @@ async def async_main() -> int:
             return_exceptions=True,
         )
         await harness.stop()
-        await credential.close()
+        if credential is not None:
+            await credential.close()
 
 
 def main() -> int:

--- a/deploy/azure-companion/live_ci.py
+++ b/deploy/azure-companion/live_ci.py
@@ -16,7 +16,6 @@ from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient
 
 
-CONNECT_TIMEOUT_SECS = 30
 DEFAULT_MESSAGE_TIMEOUT_SECS = 180
 CONNECTOR_MAX_FRAME_LENGTH = 1_048_576
 
@@ -31,6 +30,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--namespace", required=True)
     parser.add_argument("--upstream-queue", required=True)
     parser.add_argument("--downstream-queue", required=True)
+    parser.add_argument("--connect-timeout-secs", type=int)
     parser.add_argument("--message-timeout-secs", type=int, default=DEFAULT_MESSAGE_TIMEOUT_SECS)
     return parser.parse_args()
 
@@ -101,8 +101,8 @@ class ConnectorHarness:
             with contextlib.suppress(Exception):
                 await writer.wait_closed()
 
-    async def wait_connected(self) -> None:
-        await asyncio.wait_for(self.connected.wait(), timeout=CONNECT_TIMEOUT_SECS)
+    async def wait_connected(self, timeout_secs: int) -> None:
+        await asyncio.wait_for(self.connected.wait(), timeout=timeout_secs)
 
     async def send_upstream(self, payload: bytes) -> None:
         if self._writer is None:
@@ -230,6 +230,11 @@ async def run_failure_path(
 async def async_main() -> int:
     args = parse_args()
     namespace = normalize_namespace(args.namespace)
+    connect_timeout_secs = (
+        args.connect_timeout_secs
+        if args.connect_timeout_secs is not None
+        else args.message_timeout_secs
+    )
 
     socket_path = Path(args.connector_socket)
     socket_path.parent.mkdir(parents=True, exist_ok=True)
@@ -262,7 +267,7 @@ async def async_main() -> int:
             capture_stream("[companion stderr] ", companion.stderr, stderr_lines)
         )
 
-        await harness.wait_connected()
+        await harness.wait_connected(connect_timeout_secs)
         print("connector harness connected", flush=True)
 
         async with ServiceBusClient(namespace, credential=credential, logging_enable=False) as client:

--- a/deploy/azure-companion/live_ci.py
+++ b/deploy/azure-companion/live_ci.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import sys
+import time
+from pathlib import Path
+
+from azure.identity.aio import AzureCliCredential
+from azure.servicebus import ServiceBusMessage
+from azure.servicebus.aio import ServiceBusClient
+
+
+CONNECT_TIMEOUT_SECS = 30
+MESSAGE_TIMEOUT_SECS = 60
+CONNECTOR_MAX_FRAME_LENGTH = 1_048_576
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run live Azure companion validation against Service Bus."
+    )
+    parser.add_argument("--companion-bin", required=True)
+    parser.add_argument("--state-dir", required=True)
+    parser.add_argument("--connector-socket", required=True)
+    parser.add_argument("--namespace", required=True)
+    parser.add_argument("--upstream-queue", required=True)
+    parser.add_argument("--downstream-queue", required=True)
+    return parser.parse_args()
+
+
+def normalize_namespace(namespace: str) -> str:
+    namespace = namespace.strip()
+    if namespace.endswith(".servicebus.windows.net"):
+        return namespace
+    return f"{namespace}.servicebus.windows.net"
+
+
+async def write_framed(writer: asyncio.StreamWriter, payload: bytes) -> None:
+    writer.write(len(payload).to_bytes(4, "big"))
+    writer.write(payload)
+    await writer.drain()
+
+
+async def read_framed(reader: asyncio.StreamReader) -> bytes | None:
+    try:
+        length_bytes = await reader.readexactly(4)
+    except asyncio.IncompleteReadError as exc:
+        if exc.partial:
+            raise RuntimeError("truncated connector frame length prefix") from exc
+        return None
+    frame_length = int.from_bytes(length_bytes, "big")
+    if frame_length > CONNECTOR_MAX_FRAME_LENGTH:
+        raise RuntimeError(
+            f"connector frame length {frame_length} exceeds max {CONNECTOR_MAX_FRAME_LENGTH}"
+        )
+    return await reader.readexactly(frame_length)
+
+
+def service_bus_body_bytes(message) -> bytes:
+    return b"".join(
+        chunk if isinstance(chunk, (bytes, bytearray)) else bytes(chunk)
+        for chunk in message.body
+    )
+
+
+class ConnectorHarness:
+    def __init__(self, socket_path: Path) -> None:
+        self.socket_path = socket_path
+        self.connected = asyncio.Event()
+        self.received_frame = asyncio.Event()
+        self._server: asyncio.AbstractServer | None = None
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._downstream_payloads: list[bytes] = []
+
+    async def start(self) -> None:
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+        self._server = await asyncio.start_unix_server(self._handle_client, path=str(self.socket_path))
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self.connected.set()
+        try:
+            while True:
+                payload = await read_framed(reader)
+                if payload is None:
+                    break
+                self._downstream_payloads.append(payload)
+                self.received_frame.set()
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    async def wait_connected(self) -> None:
+        await asyncio.wait_for(self.connected.wait(), timeout=CONNECT_TIMEOUT_SECS)
+
+    async def send_upstream(self, payload: bytes) -> None:
+        if self._writer is None:
+            raise RuntimeError("connector harness has no connected writer")
+        await write_framed(self._writer, payload)
+
+    async def wait_downstream(self) -> bytes:
+        await asyncio.wait_for(self.received_frame.wait(), timeout=MESSAGE_TIMEOUT_SECS)
+        if not self._downstream_payloads:
+            raise RuntimeError("connector harness did not capture a downstream payload")
+        return self._downstream_payloads.pop(0)
+
+    async def close_peer(self) -> None:
+        if self._writer is not None:
+            self._writer.close()
+            with contextlib.suppress(Exception):
+                await self._writer.wait_closed()
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+
+
+async def receive_one(
+    client: ServiceBusClient, queue_name: str, timeout_secs: int = MESSAGE_TIMEOUT_SECS
+):
+    deadline = time.monotonic() + timeout_secs
+    async with client.get_queue_receiver(queue_name=queue_name, max_wait_time=5) as receiver:
+        while time.monotonic() < deadline:
+            messages = await receiver.receive_messages(max_message_count=1, max_wait_time=5)
+            if messages:
+                return receiver, messages[0]
+    raise RuntimeError(f"timed out waiting for a message on queue `{queue_name}`")
+
+
+async def expect_queue_empty(
+    client: ServiceBusClient, queue_name: str, timeout_secs: int = 10
+) -> None:
+    async with client.get_queue_receiver(queue_name=queue_name, max_wait_time=5) as receiver:
+        messages = await receiver.receive_messages(max_message_count=1, max_wait_time=timeout_secs)
+        if messages:
+            first = messages[0]
+            await receiver.abandon_message(first)
+            raise RuntimeError(f"expected queue `{queue_name}` to be empty after settlement")
+
+
+async def capture_stream(prefix: str, stream: asyncio.StreamReader, sink: list[str]) -> None:
+    while True:
+        line = await stream.readline()
+        if not line:
+            return
+        text = line.decode("utf-8", errors="replace")
+        sink.append(text)
+        print(f"{prefix}{text}", end="", flush=True)
+
+
+async def terminate_process(process: asyncio.subprocess.Process) -> int:
+    if process.returncode is not None:
+        return process.returncode
+    process.terminate()
+    try:
+        await asyncio.wait_for(process.wait(), timeout=10)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+    return process.returncode
+
+
+async def run_success_path(
+    harness: ConnectorHarness,
+    client: ServiceBusClient,
+    upstream_queue: str,
+    downstream_queue: str,
+) -> None:
+    upstream_payload = b"ci-live-upstream-payload"
+    downstream_payload = b"ci-live-downstream-payload"
+
+    await harness.send_upstream(upstream_payload)
+    upstream_receiver, upstream_message = await receive_one(client, upstream_queue)
+    actual_upstream = service_bus_body_bytes(upstream_message)
+    if actual_upstream != upstream_payload:
+        raise RuntimeError(
+            f"upstream payload mismatch: expected {upstream_payload!r}, got {actual_upstream!r}"
+        )
+    await upstream_receiver.complete_message(upstream_message)
+
+    async with client.get_queue_sender(queue_name=downstream_queue) as sender:
+        await sender.send_messages(ServiceBusMessage(downstream_payload))
+
+    actual_downstream = await harness.wait_downstream()
+    if actual_downstream != downstream_payload:
+        raise RuntimeError(
+            f"downstream payload mismatch: expected {downstream_payload!r}, got {actual_downstream!r}"
+        )
+
+    await expect_queue_empty(client, downstream_queue)
+
+
+async def run_failure_path(
+    client: ServiceBusClient, downstream_queue: str, companion: asyncio.subprocess.Process
+) -> None:
+    oversized_payload = b"x" * (CONNECTOR_MAX_FRAME_LENGTH + 1)
+    async with client.get_queue_sender(queue_name=downstream_queue) as sender:
+        await sender.send_messages(ServiceBusMessage(oversized_payload))
+
+    try:
+        await asyncio.wait_for(companion.wait(), timeout=MESSAGE_TIMEOUT_SECS)
+    except asyncio.TimeoutError as exc:
+        raise RuntimeError("companion did not exit after oversized downstream payload") from exc
+    if companion.returncode == 0:
+        raise RuntimeError("companion unexpectedly succeeded after oversized downstream payload")
+
+    downstream_receiver, downstream_message = await receive_one(client, downstream_queue)
+    actual_payload = service_bus_body_bytes(downstream_message)
+    if actual_payload != oversized_payload:
+        raise RuntimeError("downstream message was altered before re-delivery after failure")
+    await downstream_receiver.complete_message(downstream_message)
+
+
+async def async_main() -> int:
+    args = parse_args()
+    namespace = normalize_namespace(args.namespace)
+
+    socket_path = Path(args.connector_socket)
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+
+    harness = ConnectorHarness(socket_path)
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+    companion: asyncio.subprocess.Process | None = None
+
+    await harness.start()
+    credential = AzureCliCredential()
+    client = ServiceBusClient(namespace, credential=credential, logging_enable=False)
+
+    try:
+        companion = await asyncio.create_subprocess_exec(
+            args.companion_bin,
+            "--connector-socket",
+            args.connector_socket,
+            "--state-dir",
+            args.state_dir,
+            "run",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_task = asyncio.create_task(
+            capture_stream("[companion stdout] ", companion.stdout, stdout_lines)
+        )
+        stderr_task = asyncio.create_task(
+            capture_stream("[companion stderr] ", companion.stderr, stderr_lines)
+        )
+
+        await harness.wait_connected()
+        print("connector harness connected", flush=True)
+
+        async with client:
+            await run_success_path(harness, client, args.upstream_queue, args.downstream_queue)
+            print("success path passed", flush=True)
+
+            await run_failure_path(client, args.downstream_queue, companion)
+            print("failure path passed", flush=True)
+
+        await stdout_task
+        await stderr_task
+        return 0
+    finally:
+        if companion is not None:
+            await terminate_process(companion)
+        await harness.stop()
+        await credential.close()
+
+
+def main() -> int:
+    try:
+        return asyncio.run(async_main())
+    except Exception as exc:  # noqa: BLE001
+        print(f"live Azure validation failed: {exc}", file=sys.stderr, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/azure-companion/live_ci.py
+++ b/deploy/azure-companion/live_ci.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
+import socket
 import sys
 import time
 from pathlib import Path
@@ -116,6 +117,14 @@ class ConnectorHarness:
             raise RuntimeError("connector harness did not capture a downstream payload")
         return self._downstream_payloads.pop(0)
 
+    def reject_downstream_writes(self) -> None:
+        if self._writer is None:
+            raise RuntimeError("connector harness has no connected writer")
+        sock = self._writer.get_extra_info("socket")
+        if sock is None:
+            raise RuntimeError("connector harness socket is unavailable")
+        sock.shutdown(socket.SHUT_RD)
+
     async def close_peer(self) -> None:
         if self._writer is not None:
             self._writer.close()
@@ -130,15 +139,18 @@ class ConnectorHarness:
             self.socket_path.unlink()
 
 
-async def receive_one(
+async def receive_one_body(
     client: ServiceBusClient, queue_name: str, timeout_secs: int = MESSAGE_TIMEOUT_SECS
-):
+) -> bytes:
     deadline = time.monotonic() + timeout_secs
     async with client.get_queue_receiver(queue_name=queue_name, max_wait_time=5) as receiver:
         while time.monotonic() < deadline:
             messages = await receiver.receive_messages(max_message_count=1, max_wait_time=5)
             if messages:
-                return receiver, messages[0]
+                message = messages[0]
+                body = service_bus_body_bytes(message)
+                await receiver.complete_message(message)
+                return body
     raise RuntimeError(f"timed out waiting for a message on queue `{queue_name}`")
 
 
@@ -185,13 +197,11 @@ async def run_success_path(
     downstream_payload = b"ci-live-downstream-payload"
 
     await harness.send_upstream(upstream_payload)
-    upstream_receiver, upstream_message = await receive_one(client, upstream_queue)
-    actual_upstream = service_bus_body_bytes(upstream_message)
+    actual_upstream = await receive_one_body(client, upstream_queue)
     if actual_upstream != upstream_payload:
         raise RuntimeError(
             f"upstream payload mismatch: expected {upstream_payload!r}, got {actual_upstream!r}"
         )
-    await upstream_receiver.complete_message(upstream_message)
 
     async with client.get_queue_sender(queue_name=downstream_queue) as sender:
         await sender.send_messages(ServiceBusMessage(downstream_payload))
@@ -206,24 +216,26 @@ async def run_success_path(
 
 
 async def run_failure_path(
-    client: ServiceBusClient, downstream_queue: str, companion: asyncio.subprocess.Process
+    harness: ConnectorHarness,
+    client: ServiceBusClient,
+    downstream_queue: str,
+    companion: asyncio.subprocess.Process,
 ) -> None:
-    oversized_payload = b"x" * (CONNECTOR_MAX_FRAME_LENGTH + 1)
+    failed_handoff_payload = b"ci-live-downstream-write-failure"
+    harness.reject_downstream_writes()
     async with client.get_queue_sender(queue_name=downstream_queue) as sender:
-        await sender.send_messages(ServiceBusMessage(oversized_payload))
+        await sender.send_messages(ServiceBusMessage(failed_handoff_payload))
 
     try:
         await asyncio.wait_for(companion.wait(), timeout=MESSAGE_TIMEOUT_SECS)
     except asyncio.TimeoutError as exc:
-        raise RuntimeError("companion did not exit after oversized downstream payload") from exc
+        raise RuntimeError("companion did not exit after failed downstream handoff") from exc
     if companion.returncode == 0:
-        raise RuntimeError("companion unexpectedly succeeded after oversized downstream payload")
+        raise RuntimeError("companion unexpectedly succeeded after failed downstream handoff")
 
-    downstream_receiver, downstream_message = await receive_one(client, downstream_queue)
-    actual_payload = service_bus_body_bytes(downstream_message)
-    if actual_payload != oversized_payload:
+    actual_payload = await receive_one_body(client, downstream_queue)
+    if actual_payload != failed_handoff_payload:
         raise RuntimeError("downstream message was altered before re-delivery after failure")
-    await downstream_receiver.complete_message(downstream_message)
 
 
 async def async_main() -> int:
@@ -237,6 +249,8 @@ async def async_main() -> int:
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
     companion: asyncio.subprocess.Process | None = None
+    stdout_task: asyncio.Task[None] | None = None
+    stderr_task: asyncio.Task[None] | None = None
 
     await harness.start()
     credential = AzureCliCredential()
@@ -267,15 +281,21 @@ async def async_main() -> int:
             await run_success_path(harness, client, args.upstream_queue, args.downstream_queue)
             print("success path passed", flush=True)
 
-            await run_failure_path(client, args.downstream_queue, companion)
+            await run_failure_path(harness, client, args.downstream_queue, companion)
             print("failure path passed", flush=True)
 
-        await stdout_task
-        await stderr_task
         return 0
     finally:
         if companion is not None:
             await terminate_process(companion)
+        await asyncio.gather(
+            *[
+                task
+                for task in (stdout_task, stderr_task)
+                if task is not None
+            ],
+            return_exceptions=True,
+        )
         await harness.stop()
         await credential.close()
 

--- a/deploy/azure-companion/live_ci.py
+++ b/deploy/azure-companion/live_ci.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import contextlib
-import socket
 import sys
 import time
 from pathlib import Path
@@ -114,14 +113,6 @@ class ConnectorHarness:
             self._downstream_payloads.get(), timeout=MESSAGE_TIMEOUT_SECS
         )
 
-    def reject_downstream_writes(self) -> None:
-        if self._writer is None:
-            raise RuntimeError("connector harness has no connected writer")
-        sock = self._writer.get_extra_info("socket")
-        if sock is None:
-            raise RuntimeError("connector harness socket is unavailable")
-        sock.shutdown(socket.SHUT_RD)
-
     async def close_peer(self) -> None:
         if self._writer is not None:
             self._writer.close()
@@ -219,7 +210,7 @@ async def run_failure_path(
     companion: asyncio.subprocess.Process,
 ) -> None:
     failed_handoff_payload = b"ci-live-downstream-write-failure"
-    harness.reject_downstream_writes()
+    await harness.close_peer()
     async with client.get_queue_sender(queue_name=downstream_queue) as sender:
         await sender.send_messages(ServiceBusMessage(failed_handoff_payload))
 

--- a/deploy/azure-companion/live_ci.py
+++ b/deploy/azure-companion/live_ci.py
@@ -74,11 +74,10 @@ class ConnectorHarness:
     def __init__(self, socket_path: Path) -> None:
         self.socket_path = socket_path
         self.connected = asyncio.Event()
-        self.received_frame = asyncio.Event()
         self._server: asyncio.AbstractServer | None = None
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
-        self._downstream_payloads: list[bytes] = []
+        self._downstream_payloads: asyncio.Queue[bytes] = asyncio.Queue()
 
     async def start(self) -> None:
         if self.socket_path.exists():
@@ -96,8 +95,7 @@ class ConnectorHarness:
                 payload = await read_framed(reader)
                 if payload is None:
                     break
-                self._downstream_payloads.append(payload)
-                self.received_frame.set()
+                await self._downstream_payloads.put(payload)
         finally:
             writer.close()
             with contextlib.suppress(Exception):
@@ -112,10 +110,9 @@ class ConnectorHarness:
         await write_framed(self._writer, payload)
 
     async def wait_downstream(self) -> bytes:
-        await asyncio.wait_for(self.received_frame.wait(), timeout=MESSAGE_TIMEOUT_SECS)
-        if not self._downstream_payloads:
-            raise RuntimeError("connector harness did not capture a downstream payload")
-        return self._downstream_payloads.pop(0)
+        return await asyncio.wait_for(
+            self._downstream_payloads.get(), timeout=MESSAGE_TIMEOUT_SECS
+        )
 
     def reject_downstream_writes(self) -> None:
         if self._writer is None:

--- a/deploy/azure-companion/live_ci.py
+++ b/deploy/azure-companion/live_ci.py
@@ -17,7 +17,7 @@ from azure.servicebus.aio import ServiceBusClient
 
 
 CONNECT_TIMEOUT_SECS = 30
-MESSAGE_TIMEOUT_SECS = 60
+DEFAULT_MESSAGE_TIMEOUT_SECS = 180
 CONNECTOR_MAX_FRAME_LENGTH = 1_048_576
 
 
@@ -31,6 +31,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--namespace", required=True)
     parser.add_argument("--upstream-queue", required=True)
     parser.add_argument("--downstream-queue", required=True)
+    parser.add_argument("--message-timeout-secs", type=int, default=DEFAULT_MESSAGE_TIMEOUT_SECS)
     return parser.parse_args()
 
 
@@ -108,10 +109,8 @@ class ConnectorHarness:
             raise RuntimeError("connector harness has no connected writer")
         await write_framed(self._writer, payload)
 
-    async def wait_downstream(self) -> bytes:
-        return await asyncio.wait_for(
-            self._downstream_payloads.get(), timeout=MESSAGE_TIMEOUT_SECS
-        )
+    async def wait_downstream(self, timeout_secs: int) -> bytes:
+        return await asyncio.wait_for(self._downstream_payloads.get(), timeout=timeout_secs)
 
     async def close_peer(self) -> None:
         if self._writer is not None:
@@ -128,7 +127,7 @@ class ConnectorHarness:
 
 
 async def receive_one_body(
-    client: ServiceBusClient, queue_name: str, timeout_secs: int = MESSAGE_TIMEOUT_SECS
+    client: ServiceBusClient, queue_name: str, timeout_secs: int
 ) -> bytes:
     deadline = time.monotonic() + timeout_secs
     async with client.get_queue_receiver(queue_name=queue_name, max_wait_time=5) as receiver:
@@ -180,12 +179,13 @@ async def run_success_path(
     client: ServiceBusClient,
     upstream_queue: str,
     downstream_queue: str,
+    message_timeout_secs: int,
 ) -> None:
     upstream_payload = b"ci-live-upstream-payload"
     downstream_payload = b"ci-live-downstream-payload"
 
     await harness.send_upstream(upstream_payload)
-    actual_upstream = await receive_one_body(client, upstream_queue)
+    actual_upstream = await receive_one_body(client, upstream_queue, message_timeout_secs)
     if actual_upstream != upstream_payload:
         raise RuntimeError(
             f"upstream payload mismatch: expected {upstream_payload!r}, got {actual_upstream!r}"
@@ -194,7 +194,7 @@ async def run_success_path(
     async with client.get_queue_sender(queue_name=downstream_queue) as sender:
         await sender.send_messages(ServiceBusMessage(downstream_payload))
 
-    actual_downstream = await harness.wait_downstream()
+    actual_downstream = await harness.wait_downstream(message_timeout_secs)
     if actual_downstream != downstream_payload:
         raise RuntimeError(
             f"downstream payload mismatch: expected {downstream_payload!r}, got {actual_downstream!r}"
@@ -208,6 +208,7 @@ async def run_failure_path(
     client: ServiceBusClient,
     downstream_queue: str,
     companion: asyncio.subprocess.Process,
+    message_timeout_secs: int,
 ) -> None:
     failed_handoff_payload = b"ci-live-downstream-write-failure"
     await harness.close_peer()
@@ -215,13 +216,13 @@ async def run_failure_path(
         await sender.send_messages(ServiceBusMessage(failed_handoff_payload))
 
     try:
-        await asyncio.wait_for(companion.wait(), timeout=MESSAGE_TIMEOUT_SECS)
+        await asyncio.wait_for(companion.wait(), timeout=message_timeout_secs)
     except asyncio.TimeoutError as exc:
         raise RuntimeError("companion did not exit after failed downstream handoff") from exc
     if companion.returncode == 0:
         raise RuntimeError("companion unexpectedly succeeded after failed downstream handoff")
 
-    actual_payload = await receive_one_body(client, downstream_queue)
+    actual_payload = await receive_one_body(client, downstream_queue, message_timeout_secs)
     if actual_payload != failed_handoff_payload:
         raise RuntimeError("downstream message was altered before re-delivery after failure")
 
@@ -240,12 +241,10 @@ async def async_main() -> int:
     stdout_task: asyncio.Task[None] | None = None
     stderr_task: asyncio.Task[None] | None = None
     credential: AzureCliCredential | None = None
-    client: ServiceBusClient | None = None
 
     try:
         await harness.start()
         credential = AzureCliCredential()
-        client = ServiceBusClient(namespace, credential=credential, logging_enable=False)
         companion = await asyncio.create_subprocess_exec(
             args.companion_bin,
             "--connector-socket",
@@ -266,11 +265,23 @@ async def async_main() -> int:
         await harness.wait_connected()
         print("connector harness connected", flush=True)
 
-        async with client:
-            await run_success_path(harness, client, args.upstream_queue, args.downstream_queue)
+        async with ServiceBusClient(namespace, credential=credential, logging_enable=False) as client:
+            await run_success_path(
+                harness,
+                client,
+                args.upstream_queue,
+                args.downstream_queue,
+                args.message_timeout_secs,
+            )
             print("success path passed", flush=True)
 
-            await run_failure_path(harness, client, args.downstream_queue, companion)
+            await run_failure_path(
+                harness,
+                client,
+                args.downstream_queue,
+                companion,
+                args.message_timeout_secs,
+            )
             print("failure path passed", flush=True)
 
         return 0

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -108,9 +108,10 @@ explicitly after teardown.
 
 ## Live CI prerequisites
 
-The repository's on-demand Azure live-validation workflow reads its target from
-repository or environment variables rather than hard-coding a subscription into
-the workflow file. A typical setup provides:
+The repository's on-demand Azure live-validation workflow binds the job to the
+GitHub environment `azure-live-ci`, so its target values can come from either
+repository variables or variables defined on that environment. A typical setup
+provides:
 
 - `SONDE_AZURE_CI_CLIENT_ID`
 - `SONDE_AZURE_CI_TENANT_ID`

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -144,5 +144,6 @@ For destructive cleanup safety, the workflow only deletes a resource group when
 both of the following are true:
 
 - the configured resource-group name starts with the configured CI prefix (by
-  default `${SONDE_AZURE_CI_PROJECT_NAME}-ci-`), and
+  default `sonde-ci-`, or `${SONDE_AZURE_CI_PROJECT_NAME}-ci-` when the project
+  name is overridden), and
 - the existing group is tagged `sonde-ci-owner=azure-live-ci`.

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -31,6 +31,7 @@ Azure companion architecture.
 | `location` | `eastus` | Azure region for the stack |
 | `project_name` | `sonde` | Prefix for resource names and tags |
 | `resource_group_name` | empty | Optional override for the resource group name |
+| `resourceGroupOwnerTag` | empty | Optional `sonde-ci-owner` tag value applied to the deployment resource group |
 | `companionCertificateBase64` | none | Base64-encoded DER certificate public material registered on the Azure companion app |
 | `companionCertificateDisplayName` | `sonde-azure-companion` | Optional display name for the registered certificate credential |
 | `serviceBusNamespaceName` | derived | Optional Service Bus namespace override |

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -105,3 +105,22 @@ az group delete --name <resource-group-name> --yes --no-wait
 This removes the Azure resource-plane stack. If you also want to remove the
 Entra application and service principal, delete those identity objects
 explicitly after teardown.
+
+## Live CI prerequisites
+
+The repository's on-demand Azure live-validation workflow reads its target from
+repository or environment variables rather than hard-coding a subscription into
+the workflow file. A typical setup provides:
+
+- `SONDE_AZURE_CI_CLIENT_ID`
+- `SONDE_AZURE_CI_TENANT_ID`
+- `SONDE_AZURE_CI_SUBSCRIPTION_ID`
+- `SONDE_AZURE_CI_RESOURCE_GROUP`
+- optional `SONDE_AZURE_CI_LOCATION`
+- optional `SONDE_AZURE_CI_PROJECT_NAME`
+
+The workflow uses GitHub OIDC for Azure login. The configured identity needs:
+
+- permission to create, inspect, and delete the dedicated disposable CI resource group,
+- permission to deploy the Bicep stack in that subscription, and
+- Microsoft Graph permissions required by `modules/companion-identity.bicep` to create the Entra application and service principal used by `sonde-azure-companion`.

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -117,6 +117,7 @@ provides:
 - `SONDE_AZURE_CI_TENANT_ID`
 - `SONDE_AZURE_CI_SUBSCRIPTION_ID`
 - `SONDE_AZURE_CI_RESOURCE_GROUP`
+- optional `SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX`
 - optional `SONDE_AZURE_CI_LOCATION`
 - optional `SONDE_AZURE_CI_PROJECT_NAME`
 
@@ -137,3 +138,10 @@ Service Bus queue permissions to:
 Those rights can be granted either with queue-scoped assignments or with a
 broader namespace-scoped data role if that is the repository's preferred
 operational model.
+
+For destructive cleanup safety, the workflow only deletes a resource group when
+both of the following are true:
+
+- the configured resource-group name starts with the configured CI prefix (by
+  default `${SONDE_AZURE_CI_PROJECT_NAME}-ci-`), and
+- the existing group is tagged `sonde-ci-owner=azure-live-ci`.

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -123,4 +123,16 @@ The workflow uses GitHub OIDC for Azure login. The configured identity needs:
 
 - permission to create, inspect, and delete the dedicated disposable CI resource group,
 - permission to deploy the Bicep stack in that subscription, and
-- Microsoft Graph permissions required by `modules/companion-identity.bicep` to create the Entra application and service principal used by `sonde-azure-companion`.
+- Microsoft Graph permissions required by `modules/companion-identity.bicep` to create the Entra application and service principal used by `sonde-azure-companion`, and
+- Service Bus data-plane roles that let the live-validation harness send to and receive from the deployed queues when it authenticates via `AzureCliCredential`.
+
+For the default queue topology, the GitHub OIDC identity therefore needs enough
+Service Bus queue permissions to:
+
+- receive from `connector-upstream`,
+- send to `desired-state`, and
+- receive from `desired-state`.
+
+Those rights can be granted either with queue-scoped assignments or with a
+broader namespace-scoped data role if that is the repository's preferred
+operational model.

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -18,6 +18,9 @@ param companionCertificateBase64 string
 @description('Display name for the registered companion certificate credential.')
 param companionCertificateDisplayName string = 'sonde-azure-companion'
 
+@description('Optional ownership tag value applied to the deployment resource group. Leave empty for non-CI deployments.')
+param resourceGroupOwnerTag string = ''
+
 @description('Optional override for the Service Bus namespace name.')
 param serviceBusNamespaceName string = ''
 
@@ -57,11 +60,16 @@ var effectiveFunctionPlanName = empty(functionPlanName)
 var tags = {
   project: project_name
 }
+var resourceGroupTags = empty(resourceGroupOwnerTag)
+  ? tags
+  : union(tags, {
+      'sonde-ci-owner': resourceGroupOwnerTag
+    })
 
 resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2024-03-01' = {
   name: effectiveResourceGroupName
   location: location
-  tags: tags
+  tags: resourceGroupTags
 }
 
 module companionIdentity './modules/companion-identity.bicep' = {

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -60,7 +60,7 @@ The long-running binary is named `sonde-azure-companion`.
 
 ## 3  Runtime architecture
 
-> **Requirements:** AZC-0100, AZC-0101, AZC-0102, AZC-0301, AZC-0302, AZC-0303, AZC-0304, AZC-0305
+> **Requirements:** AZC-0100, AZC-0101, AZC-0102, AZC-0301, AZC-0302, AZC-0303, AZC-0304, AZC-0305, AZC-0310, AZC-0311
 
 ### 3.1  Process model
 
@@ -117,6 +117,39 @@ Startup follows this decision:
 
 When bootstrap is entered, the unified `bootstrap` subcommand orchestrates the
 full provisioning lifecycle as described in section 4.2.
+
+---
+
+### 3.4  Live Azure CI runtime topology
+
+The live Azure validation workflow uses a narrower runtime topology than a full
+gateway deployment. It starts the real `sonde-azure-companion` runtime against:
+
+1. a local connector harness that speaks the framed connector protocol, and
+2. the disposable Azure Service Bus namespace and queues created earlier in the
+   same workflow run.
+
+The harness is sufficient because the purpose of this workflow is to validate
+the Azure companion's cloud bridge contract at the connector boundary, not to
+re-validate gateway startup, modem ownership, or admin gRPC behavior.
+
+### 3.5  Live validation sequence
+
+Within the single manually triggered workflow, the live validation sequence is:
+
+1. provision the disposable Azure stack,
+2. derive runtime configuration from the deployment outputs,
+3. start the local connector harness,
+4. start the real `sonde-azure-companion` runtime in bootstrap-complete mode,
+5. inject representative upstream connector payloads through the harness and
+   assert they reach the upstream queue unchanged,
+6. enqueue representative downstream desired-state payloads in Azure Service Bus
+   and assert they are delivered unchanged to the harness, and
+7. assert that downstream settlement happens only after the harness accepts the
+   local handoff.
+
+This sequence keeps live Azure validation focused on the real Service Bus
+transport and the runtime bridge semantics already defined in section 5.
 
 ---
 

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -417,6 +417,48 @@ logging, process status, or both.
 
 ---
 
+### AZC-0310  Live Azure CI bridge validation against a connector harness
+
+**Priority:** Must
+**Source:** CI validation discovery review
+
+**Description:**
+The repository MUST support an on-demand live Azure validation workflow that
+runs the real `sonde-azure-companion` runtime against a local connector test
+harness and the disposable Azure Service Bus resources created for that run. The
+workflow validates the Azure companion bridge at the connector boundary and MUST
+NOT require a full `sonde-gateway` process for this live cloud test.
+
+**Acceptance criteria:**
+
+1. The live Azure validation workflow starts the real `sonde-azure-companion` runtime.
+2. The runtime connects to a local connector harness rather than a full `sonde-gateway` process.
+3. The runtime uses the disposable Azure Service Bus namespace and queue names provisioned for that workflow run.
+4. The live validation covers both upstream publish and downstream desired-state delivery.
+5. The workflow remains on-demand rather than part of routine PR CI.
+
+---
+
+### AZC-0311  Live Azure CI verifies concrete Service Bus handoff semantics
+
+**Priority:** Must
+**Source:** CI validation discovery review, AZC-0304, AZC-0308, AZC-0309
+
+**Description:**
+The live Azure validation workflow MUST verify the bridge semantics that matter
+at the cloud boundary: transparent upstream payload publication, transparent
+downstream desired-state delivery, and downstream settlement only after the
+local connector harness accepts the payload.
+
+**Acceptance criteria:**
+
+1. At least one representative upstream connector payload is published through the real Azure Service Bus transport during the live workflow.
+2. At least one representative downstream desired-state payload is received from Azure Service Bus and written unchanged to the local connector harness.
+3. The workflow demonstrates that downstream settlement occurs only after successful local connector handoff.
+4. Detected Azure transport or local connector handoff failures are surfaced by the workflow rather than silently ignored.
+
+---
+
 ## 6  Bootstrap provisioning orchestration
 
 ### AZC-0400  Self-signed certificate generation

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -222,6 +222,47 @@
 
 ---
 
+### T-AZC-0116  Live Azure workflow publishes upstream payloads through the real bridge
+
+**Validates:** AZC-0310, AZC-0311
+
+**Procedure:**
+1. Dispatch the live Azure validation workflow after provisioning a disposable Azure stack.
+2. Start the real `sonde-azure-companion` runtime in bootstrap-complete mode against the workflow's connector harness.
+3. Inject at least one representative upstream connector payload through the harness.
+4. Read the configured upstream Service Bus queue.
+5. Assert: the queue receives the raw connector payload bytes unchanged.
+6. Assert: the runtime under test is the real `sonde-azure-companion`, not a broker mock.
+
+---
+
+### T-AZC-0117  Live Azure workflow delivers downstream desired state unchanged
+
+**Validates:** AZC-0310, AZC-0311
+
+**Procedure:**
+1. Dispatch the live Azure validation workflow after provisioning a disposable Azure stack.
+2. Start the real `sonde-azure-companion` runtime against the connector harness.
+3. Enqueue a representative raw desired-state connector payload into the configured downstream Service Bus queue.
+4. Observe the payload received by the connector harness.
+5. Assert: the harness receives the raw payload bytes unchanged.
+6. Assert: the workflow does not require a full `sonde-gateway` process to validate this handoff.
+
+---
+
+### T-AZC-0118  Live Azure workflow settles downstream messages only after local handoff
+
+**Validates:** AZC-0311
+
+**Procedure:**
+1. Dispatch the live Azure validation workflow with a connector harness that can delay or reject local writes.
+2. Enqueue one desired-state message in the downstream queue.
+3. In the success sub-case, allow the harness write to complete and assert the Service Bus message is then settled successfully.
+4. In the failure sub-case, force the harness write to fail and assert the message is not reported as successfully processed.
+5. Assert: detected transport or local handoff failure is surfaced in workflow logs or process status.
+
+---
+
 ### T-AZC-0400  Bootstrap generates ECDSA P-256 self-signed certificate
 
 **Validates:** AZC-0400

--- a/docs/azure-provisioning-design.md
+++ b/docs/azure-provisioning-design.md
@@ -229,7 +229,7 @@ workflow makes the necessary values available to the bootstrap path that does.
 
 ## 6  Outputs and lifecycle
 
-> **Requirements:** AZP-0100, AZP-0102, AZP-0103, AZP-0104, AZP-0300, AZP-0301
+> **Requirements:** AZP-0100, AZP-0102, AZP-0103, AZP-0104, AZP-0300, AZP-0301, AZP-0302, AZP-0303, AZP-0304
 
 ### 6.1  Outputs
 
@@ -256,4 +256,41 @@ Teardown removes the resource-plane stack or clearly documents any intentionally
 retained artifacts. If some identity artifacts cannot be safely removed by the
 same workflow, the teardown documentation must say so plainly rather than
 pretending full cleanup occurred.
+
+### 6.4  Live Azure CI workflow boundary
+
+The repository also exposes a manually triggered GitHub Actions workflow for
+live Azure validation. This workflow is intentionally separate from routine PR
+CI so ordinary code-review runs do not require Azure credentials or incur cloud
+cost.
+
+That workflow performs one end-to-end disposable validation cycle:
+
+1. log in to Azure with GitHub OIDC,
+2. preflight-delete the dedicated CI-owned resource group and wait until Azure reports it absent,
+3. deploy the Bicep stack into that clean resource group,
+4. run live validation against the deployed resources, and
+5. attempt teardown again in an `always()`-style cleanup step.
+
+### 6.5  CI configuration model
+
+The workflow logic is repository-owned, but its Azure target is repo-specific.
+To keep the workflow fork-portable, subscription ID, tenant/client identifiers,
+the dedicated CI resource-group name, and similar deployment defaults are read
+from repository or environment configuration rather than being embedded in the
+workflow file itself.
+
+The design assumes GitHub Actions OIDC federation into an Azure application or
+service principal that has only the RBAC required to:
+
+1. create/update the disposable stack,
+2. inspect deployed resources for validation, and
+3. delete the CI-owned resource group afterward.
+
+### 6.6  Disposable resource-group safety rule
+
+Because the workflow performs destructive preflight cleanup, it must never point
+at an arbitrary shared resource group. The configured resource group for this
+workflow is therefore part of the safety boundary: it is a dedicated,
+CI-owned disposable group reserved exclusively for this live validation path.
 

--- a/docs/azure-provisioning-requirements.md
+++ b/docs/azure-provisioning-requirements.md
@@ -262,3 +262,68 @@ require explicit manual handling.
 1. The documented teardown path removes the resource-plane infrastructure created for this stack, or clearly enumerates any retained artifacts.
 2. Teardown behavior is documented for Service Bus, Storage, and Function placeholder resources.
 
+---
+
+### AZP-0302  On-demand disposable CI deployment workflow
+
+**Priority:** Must
+**Source:** CI validation discovery review, [azure-companion-requirements.md](azure-companion-requirements.md)
+
+**Description:**
+The repository MUST provide an on-demand GitHub Actions workflow that exercises
+the provisioning workflow against a disposable Azure test stack. This workflow
+MUST remain separate from routine pull-request CI and MUST provision, validate,
+and tear down the stack within the same manually triggered run.
+
+**Acceptance criteria:**
+
+1. The repository contains a manually triggered GitHub Actions workflow dedicated to live Azure validation.
+2. The workflow provisions a disposable test stack using the repository-owned Bicep entrypoint rather than a separate ad hoc deployment path.
+3. The workflow runs validation steps against the deployed Azure resources before teardown.
+4. The workflow attempts teardown in the same run after validation completes.
+5. The workflow is not required for routine pull-request CI on every change.
+
+---
+
+### AZP-0303  Federated CI authentication with repo-configured targeting
+
+**Priority:** Must
+**Source:** CI validation discovery review
+
+**Description:**
+The live Azure validation workflow MUST authenticate to Azure using GitHub
+federated identity (OIDC) rather than a stored Azure client secret. The target
+subscription and disposable resource-group name MUST be supplied through
+repository or environment configuration so forks can bind the same workflow
+logic to their own Azure subscription without editing workflow code.
+
+**Acceptance criteria:**
+
+1. The workflow uses GitHub OIDC/federated identity for Azure login.
+2. The workflow does not require a long-lived Azure client secret for CI authentication.
+3. The target subscription ID is supplied through repository or environment configuration rather than being hard-coded in the workflow.
+4. The disposable CI resource-group name is supplied through repository or environment configuration rather than being hard-coded in the workflow.
+5. The documented setup identifies the minimum Azure RBAC needed by the federated CI identity for deployment, validation, and teardown.
+
+---
+
+### AZP-0304  Dedicated CI-owned resource-group cleanup
+
+**Priority:** Must
+**Source:** CI validation discovery review
+
+**Description:**
+The live Azure validation workflow MUST use a dedicated disposable resource
+group that is owned exclusively by CI for this purpose. Before provisioning, the
+workflow MUST delete any pre-existing copy of that CI-owned resource group to
+remove leftovers from prior failed runs. After validation, the workflow MUST
+attempt teardown again even when earlier steps failed.
+
+**Acceptance criteria:**
+
+1. The live Azure validation workflow targets only a dedicated disposable CI-owned resource group for destructive cleanup.
+2. The workflow performs preflight deletion of that resource group and does not begin provisioning until the previous group instance is confirmed absent.
+3. The workflow performs teardown in a failure-safe post-run path even if provisioning or validation fails.
+4. If teardown fails, the workflow surfaces the retained resource-group failure explicitly rather than silently reporting success.
+5. The workflow documentation states that arbitrary operator-managed resource groups are out of scope for CI deletion.
+

--- a/docs/azure-provisioning-validation.md
+++ b/docs/azure-provisioning-validation.md
@@ -159,3 +159,44 @@
 3. Assert: the resource-plane stack is removed, or any retained artifacts are explicitly identified by the documentation.
 4. Assert: teardown expectations for Service Bus, Storage, and Function placeholder resources are clear.
 
+---
+
+### T-AZP-0302  On-demand workflow deploys and tears down a disposable stack
+
+**Validates:** AZP-0302, AZP-0304
+
+**Procedure:**
+1. Manually dispatch the live Azure validation workflow with repository or environment configuration pointing at the dedicated CI-owned disposable resource group.
+2. Observe the workflow run.
+3. Assert: the workflow performs preflight deletion of the configured CI-owned resource group before provisioning.
+4. Assert: provisioning does not begin until the previous resource-group instance is confirmed absent.
+5. Assert: the workflow deploys the Bicep stack into that resource group.
+6. Assert: the workflow proceeds to validation rather than stopping immediately after deployment.
+7. Assert: the workflow attempts teardown in the same run after validation completes.
+
+---
+
+### T-AZP-0303  Live workflow uses federated identity and repo-configured targeting
+
+**Validates:** AZP-0303
+
+**Procedure:**
+1. Inspect the GitHub Actions workflow and its documented setup.
+2. Assert: Azure login is performed using GitHub OIDC/federated identity.
+3. Assert: the workflow does not require a long-lived Azure client secret.
+4. Assert: subscription ID and disposable resource-group name come from repository or environment configuration rather than workflow constants.
+5. Assert: the setup documentation identifies the minimum RBAC needed by the federated CI identity.
+
+---
+
+### T-AZP-0304  Failed runs still attempt teardown and surface cleanup failures
+
+**Validates:** AZP-0304
+
+**Procedure:**
+1. Dispatch the live Azure validation workflow against the dedicated CI-owned disposable resource group.
+2. Force a validation-step failure after the Azure stack has been created.
+3. Assert: the workflow still executes its teardown path after the injected failure.
+4. If teardown succeeds, assert: the disposable resource group is removed.
+5. If teardown fails, assert: the workflow reports the retained resource group explicitly instead of reporting overall success.
+


### PR DESCRIPTION
## Summary
- add an on-demand GitHub Actions workflow for live Azure validation using OIDC and repo/environment configuration
- provision a disposable Azure stack, run the real `sonde-azure-companion` against a connector harness and live Service Bus, and always tear the CI-owned resource group down
- update the Azure provisioning/companion requirements, design, and validation specs plus README guidance for workflow prerequisites

## Traceability
- Phase 1: approved discovery scoped this to a single manual workflow, repo-configured subscription/resource-group targeting, and a connector harness instead of a full gateway process
- Phase 2-4: updated the Azure spec stack with AZP-0302..0304 and AZC-0310..0311 plus matching design/validation sections
- Phase 5-7: implemented `.github/workflows/azure-live-ci.yml`, `deploy/azure-companion/live_ci.py`, and prerequisite documentation

## Validation
- python -m py_compile deploy/azure-companion/live_ci.py
- cargo test -p sonde-azure-companion --all-targets