### PR TITLE
Support Windows Azure companion bootstrap

### DIFF
--- a/crates/sonde-azure-companion/Cargo.toml
+++ b/crates/sonde-azure-companion/Cargo.toml
@@ -35,7 +35,7 @@ x509-cert = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.8.0"
-windows-sys = { version = "0.61", features = ["Win32_Foundation"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Services", "Win32_System_Threading"] }
 
 [dev-dependencies]
 futures = "0.3"

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -606,32 +606,309 @@ fn generate_certificate(staging_dir: &Path) -> Result<(PathBuf, PathBuf, String)
     Ok((cert_path, key_path, cert_base64))
 }
 
-fn write_private_key_pem(path: &Path, pem: &str) -> Result<(), CompanionError> {
-    #[cfg(unix)]
-    {
-        use std::fs::OpenOptions;
-        use std::io::Write as _;
-        use std::os::unix::fs::OpenOptionsExt;
+#[cfg(windows)]
+fn wide_null(value: &std::ffi::OsStr) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
 
-        let mut file = OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .mode(0o600)
-            .open(path)?;
-        file.write_all(pem.as_bytes())?;
-        file.flush()?;
-        Ok(())
+    value.encode_wide().chain(std::iter::once(0)).collect()
+}
+
+#[cfg(windows)]
+fn null_terminated_wide_to_string(value: *const u16) -> String {
+    use std::slice;
+
+    let mut len = 0usize;
+    while unsafe { *value.add(len) } != 0 {
+        len += 1;
+    }
+    String::from_utf16_lossy(unsafe { slice::from_raw_parts(value, len) })
+}
+
+#[cfg(windows)]
+fn sid_to_string(sid: windows_sys::Win32::Security::PSID) -> Result<String, CompanionError> {
+    use windows_sys::Win32::Foundation::LocalFree;
+    use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+
+    let mut sid_wide = std::ptr::null_mut();
+    if unsafe { ConvertSidToStringSidW(sid, &mut sid_wide) } == 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let sid_string = null_terminated_wide_to_string(sid_wide);
+    unsafe {
+        let _ = LocalFree(sid_wide.cast());
+    }
+    Ok(sid_string)
+}
+
+#[cfg(windows)]
+fn current_user_sid_string() -> Result<String, CompanionError> {
+
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Security::{
+        GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    let mut token = std::ptr::null_mut();
+    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err(std::io::Error::last_os_error().into());
     }
 
-    #[cfg(not(unix))]
+    let result = {
+        let mut required_len = 0;
+        let _ = unsafe {
+            GetTokenInformation(
+                token,
+                TokenUser,
+                std::ptr::null_mut(),
+                0,
+                &mut required_len,
+            )
+        };
+        if required_len == 0 {
+            Err(std::io::Error::last_os_error().into())
+        } else {
+            let mut buffer = vec![0u8; required_len as usize];
+            if unsafe {
+                GetTokenInformation(
+                    token,
+                    TokenUser,
+                    buffer.as_mut_ptr().cast(),
+                    required_len,
+                    &mut required_len,
+                )
+            } == 0
+            {
+                Err(std::io::Error::last_os_error().into())
+            } else {
+                let token_user = unsafe { &*(buffer.as_ptr().cast::<TOKEN_USER>()) };
+                sid_to_string(token_user.User.Sid)
+            }
+        }
+    };
+
+    unsafe {
+        let _ = CloseHandle(token);
+    }
+
+    result
+}
+
+#[cfg(windows)]
+fn lookup_account_sid_string(account_name: &str) -> Result<String, CompanionError> {
+    use windows_sys::Win32::Security::{LookupAccountNameW, SID_NAME_USE};
+
+    let account_name_wide = wide_null(std::ffi::OsStr::new(account_name));
+    let mut sid_len = 0u32;
+    let mut domain_len = 0u32;
+    let mut sid_use: SID_NAME_USE = 0;
+    let _ = unsafe {
+        LookupAccountNameW(
+            std::ptr::null(),
+            account_name_wide.as_ptr(),
+            std::ptr::null_mut(),
+            &mut sid_len,
+            std::ptr::null_mut(),
+            &mut domain_len,
+            &mut sid_use,
+        )
+    };
+    if sid_len == 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut sid_buffer = vec![0u8; sid_len as usize];
+    let mut domain_buffer = vec![0u16; domain_len as usize];
+    let domain_ptr = if domain_buffer.is_empty() {
+        std::ptr::null_mut()
+    } else {
+        domain_buffer.as_mut_ptr()
+    };
+    if unsafe {
+        LookupAccountNameW(
+            std::ptr::null(),
+            account_name_wide.as_ptr(),
+            sid_buffer.as_mut_ptr().cast(),
+            &mut sid_len,
+            domain_ptr,
+            &mut domain_len,
+            &mut sid_use,
+        )
+    } == 0
     {
-        let _ = (path, pem);
-        Err(CompanionError::Config(
-            "bootstrap private-key generation requires Unix so the key file can be created with owner-only permissions"
-                .to_string(),
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    sid_to_string(sid_buffer.as_mut_ptr().cast())
+}
+
+#[cfg(windows)]
+fn configured_windows_service_sid_string() -> Result<String, CompanionError> {
+    use windows_sys::Win32::Foundation::ERROR_SERVICE_DOES_NOT_EXIST;
+    use windows_sys::Win32::System::Services::{
+        CloseServiceHandle, OpenSCManagerW, OpenServiceW, QueryServiceConfigW,
+        QUERY_SERVICE_CONFIGW, SC_MANAGER_CONNECT, SERVICE_QUERY_CONFIG,
+    };
+
+    let manager = unsafe { OpenSCManagerW(std::ptr::null(), std::ptr::null(), SC_MANAGER_CONNECT) };
+    if manager.is_null() {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let result = {
+        let service_name_wide = wide_null(std::ffi::OsStr::new(SERVICE_NAME));
+        let service = unsafe { OpenServiceW(manager, service_name_wide.as_ptr(), SERVICE_QUERY_CONFIG) };
+        if service.is_null() {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
+                Ok(String::from("SY"))
+            } else {
+                Err(err.into())
+            }
+        } else {
+            let service_result = {
+                let mut bytes_needed = 0u32;
+                let _ = unsafe {
+                    QueryServiceConfigW(service, std::ptr::null_mut(), 0, &mut bytes_needed)
+                };
+                if bytes_needed == 0 {
+                    Err(std::io::Error::last_os_error().into())
+                } else {
+                    let mut buffer = vec![0u8; bytes_needed as usize];
+                    if unsafe {
+                        QueryServiceConfigW(
+                            service,
+                            buffer.as_mut_ptr().cast::<QUERY_SERVICE_CONFIGW>(),
+                            bytes_needed,
+                            &mut bytes_needed,
+                        )
+                    } == 0
+                    {
+                        Err(std::io::Error::last_os_error().into())
+                    } else {
+                        let config = unsafe { &*(buffer.as_ptr().cast::<QUERY_SERVICE_CONFIGW>()) };
+                        let account_name = null_terminated_wide_to_string(config.lpServiceStartName);
+                        if account_name.eq_ignore_ascii_case("localsystem")
+                            || account_name.eq_ignore_ascii_case(r"NT AUTHORITY\SYSTEM")
+                        {
+                            Ok(String::from("SY"))
+                        } else {
+                            lookup_account_sid_string(&account_name)
+                        }
+                    }
+                }
+            };
+            unsafe {
+                let _ = CloseServiceHandle(service);
+            }
+            service_result
+        }
+    };
+
+    unsafe {
+        let _ = CloseServiceHandle(manager);
+    }
+
+    result
+}
+
+#[cfg(windows)]
+fn windows_private_key_sddl() -> Result<String, CompanionError> {
+    let current_user_sid = current_user_sid_string()?;
+    let service_sid = configured_windows_service_sid_string()?;
+    if service_sid == current_user_sid {
+        Ok(format!("D:P(A;;FA;;;{current_user_sid})"))
+    } else {
+        Ok(format!(
+            "D:P(A;;FA;;;{current_user_sid})(A;;GR;;;{service_sid})"
         ))
     }
+}
+
+#[cfg(unix)]
+fn write_private_key_pem(path: &Path, pem: &str) -> Result<(), CompanionError> {
+    use std::fs::OpenOptions;
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(pem.as_bytes())?;
+    file.flush()?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn write_private_key_pem(path: &Path, pem: &str) -> Result<(), CompanionError> {
+    use std::fs::File;
+    use std::io::Write as _;
+    use std::os::windows::io::FromRawHandle;
+
+    use windows_sys::Win32::Foundation::{LocalFree, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
+    use windows_sys::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_WRITE,
+    };
+
+    let private_key_sddl = windows_private_key_sddl()?;
+    let private_key_sddl_wide = wide_null(std::ffi::OsStr::new(&private_key_sddl));
+    let mut security_descriptor: PSECURITY_DESCRIPTOR = std::ptr::null_mut();
+    if unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            private_key_sddl_wide.as_ptr(),
+            1,
+            &mut security_descriptor,
+            std::ptr::null_mut(),
+        )
+    } == 0
+    {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let path_wide = wide_null(path.as_os_str());
+    let security_attributes = SECURITY_ATTRIBUTES {
+        nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: security_descriptor,
+        bInheritHandle: 0,
+    };
+
+    let result: Result<(), CompanionError> = {
+        let handle = unsafe {
+            CreateFileW(
+                path_wide.as_ptr(),
+                FILE_GENERIC_WRITE,
+                0,
+                &security_attributes,
+                CREATE_ALWAYS,
+                FILE_ATTRIBUTE_NORMAL,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            Err(std::io::Error::last_os_error().into())
+        } else {
+            let mut file = unsafe { File::from_raw_handle(handle) };
+            file.write_all(pem.as_bytes())?;
+            file.flush()?;
+            Ok(())
+        }
+    };
+
+    unsafe {
+        let _ = LocalFree(security_descriptor.cast());
+    }
+
+    if let Err(err) = result {
+        let _ = std::fs::remove_file(path);
+        return Err(err);
+    }
+
+    Ok(())
 }
 
 fn resolve_state_relative_path(state_dir: &Path, value: &str) -> Result<PathBuf, CompanionError> {
@@ -2335,9 +2612,11 @@ mod tests {
         SERVICE_PRINCIPAL_STATE_FILENAME, STATE_GENERATION_PREFIX,
     };
     #[cfg(windows)]
-    use super::{Cli, Command};
+    use super::{
+        configured_windows_service_sid_string, current_user_sid_string, windows_private_key_sddl,
+        Cli, Command,
+    };
     use azure_core::credentials::TokenCredential;
-    #[cfg(unix)]
     use base64::Engine as _;
     use bollard::{Docker, API_DEFAULT_VERSION};
     use jsonwebtoken::{Algorithm, EncodingKey};
@@ -2363,9 +2642,7 @@ mod tests {
     use tokio::sync::{Mutex, Notify};
     use wiremock::matchers::{method, path, path_regex};
     use wiremock::{Mock, MockServer, ResponseTemplate};
-    #[cfg(unix)]
     use x509_cert::der::Decode;
-    #[cfg(unix)]
     use x509_cert::Certificate;
 
     fn lines(values: &[&str]) -> Vec<String> {
@@ -2852,49 +3129,60 @@ mod tests {
     #[test]
     fn test_generate_certificate() {
         let temp = TempDir::new().unwrap();
+        let (cert_path, key_path, cert_base64) = generate_certificate(temp.path()).unwrap();
 
-        #[cfg(not(unix))]
-        {
-            let err = generate_certificate(temp.path()).unwrap_err();
-            assert!(err
-                .to_string()
-                .contains("bootstrap private-key generation requires Unix"));
-        }
+        assert_eq!(cert_path, temp.path().join(CERT_PEM_FILENAME));
+        assert_eq!(key_path, temp.path().join(KEY_PEM_FILENAME));
+        assert!(cert_path.is_file());
+        assert!(key_path.is_file());
+
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(cert_base64)
+            .unwrap();
+        let cert_file = std::fs::File::open(&cert_path).unwrap();
+        let mut reader = std::io::BufReader::new(cert_file);
+        let cert_der = rustls_pemfile::certs(&mut reader)
+            .next()
+            .transpose()
+            .unwrap()
+            .unwrap();
+        assert_eq!(decoded, cert_der.as_ref());
+
+        let certificate = Certificate::from_der(cert_der.as_ref()).unwrap();
+        assert_ne!(
+            certificate.tbs_certificate.validity.not_before,
+            certificate.tbs_certificate.validity.not_after
+        );
+        let (algorithm, _) = load_signing_key(&key_path).unwrap();
+        assert_eq!(algorithm, Algorithm::ES256);
 
         #[cfg(unix)]
         {
-            let (cert_path, key_path, cert_base64) = generate_certificate(temp.path()).unwrap();
-
-            assert_eq!(cert_path, temp.path().join(CERT_PEM_FILENAME));
-            assert_eq!(key_path, temp.path().join(KEY_PEM_FILENAME));
-            assert!(cert_path.is_file());
-            assert!(key_path.is_file());
-
-            let decoded = base64::engine::general_purpose::STANDARD
-                .decode(cert_base64)
-                .unwrap();
-            let cert_file = std::fs::File::open(&cert_path).unwrap();
-            let mut reader = std::io::BufReader::new(cert_file);
-            let cert_der = rustls_pemfile::certs(&mut reader)
-                .next()
-                .transpose()
-                .unwrap()
-                .unwrap();
-            assert_eq!(decoded, cert_der.as_ref());
-
-            let certificate = Certificate::from_der(cert_der.as_ref()).unwrap();
-            assert_ne!(
-                certificate.tbs_certificate.validity.not_before,
-                certificate.tbs_certificate.validity.not_after
-            );
-            let (algorithm, _) = load_signing_key(&key_path).unwrap();
-            assert_eq!(algorithm, Algorithm::ES256);
             validate_certificate_matches_private_key(&cert_path, &key_path).unwrap();
 
             use std::os::unix::fs::PermissionsExt;
 
             let key_mode = std::fs::metadata(&key_path).unwrap().permissions().mode() & 0o777;
             assert_eq!(key_mode, 0o600);
+        }
+
+        #[cfg(windows)]
+        {
+            let key_pem = std::fs::read_to_string(&key_path).unwrap();
+            assert!(key_pem.contains("BEGIN PRIVATE KEY"));
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_private_key_sddl_grants_current_user_and_runtime_service_identity() {
+        let current_user_sid = current_user_sid_string().unwrap();
+        let runtime_service_sid = configured_windows_service_sid_string().unwrap();
+        let sddl = windows_private_key_sddl().unwrap();
+        assert!(sddl.starts_with("D:P"));
+        assert!(sddl.contains(&format!("(A;;FA;;;{current_user_sid})")));
+        if runtime_service_sid != current_user_sid {
+            assert!(sddl.contains(&format!("(A;;GR;;;{runtime_service_sid})")));
         }
     }
 

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -642,11 +642,8 @@ fn sid_to_string(sid: windows_sys::Win32::Security::PSID) -> Result<String, Comp
 
 #[cfg(windows)]
 fn current_user_sid_string() -> Result<String, CompanionError> {
-
     use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::Security::{
-        GetTokenInformation, TOKEN_QUERY, TOKEN_USER, TokenUser,
-    };
+    use windows_sys::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER};
     use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
     let mut token = std::ptr::null_mut();
@@ -657,13 +654,7 @@ fn current_user_sid_string() -> Result<String, CompanionError> {
     let result = {
         let mut required_len = 0;
         let _ = unsafe {
-            GetTokenInformation(
-                token,
-                TokenUser,
-                std::ptr::null_mut(),
-                0,
-                &mut required_len,
-            )
+            GetTokenInformation(token, TokenUser, std::ptr::null_mut(), 0, &mut required_len)
         };
         if required_len == 0 {
             Err(std::io::Error::last_os_error().into())
@@ -757,7 +748,8 @@ fn configured_windows_service_sid_string() -> Result<String, CompanionError> {
 
     let result = {
         let service_name_wide = wide_null(std::ffi::OsStr::new(SERVICE_NAME));
-        let service = unsafe { OpenServiceW(manager, service_name_wide.as_ptr(), SERVICE_QUERY_CONFIG) };
+        let service =
+            unsafe { OpenServiceW(manager, service_name_wide.as_ptr(), SERVICE_QUERY_CONFIG) };
         if service.is_null() {
             let err = std::io::Error::last_os_error();
             if err.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
@@ -787,7 +779,8 @@ fn configured_windows_service_sid_string() -> Result<String, CompanionError> {
                         Err(std::io::Error::last_os_error().into())
                     } else {
                         let config = unsafe { &*(buffer.as_ptr().cast::<QUERY_SERVICE_CONFIGW>()) };
-                        let account_name = null_terminated_wide_to_string(config.lpServiceStartName);
+                        let account_name =
+                            null_terminated_wide_to_string(config.lpServiceStartName);
                         if account_name.eq_ignore_ascii_case("localsystem")
                             || account_name.eq_ignore_ascii_case(r"NT AUTHORITY\SYSTEM")
                         {
@@ -849,8 +842,8 @@ fn write_private_key_pem(path: &Path, pem: &str) -> Result<(), CompanionError> {
     use std::os::windows::io::FromRawHandle;
 
     use windows_sys::Win32::Foundation::{LocalFree, INVALID_HANDLE_VALUE};
-    use windows_sys::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
     use windows_sys::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
+    use windows_sys::Win32::Security::{PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES};
     use windows_sys::Win32::Storage::FileSystem::{
         CreateFileW, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, FILE_GENERIC_WRITE,
     };

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -677,7 +677,8 @@ fn current_user_sid_string() -> Result<String, CompanionError> {
             {
                 Err(std::io::Error::last_os_error().into())
             } else {
-                let token_user = unsafe { &*(buffer.as_ptr().cast::<TOKEN_USER>()) };
+                let token_user =
+                    unsafe { std::ptr::read_unaligned(buffer.as_ptr().cast::<TOKEN_USER>()) };
                 sid_to_string(token_user.User.Sid)
             }
         }
@@ -783,7 +784,11 @@ fn configured_windows_service_sid_string() -> Result<String, CompanionError> {
                     {
                         Err(std::io::Error::last_os_error().into())
                     } else {
-                        let config = unsafe { &*(buffer.as_ptr().cast::<QUERY_SERVICE_CONFIGW>()) };
+                        let config = unsafe {
+                            std::ptr::read_unaligned(
+                                buffer.as_ptr().cast::<QUERY_SERVICE_CONFIGW>(),
+                            )
+                        };
                         let account_name = unsafe {
                             null_terminated_wide_to_string(
                                 std::ptr::NonNull::new(config.lpServiceStartName).ok_or_else(

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -614,14 +614,15 @@ fn wide_null(value: &std::ffi::OsStr) -> Vec<u16> {
 }
 
 #[cfg(windows)]
-fn null_terminated_wide_to_string(value: *const u16) -> String {
+unsafe fn null_terminated_wide_to_string(value: std::ptr::NonNull<u16>) -> String {
     use std::slice;
 
+    let value = value.as_ptr();
     let mut len = 0usize;
-    while unsafe { *value.add(len) } != 0 {
+    while *value.add(len) != 0 {
         len += 1;
     }
-    String::from_utf16_lossy(unsafe { slice::from_raw_parts(value, len) })
+    String::from_utf16_lossy(slice::from_raw_parts(value, len))
 }
 
 #[cfg(windows)]
@@ -633,7 +634,11 @@ fn sid_to_string(sid: windows_sys::Win32::Security::PSID) -> Result<String, Comp
     if unsafe { ConvertSidToStringSidW(sid, &mut sid_wide) } == 0 {
         return Err(std::io::Error::last_os_error().into());
     }
-    let sid_string = null_terminated_wide_to_string(sid_wide);
+    let sid_string = unsafe {
+        null_terminated_wide_to_string(std::ptr::NonNull::new(sid_wide).ok_or_else(|| {
+            CompanionError::Config("ConvertSidToStringSidW returned a null SID string".to_string())
+        })?)
+    };
     unsafe {
         let _ = LocalFree(sid_wide.cast());
     }
@@ -753,7 +758,7 @@ fn configured_windows_service_sid_string() -> Result<String, CompanionError> {
         if service.is_null() {
             let err = std::io::Error::last_os_error();
             if err.raw_os_error() == Some(ERROR_SERVICE_DOES_NOT_EXIST as i32) {
-                Ok(String::from("SY"))
+                Ok(String::from("S-1-5-18"))
             } else {
                 Err(err.into())
             }
@@ -779,12 +784,22 @@ fn configured_windows_service_sid_string() -> Result<String, CompanionError> {
                         Err(std::io::Error::last_os_error().into())
                     } else {
                         let config = unsafe { &*(buffer.as_ptr().cast::<QUERY_SERVICE_CONFIGW>()) };
-                        let account_name =
-                            null_terminated_wide_to_string(config.lpServiceStartName);
+                        let account_name = unsafe {
+                            null_terminated_wide_to_string(
+                                std::ptr::NonNull::new(config.lpServiceStartName).ok_or_else(
+                                    || {
+                                        CompanionError::Config(
+                                            "service configuration returned a null service account"
+                                                .to_string(),
+                                        )
+                                    },
+                                )?,
+                            )
+                        };
                         if account_name.eq_ignore_ascii_case("localsystem")
                             || account_name.eq_ignore_ascii_case(r"NT AUTHORITY\SYSTEM")
                         {
-                            Ok(String::from("SY"))
+                            Ok(String::from("S-1-5-18"))
                         } else {
                             lookup_account_sid_string(&account_name)
                         }
@@ -2606,8 +2621,8 @@ mod tests {
     };
     #[cfg(windows)]
     use super::{
-        configured_windows_service_sid_string, current_user_sid_string, windows_private_key_sddl,
-        Cli, Command,
+        configured_windows_service_sid_string, current_user_sid_string, sid_to_string, wide_null,
+        windows_private_key_sddl, Cli, Command,
     };
     use azure_core::credentials::TokenCredential;
     use base64::Engine as _;
@@ -3176,6 +3191,119 @@ mod tests {
         assert!(sddl.contains(&format!("(A;;FA;;;{current_user_sid})")));
         if runtime_service_sid != current_user_sid {
             assert!(sddl.contains(&format!("(A;;GR;;;{runtime_service_sid})")));
+        }
+    }
+
+    #[cfg(windows)]
+    fn read_allowed_file_acl_entries(path: &Path) -> Result<Vec<(String, u32)>, CompanionError> {
+        use windows_sys::Win32::Foundation::LocalFree;
+        use windows_sys::Win32::Security::Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT};
+        use windows_sys::Win32::Security::{
+            GetAce, ACCESS_ALLOWED_ACE, DACL_SECURITY_INFORMATION,
+            PROTECTED_DACL_SECURITY_INFORMATION,
+        };
+
+        const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+
+        let path_wide = wide_null(path.as_os_str());
+        let mut dacl = std::ptr::null_mut();
+        let mut security_descriptor = std::ptr::null_mut();
+        let error = unsafe {
+            GetNamedSecurityInfoW(
+                path_wide.as_ptr(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut dacl,
+                std::ptr::null_mut(),
+                &mut security_descriptor,
+            )
+        };
+        if error != 0 {
+            return Err(std::io::Error::from_raw_os_error(error as i32).into());
+        }
+
+        let result = (|| -> Result<Vec<(String, u32)>, CompanionError> {
+            if dacl.is_null() {
+                return Err(CompanionError::Config(
+                    "private key file did not have a DACL".to_string(),
+                ));
+            }
+
+            let ace_count = unsafe { (*dacl).AceCount };
+            let mut entries = Vec::with_capacity(ace_count as usize);
+            for index in 0..ace_count {
+                let mut ace_ptr = std::ptr::null_mut();
+                if unsafe { GetAce(dacl, index.into(), &mut ace_ptr) } == 0 {
+                    return Err(std::io::Error::last_os_error().into());
+                }
+
+                let header =
+                    unsafe { &*(ace_ptr.cast::<windows_sys::Win32::Security::ACE_HEADER>()) };
+                if header.AceType != ACCESS_ALLOWED_ACE_TYPE {
+                    continue;
+                }
+
+                let ace = unsafe { &*(ace_ptr.cast::<ACCESS_ALLOWED_ACE>()) };
+                let sid = sid_to_string(
+                    std::ptr::addr_of!(ace.SidStart)
+                        .cast::<u32>()
+                        .cast_mut()
+                        .cast(),
+                )?;
+                entries.push((sid, ace.Mask));
+            }
+
+            Ok(entries)
+        })();
+
+        unsafe {
+            let _ = LocalFree(security_descriptor.cast());
+        }
+
+        result
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn generated_private_key_acl_excludes_broad_principals_and_allows_runtime_identities() {
+        use windows_sys::Win32::Foundation::{GENERIC_ALL, GENERIC_READ};
+        use windows_sys::Win32::Storage::FileSystem::{FILE_ALL_ACCESS, FILE_GENERIC_READ};
+
+        let temp = TempDir::new().unwrap();
+        let (_cert_path, key_path, _cert_base64) = generate_certificate(temp.path()).unwrap();
+        let acl_entries = read_allowed_file_acl_entries(&key_path).unwrap();
+        let current_user_sid = current_user_sid_string().unwrap();
+        let runtime_service_sid = configured_windows_service_sid_string().unwrap();
+
+        assert!(!acl_entries.is_empty());
+        assert!(!acl_entries
+            .iter()
+            .any(|(sid, _)| sid == "S-1-1-0" || sid == "S-1-5-32-545"));
+
+        let current_user_mask = acl_entries
+            .iter()
+            .find(|(sid, _)| sid == &current_user_sid)
+            .map(|(_, mask)| *mask)
+            .unwrap();
+        assert!(
+            (current_user_mask & FILE_ALL_ACCESS) == FILE_ALL_ACCESS
+                || (current_user_mask & GENERIC_ALL) == GENERIC_ALL
+        );
+
+        if runtime_service_sid != current_user_sid {
+            let runtime_service_mask = acl_entries
+                .iter()
+                .find(|(sid, _)| sid == &runtime_service_sid)
+                .map(|(_, mask)| *mask)
+                .unwrap();
+            assert!(
+                (runtime_service_mask & FILE_GENERIC_READ) == FILE_GENERIC_READ
+                    || (runtime_service_mask & GENERIC_READ) == GENERIC_READ
+                    || (runtime_service_mask & FILE_ALL_ACCESS) == FILE_ALL_ACCESS
+                    || (runtime_service_mask & GENERIC_ALL) == GENERIC_ALL
+            );
         }
     }
 

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -222,7 +222,9 @@ explicitly.
 
 Re-running the `bootstrap` subcommand explicitly (e.g., for credential rotation)
 is safe: it regenerates the certificate, re-runs Bicep, and rewrites the runtime
-artifacts.
+artifacts. This explicit bootstrap path is supported from the Windows native
+binary as well as from the Linux/container deployment path; only the Windows
+service auto-start path is fail-closed before bootstrap-complete state exists.
 
 ### 4.2  Unified bootstrap sequence
 
@@ -233,7 +235,11 @@ When bootstrap is required, the Azure companion performs this sequence:
 3. Generate a self-signed ECDSA P-256 X.509 certificate and private key using
    Rust crypto libraries. The certificate has a 2-year default validity period.
    Write the certificate PEM and private-key PEM to a staging directory within
-   the mounted state volume.
+   the mounted state volume using platform-appropriate restricted permissions for
+   the private key. On Unix this is mode `0600`; on Windows this is a restricted
+   ACL that allows the bootstrap operator and the configured Windows service
+   identity for steady-state runtime to read the key while excluding generic
+   broad-access principals.
 4. Base64-encode the certificate's DER public material for the Bicep
    `companionCertificateBase64` parameter.
 5. Display "Authenticating…" on the modem display.
@@ -514,8 +520,12 @@ staged files into the state volume root, replacing any previous artifacts.
 If any write fails (e.g., disk full), the staging directory is removed and the
 previous state remains intact.
 
-The `key.pem` file MUST be written with owner-only read permissions (mode 0600)
-to protect the private key material.
+The `key.pem` file MUST be written with platform-appropriate restricted access
+to protect the private key material. On Unix this is owner-only read permissions
+(mode `0600`). On Windows this is a restricted ACL that permits read access to
+the bootstrap operator and the configured Windows service identity for
+steady-state runtime while excluding generic broad-access principals such as
+`Everyone` and `Users`.
 
 The runtime's `check-runtime-ready` path is updated to also check for the
 persisted Service Bus configuration file (`service-bus.json`) as an alternative

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -205,7 +205,7 @@ the bootstrap workflow instead of normal runtime mode.
 ### AZC-0201  Unified bootstrap subcommand
 
 **Priority:** Must
-**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), [issue #849](https://github.com/Alan-Jowett/sonde/issues/849), discovery review
 
 **Description:**
 When bootstrap is required, the Azure companion MUST provide a single unified
@@ -216,7 +216,9 @@ creation. The earlier `bootstrap-auth` subcommand is retired and replaced by
 this unified command. Device-code authentication occurs inside the
 digest-pinned Azure CLI container via `az login --use-device-code`; the Rust
 companion monitors the container output to extract the device code and display
-it on the modem.
+it on the modem. The same explicit `bootstrap` subcommand MUST be supported by
+the Windows native binary when invoked manually by an operator; Windows service
+startup remains a separate fail-closed path governed by AZC-0205.
 
 **Acceptance criteria:**
 
@@ -225,6 +227,7 @@ it on the modem.
 3. If any phase of the unified bootstrap fails, the subcommand exits with a non-zero status and does not report success.
 4. Successful device-code login alone is not treated as bootstrap completion; the bootstrap path reports success only after bootstrap-complete state has been established.
 5. The earlier `bootstrap-auth` subcommand name is no longer accepted.
+6. Invoking `sonde-azure-companion bootstrap` from the Windows native binary performs the same end-to-end provisioning lifecycle as the Linux bootstrap path, subject to the same Docker and Azure prerequisites.
 
 ---
 
@@ -555,7 +558,7 @@ local connector harness accepts the payload.
 ### AZC-0400  Self-signed certificate generation
 
 **Priority:** Must
-**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), [issue #849](https://github.com/Alan-Jowett/sonde/issues/849), discovery review
 
 **Description:**
 The unified `bootstrap` subcommand MUST generate a self-signed ECDSA P-256
@@ -570,7 +573,8 @@ mounted state volume as PEM files.
 3. The certificate PEM and private-key PEM are written to the mounted state volume.
 4. The certificate's DER-encoded public material can be base64-encoded and passed to the Bicep deployment's `companionCertificateBase64` parameter.
 5. Re-running bootstrap regenerates the certificate and private key.
-6. The private-key PEM file MUST be written with owner-only read permissions (mode 0600).
+6. On Unix platforms, the private-key PEM file MUST be written with owner-only read permissions (mode 0600).
+7. On Windows, the private-key PEM file MUST be protected with a restricted ACL that permits read access to the bootstrap operator and the configured Windows service identity for steady-state runtime, while denying broad access to generic principals such as `Everyone` and `Users`.
 
 ---
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -516,12 +516,28 @@
 **Procedure:**
 1. Run bootstrap to completion.
 2. Inspect the file permissions of `key.pem` in the state volume.
-3. Assert: the private key file has owner-only read permissions (mode 0600 or equivalent).
-4. Assert: the certificate file (`cert.pem`) is world-readable.
+3. Assert: on Unix, the private key file has owner-only read permissions (mode 0600).
+4. Assert: on Windows, the private key file ACL grants read access to the bootstrap operator and the configured Windows service identity for steady-state runtime, and does not grant read access to generic broad-access principals such as `Everyone` or `Users`.
+5. Assert: the certificate file (`cert.pem`) is world-readable or otherwise readable by the normal runtime without requiring elevated access.
 
 ---
 
-### T-AZC-0414  Access token is not logged
+### T-AZC-0414  Windows native bootstrap completes and produces service-readable key material
+
+**Validates:** AZC-0201, AZC-0400
+
+**Procedure:**
+1. On a Windows machine with Docker available, run `sonde-azure-companion bootstrap` from an elevated PowerShell prompt with the required Azure environment variables set and the gateway admin pipe exposed.
+2. Assert: the command completes successfully without emitting the Unix-only private-key creation failure.
+3. Assert: the generated `cert.pem`, `key.pem`, `service-principal.json`, and `service-bus.json` files exist in `%ProgramData%\sonde-azure-companion\` (or the configured state directory).
+4. Inspect the ACL on `key.pem`.
+5. Assert: the ACL permits read access to the bootstrap operator and the configured Windows service identity for steady-state runtime.
+6. If the `sonde-azure-companion` Windows service is not yet installed, install it; then start or restart the service against the generated state.
+7. Assert: the service reaches the normal runtime path without failing due to private-key access.
+
+---
+
+### T-AZC-0415  Access token is not logged
 
 **Validates:** AZC-0401
 


### PR DESCRIPTION
## Summary
- support Windows `sonde-azure-companion bootstrap` instead of failing on Unix-only private-key creation
- update Azure companion requirements, design, and validation docs to make Windows explicit bootstrap support and Windows ACL-based key protection explicit
- add Windows-focused test coverage for certificate generation and runtime-service key access expectations

## Traceability
- **Requirements:** `AZC-0201` now explicitly keeps manual Windows `bootstrap` supported; `AZC-0400` now distinguishes Unix `0600` from Windows restricted ACL behavior
- **Design:** Windows service auto-start remains fail-closed before bootstrap-complete state exists, while manual Windows `bootstrap` is supported and must create service-readable protected key material
- **Validation:** adds a Windows bootstrap validation case and refines private-key permission validation for Unix vs Windows

## Implementation
- replace the Windows non-Unix rejection in `write_private_key_pem()` with secure `CreateFileW` creation using a protected SDDL descriptor
- grant key access to the bootstrap operator plus the configured Windows service identity when the service already exists, with a `SYSTEM` fallback before installation
- keep the Unix `0600` path unchanged

## Audit
- **Specification audit:** PASS
- **Implementation audit:** PASS

## Validation
- `cargo clippy -p sonde-azure-companion --all-targets -- -D warnings`
- `cargo test -p sonde-azure-companion`
- `cargo build --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #849
