### PR TITLE
Add dedicated azure bootstrap image

### DIFF
--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -11,3 +11,5 @@ COPY deploy/bicep/ /opt/sonde/deploy/bicep/
 
 RUN chmod +x /opt/sonde/deploy/azure-bootstrap/bootstrap.sh \
     && mkdir -p /cert
+
+ENTRYPOINT ["/opt/sonde/deploy/azure-bootstrap/bootstrap.sh"]

--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Bootstrap image for Azure companion provisioning. Contains Azure CLI plus the
+# bundled Bicep deployment surface and bootstrap script.
+
+FROM mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7
+
+COPY deploy/azure-bootstrap/bootstrap.sh /opt/sonde/deploy/azure-bootstrap/bootstrap.sh
+COPY deploy/bicep/ /opt/sonde/deploy/bicep/
+
+RUN chmod +x /opt/sonde/deploy/azure-bootstrap/bootstrap.sh \
+    && mkdir -p /cert

--- a/.github/docker/Dockerfile.azure-companion
+++ b/.github/docker/Dockerfile.azure-companion
@@ -3,7 +3,7 @@
 #
 # Multi-stage Dockerfile for the Azure companion container image.
 # Produces a minimal Alpine-based image containing the
-# `sonde-azure-companion` binary plus bootstrap scripts.
+# `sonde-azure-companion` binary plus runtime orchestration scripts.
 
 # ── Stage 1: build ──────────────────────────────────────────────────────────
 # rust:alpine — pinned by digest for reproducible builds.
@@ -25,7 +25,6 @@ RUN apk add --no-cache ca-certificates \
 COPY --from=builder /sonde/target/release/sonde-azure-companion /usr/local/bin/sonde-azure-companion
 COPY deploy/azure-companion/bootstrap.sh /opt/sonde/deploy/azure-companion/bootstrap.sh
 COPY deploy/azure-companion/entrypoint.sh /opt/sonde/deploy/azure-companion/entrypoint.sh
-COPY deploy/bicep/ /opt/sonde/deploy/bicep/
 
 RUN chmod +x /usr/local/bin/sonde-azure-companion \
     /opt/sonde/deploy/azure-companion/bootstrap.sh \

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -66,7 +66,11 @@ jobs:
              && test -r /opt/sonde/deploy/bicep/bicepconfig.json \
              && test -d /opt/sonde/deploy/bicep/modules'
 
-      - name: Smoke test — runtime image excludes Rust toolchain and source tree
+      - name: Smoke test — bootstrap image entrypoint
+        run: |
+          test "$(docker image inspect ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --format '{{json .Config.Entrypoint}}')" = '["/opt/sonde/deploy/azure-bootstrap/bootstrap.sh"]'
+
+      - name: Smoke test — bootstrap image excludes Rust toolchain and source tree
         run: |
           docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
             '! command -v cargo >/dev/null 2>&1 \

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Build and publish the sonde-azure-bootstrap multi-arch container image to GHCR.
+
+name: Azure Bootstrap Container
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: alan-jowett/sonde-azure-bootstrap
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
+
+      - name: Build container image
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: .github/docker/Dockerfile.azure-bootstrap
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }}
+
+      - name: Smoke test — Azure CLI and bundled assets
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'az version >/dev/null \
+             && test -x /opt/sonde/deploy/azure-bootstrap/bootstrap.sh \
+             && test -r /opt/sonde/deploy/bicep/main.bicep \
+             && test -r /opt/sonde/deploy/bicep/bicepconfig.json \
+             && test -d /opt/sonde/deploy/bicep/modules'
+
+      - name: Smoke test — runtime image excludes Rust toolchain and source tree
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            '! command -v cargo >/dev/null 2>&1 \
+             && ! command -v rustc >/dev/null 2>&1 \
+             && ! test -d /root/.cargo \
+             && ! test -d /usr/local/cargo \
+             && ! test -d /src'
+
+      - name: Push per-arch image
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        run: |
+          ARCH_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-${{ github.sha }}-${{ github.run_id }}-${{ matrix.arch }}"
+          docker tag "${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }}" "$ARCH_TAG"
+          docker push "$ARCH_TAG"
+
+  manifest:
+    name: Publish multi-arch manifest
+    needs: [build]
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
+
+      - name: Determine tags
+        id: tags
+        run: |
+          set -euo pipefail
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          VERSION="$(sed -n '/\[workspace\.package\]/,/^\[/{ s/^version *= *"\(.*\)"/\1/p; }' Cargo.toml)"
+          TAGS="sha-${SHORT_SHA},${VERSION}"
+
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            TAGS="${TAGS},latest"
+          else
+            DATE=$(date -u +%Y%m%d)
+            TAGS="${TAGS},nightly,nightly-${DATE}"
+          fi
+
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push multi-arch manifest
+        run: |
+          set -euo pipefail
+          BASE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          AMD64="${BASE}:build-${{ github.sha }}-${{ github.run_id }}-amd64"
+          ARM64="${BASE}:build-${{ github.sha }}-${{ github.run_id }}-arm64"
+
+          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          for TAG in "${TAG_ARRAY[@]}"; do
+            docker buildx imagetools create \
+              --tag "${BASE}:${TAG}" \
+              "${AMD64}" "${ARM64}"
+          done
+
+      - name: Clean up temporary per-arch tags
+        run: |
+          echo "Manifest published successfully."

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -164,6 +164,15 @@ jobs:
       contents: read
       packages: write
 
+  azure-bootstrap-container:
+    name: Azure bootstrap container
+    needs: [should_run]
+    if: needs.should_run.outputs.run_builds == 'true'
+    uses: ./.github/workflows/azure-bootstrap-container.yml
+    permissions:
+      contents: read
+      packages: write
+
   node-firmware:
     name: Node firmware
     needs: [should_run]
@@ -423,6 +432,7 @@ jobs:
           | Installer — Linux (amd64) | `sonde_*_amd64.deb` |
           | Installer — Linux (arm64) | `sonde_*_arm64.deb` |
           | Container (multi-arch) | `ghcr.io/alan-jowett/sonde-gateway` |
+          | Azure bootstrap container (multi-arch) | `ghcr.io/alan-jowett/sonde-azure-bootstrap` |
 
           ### Flashing firmware
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -344,7 +344,7 @@ jobs:
   # ── Publish release ────────────────────────────────────────────────
   release:
     name: Publish nightly
-    needs: [should_run, gateway, bpf-test-programs, sensor-handlers, gateway-container, node-firmware, modem-firmware, desktop, android, installer-linux, installer-linux-arm64, installer-windows]
+    needs: [should_run, gateway, bpf-test-programs, sensor-handlers, gateway-container, azure-bootstrap-container, node-firmware, modem-firmware, desktop, android, installer-linux, installer-linux-arm64, installer-windows]
     if: needs.should_run.outputs.run_builds == 'true'
     runs-on: ubuntu-latest
     permissions:

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -1290,10 +1290,16 @@ fn default_bootstrap_image() -> String {
 
 fn resolve_bootstrap_image(override_image: Option<&str>) -> Result<String, CompanionError> {
     match override_image {
-        Some(image) if image.trim().is_empty() => Err(CompanionError::Config(
-            "bootstrap image override must not be empty".into(),
-        )),
-        Some(image) => Ok(image.to_string()),
+        Some(image) => {
+            let trimmed = image.trim();
+            if trimmed.is_empty() {
+                Err(CompanionError::Config(
+                    "bootstrap image override must not be empty".into(),
+                ))
+            } else {
+                Ok(trimmed.to_string())
+            }
+        }
         None => Ok(default_bootstrap_image()),
     }
 }
@@ -3444,6 +3450,14 @@ mod tests {
     fn resolve_bootstrap_image_uses_override_when_provided() {
         assert_eq!(
             resolve_bootstrap_image(Some("sonde-azure-bootstrap:test-override")).unwrap(),
+            "sonde-azure-bootstrap:test-override"
+        );
+    }
+
+    #[test]
+    fn resolve_bootstrap_image_trims_override() {
+        assert_eq!(
+            resolve_bootstrap_image(Some("  sonde-azure-bootstrap:test-override  ")).unwrap(),
             "sonde-azure-bootstrap:test-override"
         );
     }

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -19,9 +19,9 @@ use bollard::container::LogOutput;
 use bollard::models::ContainerCreateBody;
 use bollard::query_parameters::{
     CreateContainerOptionsBuilder, CreateImageOptionsBuilder, LogsOptionsBuilder,
-    RemoveContainerOptionsBuilder, UploadToContainerOptionsBuilder, WaitContainerOptionsBuilder,
+    RemoveContainerOptionsBuilder, WaitContainerOptionsBuilder,
 };
-use bollard::{body_full, Docker};
+use bollard::Docker;
 use clap::{Args, Parser, Subcommand};
 use ed25519_dalek::pkcs8::DecodePrivateKey as Ed25519DecodePrivateKey;
 use futures_util::StreamExt;
@@ -1826,45 +1826,6 @@ async fn run(connector_socket: &str, state_dir: &Path) -> Result<(), CompanionEr
     run_with_factory(connector_socket, state_dir, &AzServiceBusTransportFactory).await
 }
 
-async fn copy_bootstrap_inputs_to_container(
-    docker: &Docker,
-    container_id: &str,
-    staging_dir: &Path,
-) -> Result<(), CompanionError> {
-    let mut archive = Vec::new();
-    {
-        let mut builder = tar::Builder::new(&mut archive);
-        let cert_path = staging_dir.join(CERT_PEM_FILENAME);
-        if !cert_path.is_file() {
-            return Err(CompanionError::Config(format!(
-                "generated certificate file not found: {}",
-                cert_path.display()
-            )));
-        }
-        builder
-            .append_path_with_name(&cert_path, format!("cert/{CERT_PEM_FILENAME}"))
-            .map_err(|e| {
-                CompanionError::Config(format!("failed to add certificate to archive: {e}"))
-            })?;
-        builder
-            .finish()
-            .map_err(|e| CompanionError::Config(format!("failed to finalize tar archive: {e}")))?;
-    }
-
-    let upload_options = UploadToContainerOptionsBuilder::default().path("/").build();
-
-    docker
-        .upload_to_container(
-            container_id,
-            Some(upload_options),
-            body_full(archive.into()),
-        )
-        .await
-        .map_err(|e| CompanionError::Config(format!("failed to copy files to container: {e}")))?;
-
-    Ok(())
-}
-
 async fn stream_container_output(
     docker: &Docker,
     container_id: &str,
@@ -1937,20 +1898,17 @@ async fn stream_container_output(
 
 async fn run_bootstrap_deployment(
     admin_socket: &str,
-    staging_dir: &Path,
     cert_base64: &str,
     args: &BootstrapArgs,
 ) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
     let docker = Docker::connect_with_local_defaults()
         .map_err(|e| CompanionError::Config(format!("failed to connect to Docker daemon: {e}")))?;
-    run_bootstrap_deployment_with_docker(&docker, admin_socket, staging_dir, cert_base64, args)
-        .await
+    run_bootstrap_deployment_with_docker(&docker, admin_socket, cert_base64, args).await
 }
 
 async fn run_bootstrap_deployment_with_docker(
     docker: &Docker,
     admin_socket: &str,
-    staging_dir: &Path,
     cert_base64: &str,
     args: &BootstrapArgs,
 ) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
@@ -1958,7 +1916,6 @@ async fn run_bootstrap_deployment_with_docker(
     run_bootstrap_deployment_with_docker_and_image(
         docker,
         admin_socket,
-        staging_dir,
         cert_base64,
         args,
         &bootstrap_image,
@@ -1969,7 +1926,6 @@ async fn run_bootstrap_deployment_with_docker(
 async fn run_bootstrap_deployment_with_docker_and_image(
     docker: &Docker,
     admin_socket: &str,
-    staging_dir: &Path,
     cert_base64: &str,
     args: &BootstrapArgs,
     bootstrap_image: &str,
@@ -2010,7 +1966,6 @@ async fn run_bootstrap_deployment_with_docker_and_image(
     let container_id = container.id;
 
     let bootstrap_result = async {
-        copy_bootstrap_inputs_to_container(docker, &container_id, staging_dir).await?;
         docker
             .start_container(&container_id, None)
             .await
@@ -2109,7 +2064,7 @@ async fn bootstrap(
     }
     eprintln!("Starting sonde-azure-bootstrap for device-code auth and Bicep deployment");
     let (sp_state, sb_config) =
-        match run_bootstrap_deployment(admin_socket, &staging_dir, &cert_base64, &args).await {
+        match run_bootstrap_deployment(admin_socket, &cert_base64, &args).await {
             Ok(result) => result,
             Err(e) => return report_bootstrap_failure(admin_socket, &staging_dir, e).await,
         };
@@ -3685,8 +3640,6 @@ mod tests {
             .await;
 
         let docker = Docker::connect_with_http(&server.uri(), 120, API_DEFAULT_VERSION).unwrap();
-        let temp = TempDir::new().unwrap();
-        std::fs::write(temp.path().join(CERT_PEM_FILENAME), b"test-cert").unwrap();
         let args = super::BootstrapArgs {
             azure_location: "westus2".to_string(),
             azure_project_name: "sonde".to_string(),
@@ -3697,7 +3650,6 @@ mod tests {
         let err = run_bootstrap_deployment_with_docker_and_image(
             &docker,
             "/tmp/unused-admin.sock",
-            temp.path(),
             "dummy-cert-base64",
             &args,
             "sonde-azure-bootstrap:test-override",
@@ -3716,7 +3668,6 @@ mod tests {
             vec![
                 "POST /images/create".to_string(),
                 "POST /containers/create".to_string(),
-                "PUT /containers/test-container/archive".to_string(),
                 "POST /containers/test-container/start".to_string(),
                 "DELETE /containers/test-container".to_string(),
             ]
@@ -3726,7 +3677,8 @@ mod tests {
                 |query| query.contains("fromImage=sonde-azure-bootstrap%3Atest-override")
             )
         );
-        assert!(!requests[2].body.is_empty());
+        let create_body = String::from_utf8(requests[1].body.clone()).unwrap();
+        assert!(create_body.contains("COMPANION_CERT_BASE64=dummy-cert-base64"));
     }
 
     #[test]

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -55,7 +55,6 @@ const DEFAULT_STATE_DIR: &str = "/var/lib/sonde-azure-companion";
 
 const SERVICE_PRINCIPAL_STATE_FILENAME: &str = "service-principal.json";
 const DEFAULT_BOOTSTRAP_IMAGE_REPOSITORY: &str = "ghcr.io/alan-jowett/sonde-azure-bootstrap";
-const BOOTSTRAP_SCRIPT_PATH: &str = "/opt/sonde/deploy/azure-bootstrap/bootstrap.sh";
 const CERT_PEM_FILENAME: &str = "cert.pem";
 const KEY_PEM_FILENAME: &str = "key.pem";
 const SERVICE_BUS_CONFIG_FILENAME: &str = "service-bus.json";
@@ -1954,7 +1953,6 @@ async fn run_bootstrap_deployment_with_docker_and_image(
             ),
             ContainerCreateBody {
                 image: Some(bootstrap_image.to_string()),
-                cmd: Some(vec![BOOTSTRAP_SCRIPT_PATH.to_string()]),
                 env: Some(env_vars),
                 ..Default::default()
             },

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -54,11 +54,8 @@ const DEFAULT_CONNECTOR_SOCKET: &str = r"\\.\pipe\sonde-connector";
 const DEFAULT_STATE_DIR: &str = "/var/lib/sonde-azure-companion";
 
 const SERVICE_PRINCIPAL_STATE_FILENAME: &str = "service-principal.json";
-/// Path to bundled Bicep files inside the companion container image.
-const BUNDLED_BICEP_PATH: &str = "/opt/sonde/deploy/bicep";
-/// Pinned Azure CLI container image digest for reproducible bootstrap.
-const AZURE_CLI_IMAGE: &str =
-    "mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7";
+const DEFAULT_BOOTSTRAP_IMAGE_REPOSITORY: &str = "ghcr.io/alan-jowett/sonde-azure-bootstrap";
+const BOOTSTRAP_SCRIPT_PATH: &str = "/opt/sonde/deploy/azure-bootstrap/bootstrap.sh";
 const CERT_PEM_FILENAME: &str = "cert.pem";
 const KEY_PEM_FILENAME: &str = "key.pem";
 const SERVICE_BUS_CONFIG_FILENAME: &str = "service-bus.json";
@@ -179,6 +176,10 @@ struct BootstrapArgs {
     /// Optional Azure subscription ID override.
     #[arg(long, env = "SONDE_AZURE_SUBSCRIPTION_ID")]
     azure_subscription_id: Option<String>,
+
+    /// Optional bootstrap image override for development and test workflows.
+    #[arg(long, env = "SONDE_AZURE_BOOTSTRAP_IMAGE")]
+    bootstrap_image: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1280,22 +1281,21 @@ fn parse_bicep_outputs(
     Ok((sp, sb))
 }
 
-fn build_az_bootstrap_script() -> String {
-    r#"set -eu
-az login --use-device-code --output none >&2
-if [ -n "${SONDE_AZURE_SUBSCRIPTION_ID:-}" ]; then
-    az account set --subscription "$SONDE_AZURE_SUBSCRIPTION_ID" >&2
-fi
-echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2
-az deployment sub create \
-    --location "$SONDE_AZURE_LOCATION" \
-    --template-file /bicep/main.bicep \
-    --parameters companionCertificateBase64="$COMPANION_CERT_BASE64" \
-    --parameters location="$SONDE_AZURE_LOCATION" \
-    --parameters project_name="$SONDE_AZURE_PROJECT_NAME" \
-    --query 'properties.outputs' \
-    --output json"#
-        .to_string()
+fn default_bootstrap_image() -> String {
+    format!(
+        "{DEFAULT_BOOTSTRAP_IMAGE_REPOSITORY}:{}",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+fn resolve_bootstrap_image(override_image: Option<&str>) -> Result<String, CompanionError> {
+    match override_image {
+        Some(image) if image.trim().is_empty() => Err(CompanionError::Config(
+            "bootstrap image override must not be empty".into(),
+        )),
+        Some(image) => Ok(image.to_string()),
+        None => Ok(default_bootstrap_image()),
+    }
 }
 
 fn device_code_regex() -> &'static Regex {
@@ -1820,25 +1820,14 @@ async fn run(connector_socket: &str, state_dir: &Path) -> Result<(), CompanionEr
     run_with_factory(connector_socket, state_dir, &AzServiceBusTransportFactory).await
 }
 
-async fn copy_files_to_container(
+async fn copy_bootstrap_inputs_to_container(
     docker: &Docker,
     container_id: &str,
     staging_dir: &Path,
-    bicep_path: &Path,
 ) -> Result<(), CompanionError> {
     let mut archive = Vec::new();
     {
         let mut builder = tar::Builder::new(&mut archive);
-        if !bicep_path.is_dir() {
-            return Err(CompanionError::Config(format!(
-                "bundled Bicep path not found: {}",
-                bicep_path.display()
-            )));
-        }
-        builder.append_dir_all("bicep", bicep_path).map_err(|e| {
-            CompanionError::Config(format!("failed to add Bicep files to archive: {e}"))
-        })?;
-
         let cert_path = staging_dir.join(CERT_PEM_FILENAME);
         if !cert_path.is_file() {
             return Err(CompanionError::Config(format!(
@@ -1959,36 +1948,39 @@ async fn run_bootstrap_deployment_with_docker(
     cert_base64: &str,
     args: &BootstrapArgs,
 ) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
-    run_bootstrap_deployment_with_docker_and_bicep_dir(
+    let bootstrap_image = resolve_bootstrap_image(args.bootstrap_image.as_deref())?;
+    run_bootstrap_deployment_with_docker_and_image(
         docker,
         admin_socket,
         staging_dir,
         cert_base64,
         args,
-        Path::new(BUNDLED_BICEP_PATH),
+        &bootstrap_image,
     )
     .await
 }
 
-async fn run_bootstrap_deployment_with_docker_and_bicep_dir(
+async fn run_bootstrap_deployment_with_docker_and_image(
     docker: &Docker,
     admin_socket: &str,
     staging_dir: &Path,
     cert_base64: &str,
     args: &BootstrapArgs,
-    bicep_path: &Path,
+    bootstrap_image: &str,
 ) -> Result<(ServicePrincipalStateFile, ServiceBusConfigFile), CompanionError> {
-    eprintln!("Pulling Azure CLI container image...");
+    eprintln!("Pulling bootstrap image...");
     let pull_opts = CreateImageOptionsBuilder::default()
-        .from_image(AZURE_CLI_IMAGE)
+        .from_image(bootstrap_image)
         .build();
     let mut pull_stream = docker.create_image(Some(pull_opts), None, None);
     while let Some(result) = pull_stream.next().await {
-        result
-            .map_err(|e| CompanionError::Config(format!("failed to pull Azure CLI image: {e}")))?;
+        result.map_err(|e| {
+            CompanionError::Config(format!(
+                "failed to pull bootstrap image {bootstrap_image}: {e}"
+            ))
+        })?;
     }
 
-    let bootstrap_script = build_az_bootstrap_script();
     let env_vars = build_container_env(cert_base64, args);
     let container_name = format!("sonde-bootstrap-{}", Uuid::new_v4());
     let container = docker
@@ -1999,25 +1991,25 @@ async fn run_bootstrap_deployment_with_docker_and_bicep_dir(
                     .build(),
             ),
             ContainerCreateBody {
-                image: Some(AZURE_CLI_IMAGE.to_string()),
-                cmd: Some(vec!["sh".to_string(), "-c".to_string(), bootstrap_script]),
+                image: Some(bootstrap_image.to_string()),
+                cmd: Some(vec![BOOTSTRAP_SCRIPT_PATH.to_string()]),
                 env: Some(env_vars),
                 ..Default::default()
             },
         )
         .await
         .map_err(|e| {
-            CompanionError::Config(format!("failed to create Azure CLI container: {e}"))
+            CompanionError::Config(format!("failed to create bootstrap container: {e}"))
         })?;
     let container_id = container.id;
 
     let bootstrap_result = async {
-        copy_files_to_container(docker, &container_id, staging_dir, bicep_path).await?;
+        copy_bootstrap_inputs_to_container(docker, &container_id, staging_dir).await?;
         docker
             .start_container(&container_id, None)
             .await
             .map_err(|e| {
-                CompanionError::Config(format!("failed to start Azure CLI container: {e}"))
+                CompanionError::Config(format!("failed to start bootstrap container: {e}"))
             })?;
 
         let stdout_output = stream_container_output(docker, &container_id, admin_socket).await?;
@@ -2031,18 +2023,18 @@ async fn run_bootstrap_deployment_with_docker_and_bicep_dir(
             Some(Ok(result)) if result.status_code == 0 => {}
             Some(Ok(result)) => {
                 return Err(CompanionError::Config(format!(
-                    "Azure CLI container exited with non-zero status: {}",
+                    "bootstrap container exited with non-zero status: {}",
                     result.status_code
                 )));
             }
             Some(Err(e)) => {
                 return Err(CompanionError::Config(format!(
-                    "failed to wait for Azure CLI container: {e}"
+                    "failed to wait for bootstrap container: {e}"
                 )));
             }
             None => {
                 return Err(CompanionError::Config(
-                    "Azure CLI container wait stream ended unexpectedly".into(),
+                    "bootstrap container wait stream ended unexpectedly".into(),
                 ));
             }
         }
@@ -2109,7 +2101,7 @@ async fn bootstrap(
         cleanup_staging(&staging_dir);
         return Err(err);
     }
-    eprintln!("Starting Azure CLI container for device-code auth and Bicep deployment");
+    eprintln!("Starting sonde-azure-bootstrap for device-code auth and Bicep deployment");
     let (sp_state, sb_config) =
         match run_bootstrap_deployment(admin_socket, &staging_dir, &cert_base64, &args).await {
             Ok(result) => result,
@@ -2612,12 +2604,12 @@ mod tests {
     #[cfg(unix)]
     use super::validate_certificate_matches_private_key;
     use super::{
-        build_az_bootstrap_script, check_runtime_ready, cleanup_staging, commit_staging,
+        check_runtime_ready, cleanup_staging, commit_staging, default_bootstrap_image,
         downstream_body_to_connector_payload, extract_device_code, generate_certificate,
         load_runtime_config, load_runtime_credential_state, load_signing_key, parse_bicep_outputs,
         prepare_staging_dir, pump_downstream_once, pump_upstream_once, read_framed,
-        resolve_effective_state_dir, resolve_state_relative_path,
-        run_bootstrap_deployment_with_docker_and_bicep_dir, trim_buffer_to_max_len,
+        resolve_bootstrap_image, resolve_effective_state_dir, resolve_state_relative_path,
+        run_bootstrap_deployment_with_docker_and_image, trim_buffer_to_max_len,
         validate_display_lines, write_framed, ClientAssertionCredential, CompanionError,
         DownstreamConsumer, RuntimeConfig, RuntimeCredentialState, ServiceBusConfigFile,
         ServicePrincipalStateFile, UpstreamPublisher, ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME,
@@ -3438,11 +3430,28 @@ mod tests {
     }
 
     #[test]
-    fn build_az_bootstrap_script_passes_location_parameter_to_template() {
-        let script = build_az_bootstrap_script();
-        assert!(script.contains(r#"--location "$SONDE_AZURE_LOCATION""#));
-        assert!(script.contains(r#"--parameters location="$SONDE_AZURE_LOCATION""#));
-        assert!(script.contains(r#"echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2"#));
+    fn default_bootstrap_image_uses_package_version_tag() {
+        assert_eq!(
+            default_bootstrap_image(),
+            format!(
+                "ghcr.io/alan-jowett/sonde-azure-bootstrap:{}",
+                env!("CARGO_PKG_VERSION")
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_bootstrap_image_uses_override_when_provided() {
+        assert_eq!(
+            resolve_bootstrap_image(Some("sonde-azure-bootstrap:test-override")).unwrap(),
+            "sonde-azure-bootstrap:test-override"
+        );
+    }
+
+    #[test]
+    fn resolve_bootstrap_image_rejects_empty_override() {
+        let err = resolve_bootstrap_image(Some("   ")).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
     }
 
     #[test]
@@ -3664,26 +3673,20 @@ mod tests {
         let docker = Docker::connect_with_http(&server.uri(), 120, API_DEFAULT_VERSION).unwrap();
         let temp = TempDir::new().unwrap();
         std::fs::write(temp.path().join(CERT_PEM_FILENAME), b"test-cert").unwrap();
-        let bicep_dir = temp.path().join("bicep");
-        std::fs::create_dir_all(&bicep_dir).unwrap();
-        std::fs::write(
-            bicep_dir.join("main.bicep"),
-            b"targetScope = 'subscription'\n",
-        )
-        .unwrap();
         let args = super::BootstrapArgs {
             azure_location: "westus2".to_string(),
             azure_project_name: "sonde".to_string(),
             azure_subscription_id: None,
+            bootstrap_image: Some("sonde-azure-bootstrap:test-override".to_string()),
         };
 
-        let err = run_bootstrap_deployment_with_docker_and_bicep_dir(
+        let err = run_bootstrap_deployment_with_docker_and_image(
             &docker,
             "/tmp/unused-admin.sock",
             temp.path(),
             "dummy-cert-base64",
             &args,
-            &bicep_dir,
+            "sonde-azure-bootstrap:test-override",
         )
         .await
         .unwrap_err();
@@ -3703,6 +3706,11 @@ mod tests {
                 "POST /containers/test-container/start".to_string(),
                 "DELETE /containers/test-container".to_string(),
             ]
+        );
+        assert!(
+            requests[0].url.query().is_some_and(
+                |query| query.contains("fromImage=sonde-azure-bootstrap%3Atest-override")
+            )
         );
         assert!(!requests[2].body.is_empty());
     }
@@ -4009,6 +4017,7 @@ mod tests {
             azure_location: "westus2".to_string(),
             azure_project_name: "sonde".to_string(),
             azure_subscription_id: None,
+            bootstrap_image: None,
         };
 
         let err = super::bootstrap("/tmp/sonde-missing-admin.sock", temp.path(), args)

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+az login --use-device-code --output none >&2
+if [ -n "${SONDE_AZURE_SUBSCRIPTION_ID:-}" ]; then
+    az account set --subscription "$SONDE_AZURE_SUBSCRIPTION_ID" >&2
+fi
+echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2
+az deployment sub create \
+    --location "$SONDE_AZURE_LOCATION" \
+    --template-file /opt/sonde/deploy/bicep/main.bicep \
+    --parameters companionCertificateBase64="$COMPANION_CERT_BASE64" \
+    --parameters location="$SONDE_AZURE_LOCATION" \
+    --parameters project_name="$SONDE_AZURE_PROJECT_NAME" \
+    --query 'properties.outputs' \
+    --output json

--- a/deploy/azure-companion/bootstrap.sh
+++ b/deploy/azure-companion/bootstrap.sh
@@ -120,6 +120,7 @@ if [ "${SONDE_AZURE_COMPANION_IN_CONTAINER:-0}" != "1" ]; then
         -e SONDE_AZURE_LOCATION \
         -e SONDE_AZURE_PROJECT_NAME \
         -e SONDE_AZURE_SUBSCRIPTION_ID \
+        -e SONDE_AZURE_BOOTSTRAP_IMAGE \
         -v "$state_dir:$container_state_dir" \
         -v "$admin_socket_path:$container_admin_socket_path" \
         -v "$connector_socket_path:$container_connector_socket_path" \

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -270,10 +270,9 @@ When bootstrap is required, the Azure companion performs this sequence:
    `ghcr.io/alan-jowett/sonde-azure-bootstrap:<matching companion version>`
    unless a development or test override is configured.
 7. Use the Bollard crate to pull (if needed) that bootstrap image tag.
-8. Create a bootstrap container and copy in only dynamic inputs such as the
-   staged certificate via Bollard's `put_archive` API (not bind mounts, since
-   the runtime container's internal paths are not visible to the host Docker
-   daemon).
+8. Create a bootstrap container and pass only dynamic inputs such as the
+   generated certificate via container environment variables. The bootstrap
+   flow does not use bind mounts or host-side Bicep paths.
 9. The bootstrap container runs its bundled script, which executes
    `az login --use-device-code` followed by `az deployment sub create` using
    the Bicep files already bundled inside the bootstrap image.
@@ -478,10 +477,10 @@ Engine API. It does not shell out to the `docker` CLI. The integration flow:
    fails with a clear error message.
 4. Create a container with environment variables for deployment parameters
    (`SONDE_AZURE_LOCATION`, `COMPANION_CERT_BASE64`, etc.).
-5. Copy only dynamic bootstrap inputs such as the staged certificate into the
-   container using Bollard's `put_archive` API. The Bicep files and bootstrap
-   script are already part of the bootstrap image, so bootstrap does not depend
-   on runtime-image or host-side Bicep paths.
+5. Pass only dynamic bootstrap inputs such as the generated certificate into
+   the container environment. The Bicep files and bootstrap script are already
+   part of the bootstrap image, so bootstrap does not depend on runtime-image
+   or host-side Bicep paths.
 6. Start the container and stream its output (stdout/stderr).
 7. Monitor the output for the device-code pattern from `az login --use-device-code`.
    When detected, extract the code and display it on the modem via the admin API.

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -4,10 +4,11 @@
 
 > **Document status:** Draft
 > **Scope:** Internal design for the Azure companion deployment surfaces
-> (Linux container and Windows native service), bootstrap-state detection,
-> bootstrap trigger behavior, integrated provisioning orchestration
-> (certificate generation, Bicep deployment via Docker API, runtime artifact
-> creation), and the Service Bus AMQP runtime bridge.
+> (Linux runtime container and Windows native service), the dedicated bootstrap
+> image, bootstrap-state detection, bootstrap trigger behavior, integrated
+> provisioning orchestration (certificate generation, bootstrap-image execution
+> via Docker API, and runtime artifact creation), and the Service Bus AMQP
+> runtime bridge.
 > The Bicep module definitions themselves are specified in
 > [azure-provisioning-design.md](azure-provisioning-design.md).
 > **Audience:** Implementers building the Azure companion crate and its
@@ -30,11 +31,12 @@ The Azure companion is a Rust workspace crate that talks to
 The Azure companion now has two distinct responsibilities:
 
 1. detect whether bootstrap has already completed,
-2. invoke bootstrap on the Linux/container path when the required local
-   provisioning artifacts are missing,
+2. invoke the dedicated bootstrap image on the Linux runtime-container path when the
+   required local provisioning artifacts are missing,
 3. use the gateway admin API to display the device code during bootstrap,
-4. orchestrate the full provisioning lifecycle (certificate generation, Bicep
-   deployment via the Docker API, and runtime artifact creation), and
+4. orchestrate the full provisioning lifecycle (certificate generation,
+   bootstrap-image execution via the Docker API, and runtime artifact
+   creation), and
 5. when bootstrap-complete state exists, bridge the gateway connector session to
    Azure Service Bus over AMQP.
 
@@ -45,16 +47,18 @@ logic is confined to the Azure companion.
 
 ## 2  Repository layout
 
-> **Requirements:** AZC-0100, AZC-0102, AZC-0103, AZC-0104
+> **Requirements:** AZC-0100, AZC-0102, AZC-0103, AZC-0104, AZC-0106
 
 The implementation adds or updates the following artifacts:
 
 | Artifact | Purpose |
 |----------|---------|
 | `crates/sonde-azure-companion/` | Rust crate containing the Azure companion binary. |
-| `.github/docker/Dockerfile.azure-companion` | Dockerfile for the dedicated Azure companion image. |
-| `deploy/azure-companion/bootstrap.sh` | Host/container bootstrap script that prepares the mounted state volume, evaluates bootstrap-complete state, and starts either bootstrap or runtime. |
-| `deploy/azure-companion/entrypoint.sh` | In-container entrypoint that orchestrates bootstrap-state detection before starting the Rust binary. |
+| `.github/docker/Dockerfile.azure-companion` | Dockerfile for the dedicated Azure companion runtime image. |
+| `.github/docker/Dockerfile.azure-bootstrap` | Dockerfile for the dedicated `sonde-azure-bootstrap` provisioning image. |
+| `deploy/azure-companion/bootstrap.sh` | Host/container runtime orchestration script that prepares the mounted state volume, evaluates bootstrap-complete state, launches the bootstrap image when needed, and otherwise starts runtime. |
+| `deploy/azure-companion/entrypoint.sh` | In-container runtime entrypoint that orchestrates bootstrap-state detection before starting the Rust binary. |
+| `deploy/azure-bootstrap/bootstrap.sh` | In-bootstrap-image script that runs device-code login plus Azure deployment using bundled provisioning assets. |
 | `installer/windows/sonde.wxs` | Windows MSI definition that exposes the Azure companion as an optional installer feature and can register the companion service. |
 
 The long-running binary is named `sonde-azure-companion`.
@@ -67,20 +71,24 @@ The long-running binary is named `sonde-azure-companion`.
 
 ### 3.1  Process model
 
-The Azure companion has platform-specific deployment entrypoints:
+The Azure companion architecture separates steady-state runtime from bootstrap
+execution. The deployment entrypoints are:
 
-1. **Linux container deployment** uses a small shell entrypoint that performs
-   filesystem and startup orchestration and then execs the Rust binary.
+1. **Linux runtime container deployment** uses a small shell entrypoint that
+   performs filesystem and startup orchestration and then execs the Rust binary.
 2. **Windows native-service deployment** is started directly by SCM and runs the
    Rust binary without the Linux shell wrapper.
 
+3. **Bootstrap-image deployment** runs the dedicated `sonde-azure-bootstrap`
+   image, which contains Azure CLI, bundled Bicep files, and the bootstrap
+   script for device-code login plus Azure deployment.
+
 This keeps the gateway-facing logic and Azure-facing runtime in typed Rust while
-still allowing a small Alpine-oriented Linux image and a native Windows service
-story.
+isolating bootstrap-only tooling and provisioning assets in a separate image.
 
-#### 3.1.1  Linux container startup
+#### 3.1.1  Linux runtime container startup
 
-For Linux container deployment:
+For Linux runtime container deployment:
 
 1. **Shell script** handles environment preparation, state-directory setup, and
    bootstrap-state detection orchestration.
@@ -97,8 +105,19 @@ For Windows deployment:
 3. The service runtime uses the Windows defaults for the admin pipe, connector
    pipe, and persistent state directory unless the operator overrides them.
 4. If bootstrap-complete state is absent, the service fails closed with a clear
-   diagnostic rather than attempting to run the Docker-backed bootstrap flow
-   automatically.
+   diagnostic rather than attempting to run the bootstrap image automatically.
+
+#### 3.1.3  Bootstrap-image startup
+
+For explicit or auto-launched bootstrap:
+
+1. `sonde-azure-companion` resolves the default bootstrap image reference as
+   `ghcr.io/alan-jowett/sonde-azure-bootstrap:<matching companion version>`,
+   unless a development or test override is configured.
+2. The Rust companion uses Bollard to create and run that bootstrap image.
+3. The bootstrap image runs its bundled script, which executes
+   `az login --use-device-code` followed by Azure deployment using the bundled
+   Bicep files.
 
 ### 3.2  Mounted and configured inputs
 
@@ -109,7 +128,7 @@ The active deployment entrypoint expects the following runtime inputs:
 | State directory | Persistent storage for local provisioning artifacts such as the runtime certificate PEM, private-key PEM, service-principal metadata file, and persisted Service Bus configuration. On Linux this is the mounted state volume; on Windows this defaults to `%ProgramData%\sonde-azure-companion`. |
 | Gateway admin socket | Local IPC path used by bootstrap to call `GatewayAdmin` RPCs such as `ShowModemDisplayMessage`. |
 | Gateway connector socket | Local framed IPC path used by the long-running runtime after bootstrap succeeds. |
-| Docker socket (bootstrap only) | Docker Engine API socket, bind-mounted from the host, used by bootstrap to run the Azure CLI container via Bollard. This is part of the Linux/container bootstrap path and is not a steady-state Windows service requirement. |
+| Docker socket (bootstrap only) | Docker Engine API socket, bind-mounted from the host, used by the companion to launch the dedicated bootstrap image via Bollard. This is part of the Linux runtime-container bootstrap path and explicit Windows bootstrap, and is not a steady-state Windows service requirement. |
 | Service Bus namespace | Runtime configuration for the Azure Service Bus namespace, from environment variable or persisted `service-bus.json`. |
 | Upstream queue name | Runtime configuration for the queue that carries gateway-originated connector messages, from environment variable or persisted `service-bus.json`. |
 | Downstream queue name | Runtime configuration for the queue that carries cloud-originated desired-state messages, from environment variable or persisted `service-bus.json`. |
@@ -138,13 +157,16 @@ Startup follows a platform-specific decision:
 2. Check whether the required local provisioning artifacts exist.
 3. Check whether the required Service Bus namespace and queue configuration are
    present.
-4. **Linux container path:** if both are present, skip bootstrap and start
-   `run`; otherwise start `bootstrap`.
+4. **Linux runtime-container path:** if both are present, skip bootstrap and
+   start `run`; otherwise start `bootstrap`, which launches the dedicated
+   bootstrap image and waits for bootstrap-complete state before starting
+   runtime.
 5. **Windows service path:** if both are present, start `run`; otherwise emit a
    clear diagnostic and exit with a non-zero service status.
 
 When the Linux bootstrap path is entered, the unified `bootstrap` subcommand
-orchestrates the full provisioning lifecycle as described in section 4.2.
+orchestrates the full provisioning lifecycle by launching the dedicated
+bootstrap image as described in section 4.2.
 
 ### 3.4  Windows MSI integration
 
@@ -218,12 +240,13 @@ The Linux bootstrap path is entered only when bootstrap-complete state is
 absent. This differs from the earlier draft, which always re-entered device-code
 login on restart. The Windows service path does not auto-enter bootstrap when
 state is absent; it fails closed until the operator performs provisioning
-explicitly.
+explicitly. Both Linux auto-bootstrap and explicit Windows bootstrap use the
+same dedicated bootstrap image.
 
 Re-running the `bootstrap` subcommand explicitly (e.g., for credential rotation)
 is safe: it regenerates the certificate, re-runs Bicep, and rewrites the runtime
 artifacts. This explicit bootstrap path is supported from the Windows native
-binary as well as from the Linux/container deployment path; only the Windows
+binary as well as from the Linux runtime-container deployment path; only the Windows
 service auto-start path is fail-closed before bootstrap-complete state exists.
 
 ### 4.2  Unified bootstrap sequence
@@ -243,41 +266,44 @@ When bootstrap is required, the Azure companion performs this sequence:
 4. Base64-encode the certificate's DER public material for the Bicep
    `companionCertificateBase64` parameter.
 5. Display "Authenticating…" on the modem display.
-6. Use the Bollard crate to pull (if needed) the digest-pinned
-   `mcr.microsoft.com/azure-cli` image.
-7. Create an Azure CLI container with the bundled Bicep files and staged
-   certificate copied in via Bollard's `put_archive` API (not bind mounts,
-   since the companion's container-internal paths are not visible to the host
-   Docker daemon).
-8. The container runs a bootstrap script that executes
-   `az login --use-device-code` followed by `az deployment sub create`.
-9. Rust monitors the container's output stream, looking for the device-code
-   pattern produced by `az login --use-device-code`. Because the Azure CLI
-   image is pinned by digest, the output format is a known quantity for the
-   pinned version.
-10. When the device code is detected, call the gateway admin
+6. Resolve the default bootstrap image reference as
+   `ghcr.io/alan-jowett/sonde-azure-bootstrap:<matching companion version>`
+   unless a development or test override is configured.
+7. Use the Bollard crate to pull (if needed) that bootstrap image tag.
+8. Create a bootstrap container and copy in only dynamic inputs such as the
+   staged certificate via Bollard's `put_archive` API (not bind mounts, since
+   the runtime container's internal paths are not visible to the host Docker
+   daemon).
+9. The bootstrap container runs its bundled script, which executes
+   `az login --use-device-code` followed by `az deployment sub create` using
+   the Bicep files already bundled inside the bootstrap image.
+10. Rust monitors the bootstrap container's output stream, looking for the
+    device-code pattern produced by `az login --use-device-code`. Because the
+    bootstrap image tag is version-matched to the companion release, the output
+    format is controlled by the shipped bootstrap artifact for that release.
+11. When the device code is detected, call the gateway admin
     `ShowModemDisplayMessage` RPC with a short prompt plus the exact device
     code.
-11. Wait for the container to finish. On success, `az deployment sub create`
+12. Wait for the container to finish. On success, `az deployment sub create`
     produces JSON deployment outputs on stdout.
-12. Display "Deploying Azure…" on the modem display (transitions from auth to
+13. Display "Deploying Azure…" on the modem display (transitions from auth to
     deployment phase may overlap in the single container session).
-13. Capture and parse the JSON outputs to extract `tenantId`, `clientId`,
+14. Capture and parse the JSON outputs to extract `tenantId`, `clientId`,
     Service Bus namespace, and queue names from the `companionBootstrapValues`
     output object.
-14. Write `service-principal.json` and `service-bus.json` to the staging
+15. Write `service-principal.json` and `service-bus.json` to the staging
     directory with the extracted values and relative paths to the certificate
     and private-key PEM files.
-15. Rename the staging directory into a new generation directory under the state
+16. Rename the staging directory into a new generation directory under the state
     volume, then atomically update the `.current-state` marker to point at that
     generation, leaving the previous generation untouched until the new one is
     fully committed.
-16. Remove the Azure CLI container.
-17. Display "Bootstrap complete" on the modem display.
-18. The bootstrap wrapper/entrypoint reports overall success only after
+17. Remove the bootstrap container.
+18. Display "Bootstrap complete" on the modem display.
+19. The bootstrap wrapper/entrypoint reports overall success only after
     bootstrap-complete state has been established.
 
-If any step fails, the staging directory is cleaned up, the Azure CLI
+If any step fails, the staging directory is cleaned up, the bootstrap
 container is removed, and the existing state volume contents remain untouched,
 preserving the previous working state for the next retry or runtime start.
 
@@ -300,12 +326,12 @@ plus Windows service-management entrypoints:
 1. **`run`** — default long-running runtime mode. It connects to the gateway
    connector socket and bridges connector traffic to Azure Service Bus.
 2. **`bootstrap`** — performs the unified provisioning lifecycle: self-signed
-   ECDSA P-256 certificate generation, Azure device-code authentication and
-   Bicep deployment via the Bollard Docker API (inside a pinned Azure CLI
-   container), and runtime artifact creation (`service-principal.json`,
-   `service-bus.json`, certificate PEM, private-key PEM). The Rust code
-   monitors the Azure CLI container's output to extract the device code and
-   display it on the modem via the gateway admin API.
+   ECDSA P-256 certificate generation, launching the version-matched
+   `sonde-azure-bootstrap` image via the Bollard Docker API, and runtime
+   artifact creation (`service-principal.json`, `service-bus.json`,
+   certificate PEM, private-key PEM). The Rust code monitors the bootstrap
+   container's output to extract the device code and display it on the modem
+   via the gateway admin API.
 3. **`display-message`** — helper mode used by bootstrap logic to call the
    gateway admin `ShowModemDisplayMessage` RPC with 1 to 4 lines of text.
 4. **`install`** *(Windows)* — registers or updates the native Windows service
@@ -437,41 +463,45 @@ The DER-encoded certificate public material is base64-encoded for the Bicep
 `companionCertificateBase64` parameter. This reuses the same parameter
 interface already defined in `deploy/bicep/main.bicep`.
 
-### 8.2  Bollard Docker API integration
+### 8.2  Bollard bootstrap-image integration
 
 The `bootstrap` subcommand uses the Bollard crate to interact with the Docker
 Engine API. It does not shell out to the `docker` CLI. The integration flow:
 
 1. Connect to the Docker daemon via Bollard's auto-detection (typically
    `/var/run/docker.sock` inside the container).
-2. Pull the `mcr.microsoft.com/azure-cli` image if not already present. The
-   image reference is pinned by digest in the source code for reproducibility.
-   If the pull fails (e.g., network is unavailable), bootstrap fails with a
-   clear error message.
-3. Create a container with environment variables for deployment parameters
+2. Resolve the default bootstrap image reference as
+   `ghcr.io/alan-jowett/sonde-azure-bootstrap:<matching companion version>`
+   unless a development or test override is configured.
+3. Pull that bootstrap image if it is not already present. If the pull fails
+   (e.g., network is unavailable or the version tag is missing), bootstrap
+   fails with a clear error message.
+4. Create a container with environment variables for deployment parameters
    (`SONDE_AZURE_LOCATION`, `COMPANION_CERT_BASE64`, etc.).
-4. Copy the bundled Bicep files and staged certificate into the container
-   using Bollard's `put_archive` API. This avoids bind mounts, which would
-   fail because the companion's container-internal paths are not visible to the
-   host Docker daemon when running as a sibling container.
-5. Start the container and stream its output (stdout/stderr).
-6. Monitor the output for the device-code pattern from `az login --use-device-code`.
+5. Copy only dynamic bootstrap inputs such as the staged certificate into the
+   container using Bollard's `put_archive` API. The Bicep files and bootstrap
+   script are already part of the bootstrap image, so bootstrap does not depend
+   on runtime-image or host-side Bicep paths.
+6. Start the container and stream its output (stdout/stderr).
+7. Monitor the output for the device-code pattern from `az login --use-device-code`.
    When detected, extract the code and display it on the modem via the admin API.
-7. Wait for the container to exit and capture the JSON deployment outputs.
-8. Remove the container after completion (regardless of success or failure).
+8. Wait for the container to exit and capture the JSON deployment outputs.
+9. Remove the container after completion (regardless of success or failure).
 
 If the container fails to start or the Docker daemon is unreachable, bootstrap
 fails with a descriptive error and cleans up any created-but-unstarted
 container resources.
 
-### 8.3  Azure CLI container execution
+### 8.3  Bootstrap-image execution
 
-Inside the Azure CLI container, the bootstrap runs a shell script that:
+Inside the `sonde-azure-bootstrap` image, the bootstrap runs a shell script
+that:
 
 1. Authenticates using `az login --use-device-code`. The device code and
    verification URL appear on stderr, which Rust monitors and relays to the
-   modem display. Because the Azure CLI image is pinned by digest, the output
-   format is a known quantity that can be parsed reliably for that version.
+   modem display. Because the bootstrap image tag is version-matched to the
+   companion release, the output format is controlled by the shipped bootstrap
+   artifact for that release.
 2. Optionally sets the target subscription if `SONDE_AZURE_SUBSCRIPTION_ID` is
    provided via `az account set --subscription`.
 3. Runs `az deployment sub create` with:
@@ -532,16 +562,20 @@ persisted Service Bus configuration file (`service-bus.json`) as an alternative
 to environment variables, enabling a fully automated startup after bootstrap.
 Environment variables, if set, override the persisted file values.
 
-### 8.5  Bundled Bicep files
+### 8.5  Bootstrap-image contents
 
-The Azure companion Dockerfile includes:
+The bootstrap Dockerfile includes:
 
 ```dockerfile
 COPY deploy/bicep/ /opt/sonde/deploy/bicep/
 ```
 
-This bundles the complete Bicep deployment surface into the companion image.
-The bootstrap mounts this path into the Azure CLI container at runtime.
+It also includes the bootstrap script that runs `az login --use-device-code`
+and Azure deployment inside the bootstrap image.
+
+This bundles the complete Azure provisioning surface into the dedicated
+bootstrap image. The runtime companion image no longer needs to carry these
+bootstrap-only assets.
 
 ### 8.6  Docker socket requirements
 
@@ -562,7 +596,7 @@ The bootstrap displays these messages on the modem via the admin API:
 | Phase | Modem display | stderr log |
 |-------|--------------|------------|
 | Certificate generation | "Generating cert..." | "Generating ECDSA P-256 self-signed certificate" |
-| Azure CLI container start | "Authenticating..." | "Starting Azure CLI container for device-code auth" |
+| Bootstrap image start | "Authenticating..." | "Starting sonde-azure-bootstrap for device-code auth" |
 | Device code received | "Azure login" + device code | "Device auth: open {uri} and enter code {code}" |
 | Bicep deployment | "Deploying Azure..." | "Running Bicep deployment" |
 | Config writing | "Writing config..." | "Writing runtime artifacts to state volume" |

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -629,7 +629,7 @@ crate.
 1. Bootstrap uses the Bollard crate to create and run the `sonde-azure-bootstrap` container.
 2. Bootstrap does not invoke the `docker` CLI binary or shell out to any Docker command.
 3. By default, bootstrap uses the `sonde-azure-bootstrap` image tag that matches the companion release version.
-4. Bootstrap uploads only dynamic bootstrap inputs such as the generated certificate into the bootstrap container before running Azure deployment logic; it does not depend on host-side Bicep files.
+4. Bootstrap passes only dynamic deployment inputs such as the generated certificate into the bootstrap container before running Azure deployment logic, and does not depend on host-side Bicep files.
 5. Bootstrap authenticates by running `az login --use-device-code` inside the bootstrap container and parsing the emitted device code for modem display.
 6. Bootstrap captures the Azure deployment JSON outputs from the container's stdout.
 7. Bootstrap cleans up the bootstrap container after completion, regardless of success or failure.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -6,11 +6,12 @@
 > **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771),
 > connector redesign discovery review, and Azure Service Bus discovery review.
 > **Scope:** This document covers the Azure companion deployment surfaces
-> (Linux container and Windows native service), bootstrap-state detection,
-> bootstrap-trigger behavior, the integrated Azure provisioning orchestration
-> (certificate generation, Bicep deployment via Docker API, and runtime
-> artifact creation), and the long-running Azure Service Bus runtime bridge
-> between `sonde-gateway` and an external Azure control plane.
+> (Linux runtime container and Windows native service), the dedicated Azure
+> bootstrap container image, bootstrap-state detection, bootstrap-trigger
+> behavior, the integrated Azure provisioning orchestration (certificate
+> generation, bootstrap-image execution via Docker API, and runtime artifact
+> creation), and the long-running Azure Service Bus runtime bridge between
+> `sonde-gateway` and an external Azure control plane.
 > The Bicep module definitions themselves are specified in
 > [azure-provisioning-requirements.md](azure-provisioning-requirements.md).
 > **Related:** [azure-provisioning-requirements.md](azure-provisioning-requirements.md),
@@ -24,7 +25,8 @@
 
 | Term | Definition |
 |------|------------|
-| **Azure companion** | The Rust process that integrates with `sonde-gateway` through the local admin API for bootstrap-only operator-visible actions and the local connector API for long-running runtime traffic. On Linux it is deployed in its own container; on Windows it may be deployed as a native service. |
+| **Azure companion** | The Rust process that integrates with `sonde-gateway` through the local admin API for bootstrap-only operator-visible actions and the local connector API for long-running runtime traffic. On Linux it is deployed in its own runtime container; on Windows it may be deployed as a native service. It also acts as the launcher/orchestrator for explicit bootstrap operations. |
+| **Bootstrap image** | The dedicated `sonde-azure-bootstrap` container image that contains the Azure CLI, bundled Bicep files, and bootstrap script used to provision Azure resources for the companion. |
 | **State volume** | A mounted persistent directory reserved for Azure companion bootstrap output and other local provisioning artifacts. |
 | **State directory** | The platform-owned persistent directory that stores Azure companion provisioning artifacts. On Linux this is provided by the mounted state volume; on Windows the default location is `%ProgramData%\sonde-azure-companion`. |
 | **Provisioning artifacts** | The local certificate PEM, private-key PEM, and related companion-owned state that indicate Azure bootstrap has already completed. |
@@ -49,26 +51,27 @@ Each requirement uses the following fields:
 
 ## 3  Deployment packaging and bootstrap entrypoints
 
-### AZC-0100  Dedicated companion container image
+### AZC-0100  Dedicated companion runtime container image
 
 **Priority:** Must
 **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), Azure Service Bus discovery review
 
 **Description:**
 The repository MUST build a dedicated Docker container image for the Azure
-companion. The image MUST be separate from the gateway image and MUST contain
-the Azure companion binary plus the bootstrap scripts needed to initialize the
-mounted state volume, decide whether bootstrap is required, and start the
-long-running runtime bridge. The image MUST remain suitable for Alpine Linux
-deployment.
+companion runtime. The image MUST be separate from the gateway image and MUST
+contain the Azure companion binary plus the scripts needed to initialize the
+mounted state volume, decide whether bootstrap is required, launch the
+dedicated bootstrap image when necessary, and start the long-running runtime
+bridge. The runtime image MUST remain suitable for Alpine Linux deployment.
 
 **Acceptance criteria:**
 
-1. Building the Azure companion Dockerfile produces an image that starts the Azure companion container without requiring the gateway image.
-2. The image contains the Azure companion binary.
-3. The image is based on Alpine Linux.
-4. The image does not require Azure CLI for normal runtime connectivity to Service Bus.
-5. The image contains the bootstrap scripts used to decide between bootstrap and normal runtime startup.
+1. Building the Azure companion runtime Dockerfile produces an image that starts the Azure companion runtime container without requiring the gateway image.
+2. The runtime image contains the Azure companion binary.
+3. The runtime image is based on Alpine Linux.
+4. The runtime image does not require Azure CLI for normal runtime connectivity to Service Bus.
+5. The runtime image contains the startup/orchestration scripts used to decide between bootstrap and normal runtime startup.
+6. The runtime image does not need to bundle the Bicep deployment files or Azure CLI tooling.
 
 ---
 
@@ -100,8 +103,8 @@ NOT treat short-lived Azure access tokens as persisted runtime state.
 **Description:**
 The repository MUST provide bootstrap scripts that prepare the mounted state
 volume, decide whether bootstrap is required, and then start either the
-bootstrap workflow or the long-running Azure companion runtime inside its
-dedicated container.
+bootstrap workflow by launching the dedicated bootstrap image or the
+long-running Azure companion runtime inside its dedicated runtime container.
 
 **Acceptance criteria:**
 
@@ -180,6 +183,32 @@ service registration without deleting persisted provisioning artifacts.
 
 ---
 
+### AZC-0106  Dedicated versioned bootstrap container image
+
+**Priority:** Must
+**Source:** Discovery review
+
+**Description:**
+The repository MUST build a dedicated `sonde-azure-bootstrap` container image
+for Azure provisioning. This image MUST be separate from the runtime companion
+image and MUST contain the Azure CLI, the bundled Bicep deployment files, and
+the bootstrap script needed to execute device-code login plus Bicep deployment.
+By default, `sonde-azure-companion` MUST launch the bootstrap image reference
+`ghcr.io/alan-jowett/sonde-azure-bootstrap:<matching companion version>`.
+Development and test workflows MAY override that default image reference
+explicitly.
+
+**Acceptance criteria:**
+
+1. Building the bootstrap Dockerfile produces a `sonde-azure-bootstrap` image that can execute the bootstrap script without relying on files copied from the runtime image.
+2. The bootstrap image contains the Azure CLI tooling needed for `az login --use-device-code` and `az deployment`.
+3. The bootstrap image contains the bundled Bicep deployment files from `deploy/bicep/`.
+4. The default bootstrap image reference used by `sonde-azure-companion` is a version tag that matches the companion release version.
+5. If the matching bootstrap image tag is unavailable, bootstrap fails with a clear error rather than silently selecting a different version.
+6. Development or test workflows can override the default bootstrap image reference explicitly.
+
+---
+
 ## 4  Bootstrap-state detection and bootstrap trigger behavior
 
 ### AZC-0200  Startup decision based on bootstrap-complete state
@@ -188,11 +217,12 @@ service registration without deleting persisted provisioning artifacts.
 **Source:** Azure Service Bus discovery review
 
 **Description:**
-At startup, the Linux container entrypoint for the Azure companion MUST
+At startup, the Linux runtime container entrypoint for the Azure companion MUST
 determine whether bootstrap has already completed. Bootstrap-complete state
 requires both the local provisioning artifacts and the required queue
-configuration. If either is missing, the Linux container entrypoint MUST enter
-the bootstrap workflow instead of normal runtime mode.
+configuration. If either is missing, the Linux runtime container entrypoint
+MUST enter the bootstrap workflow by launching the dedicated bootstrap image
+instead of normal runtime mode.
 
 **Acceptance criteria:**
 
@@ -210,15 +240,17 @@ the bootstrap workflow instead of normal runtime mode.
 **Description:**
 When bootstrap is required, the Azure companion MUST provide a single unified
 `bootstrap` subcommand that performs the entire provisioning lifecycle:
-certificate generation, device-code authentication (inside the Azure CLI
-container), Bicep deployment via the Docker API, and local runtime artifact
-creation. The earlier `bootstrap-auth` subcommand is retired and replaced by
-this unified command. Device-code authentication occurs inside the
-digest-pinned Azure CLI container via `az login --use-device-code`; the Rust
-companion monitors the container output to extract the device code and display
-it on the modem. The same explicit `bootstrap` subcommand MUST be supported by
-the Windows native binary when invoked manually by an operator; Windows service
-startup remains a separate fail-closed path governed by AZC-0205.
+certificate generation, device-code authentication inside the dedicated
+`sonde-azure-bootstrap` image, Azure deployment through the Docker API, and
+local runtime artifact creation. The earlier `bootstrap-auth` subcommand is
+retired and replaced by this unified command. By default, the Rust companion
+launches the `sonde-azure-bootstrap:<matching companion version>` image tag;
+the image contains the Azure CLI, bundled Bicep files, and bootstrap script.
+The Rust companion monitors the bootstrap image output to extract the device
+code and display it on the modem. The same explicit `bootstrap` subcommand MUST
+be supported by the Windows native binary when invoked manually by an operator;
+Windows service startup remains a separate fail-closed path governed by
+AZC-0205.
 
 **Acceptance criteria:**
 
@@ -228,6 +260,7 @@ startup remains a separate fail-closed path governed by AZC-0205.
 4. Successful device-code login alone is not treated as bootstrap completion; the bootstrap path reports success only after bootstrap-complete state has been established.
 5. The earlier `bootstrap-auth` subcommand name is no longer accepted.
 6. Invoking `sonde-azure-companion bootstrap` from the Windows native binary performs the same end-to-end provisioning lifecycle as the Linux bootstrap path, subject to the same Docker and Azure prerequisites.
+7. By default, the unified bootstrap path launches the version-tagged `sonde-azure-bootstrap` image that matches the companion release version.
 
 ---
 
@@ -237,13 +270,14 @@ startup remains a separate fail-closed path governed by AZC-0205.
 **Source:** Discovery review, GW-0809
 
 **Description:**
-When the Azure CLI container's `az login --use-device-code` produces a device
-code in its output, the Rust bootstrap flow MUST extract the code and request
-a modem display update through the gateway admin API. The displayed message
-MUST include a short prompt and the exact device code. The Azure companion
-MUST NOT attempt raw modem control or bypass the gateway's display ownership
-rules. Because the Azure CLI container image is pinned by digest, the output
-format is a known quantity for the pinned version.
+When the dedicated bootstrap image's `az login --use-device-code` step produces
+a device code in its output, the Rust bootstrap flow MUST extract the code and
+request a modem display update through the gateway admin API. The displayed
+message MUST include a short prompt and the exact device code. The Azure
+companion MUST NOT attempt raw modem control or bypass the gateway's display
+ownership rules. Because the bootstrap image tag is version-matched to the
+companion release, the output format is controlled by the shipped bootstrap
+artifact for that release.
 
 **Acceptance criteria:**
 
@@ -298,7 +332,7 @@ login merely because the container restarted.
 **Description:**
 When the Windows native service starts without bootstrap-complete state, it
 MUST fail closed with a clear operator-visible diagnostic instead of entering
-the current Docker-backed bootstrap flow automatically. Windows operators are
+the bootstrap-image launch flow automatically. Windows operators are
 expected to provision or bootstrap the companion explicitly before the service
 can start successfully in steady state.
 
@@ -306,7 +340,7 @@ can start successfully in steady state.
 
 1. Starting the Windows service without the required provisioning artifacts exits with a non-zero service status and surfaces a clear diagnostic identifying the missing state.
 2. Starting the Windows service without the required queue configuration exits with a non-zero service status and surfaces a clear diagnostic identifying the missing configuration.
-3. In the missing-state cases above, the Windows service does not attempt to pull or run the Azure CLI container automatically.
+3. In the missing-state cases above, the Windows service does not attempt to pull or run the bootstrap image automatically.
 4. Once bootstrap-complete state is present, restarting the Windows service starts the runtime bridge normally without requiring installer changes.
 
 ---
@@ -578,44 +612,46 @@ mounted state volume as PEM files.
 
 ---
 
-### AZC-0401  Bicep deployment via Docker API
+### AZC-0401  Bootstrap image execution via Docker API
 
 **Priority:** Must
 **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
 
 **Description:**
-The unified `bootstrap` subcommand MUST execute the Bicep deployment by using
-the Bollard Rust Docker SDK to run the Azure CLI container image. The bootstrap
-MUST NOT shell out to the Docker CLI binary; it MUST use the Docker Engine API
-directly through the Bollard crate.
+The unified `bootstrap` subcommand MUST execute the Azure provisioning flow by
+using the Bollard Rust Docker SDK to run the dedicated
+`sonde-azure-bootstrap` image. The bootstrap MUST NOT shell out to the Docker
+CLI binary; it MUST use the Docker Engine API directly through the Bollard
+crate.
 
 **Acceptance criteria:**
 
-1. Bootstrap uses the Bollard crate to create and run an Azure CLI container for Bicep deployment.
+1. Bootstrap uses the Bollard crate to create and run the `sonde-azure-bootstrap` container.
 2. Bootstrap does not invoke the `docker` CLI binary or shell out to any Docker command.
-3. The Azure CLI container image is pinned by digest for reproducible provisioning.
-4. Bootstrap uploads the bundled Bicep files and generated certificate into the Azure CLI container before running `az deployment`.
-5. Bootstrap authenticates by running `az login --use-device-code` inside the Azure CLI container and parsing the emitted device code for modem display.
-6. Bootstrap captures the Bicep deployment JSON outputs from the container's stdout.
-7. Bootstrap cleans up the Azure CLI container after completion, regardless of success or failure.
+3. By default, bootstrap uses the `sonde-azure-bootstrap` image tag that matches the companion release version.
+4. Bootstrap uploads only dynamic bootstrap inputs such as the generated certificate into the bootstrap container before running Azure deployment logic; it does not depend on host-side Bicep files.
+5. Bootstrap authenticates by running `az login --use-device-code` inside the bootstrap container and parsing the emitted device code for modem display.
+6. Bootstrap captures the Azure deployment JSON outputs from the container's stdout.
+7. Bootstrap cleans up the bootstrap container after completion, regardless of success or failure.
 
 ---
 
-### AZC-0402  Bundled Bicep files in companion image
+### AZC-0402  Bundled Azure provisioning assets in bootstrap image
 
 **Priority:** Must
 **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
 
 **Description:**
-The Azure companion container image MUST bundle the Bicep deployment files from
-`deploy/bicep/` at build time so the bootstrap subcommand can mount them into
-the Azure CLI container without relying on host-side file access.
+The dedicated `sonde-azure-bootstrap` image MUST bundle the Azure provisioning
+assets needed for bootstrap at build time so the bootstrap workflow does not
+rely on runtime-image internals or host-side Bicep files.
 
 **Acceptance criteria:**
 
-1. The Azure companion Dockerfile copies `deploy/bicep/` into the image at a fixed path.
-2. The bundled Bicep files include the top-level `main.bicep`, all module files, and `bicepconfig.json`.
-3. Bootstrap references the bundled path when mounting Bicep files into the Azure CLI container.
+1. The bootstrap Dockerfile copies `deploy/bicep/` into the bootstrap image at a fixed path.
+2. The bundled provisioning assets include the top-level `main.bicep`, all module files, and `bicepconfig.json`.
+3. The bootstrap image includes the script that runs `az login --use-device-code` followed by Azure deployment.
+4. Bootstrap references the bundled path inside the bootstrap image rather than copying Bicep files out of the runtime companion image.
 
 ---
 
@@ -687,8 +723,9 @@ completion.
 **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), discovery review
 
 **Description:**
-The Azure companion container MUST have access to the Docker Engine API so the
-Bollard crate can create and manage the Azure CLI container during bootstrap.
+The Azure companion runtime container MUST have access to the Docker Engine API
+so the Bollard crate can create and manage the dedicated bootstrap container
+during bootstrap.
 The Docker socket MUST be bind-mounted from the host into the companion
 container.
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -567,7 +567,7 @@
 **Validates:** AZC-0106, AZC-0401
 
 **Procedure:**
-1. Configure `sonde-azure-companion` with an explicit bootstrap image override reference such as `sonde-azure-bootstrap:test-override`.
+1. Configure `sonde-azure-companion` with an explicit bootstrap image override reference such as `sonde-azure-bootstrap:test-override`, using either `SONDE_AZURE_BOOTSTRAP_IMAGE` or `--bootstrap-image`.
 2. Start bootstrap with a mock Docker API server (or equivalent traceable test double).
 3. Assert: the Docker API requests use the configured override image reference rather than the default version-matched release tag.
 4. Assert: bootstrap reaches the container-creation path using the override image reference when the override image is available.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -372,7 +372,7 @@
 1. Start the bootstrap subcommand with a mock Docker API server (Bollard supports custom connection).
 2. Assert: bootstrap sends Docker API requests to create and start a container using the version-tagged `ghcr.io/alan-jowett/sonde-azure-bootstrap` image that matches the companion release version.
 3. Assert: bootstrap does not invoke the `docker` CLI binary.
-4. Assert: bootstrap uploads only dynamic bootstrap inputs such as the generated certificate into the bootstrap container with Docker archive upload APIs before running the deployment.
+4. Assert: bootstrap passes only dynamic bootstrap inputs such as the generated certificate into the bootstrap container environment before running the deployment.
 5. Assert: bootstrap captures the container's stdout output containing Bicep deployment JSON.
 6. Assert: bootstrap removes the container after completion.
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -38,8 +38,8 @@
 
 **Procedure:**
 1. Build the `sonde-azure-bootstrap` Docker image from the repository Dockerfile.
-2. Run `docker run --rm <image> sh -c "az version >/dev/null"`.
-3. Run `docker run --rm <image> ls /opt/sonde/deploy/bicep/`.
+2. Run `docker run --rm --entrypoint sh <image> -c "az version >/dev/null"`.
+3. Run `docker run --rm --entrypoint sh <image> -c "ls /opt/sonde/deploy/bicep/"`.
 4. Assert: the image contains working Azure CLI tooling plus the bundled Bicep deployment files.
 5. Assert: the listing includes `main.bicep`, `bicepconfig.json`, and the `modules/` directory.
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -4,10 +4,10 @@
 
 > **Document status:** Draft
 > **Scope:** Validation for the Azure companion deployment surfaces (Linux
-> container and Windows native service), bootstrap-state detection, gateway
-> admin/connector integration, provisioning orchestration (certificate
-> generation, Bicep deployment via Docker API, runtime artifact creation), and
-> Azure Service Bus bridge.
+> runtime container and Windows native service), the dedicated bootstrap image,
+> bootstrap-state detection, gateway admin/connector integration, provisioning
+> orchestration (certificate generation, bootstrap-image execution via Docker
+> API, runtime artifact creation), and Azure Service Bus bridge.
 > **Audience:** Implementers and reviewers validating the Azure companion
 > bootstrap and runtime bridge behavior.
 > **Related:** [azure-provisioning-validation.md](azure-provisioning-validation.md),
@@ -32,6 +32,19 @@
 
 ---
 
+### T-AZC-0123  Azure bootstrap image smoke test
+
+**Validates:** AZC-0106, AZC-0402
+
+**Procedure:**
+1. Build the `sonde-azure-bootstrap` Docker image from the repository Dockerfile.
+2. Run `docker run --rm <image> sh -c "az version >/dev/null"`.
+3. Run `docker run --rm <image> ls /opt/sonde/deploy/bicep/`.
+4. Assert: the image contains working Azure CLI tooling plus the bundled Bicep deployment files.
+5. Assert: the listing includes `main.bicep`, `bicepconfig.json`, and the `modules/` directory.
+
+---
+
 ### T-AZC-0101  Startup enters bootstrap when provisioning artifacts are missing
 
 **Validates:** AZC-0101, AZC-0102, AZC-0200, AZC-0201
@@ -40,7 +53,7 @@
 1. Create an empty temporary directory to use as the mounted state volume.
 2. Provide valid queue configuration to the bootstrap script.
 3. Invoke the Azure companion bootstrap entrypoint with that directory mounted as the state volume.
-4. Assert: the bootstrap path runs before the long-running runtime starts.
+4. Assert: the bootstrap path runs the dedicated bootstrap image before the long-running runtime starts.
 5. Assert: the bootstrap path invokes the Rust `bootstrap` flow, parses the device code from Azure CLI stderr, and forwards it to the modem display.
 
 ---
@@ -312,7 +325,7 @@
 4. Start the service: `sc.exe start sonde-azure-companion`.
 5. Assert: the service does not reach steady `RUNNING` runtime-bridge operation.
 6. Assert: service diagnostics clearly identify the missing provisioning artifacts or queue configuration.
-7. Assert: the startup path does not attempt to pull or run the Azure CLI container automatically.
+7. Assert: the startup path does not attempt to pull or run the bootstrap image automatically.
 8. Populate bootstrap-complete state in `%ProgramData%\sonde-azure-companion\` and restart the service.
 9. Assert: the service now starts the runtime bridge normally and connects through the default named-pipe paths.
 10. Stop the service through SCM.
@@ -351,26 +364,26 @@
 
 ---
 
-### T-AZC-0401  Bootstrap uses Bollard to run Azure CLI container
+### T-AZC-0401  Bootstrap uses Bollard to run the bootstrap image
 
-**Validates:** AZC-0401, AZC-0402
+**Validates:** AZC-0106, AZC-0401, AZC-0402
 
 **Procedure:**
 1. Start the bootstrap subcommand with a mock Docker API server (Bollard supports custom connection).
-2. Assert: bootstrap sends Docker API requests to create and start a container using the pinned Azure CLI image digest.
+2. Assert: bootstrap sends Docker API requests to create and start a container using the version-tagged `ghcr.io/alan-jowett/sonde-azure-bootstrap` image that matches the companion release version.
 3. Assert: bootstrap does not invoke the `docker` CLI binary.
-4. Assert: bootstrap uploads the bundled Bicep files and generated certificate into the Azure CLI container with Docker archive upload APIs before running the deployment.
+4. Assert: bootstrap uploads only dynamic bootstrap inputs such as the generated certificate into the bootstrap container with Docker archive upload APIs before running the deployment.
 5. Assert: bootstrap captures the container's stdout output containing Bicep deployment JSON.
 6. Assert: bootstrap removes the container after completion.
 
 ---
 
-### T-AZC-0402  Companion image bundles Bicep files
+### T-AZC-0402  Bootstrap image bundles Bicep files
 
 **Validates:** AZC-0402
 
 **Procedure:**
-1. Build the Azure companion Docker image.
+1. Build the `sonde-azure-bootstrap` Docker image.
 2. Run `docker run --rm <image> ls /opt/sonde/deploy/bicep/`.
 3. Assert: the listing includes `main.bicep`, `bicepconfig.json`, and the `modules/` directory.
 4. Assert: the `modules/` directory contains the expected Bicep module files.
@@ -451,7 +464,7 @@
 
 **Procedure:**
 1. Run bootstrap with `SONDE_AZURE_SUBSCRIPTION_ID` set to a known value.
-2. Assert: the Bicep deployment command within the Azure CLI container targets the specified subscription.
+2. Assert: the Bicep deployment command within the bootstrap container targets the specified subscription.
 3. Run bootstrap without `SONDE_AZURE_SUBSCRIPTION_ID`.
 4. Assert: the Bicep deployment uses the default subscription from the device-login session.
 
@@ -474,14 +487,14 @@
 
 ### T-AZC-0410  Bootstrap fails cleanly on image pull failure
 
-**Validates:** AZC-0401, AZC-0405
+**Validates:** AZC-0106, AZC-0401, AZC-0405
 
 **Procedure:**
-1. Start bootstrap with Bollard configured to reject the image pull (simulated network failure).
+1. Start bootstrap with Bollard configured to reject the bootstrap image pull (simulated network failure or missing version tag).
 2. Assert: bootstrap fails with a non-zero exit status.
 3. Assert: the error message identifies the image pull failure.
 4. Assert: the modem displays an error indication.
-5. Assert: no Azure CLI container is left running.
+5. Assert: no bootstrap container is left running.
 
 ---
 
@@ -546,3 +559,15 @@
 2. Capture all stderr and stdout output from the bootstrap process.
 3. Assert: the access token value does not appear in any log output.
 4. Assert: the access token is not persisted to any file in the state volume.
+
+---
+
+### T-AZC-0416  Bootstrap image override is honored for development and test flows
+
+**Validates:** AZC-0106, AZC-0401
+
+**Procedure:**
+1. Configure `sonde-azure-companion` with an explicit bootstrap image override reference such as `sonde-azure-bootstrap:test-override`.
+2. Start bootstrap with a mock Docker API server (or equivalent traceable test double).
+3. Assert: the Docker API requests use the configured override image reference rather than the default version-matched release tag.
+4. Assert: bootstrap reaches the container-creation path using the override image reference when the override image is available.


### PR DESCRIPTION
## Summary
- add a dedicated `sonde-azure-bootstrap` container image that carries Azure CLI, bundled Bicep files, and the bootstrap script
- retarget `sonde-azure-companion bootstrap` to launch the published bootstrap image, support `SONDE_AZURE_BOOTSTRAP_IMAGE` overrides, and stop depending on runtime-image Bicep assets
- publish the bootstrap image from CI/nightly and keep the default version-matched image tag available on nightly builds

## Spec traceability
- requirements: split runtime vs bootstrap artifacts and add `AZC-0106` for the dedicated versioned bootstrap image
- design: describe the runtime/bootstrap artifact split and the Bollard-launched bootstrap-image flow
- validation: add bootstrap-image smoke/override coverage and update bootstrap-container expectations

## Validation
- `cargo test -p sonde-azure-companion`
- `cargo clippy -p sonde-azure-companion --all-targets -- -D warnings`
- smoke-built `Dockerfile.azure-bootstrap`
- smoke-built `Dockerfile.azure-companion`

## Audit
- spec audit: PASS after adding validation for bootstrap image override handling
- implementation audit: PASS after fixing nightly bootstrap-image tagging so version-matched default pulls work on nightly builds
