### PR TITLE
Add Azure live CI setup guide

### DIFF
--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -109,6 +109,9 @@ explicitly after teardown.
 
 ## Live CI prerequisites
 
+For the full step-by-step setup procedure, see
+[`azure-live-ci-setup.md`](azure-live-ci-setup.md).
+
 The repository's on-demand Azure live-validation workflow binds the job to the
 GitHub environment `azure-live-ci`, so its target values can come from either
 repository variables or variables defined on that environment. A typical setup
@@ -136,9 +139,11 @@ Service Bus queue permissions to:
 - send to `desired-state`, and
 - receive from `desired-state`.
 
-Those rights can be granted either with queue-scoped assignments or with a
-broader namespace-scoped data role if that is the repository's preferred
-operational model.
+Because the workflow deletes and recreates its disposable resource group, any
+role assignment scoped only inside that resource group would be deleted on
+teardown. The step-by-step setup guide therefore documents a persistent
+assignment strategy for the CI identity rather than a queue-scoped assignment
+that would not survive repeated runs.
 
 For destructive cleanup safety, the workflow only deletes a resource group when
 both of the following are true:

--- a/deploy/bicep/azure-live-ci-setup.md
+++ b/deploy/bicep/azure-live-ci-setup.md
@@ -1,0 +1,286 @@
+<!-- SPDX-License-Identifier: MIT
+  Copyright (c) 2026 sonde contributors -->
+# Azure Live CI setup guide
+
+This guide walks through the first-time setup for the repository's on-demand
+Azure live-validation workflow in `.github/workflows/azure-live-ci.yml`.
+
+Use this guide when you want GitHub Actions to:
+
+1. log in to Azure with GitHub OIDC,
+2. deploy the disposable Azure companion stack,
+3. run the real `sonde-azure-companion` against Azure Service Bus, and
+4. tear the disposable stack down again in the same run.
+
+`deploy/bicep/README.md` remains the reference document for the provisioning
+surface. This file is the operator runbook for configuring the CI workflow.
+
+## 1. What you are setting up
+
+The workflow expects:
+
+| Item | Value |
+|------|-------|
+| GitHub environment | `azure-live-ci` |
+| Required variables | `SONDE_AZURE_CI_CLIENT_ID`, `SONDE_AZURE_CI_TENANT_ID`, `SONDE_AZURE_CI_SUBSCRIPTION_ID`, `SONDE_AZURE_CI_RESOURCE_GROUP` |
+| Optional variables | `SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX`, `SONDE_AZURE_CI_LOCATION`, `SONDE_AZURE_CI_PROJECT_NAME` |
+| Default project name | `sonde` |
+| Default CI prefix | `sonde-ci-` |
+| Required OIDC audience | `api://AzureADTokenExchange` |
+| Required OIDC subject format | `repo:OWNER/REPO:environment:azure-live-ci` |
+
+The workflow only deletes resource groups that:
+
+1. match the configured CI prefix, and
+2. carry `sonde-ci-owner=azure-live-ci`.
+
+Do **not** point this workflow at an operator-managed or production resource
+group.
+
+## 2. Choose the values you will use
+
+Before touching GitHub or Azure, pick the values below.
+
+| Name | Example | Notes |
+|------|---------|-------|
+| Repository owner | `Alan-Jowett` | Used in the OIDC subject string. |
+| Repository name | `sonde` | Used in the OIDC subject string. |
+| GitHub environment | `azure-live-ci` | Fixed by the workflow. |
+| Azure subscription ID | `00000000-0000-0000-0000-000000000000` | The disposable CI subscription target. |
+| Azure location | `eastus` | Optional; defaults to `eastus`. |
+| Project name | `sonde` | Optional; defaults to `sonde`. |
+| Disposable resource group | `sonde-ci-eastus` | Must be CI-owned and disposable. |
+| Optional CI prefix override | `sonde-ci-` | If omitted, the workflow derives this from the project name. |
+
+## 3. Create the GitHub environment
+
+In GitHub:
+
+1. Open **Settings** for the repository.
+2. Open **Environments**.
+3. Create an environment named `azure-live-ci`.
+4. If you want tighter control, add environment protection rules before the
+   workflow is used broadly.
+
+The workflow reads its Azure configuration from repository variables or from
+variables defined on this environment.
+
+## 4. Create the Azure OIDC application and service principal
+
+You need one Entra application/service principal that GitHub Actions will use
+for `azure/login`.
+
+### Portal path
+
+1. Open **Microsoft Entra ID** in the Azure Portal.
+2. Open **App registrations**.
+3. Create a new registration for the workflow, for example
+   `sonde-azure-live-ci`.
+4. Open the registration and note:
+   - **Application (client) ID**
+   - **Directory (tenant) ID**
+5. Open **Enterprise applications** and confirm the matching service principal
+   exists.
+6. Open **Certificates & secrets** → **Federated credentials**.
+7. Add a GitHub federated credential with:
+   - **Issuer:** `https://token.actions.githubusercontent.com`
+   - **Audience:** `api://AzureADTokenExchange`
+   - **Subject:** `repo:OWNER/REPO:environment:azure-live-ci`
+
+### Azure CLI path
+
+```powershell
+$app = az ad app create --display-name "sonde-azure-live-ci" | ConvertFrom-Json
+$appId = $app.appId
+
+$sp = az ad sp create --id $appId | ConvertFrom-Json
+
+@"
+{
+  "name": "github-azure-live-ci",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "subject": "repo:OWNER/REPO:environment:azure-live-ci",
+  "audiences": [
+    "api://AzureADTokenExchange"
+  ]
+}
+"@ | Set-Content -Path .\federated-credential.json
+
+az ad app federated-credential create `
+  --id $appId `
+  --parameters @federated-credential.json
+```
+
+Replace `OWNER` and `REPO` with the real repository coordinates.
+
+## 5. Grant the Azure permissions the workflow needs
+
+As implemented today, the workflow needs permissions for four distinct jobs:
+
+1. create and delete the disposable resource group,
+2. run a subscription-scope Bicep deployment,
+3. create RBAC assignments inside that deployment, and
+4. send to / receive from Service Bus during live validation.
+
+### 5.1 Azure RBAC roles
+
+Grant the GitHub OIDC service principal these Azure RBAC roles:
+
+| Role | Recommended scope | Why |
+|------|-------------------|-----|
+| `Contributor` | Subscription named by `SONDE_AZURE_CI_SUBSCRIPTION_ID` | Needed for `az group create`, `az group delete`, and the subscription-scope deployment. |
+| `User Access Administrator` | Same subscription | Needed because the Bicep deployment creates queue/table `roleAssignments`. |
+| `Azure Service Bus Data Sender` | Subscription | Needed for the live validation harness to send to `desired-state`. |
+| `Azure Service Bus Data Receiver` | Subscription | Needed for the live validation harness to receive from `connector-upstream` and `desired-state`. |
+
+**Why subscription scope for the Service Bus data roles?** The workflow deletes
+and recreates the disposable resource group every run. Narrower assignments
+inside that resource group would be destroyed on teardown, so the current
+workflow needs persistent assignments above the disposable stack scope.
+
+### Portal path
+
+For each role above:
+
+1. Open the target **Subscription**.
+2. Open **Access control (IAM)**.
+3. Add a role assignment.
+4. Select the role.
+5. Assign it to the GitHub OIDC service principal you created in step 4.
+
+### Azure CLI path
+
+```powershell
+$subscriptionId = "00000000-0000-0000-0000-000000000000"
+$principalObjectId = "<service-principal-object-id>"
+$subscriptionScope = "/subscriptions/$subscriptionId"
+
+foreach ($role in @(
+  "Contributor",
+  "User Access Administrator",
+  "Azure Service Bus Data Sender",
+  "Azure Service Bus Data Receiver"
+)) {
+  az role assignment create `
+    --assignee-object-id $principalObjectId `
+    --assignee-principal-type ServicePrincipal `
+    --role $role `
+    --scope $subscriptionScope
+}
+```
+
+## 6. Grant the Microsoft Graph permission used by the Bicep Graph resources
+
+`deploy/bicep/modules/companion-identity.bicep` creates:
+
+1. `Microsoft.Graph/applications@v1.0`
+2. `Microsoft.Graph/servicePrincipals@v1.0`
+
+For the app-only identity used by GitHub OIDC, Microsoft's Graph Bicep docs list
+`Application.ReadWrite.OwnedBy` as the least-privileged application permission
+for both resource types.
+
+### Portal path
+
+1. Open the GitHub OIDC app registration from step 4.
+2. Open **API permissions**.
+3. Add a permission for **Microsoft Graph**.
+4. Choose **Application permissions**.
+5. Add `Application.ReadWrite.OwnedBy`.
+6. Grant **admin consent** for the tenant.
+
+If your tenant policy or ownership model prevents that least-privileged grant
+from working, re-check the current Microsoft Graph Bicep reference before
+granting a broader permission such as `Application.ReadWrite.All`.
+
+### CLI note
+
+This guide intentionally treats the Graph-permission grant as a Portal-first
+step. The exact automation command depends on the Graph tooling you standardize
+on for admin-consent workflows, while the required permission name is stable:
+`Application.ReadWrite.OwnedBy`.
+
+## 7. Create the GitHub variables
+
+Set these variables either:
+
+1. on the repository, or
+2. on the `azure-live-ci` environment.
+
+Required:
+
+| Variable | Example |
+|----------|---------|
+| `SONDE_AZURE_CI_CLIENT_ID` | app/client ID from step 4 |
+| `SONDE_AZURE_CI_TENANT_ID` | tenant ID from step 4 |
+| `SONDE_AZURE_CI_SUBSCRIPTION_ID` | subscription ID chosen in step 2 |
+| `SONDE_AZURE_CI_RESOURCE_GROUP` | `sonde-ci-eastus` |
+
+Optional:
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX` | `${SONDE_AZURE_CI_PROJECT_NAME}-ci-`, or `sonde-ci-` by default | Safety boundary for destructive cleanup. |
+| `SONDE_AZURE_CI_LOCATION` | `eastus` | Deployment region. |
+| `SONDE_AZURE_CI_PROJECT_NAME` | `sonde` | Drives naming and default CI prefix. |
+
+Set `SONDE_AZURE_CI_RESOURCE_GROUP_PREFIX` if you want a stricter allow-list
+than the default derived prefix.
+
+## 8. Sanity-check the disposable resource-group safety boundary
+
+Before running the workflow:
+
+1. Confirm `SONDE_AZURE_CI_RESOURCE_GROUP` is disposable.
+2. Confirm its name starts with the configured CI prefix.
+3. Confirm no operator-managed or production resource group shares that name.
+
+During the workflow, the resource group is created or updated with:
+
+```text
+sonde-ci-owner=azure-live-ci
+```
+
+The workflow refuses to delete a resource group that does not carry that tag.
+
+## 9. Run the workflow for the first time
+
+In GitHub:
+
+1. Open **Actions**.
+2. Select **Azure Live CI**.
+3. Choose **Run workflow**.
+4. Dispatch it from the branch that contains the current workflow definition.
+
+## 10. What success looks like
+
+On a healthy first run:
+
+1. **Validate required Azure CI variables** passes.
+2. **Azure login (OIDC)** passes.
+3. **Preflight-delete disposable resource group** either removes an old CI-owned
+   resource group or confirms none exists.
+4. **Generate runtime certificate and deploy disposable stack** succeeds.
+5. **Run live Azure companion validation** prints:
+   - `connector harness connected`
+   - `success path passed`
+   - `failure path passed`
+6. **Teardown disposable resource group** succeeds and the resource group no
+   longer exists in Azure.
+
+On failure:
+
+1. the workflow still attempts teardown, and
+2. GitHub uploads `azure-live-ci-artifacts` containing deployment/runtime-state
+   debug files (but not the private key).
+
+## 11. Common misconfigurations
+
+| Symptom | Likely cause |
+|--------|--------------|
+| `SONDE_AZURE_CI_* must be configured` | Missing repository/environment variables. |
+| Azure login fails | Client ID, tenant ID, subscription ID, or federated credential subject is wrong. |
+| Graph deployment fails while creating the companion identity | The OIDC app is missing `Application.ReadWrite.OwnedBy` or tenant admin consent. |
+| Bicep deployment fails on role assignments | The OIDC identity is missing `User Access Administrator`. |
+| Live validation fails with Service Bus authorization errors | The OIDC identity is missing `Azure Service Bus Data Sender` and/or `Azure Service Bus Data Receiver`. |
+| Cleanup refuses to delete the resource group | The group name is outside the configured CI prefix or the CI-ownership tag is missing. |

--- a/docs/azure-provisioning-design.md
+++ b/docs/azure-provisioning-design.md
@@ -229,7 +229,7 @@ workflow makes the necessary values available to the bootstrap path that does.
 
 ## 6  Outputs and lifecycle
 
-> **Requirements:** AZP-0100, AZP-0102, AZP-0103, AZP-0104, AZP-0300, AZP-0301, AZP-0302, AZP-0303, AZP-0304
+> **Requirements:** AZP-0100, AZP-0102, AZP-0103, AZP-0104, AZP-0300, AZP-0301, AZP-0302, AZP-0303, AZP-0304, AZP-0305
 
 ### 6.1  Outputs
 
@@ -293,4 +293,43 @@ Because the workflow performs destructive preflight cleanup, it must never point
 at an arbitrary shared resource group. The configured resource group for this
 workflow is therefore part of the safety boundary: it is a dedicated,
 CI-owned disposable group reserved exclusively for this live validation path.
+
+### 6.7  Live CI setup guide boundary
+
+The repository separates the operator-facing provisioning reference from the
+operator-facing live-CI setup runbook.
+
+1. `deploy/bicep/README.md` remains the reference surface for the Bicep
+   deployment inputs, outputs, and high-level live-CI prerequisites.
+2. `deploy/bicep/azure-live-ci-setup.md` carries the
+   step-by-step procedure for configuring and running the GitHub Actions
+   workflow.
+
+The setup guide is part of the repository-owned deployment surface, not an
+external wiki-only procedure, so operators can configure the workflow from the
+same revision they intend to run.
+`deploy/bicep/README.md` links to this guide from its live-CI prerequisite
+section so the procedural path is discoverable from the provisioning reference.
+
+### 6.8  Setup guide content contract
+
+The live-CI setup guide must present the setup flow in operator order:
+
+1. identify the GitHub environment name and the variables the workflow consumes,
+2. configure GitHub OIDC federation for the Azure identity,
+3. assign the minimum Azure RBAC, Service Bus data-plane roles, and Microsoft
+   Graph permissions required by the workflow,
+4. choose and document a safe disposable resource-group name and optional CI
+   prefix override,
+5. manually dispatch the workflow, and
+6. verify both the success path and the teardown path of the first run.
+
+For the key setup actions above, the guide provides both:
+
+1. an Azure Portal path for operators performing the setup interactively, and
+2. an Azure CLI path for operators automating or scripting the setup.
+
+The guide may reference the workflow file for exact variable names, but it must
+not force an operator to infer the required permissions or safety boundary by
+reading the YAML directly.
 

--- a/docs/azure-provisioning-requirements.md
+++ b/docs/azure-provisioning-requirements.md
@@ -327,3 +327,27 @@ attempt teardown again even when earlier steps failed.
 4. If teardown fails, the workflow surfaces the retained resource-group failure explicitly rather than silently reporting success.
 5. The workflow documentation states that arbitrary operator-managed resource groups are out of scope for CI deletion.
 
+---
+
+### AZP-0305  Step-by-step live CI setup guide
+
+**Priority:** Must
+**Source:** reviewed discovery output, operator usability review for the live Azure CI workflow
+
+**Description:**
+The repository MUST provide a standalone step-by-step setup guide for the live
+Azure validation workflow. This guide MUST tell a first-time operator how to
+configure the GitHub environment, Azure federated identity, minimum required
+permissions, disposable resource-group safety settings, and the first manual
+workflow dispatch without reverse-engineering the workflow YAML.
+
+**Acceptance criteria:**
+
+1. The repository contains a standalone operator-facing setup guide at `deploy/bicep/azure-live-ci-setup.md` rather than relying only on a brief prerequisite summary inside `deploy/bicep/README.md`.
+2. The setup guide identifies the GitHub environment name and the required repository or environment variables consumed by the workflow.
+3. The setup guide describes both an Azure Portal path and an Azure CLI path for the key setup actions where those paths are practical.
+4. The setup guide names the exact Azure RBAC roles, Service Bus data-plane roles, and Microsoft Graph permissions required by the federated CI identity.
+5. The setup guide explains the disposable resource-group safety boundary, including the default CI prefix behavior and the requirement that only CI-owned disposable groups are in scope for destructive cleanup.
+6. The setup guide describes how to manually dispatch the workflow and what success or cleanup signals an operator should expect from the first run.
+7. `deploy/bicep/README.md` links operators to `deploy/bicep/azure-live-ci-setup.md` for the procedural setup path.
+

--- a/docs/azure-provisioning-validation.md
+++ b/docs/azure-provisioning-validation.md
@@ -200,3 +200,18 @@
 4. If teardown succeeds, assert: the disposable resource group is removed.
 5. If teardown fails, assert: the workflow reports the retained resource group explicitly instead of reporting overall success.
 
+---
+
+### T-AZP-0305  Live CI setup guide is complete and operator-usable
+
+**Validates:** AZP-0305
+
+**Procedure:**
+1. Inspect `deploy/bicep/azure-live-ci-setup.md` and `deploy/bicep/README.md`.
+2. Assert: `deploy/bicep/README.md` links operators to `deploy/bicep/azure-live-ci-setup.md` for live-CI setup.
+3. Assert: the setup guide identifies the GitHub environment name and the required workflow variables.
+4. Assert: the setup guide describes both an Azure Portal path and an Azure CLI path for the key setup actions.
+5. Assert: the setup guide names the exact Azure RBAC roles, Service Bus data-plane roles, and Microsoft Graph permissions required by the federated CI identity.
+6. Assert: the setup guide explains the disposable resource-group safety boundary, including the default CI prefix behavior and the CI-owned tag/ownership expectations.
+7. Assert: the setup guide tells the operator how to manually dispatch the workflow and what first-run success and teardown signals to expect.
+


### PR DESCRIPTION
## Summary
- add a standalone `deploy/bicep/azure-live-ci-setup.md` runbook for the Azure Live CI workflow
- link the provisioning README to the new runbook and align the Service Bus assignment guidance with the disposable resource-group lifecycle
- update Azure provisioning requirements, design, and validation specs to require the standalone setup guide and README linkage

## Traceability
- Requirements: `AZP-0305` in `docs/azure-provisioning-requirements.md`
- Design: live-CI setup guide boundary and content contract in `docs/azure-provisioning-design.md`
- Validation: `T-AZP-0305` in `docs/azure-provisioning-validation.md`

## Audit summary
- Spec audit: PASS after tightening the guide to the exact path `deploy/bicep/azure-live-ci-setup.md` and requiring README linkage
- Implementation audit: PASS after aligning README with the guide's explanation of persistent Service Bus role assignment scope