### PR TITLE
maintenance: realign audit drift findings

### DIFF
--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -1486,7 +1486,7 @@ async fn t_e2e_081_ephemeral_restrictions() {
 // T-E2E-080 — Map access through full stack
 // ---------------------------------------------------------------------------
 
-/// T-E2E-080 — E2E map access through full stack.
+/// T-BPF-031 / T-E2E-080 — E2E map access through full stack.
 ///
 /// Installs a resident program with a map definition, runs two wake
 /// cycles, and verifies map allocation and persistence across cycles.

--- a/crates/sonde-gateway/tests/phase2b.rs
+++ b/crates/sonde-gateway/tests/phase2b.rs
@@ -4,9 +4,11 @@
 //! Phase 2B integration tests: protocol engine, command dispatch, chunked
 //! transfer, and authentication.
 
+use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ciborium::Value;
 use sonde_gateway::engine::{Gateway, PendingCommand};
 use sonde_gateway::program::{ProgramLibrary, VerificationProfile};
 use sonde_gateway::registry::NodeRecord;
@@ -233,6 +235,28 @@ async fn t0101_valid_cbor_encoding() {
 
     let decoded = decode_frame(&resp).unwrap();
     let plaintext = open_frame(&decoded, &node.psk, &GatewayAead, &RustCryptoSha256).unwrap();
+    let raw: Value = ciborium::from_reader(&plaintext[..]).expect("response payload must be CBOR");
+    let map = raw
+        .as_map()
+        .expect("response payload must be a top-level CBOR map");
+    let mut keys = map
+        .iter()
+        .map(|(k, _)| {
+            k.as_integer()
+                .and_then(|i| u64::try_from(i).ok())
+                .expect("all top-level keys must be non-negative integers")
+        })
+        .collect::<Vec<_>>();
+    keys.sort_unstable();
+    assert_eq!(
+        keys,
+        vec![
+            sonde_protocol::KEY_COMMAND_TYPE,
+            sonde_protocol::KEY_STARTING_SEQ,
+            sonde_protocol::KEY_TIMESTAMP_MS,
+        ],
+        "NOP COMMAND must use the expected integer-key CBOR mapping"
+    );
     // Payload must be valid CBOR decodable as a GatewayMessage
     let msg = GatewayMessage::decode(decoded.header.msg_type, &plaintext);
     assert!(msg.is_ok(), "response payload must be valid CBOR");
@@ -240,6 +264,7 @@ async fn t0101_valid_cbor_encoding() {
 
 /// T-0102: Malformed CBOR tolerance (valid HMAC, garbage payload).
 #[tokio::test]
+#[traced_test]
 async fn t0102_malformed_cbor_tolerance() {
     let storage = Arc::new(InMemoryStorage::new());
     let gw = make_gateway(storage.clone());
@@ -258,6 +283,7 @@ async fn t0102_malformed_cbor_tolerance() {
 
     let resp = gw.process_frame(&frame, node.peer_address()).await;
     assert!(resp.is_none(), "garbage CBOR must be silently discarded");
+    assert!(logs_contain("discarding WAKE with malformed CBOR payload"));
 }
 
 /// T-0103: WAKE reception and field extraction.

--- a/crates/sonde-node/src/program_store.rs
+++ b/crates/sonde-node/src/program_store.rs
@@ -334,6 +334,57 @@ mod tests {
         assert!(matches!(result, Err(NodeError::StorageError(_))));
     }
 
+    #[test]
+    fn t_bpf_032_resident_install_rejects_oversized_maps_and_keeps_active_program() {
+        let (active_cbor, active_hash) =
+            make_test_image(&[0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], &[]);
+        let oversized_maps = [MapDef {
+            map_type: 1,
+            key_size: 4,
+            value_size: 16,
+            max_entries: 4,
+        }];
+        let (oversized_cbor, oversized_hash) = make_test_image(
+            &[0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            &oversized_maps,
+        );
+
+        let mut storage = MockStorage::new();
+        storage.programs[0] = Some(active_cbor.clone());
+        storage.active_partition = 0;
+
+        {
+            let mut store = ProgramStore::new(&mut storage);
+            let result = store.install_resident(&oversized_cbor, &oversized_hash, &TestSha256, 32);
+
+            assert!(matches!(
+                result,
+                Err(NodeError::MapBudgetExceeded {
+                    required: 80,
+                    available: 32
+                })
+            ));
+
+            let (loaded_hash, loaded_raw) = store.load_active_raw(&TestSha256);
+            assert_eq!(loaded_hash, active_hash);
+            assert_eq!(loaded_raw.as_deref(), Some(active_cbor.as_slice()));
+        }
+
+        assert_eq!(
+            storage.active_partition, 0,
+            "oversized install must not flip the active partition"
+        );
+        assert_eq!(
+            storage.programs[0].as_ref(),
+            Some(&active_cbor),
+            "previously active resident program must remain intact"
+        );
+        assert!(
+            storage.programs[1].is_none(),
+            "inactive partition must remain untouched when install is rejected"
+        );
+    }
+
     // ---- load_active_raw tests ----
 
     #[test]

--- a/crates/sonde-node/src/sonde_bpf_adapter.rs
+++ b/crates/sonde-node/src/sonde_bpf_adapter.rs
@@ -402,7 +402,7 @@ mod tests {
     // -------------------------------------------------------------------
 
     #[test]
-    fn t_n929_write_to_read_only_context_silently_ignored() {
+    fn t_bpf_033_write_to_read_only_context_silently_ignored() {
         // T-N929: Load a BPF program that attempts to write to the
         // sonde_context memory region.  Verify the context is unchanged
         // and execution continues normally.

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -1332,7 +1332,7 @@ A "Custom" option MUST also be available, which reveals editable fields for the 
 **Source:** pairing-tool-ui-redesign.md §Phase A, issue #673
 
 **Description:**  
-The UI MUST be organized as a multi-page wizard with 6 pages, each implemented as a `<section>` element.  Client-side routing uses show/hide logic managed by a `Navigator` class.  No server-side routing or SPA framework is required.
+The UI MUST be organized as a multi-page wizard with 7 pages, each implemented as a `<section>` element.  Client-side routing uses show/hide logic managed by a `Navigator` class.  No server-side routing or SPA framework is required.
 
 The page layout is:
 
@@ -1343,7 +1343,8 @@ The page layout is:
 | 3 | Pairing Complete | Success confirmation, channel and key hint info | Gateway |
 | 4 | Node Scan & RSSI | Scan for nodes, device list, live RSSI indicator | Node |
 | 5 | Node Provision | Node ID input, board selector, provision button, progress | Node |
-| 6 | Done | Success summary, "Provision Another" button | Done |
+| 6 | Diagnostic Review | Diagnostic result or failure, continue / continue-anyway / cancel | Node |
+| 7 | Done | Success summary, "Provision Another" button | Done |
 
 **Acceptance criteria:**
 
@@ -1365,7 +1366,7 @@ The UI MUST display a stepper bar at the top of every page showing three phases:
 
 **Acceptance criteria:**
 
-1. The stepper bar is visible on all 6 pages.
+1. The stepper bar is visible on all 7 pages.
 2. The stepper shows exactly three steps: Gateway, Node, Done.
 3. The currently active phase is visually distinct (highlighted).
 4. Completed phases are visually marked as done (e.g., checkmark).

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -267,7 +267,7 @@ TestNode {
 
 **Procedure:**
 1. Launch the pairing tool.
-2. Assert: the UI shows a multi-page wizard flow with 6 pages.
+2. Assert: the UI shows a multi-page wizard flow with 7 pages.
 3. Navigate through all pages and assert: scan toggle, device list, device select, pair action, node ID input, board selector, status area, and error display are present on the appropriate pages.
 4. Assert: the UI does not include management, monitoring, or telemetry features.
 
@@ -1445,15 +1445,15 @@ TestNode {
 
 ## 13  Multi-page wizard navigation tests
 
-### T-PT-1217a  Six pages rendered and only one visible at a time
+### T-PT-1217a  Seven pages rendered and only one visible at a time
 
 **Validates:** PT-1217 (AC 1, 2)  
 **Type:** Manual / platform test
 
 **Procedure:**
 1. Launch the pairing tool.
-2. Assert: 6 `<section>` elements with IDs `page-welcome`, `page-gateway-scan`, `page-gateway-done`, `page-node-scan`, `page-node-provision`, `page-done` exist in the DOM.
-3. Assert: exactly one page is visible; the other 5 are hidden.
+2. Assert: 7 `<section>` elements with IDs `page-welcome`, `page-gateway-scan`, `page-gateway-done`, `page-node-scan`, `page-node-provision`, `page-diagnostic-review`, `page-done` exist in the DOM.
+3. Assert: exactly one page is visible; the other 6 are hidden.
 
 ---
 
@@ -1465,7 +1465,7 @@ TestNode {
 **Procedure:**
 1. Launch the pairing tool on page 1.
 2. Complete gateway pairing (or simulate via mock) and navigate forward through each page.
-3. Assert: each page becomes visible in order (1 → 2 → 3 → 4 → 5 → 6).
+3. Assert: each page becomes visible in order (1 → 2 → 3 → 4 → 5 → 6 → 7).
 4. Assert: the previous page is hidden when the next page becomes visible.
 
 ---
@@ -1477,7 +1477,7 @@ TestNode {
 
 **Procedure:**
 1. Launch the pairing tool.
-2. Complete a full workflow: check status (page 1) → scan and pair gateway (page 2) → confirm pairing (page 3) → scan and select node (page 4) → provision node (page 5) → view success (page 6).
+2. Complete a full workflow: check status (page 1) → scan and pair gateway (page 2) → confirm pairing (page 3) → scan and select node (page 4) → provision node (page 5) → review the diagnostic result and continue (page 6) → view success (page 7).
 3. Assert: all Tauri commands (`start_scan`, `pair_gateway`, `provision_node`, `get_pairing_status`) are invoked correctly and produce the expected results.
 
 ---
@@ -1825,7 +1825,7 @@ TestNode {
 | T-PT-1216e | PT-1216, PT-0409 | Provision with partial I2C layout rejected |
 | T-PT-1216f | PT-1216 | Espressif preset remains available |
 | T-PT-1216g | PT-1216 | Tauri provision_node command accepts structured board layout |
-| T-PT-1217a | PT-1217 | Six pages rendered and only one visible at a time |
+| T-PT-1217a | PT-1217 | Seven pages rendered and only one visible at a time |
 | T-PT-1217b | PT-1217 | Forward navigation through all pages |
 | T-PT-1217c | PT-1217 | Existing functionality works through wizard flow |
 | T-PT-1218a | PT-1218 | Stepper bar shows three phases |

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -126,7 +126,7 @@ Each wake cycle MUST follow this structure: wake → send one or more `WAKE` mes
 **Source:** protocol.md §5.1
 
 **Description:**  
-The `WAKE` message MUST include `firmware_abi_version`, `program_hash` (SHA-256 of the resident program, or zero-length if none installed), `battery_mv`, and `firmware_version` (semantic version string derived from `CARGO_PKG_VERSION` at compile time, e.g., `"0.6.0"`). The `battery_mv` field reports the battery reading stored from the previous wake cycle in RTC-retained state. On the first wake after provisioning or cold boot, before any battery value has been stored, `battery_mv` MUST be `0`. If the provisioned board layout does not assign a battery ADC pin, the firmware stores a known fallback value (`3300` mV) for use on subsequent wakes. The `nonce` header field MUST contain a fresh 64-bit random value from the hardware RNG. The WAKE message MAY include an optional `blob` field (CBOR key 10) containing a single piggybacked uplink data blob from a prior `send_async()` call. The blob is included only when exactly one message is queued and it fits within the available payload budget (223 bytes minus the space consumed by the four required fields and their CBOR encoding overhead). When the blob would not fit or multiple messages are queued, the `blob` field is omitted and data is sent via APP_DATA after receiving COMMAND.
+The `WAKE` message MUST include `firmware_abi_version`, `program_hash` (SHA-256 of the resident program, or zero-length if none installed), `battery_mv`, and `firmware_version` (semantic version string derived from `CARGO_PKG_VERSION` at compile time, e.g., `"0.6.0"`). The `battery_mv` field reports the battery reading stored from the previous wake cycle in RTC-retained state. On the first wake after provisioning or cold boot, before any battery value has been stored, `battery_mv` MUST be `0`. If the provisioned board layout does not assign a battery ADC pin, the firmware stores the explicit failure fallback value (`0` mV) for use on subsequent wakes. The `nonce` header field MUST contain a fresh 64-bit random value from the hardware RNG. The WAKE message MAY include an optional `blob` field (CBOR key 10) containing a single piggybacked uplink data blob from a prior `send_async()` call. The blob is included only when exactly one message is queued and it fits within the available payload budget (223 bytes minus the space consumed by the four required fields and their CBOR encoding overhead). When the blob would not fit or multiple messages are queued, the `blob` field is omitted and data is sent via APP_DATA after receiving COMMAND.
 
 **Acceptance criteria:**
 
@@ -134,7 +134,7 @@ The `WAKE` message MUST include `firmware_abi_version`, `program_hash` (SHA-256 
 2. `program_hash` matches the SHA-256 of the currently installed resident program.
 3. On the first wake after provisioning or cold boot, `battery_mv` is `0`.
 4. On subsequent wakes, `battery_mv` equals the battery value stored from the previous wake cycle.
-5. If the provisioned board layout does not assign a battery ADC pin, the firmware stores and later reports the known fallback value (`3300` mV).
+5. If the provisioned board layout does not assign a battery ADC pin, the firmware stores and later reports the explicit failure fallback value (`0` mV).
 6. `firmware_version` is a valid semantic version string matching the compiled firmware version.
 7. The nonce is generated from the hardware RNG (not a constant or predictable value).
 
@@ -443,7 +443,7 @@ The firmware MUST populate a read-only `sonde_context` structure before each BPF
 **Acceptance criteria:**
 
 1. `timestamp` is derived from the gateway's `timestamp_ms` plus local elapsed time since COMMAND was received.
-2. `battery_mv` is the current-cycle battery value captured after `COMMAND` processing using the provisioned board layout (fresh ADC reading when a battery ADC pin is assigned, otherwise the known fallback value).
+2. `battery_mv` is the current-cycle battery value captured after `COMMAND` processing using the provisioned board layout (fresh ADC reading when a battery ADC pin is assigned, otherwise the explicit failure fallback value).
 3. `firmware_abi_version` matches the firmware's actual ABI.
 4. `wake_reason` is set correctly: `WAKE_SCHEDULED` (0x00) for normal wake, `WAKE_EARLY` (0x01) when woken early due to `set_next_wake()`, `WAKE_PROGRAM_UPDATE` (0x02) on first execution after a program update.
 5. The context is read-only — the BPF program cannot modify it.
@@ -546,7 +546,7 @@ The firmware MUST provide `get_time()`, `get_battery_mv()`, `delay_us()`, `set_n
 **Acceptance criteria:**
 
 1. `get_time()` returns the current time in milliseconds since epoch.
-2. `get_battery_mv()` returns the current-cycle battery value captured after `COMMAND` processing using the provisioned board layout (fresh ADC reading when a battery ADC pin is assigned, otherwise the known fallback value).
+2. `get_battery_mv()` returns the current-cycle battery value captured after `COMMAND` processing using the provisioned board layout (fresh ADC reading when a battery ADC pin is assigned, otherwise the explicit failure fallback value).
 3. `delay_us()` busy-waits for the specified microseconds; the firmware enforces a maximum delay value.
 4. `set_next_wake()` sets the interval for the next wake cycle only; the firmware applies `min(requested, base interval)`.
 5. Ephemeral programs calling `set_next_wake()` receive an error.

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -182,9 +182,9 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Procedure:**
 1. Provision a board layout with `battery_adc = null`.
 2. Run one full wake cycle through `COMMAND` processing so the node computes a current-cycle battery value.
-3. Assert: the node stores `3300` mV in RTC-retained battery state.
+3. Assert: the node stores `0` mV in RTC-retained battery state.
 4. Trigger the next wake cycle and capture WAKE.
-5. Assert: `battery_mv` = 3300.
+5. Assert: `battery_mv` = 0.
 
 ---
 
@@ -1993,8 +1993,8 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Procedure:**
 1. Provision a board layout with `battery_adc=null`.
 2. Run a wake cycle through `COMMAND` processing.
-3. Assert: the current-cycle `sonde_context.battery_mv` and `get_battery_mv()` value are 3300.
-4. Assert: 3300 mV is stored in RTC-retained state for the next wake.
+3. Assert: the current-cycle `sonde_context.battery_mv` and `get_battery_mv()` value are 0.
+4. Assert: 0 mV is stored in RTC-retained state for the next wake.
 
 ---
 

--- a/docs/pairing-tool-ui-redesign.md
+++ b/docs/pairing-tool-ui-redesign.md
@@ -212,7 +212,7 @@ quality before committing to provisioning.
 The current `index.html` is a single-page layout. The redesign uses
 client-side page routing (hash-based or simple show/hide of `<section>`
 elements). No framework dependency is required — vanilla JS with a
-simple state machine is sufficient for 6 pages.
+simple state machine is sufficient for the current 7-page Phase A flow.
 
 **Suggested approach:**
 - Each step is a `<section class="page" id="page-N">` element
@@ -259,7 +259,7 @@ more seamless workflow.
 ## Phased Implementation
 
 ### Phase A — Page routing and basic wizard (no bundle integration)
-- Implement multi-page navigation with stepper bar
+- Implement multi-page navigation with stepper bar; a simple state machine is sufficient for the 7-page flow
 - Move existing functionality into separate pages
 - Add RSSI display on node selection page
 - No bundle manifest — manual node ID entry (current behavior)

--- a/docs/safe-bpf-interpreter-validation.md
+++ b/docs/safe-bpf-interpreter-validation.md
@@ -397,7 +397,7 @@ Use clearly non-zero test keys (e.g., `[0x42u8; 32]`) and non-trivial buffer con
 
 **Validates:** bpf-environment.md §5.3, ND-0504
 
-**E2E coverage:** Partially covered by T-E2E-081 (`t_e2e_081_ephemeral_restrictions`) which deploys a resident program with maps and verifies map state after BPF execution. Direct unit coverage for persistence across cycles exists in `crates/sonde-node/src/map_storage.rs` (`test_data_preserved_when_layout_matches`), which validates that map data is preserved when the RTC layout matches.
+**Direct coverage:** `crates/sonde-e2e/tests/e2e_tests.rs` (`t_e2e_080_map_access_through_full_stack`) installs a resident program with a map and verifies that the map remains allocated with its initial value across wake cycles. Supporting unit coverage in `crates/sonde-node/src/map_storage.rs` (`test_data_preserved_when_layout_matches`) continues to validate the underlying storage persistence rule directly.
 
 **Procedure:**
 1. Deploy a BPF program (via mock gateway) that calls `map_lookup_elem` on a defined map, writes a value via `map_update_elem`, then reads it back.
@@ -410,7 +410,7 @@ Use clearly non-zero test keys (e.g., `[0x42u8; 32]`) and non-trivial buffer con
 
 **Validates:** bpf-environment.md §5.3, ND-0606
 
-**E2E coverage:** Unit coverage for map budget enforcement exists in `crates/sonde-node/src/map_storage.rs` (`test_allocate_exceeds_budget`) and program-load rejection is checked in `crates/sonde-node/src/program_store.rs` via `NodeError::MapBudgetExceeded`. E2E-level coverage via T-E2E-083 (`t_e2e_083_instruction_budget_enforcement`) exercises the budget mechanism end-to-end for instruction budgets; map memory budgets are structurally similar.
+**Direct coverage:** `crates/sonde-node/src/program_store.rs` (`t_bpf_032_resident_install_rejects_oversized_maps_and_keeps_active_program`) verifies that an oversized resident program is rejected before the active partition changes and that the previously active program remains selected. Supporting unit coverage in `crates/sonde-node/src/map_storage.rs` (`test_allocate_exceeds_budget`) continues to validate the low-level budget check.
 
 **Procedure:**
 1. Deploy a BPF program (via mock gateway) that declares map definitions exceeding the node's memory budget.
@@ -423,7 +423,7 @@ Use clearly non-zero test keys (e.g., `[0x42u8; 32]`) and non-trivial buffer con
 
 **Validates:** bpf-environment.md §4, ND-0505 AC6
 
-**E2E coverage:** Context write rejection is unit-tested in `crates/sonde-node/src/sonde_bpf_adapter.rs` (`t_n929_write_to_read_only_context_silently_ignored`), which validates that writes to the read-only Context region are silently ignored. T-E2E-081 (`t_e2e_081_ephemeral_restrictions`) exercises related ephemeral-program restrictions (map writes, `set_next_wake`) at the E2E level.
+**Direct coverage:** `crates/sonde-node/src/sonde_bpf_adapter.rs` (`t_bpf_033_write_to_read_only_context_silently_ignored`) validates that writes to the read-only Context region are silently ignored and that execution continues normally.
 
 **Procedure:**
 1. Populate `sonde_context` with known non-zero field values (e.g., `timestamp = 1710000000000`, `battery_mv = 3300`).


### PR DESCRIPTION
## Summary

This PR applies the approved maintenance-audit corrections across docs and validation coverage.

It resolves 5 classified drift findings:
- `fix-spec`: 2
- `fix-impl`: 3
- `fix-both`: 0
- `accept`: 0
- `defer`: 0

## What changed

### Node fallback battery docs
- Aligned the no-ADC fallback behavior to the intended `0` mV value in:
  - `docs/node-requirements.md`
  - `docs/node-validation.md`

### BLE pairing wizard docs
- Updated the BLE pairing docs to match the shipped 7-page wizard flow in:
  - `docs/ble-pairing-tool-requirements.md`
  - `docs/ble-pairing-tool-validation.md`
  - `docs/pairing-tool-ui-redesign.md`

### Gateway validation coverage
- Strengthened `crates/sonde-gateway/tests/phase2b.rs` so:
  - `T-0101` asserts raw integer-key CBOR structure in outbound `COMMAND`
  - `T-0102` asserts malformed authenticated WAKE CBOR is logged as well as discarded

### BPF validation traceability
- Updated direct traceability for:
  - `T-BPF-031` via `T-E2E-080`
  - `T-BPF-032` via a new `program_store` rejection test
  - `T-BPF-033` via the renamed read-only context write test
- Refreshed `docs/safe-bpf-interpreter-validation.md` so it no longer claims surrogate-only coverage for those cases

## Validation

- `cargo test -p sonde-gateway --test phase2b`
- `cargo test -p sonde-node t_bpf_032_resident_install_rejects_oversized_maps_and_keeps_active_program`
- `cargo test -p sonde-node t_bpf_033_write_to_read_only_context_silently_ignored`
- `cargo test -p sonde-e2e t_e2e_080_map_access_through_full_stack`

## Deferred items

None.
