### PR TITLE
Add Windows service support for sonde-azure-companion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Build gateway and companion (release)
         run: cargo build --release -p sonde-gateway -p sonde-admin -p sonde-azure-companion
 
+      - name: Test Azure companion (Windows)
+        run: cargo test --release -p sonde-azure-companion
+
       - name: Upload Windows gateway, admin, and companion binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,16 +108,17 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build gateway (release)
-        run: cargo build --release -p sonde-gateway -p sonde-admin
+      - name: Build gateway and companion (release)
+        run: cargo build --release -p sonde-gateway -p sonde-admin -p sonde-azure-companion
 
-      - name: Upload Windows gateway and admin binaries
+      - name: Upload Windows gateway, admin, and companion binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gateway-windows-x86_64
           path: |
             target/release/sonde-gateway.exe
             target/release/sonde-admin.exe
+            target/release/sonde-azure-companion.exe
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -318,6 +318,7 @@ jobs:
             -d Version="$ver" `
             -d GatewayBin=target\release\sonde-gateway.exe `
             -d AdminBin=target\release\sonde-admin.exe `
+            -d AzureCompanionBin=target\release\sonde-azure-companion.exe `
             -d CustomActionCaDll=installer\windows\CustomActions\bin\Release\net472\SondeCustomActions.CA.dll `
             -ext WixToolset.UI.wixext `
             -ext WixToolset.Util.wixext `
@@ -380,6 +381,7 @@ jobs:
           cp artifacts/sensor-handlers-linux-arm64/sonde-tmp102-handler release-assets/sonde-tmp102-handler-arm64
           cp artifacts/gateway-windows-x86_64/sonde-gateway.exe release-assets/sonde-gateway.exe
           cp artifacts/gateway-windows-x86_64/sonde-admin.exe   release-assets/sonde-admin.exe
+          cp artifacts/gateway-windows-x86_64/sonde-azure-companion.exe release-assets/sonde-azure-companion.exe
           cp artifacts/node-firmware/flash_image.bin        release-assets/node-flash_image.bin
           cp artifacts/modem-firmware/flash_image.bin       release-assets/modem-flash_image.bin
           tar -C artifacts/bpf-test-programs -czf release-assets/sonde-bpf-test-programs.tar.gz .

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -411,6 +411,7 @@ jobs:
           | TMP102 handler (Linux arm64) | `sonde-tmp102-handler-arm64` |
           | Gateway (Windows x86_64) | `sonde-gateway.exe` |
           | Admin CLI (Windows) | `sonde-admin.exe` |
+          | Azure companion (Windows) | `sonde-azure-companion.exe` |
           | ESP32-C3 Node firmware | `node-flash_image.bin` |
           | ESP32-S3 Modem firmware | `modem-flash_image.bin` |
           | BPF test programs | `sonde-bpf-test-programs.tar.gz` |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build binaries (release)
-        run: cargo build --release -p sonde-gateway -p sonde-admin
+        run: cargo build --release -p sonde-gateway -p sonde-admin -p sonde-azure-companion
 
       - name: Install WiX 4
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'crates/sonde-gateway/**'
       - 'crates/sonde-admin/**'
+      - 'crates/sonde-azure-companion/**'
       - 'installer/**'
       - '.github/workflows/release.yml'
 
@@ -48,7 +49,7 @@ jobs:
             protobuf-compiler libudev-dev fakeroot dpkg
 
       - name: Build binaries (release)
-        run: cargo build --release -p sonde-gateway -p sonde-admin
+        run: cargo build --release -p sonde-gateway -p sonde-admin -p sonde-azure-companion
 
       - name: Set package version
         id: version
@@ -114,6 +115,7 @@ jobs:
             -d Version=${{ steps.version.outputs.version }} `
             -d GatewayBin=target\release\sonde-gateway.exe `
             -d AdminBin=target\release\sonde-admin.exe `
+            -d AzureCompanionBin=target\release\sonde-azure-companion.exe `
             -d CustomActionCaDll=installer\windows\CustomActions\bin\Release\net472\SondeCustomActions.CA.dll `
             -ext WixToolset.UI.wixext `
             -ext WixToolset.Util.wixext `

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6534,6 +6534,8 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tower",
+ "windows-service",
+ "windows-sys 0.61.2",
  "wiremock",
  "x509-cert",
 ]

--- a/crates/sonde-azure-companion/Cargo.toml
+++ b/crates/sonde-azure-companion/Cargo.toml
@@ -33,6 +33,10 @@ tar = "0.4"
 thiserror = "2"
 x509-cert = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows-service = "0.8.0"
+windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
+
 [dev-dependencies]
 futures = "0.3"
 tempfile = "3"

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -1859,14 +1859,21 @@ fn install_service(cli: &Cli) -> Result<(), CompanionError> {
         ServiceType,
     };
     use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
-    use windows_sys::Win32::Foundation::ERROR_SERVICE_EXISTS;
+    use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_SERVICE_EXISTS};
 
     let manager = ServiceManager::local_computer(
         None::<&str>,
         ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE,
     )
-    .map_err(|err| {
-        CompanionError::Config(format!("failed to open Service Control Manager: {err}"))
+    .map_err(|err| match err {
+        windows_service::Error::Winapi(win_err)
+            if win_err.raw_os_error() == Some(ERROR_ACCESS_DENIED as i32) =>
+        {
+            CompanionError::Config(
+                "Administrator privileges are required to install the service.".to_string(),
+            )
+        }
+        _ => CompanionError::Config(format!("failed to open Service Control Manager: {err}")),
     })?;
 
     let exe_path = std::env::current_exe()?;
@@ -1898,16 +1905,34 @@ fn install_service(cli: &Cli) -> Result<(), CompanionError> {
         {
             let service = manager
                 .open_service(SERVICE_NAME, ServiceAccess::CHANGE_CONFIG)
-                .map_err(|open_err| {
-                    CompanionError::Config(format!(
+                .map_err(|open_err| match open_err {
+                    windows_service::Error::Winapi(win_err)
+                        if win_err.raw_os_error() == Some(ERROR_ACCESS_DENIED as i32) =>
+                    {
+                        CompanionError::Config(
+                            "Administrator privileges are required to update the service."
+                                .to_string(),
+                        )
+                    }
+                    _ => CompanionError::Config(format!(
                         "failed to open existing {SERVICE_NAME} service: {open_err}"
-                    ))
+                    )),
                 })?;
-            service.change_config(&service_info).map_err(|change_err| {
-                CompanionError::Config(format!(
-                    "failed to update existing {SERVICE_NAME} service: {change_err}"
-                ))
-            })?;
+            service
+                .change_config(&service_info)
+                .map_err(|change_err| match change_err {
+                    windows_service::Error::Winapi(win_err)
+                        if win_err.raw_os_error() == Some(ERROR_ACCESS_DENIED as i32) =>
+                    {
+                        CompanionError::Config(
+                            "Administrator privileges are required to update the service."
+                                .to_string(),
+                        )
+                    }
+                    _ => CompanionError::Config(format!(
+                        "failed to update existing {SERVICE_NAME} service: {change_err}"
+                    )),
+                })?;
             service
                 .set_description(SERVICE_DESCRIPTION)
                 .map_err(|err| {
@@ -1915,9 +1940,18 @@ fn install_service(cli: &Cli) -> Result<(), CompanionError> {
                 })?;
         }
         Err(err) => {
-            return Err(CompanionError::Config(format!(
-                "failed to create {SERVICE_NAME} service: {err}"
-            )));
+            return Err(match err {
+                windows_service::Error::Winapi(win_err)
+                    if win_err.raw_os_error() == Some(ERROR_ACCESS_DENIED as i32) =>
+                {
+                    CompanionError::Config(
+                        "Administrator privileges are required to install the service.".to_string(),
+                    )
+                }
+                _ => CompanionError::Config(format!(
+                    "failed to create {SERVICE_NAME} service: {err}"
+                )),
+            });
         }
     }
 
@@ -1930,11 +1964,18 @@ fn uninstall_service() -> Result<(), CompanionError> {
     use std::time::{Duration, Instant};
     use windows_service::service::{ServiceAccess, ServiceState};
     use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
-    use windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST;
+    use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_SERVICE_DOES_NOT_EXIST};
 
     let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
-        .map_err(|err| {
-            CompanionError::Config(format!("failed to open Service Control Manager: {err}"))
+        .map_err(|err| match err {
+            windows_service::Error::Winapi(win_err)
+                if win_err.raw_os_error() == Some(ERROR_ACCESS_DENIED as i32) =>
+            {
+                CompanionError::Config(
+                    "Administrator privileges are required to uninstall the service.".to_string(),
+                )
+            }
+            _ => CompanionError::Config(format!("failed to open Service Control Manager: {err}")),
         })?;
 
     let service = match manager.open_service(
@@ -1949,9 +1990,19 @@ fn uninstall_service() -> Result<(), CompanionError> {
             return Ok(());
         }
         Err(err) => {
-            return Err(CompanionError::Config(format!(
-                "failed to open {SERVICE_NAME} service: {err}"
-            )));
+            return Err(match err {
+                windows_service::Error::Winapi(win_err)
+                    if win_err.raw_os_error() == Some(ERROR_ACCESS_DENIED as i32) =>
+                {
+                    CompanionError::Config(
+                        "Administrator privileges are required to uninstall the service."
+                            .to_string(),
+                    )
+                }
+                _ => {
+                    CompanionError::Config(format!("failed to open {SERVICE_NAME} service: {err}"))
+                }
+            });
         }
     };
 
@@ -2014,6 +2065,25 @@ fn set_service_status(
     controls_accepted: windows_service::service::ServiceControlAccept,
     exit_code: u32,
 ) {
+    set_service_status_with_progress(
+        status_handle,
+        current_state,
+        controls_accepted,
+        exit_code,
+        0,
+        Duration::default(),
+    );
+}
+
+#[cfg(windows)]
+fn set_service_status_with_progress(
+    status_handle: &windows_service::service_control_handler::ServiceStatusHandle,
+    current_state: windows_service::service::ServiceState,
+    controls_accepted: windows_service::service::ServiceControlAccept,
+    exit_code: u32,
+    checkpoint: u32,
+    wait_hint: Duration,
+) {
     use windows_service::service::{ServiceExitCode, ServiceStatus, ServiceType};
 
     let status = ServiceStatus {
@@ -2021,18 +2091,41 @@ fn set_service_status(
         current_state,
         controls_accepted,
         exit_code: ServiceExitCode::Win32(exit_code),
-        checkpoint: 0,
-        wait_hint: Duration::default(),
+        checkpoint,
+        wait_hint,
         process_id: None,
     };
     let _ = status_handle.set_service_status(status);
 }
 
 #[cfg(windows)]
+fn log_service_diagnostic(state_dir: &Path, message: &str) {
+    let log_path = state_dir.join("service.log");
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    {
+        Ok(mut file) => {
+            use std::io::Write as _;
+            let _ = writeln!(file, "{message}");
+        }
+        Err(err) => {
+            eprintln!(
+                "{SERVICE_NAME}: failed to write service diagnostic log {}: {err}",
+                log_path.display()
+            );
+        }
+    }
+}
+
+#[cfg(windows)]
 fn service_entry(_arguments: Vec<std::ffi::OsString>) {
     use std::sync::{Arc, Mutex};
     use windows_service::service::{ServiceControl, ServiceControlAccept, ServiceState};
-    use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
+    use windows_service::service_control_handler::{
+        self, ServiceControlHandlerResult, ServiceStatusHandle,
+    };
 
     let cli = match SERVICE_CLI.get() {
         Some(cli) => cli,
@@ -2041,11 +2134,25 @@ fn service_entry(_arguments: Vec<std::ffi::OsString>) {
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     let shutdown_tx = Arc::new(Mutex::new(Some(shutdown_tx)));
+    let status_handle_slot = Arc::new(Mutex::new(None::<ServiceStatusHandle>));
+    let status_handle_slot_for_events = Arc::clone(&status_handle_slot);
 
     let event_handler = move |control_event| -> ServiceControlHandlerResult {
         match control_event {
             ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
             ServiceControl::Stop | ServiceControl::Shutdown => {
+                if let Ok(guard) = status_handle_slot_for_events.lock() {
+                    if let Some(handle) = *guard {
+                        set_service_status_with_progress(
+                            &handle,
+                            ServiceState::StopPending,
+                            ServiceControlAccept::empty(),
+                            0,
+                            1,
+                            Duration::from_secs(30),
+                        );
+                    }
+                }
                 if let Ok(mut guard) = shutdown_tx.lock() {
                     if let Some(tx) = guard.take() {
                         let _ = tx.send(());
@@ -2061,9 +2168,16 @@ fn service_entry(_arguments: Vec<std::ffi::OsString>) {
         Ok(handle) => handle,
         Err(err) => {
             eprintln!("{SERVICE_NAME}: failed to register service control handler: {err}");
+            log_service_diagnostic(
+                &cli.state_dir,
+                &format!("{SERVICE_NAME}: failed to register service control handler: {err}"),
+            );
             return;
         }
     };
+    if let Ok(mut guard) = status_handle_slot.lock() {
+        *guard = Some(status_handle);
+    }
 
     set_service_status(
         &status_handle,
@@ -2076,6 +2190,7 @@ fn service_entry(_arguments: Vec<std::ffi::OsString>) {
         Ok(ready) => ready,
         Err(err) => {
             eprintln!("{err}");
+            log_service_diagnostic(&cli.state_dir, &err.to_string());
             set_service_status(
                 &status_handle,
                 ServiceState::Stopped,
@@ -2090,6 +2205,10 @@ fn service_entry(_arguments: Vec<std::ffi::OsString>) {
         Ok(runtime) => runtime,
         Err(err) => {
             eprintln!("failed to create tokio runtime for {SERVICE_NAME}: {err}");
+            log_service_diagnostic(
+                &cli.state_dir,
+                &format!("failed to create tokio runtime for {SERVICE_NAME}: {err}"),
+            );
             set_service_status(
                 &status_handle,
                 ServiceState::Stopped,
@@ -2119,6 +2238,7 @@ fn service_entry(_arguments: Vec<std::ffi::OsString>) {
         Ok(()) => 0,
         Err(err) => {
             eprintln!("{err}");
+            log_service_diagnostic(&cli.state_dir, &err.to_string());
             1
         }
     };

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -52,8 +52,6 @@ const DEFAULT_CONNECTOR_SOCKET: &str = "/var/run/sonde/connector.sock";
 const DEFAULT_CONNECTOR_SOCKET: &str = r"\\.\pipe\sonde-connector";
 #[cfg(unix)]
 const DEFAULT_STATE_DIR: &str = "/var/lib/sonde-azure-companion";
-#[cfg(windows)]
-const DEFAULT_STATE_DIR: &str = r"C:\ProgramData\sonde-azure-companion";
 
 const SERVICE_PRINCIPAL_STATE_FILENAME: &str = "service-principal.json";
 /// Path to bundled Bicep files inside the companion container image.
@@ -86,6 +84,19 @@ const SERVICE_DESCRIPTION: &str = "Bridges the Sonde gateway connector to Azure 
 static SERVICE_CLI: OnceLock<Cli> = OnceLock::new();
 #[cfg(windows)]
 windows_service::define_windows_service!(ffi_service_main, service_entry);
+
+#[cfg(unix)]
+fn default_state_dir() -> PathBuf {
+    PathBuf::from(DEFAULT_STATE_DIR)
+}
+
+#[cfg(windows)]
+fn default_state_dir() -> PathBuf {
+    std::env::var_os("PROGRAMDATA")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
+        .join("sonde-azure-companion")
+}
 
 #[derive(Debug, Error)]
 enum CompanionError {
@@ -122,7 +133,7 @@ struct Cli {
     connector_socket: String,
 
     /// Mounted state directory reserved for bootstrap output and runtime auth material.
-    #[arg(long, global = true, env = "SONDE_AZURE_COMPANION_STATE_DIR", default_value = DEFAULT_STATE_DIR)]
+    #[arg(long, global = true, env = "SONDE_AZURE_COMPANION_STATE_DIR", default_value_os_t = default_state_dir())]
     state_dir: PathBuf,
 
     #[command(subcommand)]
@@ -2306,6 +2317,8 @@ mod tests {
     use super::bridge_runtime_with_shutdown;
     #[cfg(windows)]
     use super::build_service_launch_args;
+    #[cfg(windows)]
+    use super::default_state_dir;
     #[cfg(unix)]
     use super::validate_certificate_matches_private_key;
     use super::{
@@ -3752,6 +3765,17 @@ mod tests {
                 OsString::from("service"),
             ]
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn default_state_dir_uses_programdata_environment() {
+        temp_env::with_var("PROGRAMDATA", Some(r"D:\RelocatedProgramData"), || {
+            assert_eq!(
+                default_state_dir(),
+                PathBuf::from(r"D:\RelocatedProgramData\sonde-azure-companion")
+            );
+        });
     }
 
     #[test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -115,15 +115,15 @@ impl<T> AsyncIo for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
 #[command(name = "sonde-azure-companion")]
 struct Cli {
     /// Gateway admin socket path (UDS on Unix, named pipe on Windows).
-    #[arg(long, env = "SONDE_GATEWAY_ADMIN_SOCKET", default_value = DEFAULT_ADMIN_SOCKET)]
+    #[arg(long, global = true, env = "SONDE_GATEWAY_ADMIN_SOCKET", default_value = DEFAULT_ADMIN_SOCKET)]
     admin_socket: String,
 
     /// Gateway connector socket path (UDS on Unix, named pipe on Windows).
-    #[arg(long, env = "SONDE_GATEWAY_CONNECTOR_SOCKET", default_value = DEFAULT_CONNECTOR_SOCKET)]
+    #[arg(long, global = true, env = "SONDE_GATEWAY_CONNECTOR_SOCKET", default_value = DEFAULT_CONNECTOR_SOCKET)]
     connector_socket: String,
 
     /// Mounted state directory reserved for bootstrap output and runtime auth material.
-    #[arg(long, env = "SONDE_AZURE_COMPANION_STATE_DIR", default_value = DEFAULT_STATE_DIR)]
+    #[arg(long, global = true, env = "SONDE_AZURE_COMPANION_STATE_DIR", default_value = DEFAULT_STATE_DIR)]
     state_dir: PathBuf,
 
     #[command(subcommand)]
@@ -1851,27 +1851,23 @@ async fn bootstrap(
 }
 
 #[cfg(windows)]
-fn build_service_launch_args() -> Vec<std::ffi::OsString> {
-    build_service_launch_args_from_iter(std::env::args_os().skip(1))
+fn build_service_launch_args(cli: &Cli) -> Vec<std::ffi::OsString> {
+    vec![
+        std::ffi::OsString::from("--admin-socket"),
+        std::ffi::OsString::from(&cli.admin_socket),
+        std::ffi::OsString::from("--connector-socket"),
+        std::ffi::OsString::from(&cli.connector_socket),
+        std::ffi::OsString::from("--state-dir"),
+        cli.state_dir.as_os_str().to_os_string(),
+        std::ffi::OsString::from("service"),
+    ]
 }
 
 #[cfg(windows)]
-fn build_service_launch_args_from_iter<I>(args: I) -> Vec<std::ffi::OsString>
-where
-    I: IntoIterator<Item = std::ffi::OsString>,
-{
-    std::iter::once(std::ffi::OsString::from("service"))
-        .chain(
-            args.into_iter()
-                .filter(|arg| arg.to_str() != Some("install")),
-        )
-        .collect()
-}
-
-#[cfg(windows)]
-fn install_service() -> Result<(), CompanionError> {
+fn install_service(cli: &Cli) -> Result<(), CompanionError> {
     use windows_service::service::{
-        ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType,
+        ServiceAccess, ServiceDependency, ServiceErrorControl, ServiceInfo, ServiceStartType,
+        ServiceType,
     };
     use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
     use windows_sys::Win32::Foundation::ERROR_SERVICE_EXISTS;
@@ -1890,8 +1886,10 @@ fn install_service() -> Result<(), CompanionError> {
         start_type: ServiceStartType::AutoStart,
         error_control: ServiceErrorControl::Normal,
         executable_path: exe_path,
-        launch_arguments: build_service_launch_args(),
-        dependencies: vec![],
+        launch_arguments: build_service_launch_args(cli),
+        dependencies: vec![ServiceDependency::Service(std::ffi::OsString::from(
+            "sonde-gateway",
+        ))],
         account_name: None,
         account_password: None,
     };
@@ -2146,7 +2144,7 @@ async fn run_cli() -> Result<(), CompanionError> {
             check_runtime_ready(&cli.state_dir)?;
         }
         #[cfg(windows)]
-        Command::Install => install_service()?,
+        Command::Install => install_service(&cli)?,
         #[cfg(windows)]
         Command::Uninstall => uninstall_service()?,
         #[cfg(windows)]
@@ -2190,7 +2188,9 @@ mod tests {
     #[cfg(unix)]
     use super::bridge_runtime_with_shutdown;
     #[cfg(windows)]
-    use super::build_service_launch_args_from_iter;
+    use super::build_service_launch_args;
+    #[cfg(windows)]
+    use super::{Cli, Command};
     use azure_core::credentials::TokenCredential;
     #[cfg(unix)]
     use base64::Engine as _;
@@ -3603,21 +3603,26 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn service_launch_args_replace_install_with_service() {
+    fn service_launch_args_use_canonical_global_option_order() {
         use std::ffi::OsString;
 
-        let args = build_service_launch_args_from_iter([
-            OsString::from("install"),
-            OsString::from("--state-dir"),
-            OsString::from(r"C:\ProgramData\sonde-azure-companion"),
-        ]);
+        let args = build_service_launch_args(&Cli {
+            admin_socket: r"\\.\pipe\custom-admin".to_string(),
+            connector_socket: r"\\.\pipe\custom-connector".to_string(),
+            state_dir: PathBuf::from(r"C:\ProgramData\sonde-azure-companion"),
+            command: Some(Command::Install),
+        });
 
         assert_eq!(
             args,
             vec![
-                OsString::from("service"),
+                OsString::from("--admin-socket"),
+                OsString::from(r"\\.\pipe\custom-admin"),
+                OsString::from("--connector-socket"),
+                OsString::from(r"\\.\pipe\custom-connector"),
                 OsString::from("--state-dir"),
                 OsString::from(r"C:\ProgramData\sonde-azure-companion"),
+                OsString::from("service"),
             ]
         );
     }

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -81,8 +81,7 @@ const SERVICE_NAME: &str = "sonde-azure-companion";
 #[cfg(windows)]
 const SERVICE_DISPLAY_NAME: &str = "Sonde Azure Companion";
 #[cfg(windows)]
-const SERVICE_DESCRIPTION: &str =
-    "Bridges the Sonde gateway connector to Azure Service Bus.";
+const SERVICE_DESCRIPTION: &str = "Bridges the Sonde gateway connector to Azure Service Bus.";
 #[cfg(windows)]
 static SERVICE_CLI: OnceLock<Cli> = OnceLock::new();
 #[cfg(windows)]
@@ -1404,23 +1403,13 @@ where
 }
 
 #[cfg(all(test, unix))]
-async fn bridge_runtime<T, P, C>(
-    stream: T,
-    publisher: P,
-    consumer: C,
-) -> Result<(), CompanionError>
+async fn bridge_runtime<T, P, C>(stream: T, publisher: P, consumer: C) -> Result<(), CompanionError>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     P: UpstreamPublisher + 'static,
     C: DownstreamConsumer + 'static,
 {
-    bridge_runtime_with_shutdown(
-        stream,
-        publisher,
-        consumer,
-        std::future::pending::<()>(),
-    )
-    .await
+    bridge_runtime_with_shutdown(stream, publisher, consumer, std::future::pending::<()>()).await
 }
 
 async fn bridge_runtime_with_shutdown<T, P, C, S>(
@@ -1876,7 +1865,9 @@ fn install_service(cli: &Cli) -> Result<(), CompanionError> {
         None::<&str>,
         ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE,
     )
-    .map_err(|err| CompanionError::Config(format!("failed to open Service Control Manager: {err}")))?;
+    .map_err(|err| {
+        CompanionError::Config(format!("failed to open Service Control Manager: {err}"))
+    })?;
 
     let exe_path = std::env::current_exe()?;
     let service_info = ServiceInfo {
@@ -1896,9 +1887,11 @@ fn install_service(cli: &Cli) -> Result<(), CompanionError> {
 
     match manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG) {
         Ok(service) => {
-            service.set_description(SERVICE_DESCRIPTION).map_err(|err| {
-                CompanionError::Config(format!("failed to set service description: {err}"))
-            })?;
+            service
+                .set_description(SERVICE_DESCRIPTION)
+                .map_err(|err| {
+                    CompanionError::Config(format!("failed to set service description: {err}"))
+                })?;
         }
         Err(windows_service::Error::Winapi(err))
             if err.raw_os_error() == Some(ERROR_SERVICE_EXISTS as i32) =>
@@ -1915,9 +1908,11 @@ fn install_service(cli: &Cli) -> Result<(), CompanionError> {
                     "failed to update existing {SERVICE_NAME} service: {change_err}"
                 ))
             })?;
-            service.set_description(SERVICE_DESCRIPTION).map_err(|err| {
-                CompanionError::Config(format!("failed to set service description: {err}"))
-            })?;
+            service
+                .set_description(SERVICE_DESCRIPTION)
+                .map_err(|err| {
+                    CompanionError::Config(format!("failed to set service description: {err}"))
+                })?;
         }
         Err(err) => {
             return Err(CompanionError::Config(format!(
@@ -1938,7 +1933,9 @@ fn uninstall_service() -> Result<(), CompanionError> {
     use windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST;
 
     let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
-        .map_err(|err| CompanionError::Config(format!("failed to open Service Control Manager: {err}")))?;
+        .map_err(|err| {
+            CompanionError::Config(format!("failed to open Service Control Manager: {err}"))
+        })?;
 
     let service = match manager.open_service(
         SERVICE_NAME,
@@ -2111,14 +2108,14 @@ fn service_entry(_arguments: Vec<std::ffi::OsString>) {
     );
 
     let exit_code = match runtime.block_on(run_checked_with_factory_and_shutdown(
-            &cli.connector_socket,
-            &runtime_config,
-            &runtime_state,
-            &AzServiceBusTransportFactory,
-            async move {
-                let _ = shutdown_rx.await;
-            },
-        )) {
+        &cli.connector_socket,
+        &runtime_config,
+        &runtime_state,
+        &AzServiceBusTransportFactory,
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    )) {
         Ok(()) => 0,
         Err(err) => {
             eprintln!("{err}");
@@ -2153,7 +2150,11 @@ async fn run_cli() -> Result<(), CompanionError> {
                 CompanionError::Config("duplicate Windows service dispatch".to_string())
             })?;
             windows_service::service_dispatcher::start(SERVICE_NAME, ffi_service_main).map_err(
-                |err| CompanionError::Config(format!("failed to start Windows service dispatcher: {err}")),
+                |err| {
+                    CompanionError::Config(format!(
+                        "failed to start Windows service dispatcher: {err}"
+                    ))
+                },
             )?;
         }
     }
@@ -2171,6 +2172,10 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     #[cfg(unix)]
+    use super::bridge_runtime_with_shutdown;
+    #[cfg(windows)]
+    use super::build_service_launch_args;
+    #[cfg(unix)]
     use super::validate_certificate_matches_private_key;
     use super::{
         build_az_bootstrap_script, check_runtime_ready, cleanup_staging, commit_staging,
@@ -2185,10 +2190,6 @@ mod tests {
         CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME, SERVICE_BUS_CONFIG_FILENAME,
         SERVICE_PRINCIPAL_STATE_FILENAME, STATE_GENERATION_PREFIX,
     };
-    #[cfg(unix)]
-    use super::bridge_runtime_with_shutdown;
-    #[cfg(windows)]
-    use super::build_service_launch_args;
     #[cfg(windows)]
     use super::{Cli, Command};
     use azure_core::credentials::TokenCredential;
@@ -3583,14 +3584,9 @@ mod tests {
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
         let bridge_task = tokio::spawn(async move {
-            bridge_runtime_with_shutdown(
-                stream,
-                FakePublisher::default(),
-                consumer,
-                async move {
-                    let _ = shutdown_rx.await;
-                },
-            )
+            bridge_runtime_with_shutdown(stream, FakePublisher::default(), consumer, async move {
+                let _ = shutdown_rx.await;
+            })
             .await
         });
 

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -2090,7 +2090,11 @@ fn set_service_status_with_progress(
         service_type: ServiceType::OWN_PROCESS,
         current_state,
         controls_accepted,
-        exit_code: ServiceExitCode::Win32(exit_code),
+        exit_code: if exit_code == 0 {
+            ServiceExitCode::Win32(0)
+        } else {
+            ServiceExitCode::ServiceSpecific(exit_code)
+        },
         checkpoint,
         wait_hint,
         process_id: None,

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -1960,19 +1960,38 @@ fn uninstall_service() -> Result<(), CompanionError> {
         }
     };
 
-    service.delete().map_err(|err| {
-        CompanionError::Config(format!("failed to delete {SERVICE_NAME} service: {err}"))
-    })?;
-
-    let status = service.query_status().map_err(|err| {
+    let mut status = service.query_status().map_err(|err| {
         CompanionError::Config(format!("failed to query {SERVICE_NAME} status: {err}"))
     })?;
     if status.current_state != ServiceState::Stopped {
-        service.stop().map_err(|err| {
-            CompanionError::Config(format!("failed to stop {SERVICE_NAME} service: {err}"))
-        })?;
-        println!("Stopping {SERVICE_NAME} service...");
+        if status.current_state != ServiceState::StopPending {
+            service.stop().map_err(|err| {
+                CompanionError::Config(format!("failed to stop {SERVICE_NAME} service: {err}"))
+            })?;
+            println!("Stopping {SERVICE_NAME} service...");
+        }
+
+        let stop_deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < stop_deadline {
+            status = service.query_status().map_err(|err| {
+                CompanionError::Config(format!("failed to query {SERVICE_NAME} status: {err}"))
+            })?;
+            if status.current_state == ServiceState::Stopped {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+
+        if status.current_state != ServiceState::Stopped {
+            return Err(CompanionError::Config(format!(
+                "timed out waiting for {SERVICE_NAME} service to stop"
+            )));
+        }
     }
+
+    service.delete().map_err(|err| {
+        CompanionError::Config(format!("failed to delete {SERVICE_NAME} service: {err}"))
+    })?;
 
     drop(service);
 
@@ -2072,15 +2091,28 @@ fn service_entry(_arguments: Vec<std::ffi::OsString>) {
         }
     };
 
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            eprintln!("failed to create tokio runtime for {SERVICE_NAME}: {err}");
+            set_service_status(
+                &status_handle,
+                ServiceState::Stopped,
+                ServiceControlAccept::empty(),
+                1,
+            );
+            return;
+        }
+    };
+
     set_service_status(
         &status_handle,
         ServiceState::Running,
-        ServiceControlAccept::STOP,
+        ServiceControlAccept::STOP | ServiceControlAccept::SHUTDOWN,
         0,
     );
 
-    let exit_code = match tokio::runtime::Runtime::new() {
-        Ok(runtime) => match runtime.block_on(run_checked_with_factory_and_shutdown(
+    let exit_code = match runtime.block_on(run_checked_with_factory_and_shutdown(
             &cli.connector_socket,
             &runtime_config,
             &runtime_state,
@@ -2089,14 +2121,9 @@ fn service_entry(_arguments: Vec<std::ffi::OsString>) {
                 let _ = shutdown_rx.await;
             },
         )) {
-            Ok(()) => 0,
-            Err(err) => {
-                eprintln!("{err}");
-                1
-            }
-        },
+        Ok(()) => 0,
         Err(err) => {
-            eprintln!("failed to create tokio runtime for {SERVICE_NAME}: {err}");
+            eprintln!("{err}");
             1
         }
     };

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -2101,6 +2101,13 @@ fn set_service_status_with_progress(
 #[cfg(windows)]
 fn log_service_diagnostic(state_dir: &Path, message: &str) {
     let log_path = state_dir.join("service.log");
+    if let Err(err) = std::fs::create_dir_all(state_dir) {
+        eprintln!(
+            "{SERVICE_NAME}: failed to create service diagnostic directory {}: {err}",
+            state_dir.display()
+        );
+        return;
+    }
     match std::fs::OpenOptions::new()
         .create(true)
         .append(true)

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -76,6 +76,18 @@ const CLIENT_ASSERTION_TYPE: &str = "urn:ietf:params:oauth:client-assertion-type
 const TOKEN_HTTP_CONNECT_TIMEOUT_SECS: u64 = 10;
 const TOKEN_HTTP_TIMEOUT_SECS: u64 = 30;
 
+#[cfg(windows)]
+const SERVICE_NAME: &str = "sonde-azure-companion";
+#[cfg(windows)]
+const SERVICE_DISPLAY_NAME: &str = "Sonde Azure Companion";
+#[cfg(windows)]
+const SERVICE_DESCRIPTION: &str =
+    "Bridges the Sonde gateway connector to Azure Service Bus.";
+#[cfg(windows)]
+static SERVICE_CLI: OnceLock<Cli> = OnceLock::new();
+#[cfg(windows)]
+windows_service::define_windows_service!(ffi_service_main, service_entry);
+
 #[derive(Debug, Error)]
 enum CompanionError {
     #[error("{0}")]
@@ -99,7 +111,7 @@ enum CompanionError {
 trait AsyncIo: AsyncRead + AsyncWrite + Unpin + Send {}
 impl<T> AsyncIo for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Clone, Parser)]
 #[command(name = "sonde-azure-companion")]
 struct Cli {
     /// Gateway admin socket path (UDS on Unix, named pipe on Windows).
@@ -118,7 +130,7 @@ struct Cli {
     command: Option<Command>,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Clone, Subcommand)]
 enum Command {
     /// Start the long-running Azure connector runtime.
     Run,
@@ -132,9 +144,19 @@ enum Command {
     /// Check whether the persisted runtime state and runtime configuration are present.
     #[command(hide = true)]
     CheckRuntimeReady,
+    /// Install the Windows service registration (requires Administrator).
+    #[cfg(windows)]
+    Install,
+    /// Remove the Windows service registration (requires Administrator).
+    #[cfg(windows)]
+    Uninstall,
+    /// Run under the Windows Service Control Manager.
+    #[cfg(windows)]
+    #[command(hide = true)]
+    Service,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 struct BootstrapArgs {
     /// Azure region for Bicep deployment.
     #[arg(long, env = "SONDE_AZURE_LOCATION", default_value = "eastus")]
@@ -1381,15 +1403,37 @@ where
     Ok(())
 }
 
+#[cfg(all(test, unix))]
 async fn bridge_runtime<T, P, C>(
     stream: T,
-    mut publisher: P,
-    mut consumer: C,
+    publisher: P,
+    consumer: C,
 ) -> Result<(), CompanionError>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     P: UpstreamPublisher + 'static,
     C: DownstreamConsumer + 'static,
+{
+    bridge_runtime_with_shutdown(
+        stream,
+        publisher,
+        consumer,
+        std::future::pending::<()>(),
+    )
+    .await
+}
+
+async fn bridge_runtime_with_shutdown<T, P, C, S>(
+    stream: T,
+    mut publisher: P,
+    mut consumer: C,
+    shutdown: S,
+) -> Result<(), CompanionError>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    P: UpstreamPublisher + 'static,
+    C: DownstreamConsumer + 'static,
+    S: std::future::Future<Output = ()>,
 {
     let (mut reader, mut writer) = tokio::io::split(stream);
     let upstream = async move {
@@ -1397,6 +1441,7 @@ where
         Ok::<(), CompanionError>(())
     };
     tokio::pin!(upstream);
+    tokio::pin!(shutdown);
 
     loop {
         tokio::select! {
@@ -1413,6 +1458,12 @@ where
                     }
                     return Err(err);
                 }
+            }
+            _ = &mut shutdown => {
+                if let Err(abandon_err) = consumer.abandon_inflight().await {
+                    eprintln!("failed to abandon downstream Service Bus message during service shutdown: {abandon_err}");
+                }
+                return Ok(());
             }
         }
     }
@@ -1443,13 +1494,36 @@ where
     F::Publisher: 'static,
     F::Consumer: 'static,
 {
+    run_checked_with_factory_and_shutdown(
+        connector_socket,
+        runtime_config,
+        runtime_state,
+        factory,
+        std::future::pending::<()>(),
+    )
+    .await
+}
+
+async fn run_checked_with_factory_and_shutdown<F, S>(
+    connector_socket: &str,
+    runtime_config: &RuntimeConfig,
+    runtime_state: &RuntimeCredentialState,
+    factory: &F,
+    shutdown: S,
+) -> Result<(), CompanionError>
+where
+    F: BrokerTransportFactory,
+    F::Publisher: 'static,
+    F::Consumer: 'static,
+    S: std::future::Future<Output = ()>,
+{
     let (publisher, consumer) = factory.connect(runtime_config, runtime_state).await?;
     let stream = connect_connector(connector_socket).await?;
     eprintln!(
         "connected to gateway connector at {connector_socket} and Azure Service Bus namespace {}",
         runtime_config.namespace
     );
-    bridge_runtime(stream, publisher, consumer).await
+    bridge_runtime_with_shutdown(stream, publisher, consumer, shutdown).await
 }
 
 async fn run(connector_socket: &str, state_dir: &Path) -> Result<(), CompanionError> {
@@ -1776,14 +1850,286 @@ async fn bootstrap(
     Ok(())
 }
 
+#[cfg(windows)]
+fn build_service_launch_args() -> Vec<std::ffi::OsString> {
+    build_service_launch_args_from_iter(std::env::args_os().skip(1))
+}
+
+#[cfg(windows)]
+fn build_service_launch_args_from_iter<I>(args: I) -> Vec<std::ffi::OsString>
+where
+    I: IntoIterator<Item = std::ffi::OsString>,
+{
+    std::iter::once(std::ffi::OsString::from("service"))
+        .chain(
+            args.into_iter()
+                .filter(|arg| arg.to_str() != Some("install")),
+        )
+        .collect()
+}
+
+#[cfg(windows)]
+fn install_service() -> Result<(), CompanionError> {
+    use windows_service::service::{
+        ServiceAccess, ServiceErrorControl, ServiceInfo, ServiceStartType, ServiceType,
+    };
+    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+    use windows_sys::Win32::Foundation::ERROR_SERVICE_EXISTS;
+
+    let manager = ServiceManager::local_computer(
+        None::<&str>,
+        ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE,
+    )
+    .map_err(|err| CompanionError::Config(format!("failed to open Service Control Manager: {err}")))?;
+
+    let exe_path = std::env::current_exe()?;
+    let service_info = ServiceInfo {
+        name: std::ffi::OsString::from(SERVICE_NAME),
+        display_name: std::ffi::OsString::from(SERVICE_DISPLAY_NAME),
+        service_type: ServiceType::OWN_PROCESS,
+        start_type: ServiceStartType::AutoStart,
+        error_control: ServiceErrorControl::Normal,
+        executable_path: exe_path,
+        launch_arguments: build_service_launch_args(),
+        dependencies: vec![],
+        account_name: None,
+        account_password: None,
+    };
+
+    match manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG) {
+        Ok(service) => {
+            service.set_description(SERVICE_DESCRIPTION).map_err(|err| {
+                CompanionError::Config(format!("failed to set service description: {err}"))
+            })?;
+        }
+        Err(windows_service::Error::Winapi(err))
+            if err.raw_os_error() == Some(ERROR_SERVICE_EXISTS as i32) =>
+        {
+            let service = manager
+                .open_service(SERVICE_NAME, ServiceAccess::CHANGE_CONFIG)
+                .map_err(|open_err| {
+                    CompanionError::Config(format!(
+                        "failed to open existing {SERVICE_NAME} service: {open_err}"
+                    ))
+                })?;
+            service.change_config(&service_info).map_err(|change_err| {
+                CompanionError::Config(format!(
+                    "failed to update existing {SERVICE_NAME} service: {change_err}"
+                ))
+            })?;
+            service.set_description(SERVICE_DESCRIPTION).map_err(|err| {
+                CompanionError::Config(format!("failed to set service description: {err}"))
+            })?;
+        }
+        Err(err) => {
+            return Err(CompanionError::Config(format!(
+                "failed to create {SERVICE_NAME} service: {err}"
+            )));
+        }
+    }
+
+    println!("{SERVICE_NAME} service installed successfully.");
+    Ok(())
+}
+
+#[cfg(windows)]
+fn uninstall_service() -> Result<(), CompanionError> {
+    use std::time::{Duration, Instant};
+    use windows_service::service::{ServiceAccess, ServiceState};
+    use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
+    use windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST;
+
+    let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
+        .map_err(|err| CompanionError::Config(format!("failed to open Service Control Manager: {err}")))?;
+
+    let service = match manager.open_service(
+        SERVICE_NAME,
+        ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE,
+    ) {
+        Ok(service) => service,
+        Err(windows_service::Error::Winapi(err))
+            if err.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) =>
+        {
+            println!("{SERVICE_NAME} service is not registered.");
+            return Ok(());
+        }
+        Err(err) => {
+            return Err(CompanionError::Config(format!(
+                "failed to open {SERVICE_NAME} service: {err}"
+            )));
+        }
+    };
+
+    service.delete().map_err(|err| {
+        CompanionError::Config(format!("failed to delete {SERVICE_NAME} service: {err}"))
+    })?;
+
+    let status = service.query_status().map_err(|err| {
+        CompanionError::Config(format!("failed to query {SERVICE_NAME} status: {err}"))
+    })?;
+    if status.current_state != ServiceState::Stopped {
+        service.stop().map_err(|err| {
+            CompanionError::Config(format!("failed to stop {SERVICE_NAME} service: {err}"))
+        })?;
+        println!("Stopping {SERVICE_NAME} service...");
+    }
+
+    drop(service);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        match manager.open_service(SERVICE_NAME, ServiceAccess::QUERY_STATUS) {
+            Err(windows_service::Error::Winapi(err))
+                if err.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) =>
+            {
+                println!("{SERVICE_NAME} service uninstalled successfully.");
+                return Ok(());
+            }
+            _ => std::thread::sleep(Duration::from_millis(500)),
+        }
+    }
+
+    println!("{SERVICE_NAME} service is marked for deletion.");
+    Ok(())
+}
+
+#[cfg(windows)]
+fn set_service_status(
+    status_handle: &windows_service::service_control_handler::ServiceStatusHandle,
+    current_state: windows_service::service::ServiceState,
+    controls_accepted: windows_service::service::ServiceControlAccept,
+    exit_code: u32,
+) {
+    use windows_service::service::{ServiceExitCode, ServiceStatus, ServiceType};
+
+    let status = ServiceStatus {
+        service_type: ServiceType::OWN_PROCESS,
+        current_state,
+        controls_accepted,
+        exit_code: ServiceExitCode::Win32(exit_code),
+        checkpoint: 0,
+        wait_hint: Duration::default(),
+        process_id: None,
+    };
+    let _ = status_handle.set_service_status(status);
+}
+
+#[cfg(windows)]
+fn service_entry(_arguments: Vec<std::ffi::OsString>) {
+    use std::sync::{Arc, Mutex};
+    use windows_service::service::{ServiceControl, ServiceControlAccept, ServiceState};
+    use windows_service::service_control_handler::{self, ServiceControlHandlerResult};
+
+    let cli = match SERVICE_CLI.get() {
+        Some(cli) => cli,
+        None => return,
+    };
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let shutdown_tx = Arc::new(Mutex::new(Some(shutdown_tx)));
+
+    let event_handler = move |control_event| -> ServiceControlHandlerResult {
+        match control_event {
+            ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+            ServiceControl::Stop | ServiceControl::Shutdown => {
+                if let Ok(mut guard) = shutdown_tx.lock() {
+                    if let Some(tx) = guard.take() {
+                        let _ = tx.send(());
+                    }
+                }
+                ServiceControlHandlerResult::NoError
+            }
+            _ => ServiceControlHandlerResult::NotImplemented,
+        }
+    };
+
+    let status_handle = match service_control_handler::register(SERVICE_NAME, event_handler) {
+        Ok(handle) => handle,
+        Err(err) => {
+            eprintln!("{SERVICE_NAME}: failed to register service control handler: {err}");
+            return;
+        }
+    };
+
+    set_service_status(
+        &status_handle,
+        ServiceState::StartPending,
+        ServiceControlAccept::empty(),
+        0,
+    );
+
+    let (runtime_config, runtime_state) = match check_runtime_ready(&cli.state_dir) {
+        Ok(ready) => ready,
+        Err(err) => {
+            eprintln!("{err}");
+            set_service_status(
+                &status_handle,
+                ServiceState::Stopped,
+                ServiceControlAccept::empty(),
+                1,
+            );
+            return;
+        }
+    };
+
+    set_service_status(
+        &status_handle,
+        ServiceState::Running,
+        ServiceControlAccept::STOP,
+        0,
+    );
+
+    let exit_code = match tokio::runtime::Runtime::new() {
+        Ok(runtime) => match runtime.block_on(run_checked_with_factory_and_shutdown(
+            &cli.connector_socket,
+            &runtime_config,
+            &runtime_state,
+            &AzServiceBusTransportFactory,
+            async move {
+                let _ = shutdown_rx.await;
+            },
+        )) {
+            Ok(()) => 0,
+            Err(err) => {
+                eprintln!("{err}");
+                1
+            }
+        },
+        Err(err) => {
+            eprintln!("failed to create tokio runtime for {SERVICE_NAME}: {err}");
+            1
+        }
+    };
+
+    set_service_status(
+        &status_handle,
+        ServiceState::Stopped,
+        ServiceControlAccept::empty(),
+        exit_code,
+    );
+}
+
 async fn run_cli() -> Result<(), CompanionError> {
     let cli = Cli::parse();
-    match cli.command.unwrap_or(Command::Run) {
+    match cli.command.clone().unwrap_or(Command::Run) {
         Command::Run => run(&cli.connector_socket, &cli.state_dir).await?,
         Command::Bootstrap(args) => bootstrap(&cli.admin_socket, &cli.state_dir, args).await?,
         Command::DisplayMessage { lines } => display_message(&cli.admin_socket, lines).await?,
         Command::CheckRuntimeReady => {
             check_runtime_ready(&cli.state_dir)?;
+        }
+        #[cfg(windows)]
+        Command::Install => install_service()?,
+        #[cfg(windows)]
+        Command::Uninstall => uninstall_service()?,
+        #[cfg(windows)]
+        Command::Service => {
+            SERVICE_CLI.set(cli.clone()).map_err(|_| {
+                CompanionError::Config("duplicate Windows service dispatch".to_string())
+            })?;
+            windows_service::service_dispatcher::start(SERVICE_NAME, ffi_service_main).map_err(
+                |err| CompanionError::Config(format!("failed to start Windows service dispatcher: {err}")),
+            )?;
         }
     }
     Ok(())
@@ -1814,6 +2160,10 @@ mod tests {
         CONNECTOR_MAX_FRAME_LENGTH, KEY_PEM_FILENAME, SERVICE_BUS_CONFIG_FILENAME,
         SERVICE_PRINCIPAL_STATE_FILENAME, STATE_GENERATION_PREFIX,
     };
+    #[cfg(unix)]
+    use super::bridge_runtime_with_shutdown;
+    #[cfg(windows)]
+    use super::build_service_launch_args_from_iter;
     use azure_core::credentials::TokenCredential;
     #[cfg(unix)]
     use base64::Engine as _;
@@ -3184,6 +3534,65 @@ mod tests {
             .contains("injected downstream write failure"));
         assert_eq!(abandon_inflight_calls.load(Ordering::SeqCst), 1);
         assert_eq!(abandon_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bridge_runtime_returns_ok_on_shutdown_signal() {
+        let reader_state = Arc::new(ReaderState::new());
+        let write_started = Arc::new(Notify::new());
+        let inflight_set = Arc::new(Notify::new());
+        let abandons = Arc::new(AtomicUsize::new(0));
+        let stream = ShutdownTestStream {
+            reader_state,
+            write_started,
+        };
+        let consumer = ShutdownAwareConsumer {
+            payload: Some(vec![1u8, 2, 3]),
+            inflight: false,
+            inflight_set: Arc::clone(&inflight_set),
+            abandons: Arc::clone(&abandons),
+        };
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let bridge_task = tokio::spawn(async move {
+            bridge_runtime_with_shutdown(
+                stream,
+                FakePublisher::default(),
+                consumer,
+                async move {
+                    let _ = shutdown_rx.await;
+                },
+            )
+            .await
+        });
+
+        inflight_set.notified().await;
+        shutdown_tx.send(()).unwrap();
+
+        bridge_task.await.unwrap().unwrap();
+        assert_eq!(abandons.load(Ordering::SeqCst), 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn service_launch_args_replace_install_with_service() {
+        use std::ffi::OsString;
+
+        let args = build_service_launch_args_from_iter([
+            OsString::from("install"),
+            OsString::from("--state-dir"),
+            OsString::from(r"C:\ProgramData\sonde-azure-companion"),
+        ]);
+
+        assert_eq!(
+            args,
+            vec![
+                OsString::from("service"),
+                OsString::from("--state-dir"),
+                OsString::from(r"C:\ProgramData\sonde-azure-companion"),
+            ]
+        );
     }
 
     #[test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -132,7 +132,7 @@ struct Cli {
     #[arg(long, global = true, env = "SONDE_GATEWAY_CONNECTOR_SOCKET", default_value = DEFAULT_CONNECTOR_SOCKET)]
     connector_socket: String,
 
-    /// Mounted state directory reserved for bootstrap output and runtime auth material.
+    /// Persistent state directory reserved for bootstrap output and runtime auth material.
     #[arg(long, global = true, env = "SONDE_AZURE_COMPANION_STATE_DIR", default_value_os_t = default_state_dir())]
     state_dir: PathBuf,
 

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -3,8 +3,9 @@
 # Azure Companion Design Specification
 
 > **Document status:** Draft
-> **Scope:** Internal design for the Azure companion container, bootstrap-state
-> detection, bootstrap trigger behavior, integrated provisioning orchestration
+> **Scope:** Internal design for the Azure companion deployment surfaces
+> (Linux container and Windows native service), bootstrap-state detection,
+> bootstrap trigger behavior, integrated provisioning orchestration
 > (certificate generation, Bicep deployment via Docker API, runtime artifact
 > creation), and the Service Bus AMQP runtime bridge.
 > The Bicep module definitions themselves are specified in
@@ -20,8 +21,8 @@
 
 ## 1  Overview
 
-The Azure companion is a Rust workspace crate that runs in its own container and
-talks to `sonde-gateway` over two local gateway-facing surfaces:
+The Azure companion is a Rust workspace crate that talks to
+`sonde-gateway` over two local gateway-facing surfaces:
 
 1. the admin gRPC API for bootstrap-only operator-visible actions, and
 2. the local framed connector API for long-running runtime traffic.
@@ -29,7 +30,8 @@ talks to `sonde-gateway` over two local gateway-facing surfaces:
 The Azure companion now has two distinct responsibilities:
 
 1. detect whether bootstrap has already completed,
-2. invoke bootstrap when the required local provisioning artifacts are missing,
+2. invoke bootstrap on the Linux/container path when the required local
+   provisioning artifacts are missing,
 3. use the gateway admin API to display the device code during bootstrap,
 4. orchestrate the full provisioning lifecycle (certificate generation, Bicep
    deployment via the Docker API, and runtime artifact creation), and
@@ -43,7 +45,7 @@ logic is confined to the Azure companion.
 
 ## 2  Repository layout
 
-> **Requirements:** AZC-0100, AZC-0102
+> **Requirements:** AZC-0100, AZC-0102, AZC-0103, AZC-0104
 
 The implementation adds or updates the following artifacts:
 
@@ -53,6 +55,7 @@ The implementation adds or updates the following artifacts:
 | `.github/docker/Dockerfile.azure-companion` | Dockerfile for the dedicated Azure companion image. |
 | `deploy/azure-companion/bootstrap.sh` | Host/container bootstrap script that prepares the mounted state volume, evaluates bootstrap-complete state, and starts either bootstrap or runtime. |
 | `deploy/azure-companion/entrypoint.sh` | In-container entrypoint that orchestrates bootstrap-state detection before starting the Rust binary. |
+| `installer/windows/sonde.wxs` | Windows MSI definition that exposes the Azure companion as an optional installer feature and can register the companion service. |
 
 The long-running binary is named `sonde-azure-companion`.
 
@@ -60,67 +63,118 @@ The long-running binary is named `sonde-azure-companion`.
 
 ## 3  Runtime architecture
 
-> **Requirements:** AZC-0100, AZC-0101, AZC-0102, AZC-0301, AZC-0302, AZC-0303, AZC-0304, AZC-0305, AZC-0310, AZC-0311
+> **Requirements:** AZC-0100, AZC-0101, AZC-0102, AZC-0103, AZC-0104, AZC-0105, AZC-0205, AZC-0301, AZC-0302, AZC-0303, AZC-0304, AZC-0305, AZC-0310, AZC-0311
 
 ### 3.1  Process model
 
-The container runs a small shell entrypoint that performs filesystem and startup
-orchestration and then execs the Rust binary. The split is intentional:
+The Azure companion has platform-specific deployment entrypoints:
+
+1. **Linux container deployment** uses a small shell entrypoint that performs
+   filesystem and startup orchestration and then execs the Rust binary.
+2. **Windows native-service deployment** is started directly by SCM and runs the
+   Rust binary without the Linux shell wrapper.
+
+This keeps the gateway-facing logic and Azure-facing runtime in typed Rust while
+still allowing a small Alpine-oriented Linux image and a native Windows service
+story.
+
+#### 3.1.1  Linux container startup
+
+For Linux container deployment:
 
 1. **Shell script** handles environment preparation, state-directory setup, and
    bootstrap-state detection orchestration.
 2. **Rust binary** owns gateway admin gRPC communication, connector-socket
    runtime communication, bootstrap device flow, and broker integration.
 
-This keeps the gateway-facing logic and Azure-facing runtime in typed Rust while
-still allowing a small Alpine-oriented container image.
+#### 3.1.2  Windows native-service startup
+
+For Windows deployment:
+
+1. SCM launches the real `sonde-azure-companion` binary directly.
+2. The binary exposes service-management entrypoints (`install` / `uninstall`)
+   plus a service runtime entrypoint used by SCM.
+3. The service runtime uses the Windows defaults for the admin pipe, connector
+   pipe, and persistent state directory unless the operator overrides them.
+4. If bootstrap-complete state is absent, the service fails closed with a clear
+   diagnostic rather than attempting to run the Docker-backed bootstrap flow
+   automatically.
 
 ### 3.2  Mounted and configured inputs
 
-The container expects the following runtime inputs:
+The active deployment entrypoint expects the following runtime inputs:
 
 | Input | Purpose |
 |-------|---------|
-| State volume | Persistent storage for local provisioning artifacts such as the runtime certificate PEM, private-key PEM, service-principal metadata file, and persisted Service Bus configuration. |
+| State directory | Persistent storage for local provisioning artifacts such as the runtime certificate PEM, private-key PEM, service-principal metadata file, and persisted Service Bus configuration. On Linux this is the mounted state volume; on Windows this defaults to `%ProgramData%\sonde-azure-companion`. |
 | Gateway admin socket | Local IPC path used by bootstrap to call `GatewayAdmin` RPCs such as `ShowModemDisplayMessage`. |
 | Gateway connector socket | Local framed IPC path used by the long-running runtime after bootstrap succeeds. |
-| Docker socket (bootstrap only) | Docker Engine API socket, bind-mounted from the host, used by bootstrap to run the Azure CLI container via Bollard. Not required for normal runtime operation. |
+| Docker socket (bootstrap only) | Docker Engine API socket, bind-mounted from the host, used by bootstrap to run the Azure CLI container via Bollard. This is part of the Linux/container bootstrap path and is not a steady-state Windows service requirement. |
 | Service Bus namespace | Runtime configuration for the Azure Service Bus namespace, from environment variable or persisted `service-bus.json`. |
 | Upstream queue name | Runtime configuration for the queue that carries gateway-originated connector messages, from environment variable or persisted `service-bus.json`. |
 | Downstream queue name | Runtime configuration for the queue that carries cloud-originated desired-state messages, from environment variable or persisted `service-bus.json`. |
 
 Bootstrap-complete state is defined by the combination of:
 
-1. the required local provisioning artifacts in the state volume, and
+1. the required local provisioning artifacts in the state directory, and
 2. the required queue configuration (from either environment variables or
-   persisted `service-bus.json` in the state volume).
+   persisted `service-bus.json` in the state directory).
 
 The current runtime artifact shape is a companion-owned `service-principal.json`
 file containing the Entra tenant ID, client ID, PEM certificate path, and PEM
-private-key path, plus the referenced certificate and key files in the mounted
-state directory. After bootstrap, the state volume also contains
+private-key path, plus the referenced certificate and key files in the state
+directory. After bootstrap, the state directory also contains
 `service-bus.json` with the Service Bus namespace and queue names. New bootstrap
-commits are written into a generation directory under the state volume and made
+commits are written into a generation directory under the state directory and made
 current by atomically updating a `.current-state` marker file. For backward
 compatibility, startup also accepts the legacy flat-file layout when the marker
 is absent.
 
 ### 3.3  Bootstrap-state decision
 
-Startup follows this decision:
+Startup follows a platform-specific decision:
 
-1. Ensure the mounted state directory exists and is writable.
+1. Ensure the state directory exists and is writable.
 2. Check whether the required local provisioning artifacts exist.
-3. Check whether the required Service Bus namespace and queue configuration are present.
-4. If both are present, skip bootstrap and start `run`.
-5. Otherwise, start `bootstrap`.
+3. Check whether the required Service Bus namespace and queue configuration are
+   present.
+4. **Linux container path:** if both are present, skip bootstrap and start
+   `run`; otherwise start `bootstrap`.
+5. **Windows service path:** if both are present, start `run`; otherwise emit a
+   clear diagnostic and exit with a non-zero service status.
 
-When bootstrap is entered, the unified `bootstrap` subcommand orchestrates the
-full provisioning lifecycle as described in section 4.2.
+When the Linux bootstrap path is entered, the unified `bootstrap` subcommand
+orchestrates the full provisioning lifecycle as described in section 4.2.
+
+### 3.4  Windows MSI integration
+
+The Windows installer exposes the Azure companion as an optional feature rather
+than a mandatory peer of the gateway binaries.
+
+1. The Azure companion feature is unchecked by default.
+2. If selected, the MSI installs the companion binary and registers the
+   `sonde-azure-companion` service with `SERVICE_AUTO_START`.
+3. If not selected, the MSI leaves the companion service unregistered.
+4. The MSI does not collect Azure tenant, subscription, namespace, queue, or
+   certificate settings; those are established later through explicit bootstrap
+   or provisioning steps outside the installer UI.
+5. Silent or unattended installs select the feature through standard MSI
+   feature/property input rather than requiring an interactive dialog.
+
+### 3.5  Windows CLI service management
+
+The companion binary mirrors the gateway's Windows service-management fallback:
+
+1. `sonde-azure-companion install` validates Administrator privileges and then
+   creates or updates the SCM service definition.
+2. `sonde-azure-companion uninstall` stops and deletes the service registration
+   idempotently.
+3. These commands manage only the service registration; they preserve the
+   companion state directory and provisioning artifacts.
 
 ---
 
-### 3.4  Live Azure CI runtime topology
+### 3.6  Live Azure CI runtime topology
 
 The live Azure validation workflow uses a narrower runtime topology than a full
 gateway deployment. It starts the real `sonde-azure-companion` runtime against:
@@ -133,7 +187,7 @@ The harness is sufficient because the purpose of this workflow is to validate
 the Azure companion's cloud bridge contract at the connector boundary, not to
 re-validate gateway startup, modem ownership, or admin gRPC behavior.
 
-### 3.5  Live validation sequence
+### 3.7  Live validation sequence
 
 Within the single manually triggered workflow, the live validation sequence is:
 
@@ -155,13 +209,16 @@ transport and the runtime bridge semantics already defined in section 5.
 
 ## 4  Bootstrap flow
 
-> **Requirements:** AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204, AZC-0300,
+> **Requirements:** AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204, AZC-0205, AZC-0300,
 > AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0407, AZC-0408
 
 ### 4.1  Bootstrap trigger
 
-Bootstrap is entered only when bootstrap-complete state is absent. This differs
-from the earlier draft, which always re-entered device-code login on restart.
+The Linux bootstrap path is entered only when bootstrap-complete state is
+absent. This differs from the earlier draft, which always re-entered device-code
+login on restart. The Windows service path does not auto-enter bootstrap when
+state is absent; it fails closed until the operator performs provisioning
+explicitly.
 
 Re-running the `bootstrap` subcommand explicitly (e.g., for credential rotation)
 is safe: it regenerates the certificate, re-runs Bicep, and rewrites the runtime
@@ -228,10 +285,11 @@ non-zero status. It does not continue to a console-only fallback.
 
 ## 5  Rust binary interface
 
-> **Requirements:** AZC-0100, AZC-0102, AZC-0201, AZC-0202, AZC-0300, AZC-0301, AZC-0302, AZC-0304, AZC-0305,
+> **Requirements:** AZC-0100, AZC-0102, AZC-0103, AZC-0104, AZC-0105, AZC-0201, AZC-0202, AZC-0205, AZC-0300, AZC-0301, AZC-0302, AZC-0304, AZC-0305,
 > AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406
 
-The `sonde-azure-companion` binary exposes three modes:
+The `sonde-azure-companion` binary exposes three cross-platform runtime modes
+plus Windows service-management entrypoints:
 
 1. **`run`** — default long-running runtime mode. It connects to the gateway
    connector socket and bridges connector traffic to Azure Service Bus.
@@ -244,6 +302,13 @@ The `sonde-azure-companion` binary exposes three modes:
    display it on the modem via the gateway admin API.
 3. **`display-message`** — helper mode used by bootstrap logic to call the
    gateway admin `ShowModemDisplayMessage` RPC with 1 to 4 lines of text.
+4. **`install`** *(Windows)* — registers or updates the native Windows service
+   definition used for steady-state runtime.
+5. **`uninstall`** *(Windows)* — removes the native Windows service definition
+   without deleting persisted companion state.
+6. **service runtime entrypoint** *(Windows)* — the SCM-launched execution path
+   that performs the runtime-ready check and either starts `run` or fails closed
+   per AZC-0205.
 
 The companion receives explicit runtime configuration for the Service Bus
 namespace and queue names rather than inferring deployment-specific defaults.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -5,11 +5,12 @@
 > **Document status:** Draft
 > **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771),
 > connector redesign discovery review, and Azure Service Bus discovery review.
-> **Scope:** This document covers the Azure companion container, bootstrap-state
-> detection, bootstrap-trigger behavior, the integrated Azure provisioning
-> orchestration (certificate generation, Bicep deployment via Docker API, and
-> runtime artifact creation), and the long-running Azure Service Bus runtime
-> bridge between `sonde-gateway` and an external Azure control plane.
+> **Scope:** This document covers the Azure companion deployment surfaces
+> (Linux container and Windows native service), bootstrap-state detection,
+> bootstrap-trigger behavior, the integrated Azure provisioning orchestration
+> (certificate generation, Bicep deployment via Docker API, and runtime
+> artifact creation), and the long-running Azure Service Bus runtime bridge
+> between `sonde-gateway` and an external Azure control plane.
 > The Bicep module definitions themselves are specified in
 > [azure-provisioning-requirements.md](azure-provisioning-requirements.md).
 > **Related:** [azure-provisioning-requirements.md](azure-provisioning-requirements.md),
@@ -23,8 +24,9 @@
 
 | Term | Definition |
 |------|------------|
-| **Azure companion** | The Rust process that runs in its own container and integrates with `sonde-gateway` through the local admin API for bootstrap-only operator-visible actions and the local connector API for long-running runtime traffic. |
+| **Azure companion** | The Rust process that integrates with `sonde-gateway` through the local admin API for bootstrap-only operator-visible actions and the local connector API for long-running runtime traffic. On Linux it is deployed in its own container; on Windows it may be deployed as a native service. |
 | **State volume** | A mounted persistent directory reserved for Azure companion bootstrap output and other local provisioning artifacts. |
+| **State directory** | The platform-owned persistent directory that stores Azure companion provisioning artifacts. On Linux this is provided by the mounted state volume; on Windows the default location is `%ProgramData%\sonde-azure-companion`. |
 | **Provisioning artifacts** | The local certificate PEM, private-key PEM, and related companion-owned state that indicate Azure bootstrap has already completed. |
 | **Queue configuration** | The Azure Service Bus namespace and the names of the upstream and downstream queues, supplied to the companion through either environment variables or a persisted configuration file (`service-bus.json`) written by bootstrap. Both sources are valid; persisted configuration is the primary source after bootstrap, and environment variables may override it. |
 | **Bootstrap-complete state** | The condition where the required provisioning artifacts exist and the required queue configuration is present (from either source), allowing the companion to skip bootstrap and start runtime directly. |
@@ -45,7 +47,7 @@ Each requirement uses the following fields:
 
 ---
 
-## 3  Container packaging and bootstrap entrypoints
+## 3  Deployment packaging and bootstrap entrypoints
 
 ### AZC-0100  Dedicated companion container image
 
@@ -111,6 +113,73 @@ dedicated container.
 
 ---
 
+### AZC-0103  Windows native service deployment
+
+**Priority:** Must
+**Source:** [issue #837](https://github.com/Alan-Jowett/sonde/issues/837), gateway Windows service model
+
+**Description:**
+On Windows, the repository MUST support deploying `sonde-azure-companion` as a
+native SCM-managed service rather than requiring the Linux-oriented container
+wrapper. The native service MUST use the companion's Windows defaults for the
+gateway admin pipe, gateway connector pipe, and persistent state directory
+unless the operator overrides them explicitly.
+
+**Acceptance criteria:**
+
+1. `sonde-azure-companion` can be registered as a Windows service that starts the real native binary, not the Linux container bootstrap wrapper.
+2. The registered service uses `SERVICE_AUTO_START`.
+3. By default, the Windows service uses `\\.\pipe\sonde-admin` for the admin pipe, `\\.\pipe\sonde-connector` for the connector pipe, and `%ProgramData%\sonde-azure-companion` for persistent state.
+4. Starting and stopping the service through SCM reaches the same runtime bridge behavior as invoking the native binary directly.
+
+---
+
+### AZC-0104  Optional Windows MSI companion component
+
+**Priority:** Must
+**Source:** [issue #837](https://github.com/Alan-Jowett/sonde/issues/837)
+
+**Description:**
+The Windows MSI installer MUST offer `sonde-azure-companion` as an optional
+component instead of always installing it with the gateway. The UI MUST expose
+this component as a checkbox that defaults to off. If the operator selects the
+component, the installer MUST install the companion binary and register the
+Windows service. The installer MUST NOT require an Azure-specific settings page
+or collect Azure runtime configuration during installation.
+
+**Acceptance criteria:**
+
+1. The MSI presents an Azure companion component choice whose default state is unchecked.
+2. When the component is not selected, the installer does not register a `sonde-azure-companion` service.
+3. When the component is selected, the installer installs the companion binary and registers the companion service.
+4. The installer does not prompt for Azure namespace, queue, tenant, subscription, certificate, or other Azure-specific settings.
+5. Silent or unattended installation can select the component through an MSI feature/property rather than requiring interactive UI.
+
+---
+
+### AZC-0105  Windows CLI service-management fallback
+
+**Priority:** Must
+**Source:** [issue #837](https://github.com/Alan-Jowett/sonde/issues/837), gateway Windows service model
+
+**Description:**
+The `sonde-azure-companion` binary MUST provide Windows CLI fallback commands
+to install and uninstall the companion service for scripted, repair, and
+headless scenarios. Re-running install with updated arguments MUST behave as an
+idempotent service configuration update. Uninstall MUST stop and delete the
+service registration without deleting persisted provisioning artifacts.
+
+**Acceptance criteria:**
+
+1. `sonde-azure-companion install` registers or updates the Windows service and exits successfully when run with Administrator privileges.
+2. Re-running `sonde-azure-companion install` updates the existing service configuration rather than failing with "service exists".
+3. `sonde-azure-companion uninstall` stops and removes the service registration.
+4. Running `sonde-azure-companion uninstall` when no service is registered exits successfully with an informational message.
+5. The install and uninstall commands require elevated privileges and fail with a clear message when run unprivileged.
+6. Installing or uninstalling the service does not delete `%ProgramData%\sonde-azure-companion` or its provisioning artifacts.
+
+---
+
 ## 4  Bootstrap-state detection and bootstrap trigger behavior
 
 ### AZC-0200  Startup decision based on bootstrap-complete state
@@ -119,10 +188,11 @@ dedicated container.
 **Source:** Azure Service Bus discovery review
 
 **Description:**
-At startup, the Azure companion MUST determine whether bootstrap has already
-completed. Bootstrap-complete state requires both the local provisioning
-artifacts and the required queue configuration. If either is missing, the
-companion MUST enter the bootstrap workflow instead of normal runtime mode.
+At startup, the Linux container entrypoint for the Azure companion MUST
+determine whether bootstrap has already completed. Bootstrap-complete state
+requires both the local provisioning artifacts and the required queue
+configuration. If either is missing, the Linux container entrypoint MUST enter
+the bootstrap workflow instead of normal runtime mode.
 
 **Acceptance criteria:**
 
@@ -214,6 +284,27 @@ login merely because the container restarted.
 1. Restarting the container with the required provisioning artifacts and queue configuration skips device-code login.
 2. Runtime startup after a restart does not require operator-visible bootstrap interaction when bootstrap-complete state is present.
 3. Removing either the required provisioning artifacts or queue configuration causes the next start to re-enter bootstrap.
+
+---
+
+### AZC-0205  Windows service startup fails closed before bootstrap
+
+**Priority:** Must
+**Source:** [issue #837](https://github.com/Alan-Jowett/sonde/issues/837)
+
+**Description:**
+When the Windows native service starts without bootstrap-complete state, it
+MUST fail closed with a clear operator-visible diagnostic instead of entering
+the current Docker-backed bootstrap flow automatically. Windows operators are
+expected to provision or bootstrap the companion explicitly before the service
+can start successfully in steady state.
+
+**Acceptance criteria:**
+
+1. Starting the Windows service without the required provisioning artifacts exits with a non-zero service status and surfaces a clear diagnostic identifying the missing state.
+2. Starting the Windows service without the required queue configuration exits with a non-zero service status and surfaces a clear diagnostic identifying the missing configuration.
+3. In the missing-state cases above, the Windows service does not attempt to pull or run the Azure CLI container automatically.
+4. Once bootstrap-complete state is present, restarting the Windows service starts the runtime bridge normally without requiring installer changes.
 
 ---
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -3,10 +3,11 @@
 # Azure Companion Validation Plan
 
 > **Document status:** Draft
-> **Scope:** Validation for the Azure companion container, bootstrap-state
-> detection, gateway admin/connector integration, provisioning orchestration
-> (certificate generation, Bicep deployment via Docker API, runtime artifact
-> creation), and Azure Service Bus bridge.
+> **Scope:** Validation for the Azure companion deployment surfaces (Linux
+> container and Windows native service), bootstrap-state detection, gateway
+> admin/connector integration, provisioning orchestration (certificate
+> generation, Bicep deployment via Docker API, runtime artifact creation), and
+> Azure Service Bus bridge.
 > **Audience:** Implementers and reviewers validating the Azure companion
 > bootstrap and runtime bridge behavior.
 > **Related:** [azure-provisioning-validation.md](azure-provisioning-validation.md),
@@ -260,6 +261,79 @@
 3. In the success sub-case, allow the harness write to complete and assert the Service Bus message is then settled successfully.
 4. In the failure sub-case, force the harness write to fail and assert the message is not reported as successfully processed.
 5. Assert: detected transport or local handoff failure is surfaced in workflow logs or process status.
+
+---
+
+### T-AZC-0119  `sonde-azure-companion install` registers the Windows service
+
+**Validates:** AZC-0103, AZC-0105
+
+**Procedure:**
+1. On a Windows machine with the companion binary on PATH, open an elevated PowerShell prompt.
+2. Run `sonde-azure-companion install`.
+3. Assert: the command exits with code 0 and prints a success message.
+4. Run `sc.exe qc sonde-azure-companion`.
+5. Assert: the service exists with `START_TYPE` = `AUTO_START`.
+6. Assert: the binary path references the native `sonde-azure-companion.exe` executable rather than the Linux container bootstrap wrapper.
+7. Run `sonde-azure-companion install` again.
+8. Assert: the command exits with code 0 and updates the existing service definition idempotently.
+9. Run `sonde-azure-companion install` from a non-elevated prompt.
+10. Assert: the command exits with a clear privilege error instead of modifying the service registration.
+
+---
+
+### T-AZC-0120  `sonde-azure-companion uninstall` removes the Windows service idempotently
+
+**Validates:** AZC-0105
+
+**Procedure:**
+1. Prerequisite: a service registered via `sonde-azure-companion install`.
+2. Start the service: `sc.exe start sonde-azure-companion`.
+3. Run `sonde-azure-companion uninstall` from an elevated prompt.
+4. Assert: the command exits with code 0.
+5. Run `sc.exe query sonde-azure-companion`.
+6. Assert: the service is not found.
+7. Assert: `%ProgramData%\sonde-azure-companion\` is preserved on disk.
+8. Run `sonde-azure-companion uninstall` again.
+9. Assert: the command exits with code 0 and prints an informational "not registered" message.
+10. Re-register the service, then run `sonde-azure-companion uninstall` from a non-elevated prompt.
+11. Assert: the command exits with a clear privilege error instead of deleting the service.
+
+---
+
+### T-AZC-0121  Windows service startup fails closed when bootstrap-complete state is missing
+
+**Validates:** AZC-0103, AZC-0205
+
+**Procedure:**
+1. Register the service via `sonde-azure-companion install`.
+2. Expose the gateway admin and connector named pipes at their default Windows paths.
+3. Ensure `%ProgramData%\sonde-azure-companion\` does not contain bootstrap-complete state.
+4. Start the service: `sc.exe start sonde-azure-companion`.
+5. Assert: the service does not reach steady `RUNNING` runtime-bridge operation.
+6. Assert: service diagnostics clearly identify the missing provisioning artifacts or queue configuration.
+7. Assert: the startup path does not attempt to pull or run the Azure CLI container automatically.
+8. Populate bootstrap-complete state in `%ProgramData%\sonde-azure-companion\` and restart the service.
+9. Assert: the service now starts the runtime bridge normally and connects through the default named-pipe paths.
+10. Stop the service through SCM.
+11. Assert: the service stops cleanly without deleting the populated bootstrap-complete state.
+
+---
+
+### T-AZC-0122  MSI companion feature is optional and defaults off
+
+**Validates:** AZC-0104
+
+**Procedure:**
+1. Install the MSI on a clean Windows VM and inspect the feature-selection UI.
+2. Assert: the Azure companion component is presented as an optional choice and is unchecked by default.
+3. Complete installation without selecting the component.
+4. Assert: `sc.exe query sonde-azure-companion` reports that the service is not installed.
+5. Re-run installation with the component selected.
+6. Assert: the companion binary is installed and `sc.exe qc sonde-azure-companion` succeeds.
+7. Assert: the installer does not prompt for Azure tenant, subscription, namespace, queue, or certificate settings.
+8. Perform a silent install selecting the companion feature via MSI property/feature selection.
+9. Assert: the companion service is installed successfully without interactive UI.
 
 ---
 

--- a/installer/windows/sonde.wxs
+++ b/installer/windows/sonde.wxs
@@ -141,7 +141,9 @@
                         Start="auto"
                         Type="ownProcess"
                         ErrorControl="normal"
-                        Arguments="service --state-dir &quot;[AZUREDATADIR]&quot;" />
+                        Arguments="--state-dir &quot;[AZUREDATADIR]&quot; service">
+          <ServiceDependency Id="sonde-gateway" />
+        </ServiceInstall>
         <ServiceControl Id="SondeAzureCompanionControl"
                         Name="sonde-azure-companion"
                         Stop="both"

--- a/installer/windows/sonde.wxs
+++ b/installer/windows/sonde.wxs
@@ -16,6 +16,7 @@
          -d Version=VERSION ^
          -d GatewayBin=target\release\sonde-gateway.exe ^
          -d AdminBin=target\release\sonde-admin.exe ^
+         -d AzureCompanionBin=target\release\sonde-azure-companion.exe ^
          -d CustomActionCaDll=installer\windows\CustomActions\bin\Release\net472\SondeCustomActions.CA.dll ^
          -ext WixToolset.UI.wixext ^
          -ext WixToolset.Util.wixext ^
@@ -36,7 +37,7 @@
     Compressed="yes"
     Scope="perMachine">
 
-    <SummaryInformation Keywords="Installer" Description="Sonde gateway and admin tools installer" />
+    <SummaryInformation Keywords="Installer" Description="Sonde gateway, admin tools, and optional Azure companion installer" />
 
     <MajorUpgrade
       DowngradeErrorMessage="A newer version of Sonde is already installed."
@@ -52,8 +53,14 @@
 
     <!-- ── Feature tree ──────────────────────────────────────────────── -->
     <Feature Id="ProductFeature" Title="Sonde" Level="1">
-      <ComponentGroupRef Id="BinariesGroup" />
-      <ComponentGroupRef Id="ConfigGroup" />
+      <Feature Id="GatewayFeature" Title="Gateway and admin tools" Level="1">
+        <ComponentGroupRef Id="BinariesGroup" />
+        <ComponentGroupRef Id="ConfigGroup" />
+      </Feature>
+      <Feature Id="AzureCompanionFeature" Title="Azure companion" Description="Optional Azure Service Bus bridge service" Level="2">
+        <ComponentGroupRef Id="AzureCompanionBinariesGroup" />
+        <ComponentGroupRef Id="AzureCompanionConfigGroup" />
+      </Feature>
     </Feature>
 
     <!-- ── Directory tree ───────────────────────────────────────────── -->
@@ -65,6 +72,7 @@
 
     <StandardDirectory Id="CommonAppDataFolder">
       <Directory Id="DATADIR" Name="sonde" />
+      <Directory Id="AZUREDATADIR" Name="sonde-azure-companion" />
     </StandardDirectory>
 
     <!-- ── Components ───────────────────────────────────────────────── -->
@@ -120,6 +128,34 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="AzureCompanionBinariesGroup" Directory="BinDir">
+      <Component Id="AzureCompanionExe" Guid="D4E5F6A7-B8C9-0123-DEF0-123456789012">
+        <File Id="AzureCompanionExeFile"
+              Source="$(var.AzureCompanionBin)"
+              Name="sonde-azure-companion.exe"
+              KeyPath="yes" />
+        <ServiceInstall Id="SondeAzureCompanionService"
+                        Name="sonde-azure-companion"
+                        DisplayName="Sonde Azure Companion"
+                        Description="Bridges the Sonde gateway connector to Azure Service Bus."
+                        Start="auto"
+                        Type="ownProcess"
+                        ErrorControl="normal"
+                        Arguments="service --state-dir [CommonAppDataFolder]sonde-azure-companion" />
+        <ServiceControl Id="SondeAzureCompanionControl"
+                        Name="sonde-azure-companion"
+                        Stop="both"
+                        Remove="uninstall"
+                        Wait="yes" />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="AzureCompanionConfigGroup" Directory="AZUREDATADIR">
+      <Component Id="AzureCompanionDataDirComp" Guid="E5F6A7B8-C9D0-1234-EF01-234567890123">
+        <CreateFolder />
+      </Component>
+    </ComponentGroup>
+
     <!-- ── Custom action: auto-detect ESP32-S3 modem COM port ────────
          GW-1501 AC2: Scans USB devices for VID 303A / PID 1001 and
          pre-populates the MODEM_PORT property. Scheduled After AppSearch
@@ -154,8 +190,7 @@
     </InstallExecuteSequence>
 
     <!-- ── UI ───────────────────────────────────────────────────────── -->
-    <ui:WixUI Id="WixUI_InstallDir" />
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+    <ui:WixUI Id="WixUI_FeatureTree" />
     <WixVariable Id="WixUILicenseRtf" Value="installer\windows\license.rtf" />
 
   </Package>

--- a/installer/windows/sonde.wxs
+++ b/installer/windows/sonde.wxs
@@ -53,7 +53,7 @@
 
     <!-- ── Feature tree ──────────────────────────────────────────────── -->
     <Feature Id="ProductFeature" Title="Sonde" Level="1">
-      <Feature Id="GatewayFeature" Title="Gateway and admin tools" Level="1">
+      <Feature Id="GatewayFeature" Title="Gateway and admin tools" Level="1" AllowAbsent="no">
         <ComponentGroupRef Id="BinariesGroup" />
         <ComponentGroupRef Id="ConfigGroup" />
       </Feature>

--- a/installer/windows/sonde.wxs
+++ b/installer/windows/sonde.wxs
@@ -141,7 +141,7 @@
                         Start="auto"
                         Type="ownProcess"
                         ErrorControl="normal"
-                        Arguments="service --state-dir [CommonAppDataFolder]sonde-azure-companion" />
+                        Arguments="service --state-dir &quot;[AZUREDATADIR]&quot;" />
         <ServiceControl Id="SondeAzureCompanionControl"
                         Name="sonde-azure-companion"
                         Stop="both"
@@ -191,6 +191,7 @@
 
     <!-- ── UI ───────────────────────────────────────────────────────── -->
     <ui:WixUI Id="WixUI_FeatureTree" />
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
     <WixVariable Id="WixUILicenseRtf" Value="installer\windows\license.rtf" />
 
   </Package>

--- a/installer/windows/sonde.wxs
+++ b/installer/windows/sonde.wxs
@@ -141,7 +141,7 @@
                         Start="auto"
                         Type="ownProcess"
                         ErrorControl="normal"
-                        Arguments="--state-dir &quot;[AZUREDATADIR]&quot; service">
+                        Arguments="--state-dir [AZUREDATADIR] service">
           <ServiceDependency Id="sonde-gateway" />
         </ServiceInstall>
         <ServiceControl Id="SondeAzureCompanionControl"

--- a/installer/windows/sonde.wxs
+++ b/installer/windows/sonde.wxs
@@ -57,7 +57,7 @@
         <ComponentGroupRef Id="BinariesGroup" />
         <ComponentGroupRef Id="ConfigGroup" />
       </Feature>
-      <Feature Id="AzureCompanionFeature" Title="Azure companion" Description="Optional Azure Service Bus bridge service" Level="2">
+      <Feature Id="AzureCompanionFeature" Title="Azure companion" Description="Optional Azure Service Bus bridge service" Level="4">
         <ComponentGroupRef Id="AzureCompanionBinariesGroup" />
         <ComponentGroupRef Id="AzureCompanionConfigGroup" />
       </Feature>


### PR DESCRIPTION
## Summary
- add Windows service install, uninstall, and service runtime support for sonde-azure-companion`n- add an optional default-off MSI feature for the Azure companion and wire companion packaging into Windows workflows
- update Azure companion requirements, design, and validation docs for the Windows deployment story

## Validation
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cargo build --workspace

Closes #837