### PR TITLE
Fix Azure live CI cleanup and key generation

### DIFF
--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -86,7 +86,7 @@ jobs:
             exit 1
           fi
           if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "true" ]; then
-            ci_owner_tag="$(az group show --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --query "tags.sonde-ci-owner" --output tsv)"
+            ci_owner_tag="$(az group show --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --query 'tags."sonde-ci-owner"' --output tsv)"
             if [ "$ci_owner_tag" != "azure-live-ci" ]; then
               echo "::error::refusing to delete resource group $SONDE_AZURE_CI_RESOURCE_GROUP without tags.sonde-ci-owner=azure-live-ci"
               exit 1
@@ -111,7 +111,9 @@ jobs:
             --name "$SONDE_AZURE_CI_RESOURCE_GROUP" \
             --location "$SONDE_AZURE_CI_LOCATION" \
             --tags sonde-ci-owner=azure-live-ci project="$SONDE_AZURE_CI_PROJECT_NAME" > /dev/null
-          openssl ecparam -name prime256v1 -genkey -noout -out .azure-live-state/key.pem
+          openssl genpkey -algorithm EC \
+            -pkeyopt ec_paramgen_curve:P-256 \
+            -out .azure-live-state/key.pem
           chmod 600 .azure-live-state/key.pem
           openssl req -new -x509 \
             -key .azure-live-state/key.pem \
@@ -198,7 +200,7 @@ jobs:
             exit 1
           fi
           if [ "$(az group exists --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --output tsv)" = "true" ]; then
-            ci_owner_tag="$(az group show --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --query "tags.sonde-ci-owner" --output tsv)"
+            ci_owner_tag="$(az group show --name "$SONDE_AZURE_CI_RESOURCE_GROUP" --query 'tags."sonde-ci-owner"' --output tsv)"
             if [ "$ci_owner_tag" != "azure-live-ci" ]; then
               echo "::error::refusing to delete resource group $SONDE_AZURE_CI_RESOURCE_GROUP without tags.sonde-ci-owner=azure-live-ci"
               exit 1


### PR DESCRIPTION
## Summary
- fix the Azure CLI tag query used by preflight and teardown cleanup for the disposable resource group
- generate the live-validation EC private key in PKCS#8 PEM format so `sonde-azure-companion` can load it

## Root causes
1. `az group show --query "tags.sonde-ci-owner"` is invalid because the tag key contains hyphens; the cleanup steps exited before calling `az group delete`.
2. `openssl ecparam -genkey` wrote a traditional EC private key PEM that the companion's signing-key loader rejected during live validation.

## Validation
- `git diff --check`