### PR TITLE
Fix warning cleanup in node and pair UI

### DIFF
--- a/crates/sonde-node/src/map_storage.rs
+++ b/crates/sonde-node/src/map_storage.rs
@@ -192,7 +192,7 @@ fn make_map_data(size: usize, offset: usize) -> MapData {
     // that every call to `make_map_data` receives a unique, non-overlapping
     // `[offset, offset+size)` range within `MAP_BACKING`.
     unsafe {
-        let ptr = MAP_BACKING.as_mut_ptr().add(offset);
+        let ptr = core::ptr::addr_of_mut!(MAP_BACKING).cast::<u8>().add(offset);
         core::ptr::write_bytes(ptr, 0, size);
         RtcSlice {
             ptr,
@@ -360,7 +360,9 @@ impl MapStorage {
             // SAFETY: offset + total_size ≤ total_bytes ≤ MAP_BUDGET.
             let data = unsafe {
                 RtcSlice {
-                    ptr: MAP_BACKING.as_mut_ptr().add(offset),
+                    ptr: core::ptr::addr_of_mut!(MAP_BACKING)
+                        .cast::<u8>()
+                        .add(offset),
                     len: total_size,
                     _not_send_sync: PhantomData,
                 }

--- a/crates/sonde-node/src/map_storage.rs
+++ b/crates/sonde-node/src/map_storage.rs
@@ -192,7 +192,9 @@ fn make_map_data(size: usize, offset: usize) -> MapData {
     // that every call to `make_map_data` receives a unique, non-overlapping
     // `[offset, offset+size)` range within `MAP_BACKING`.
     unsafe {
-        let ptr = core::ptr::addr_of_mut!(MAP_BACKING).cast::<u8>().add(offset);
+        let ptr = core::ptr::addr_of_mut!(MAP_BACKING)
+            .cast::<u8>()
+            .add(offset);
         core::ptr::write_bytes(ptr, 0, size);
         RtcSlice {
             ptr,

--- a/crates/sonde-pair-ui/src-tauri/Cargo.toml
+++ b/crates/sonde-pair-ui/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "Tauri v2 BLE pairing tool for sonde sensor nodes"
 
 [lib]
-name = "sonde_pair_ui"
+name = "sonde_pair_ui_backend"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]

--- a/crates/sonde-pair-ui/src-tauri/src/lib.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/lib.rs
@@ -932,9 +932,11 @@ pub fn run() {
         )
         .with({
             #[cfg(debug_assertions)]
-            const DEFAULT_FILTER: &str = "sonde_pair=info,sonde_pair_ui=info";
+            const DEFAULT_FILTER: &str =
+                "sonde_pair=info,sonde_pair_ui=info,sonde_pair_ui_backend=info";
             #[cfg(not(debug_assertions))]
-            const DEFAULT_FILTER: &str = "sonde_pair=warn,sonde_pair_ui=warn";
+            const DEFAULT_FILTER: &str =
+                "sonde_pair=warn,sonde_pair_ui=warn,sonde_pair_ui_backend=warn";
 
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| DEFAULT_FILTER.into())

--- a/crates/sonde-pair-ui/src-tauri/src/main.rs
+++ b/crates/sonde-pair-ui/src-tauri/src/main.rs
@@ -4,5 +4,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    sonde_pair_ui::run();
+    sonde_pair_ui_backend::run();
 }


### PR DESCRIPTION
## Summary
- replace temporary &mut access to MAP_BACKING with raw-pointer access in sonde-node
- rename the internal sonde-pair-ui library target to avoid Windows Cargo output filename collision warnings
- keep the workspace warning-clean on the existing CI lint lane

Closes #824.