### PR TITLE
Fix Azure bootstrap Bicep namespace resolution

### DIFF
--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -18,8 +18,8 @@ param deploymentContainerUrl string
 @description('Storage Account name used by the Function placeholder deployment configuration.')
 param storageAccountName string
 
-@description('Service Bus namespace name.')
-param serviceBusNamespaceName string
+@description('Service Bus fully qualified namespace.')
+param serviceBusFullyQualifiedNamespace string
 
 @description('Queue name for gateway-originated connector traffic.')
 param upstreamQueueName string
@@ -41,7 +41,6 @@ resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' e
 }
 
 var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${existingStorageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${existingStorageAccount.listKeys().keys[0].value}'
-var serviceBusFullyQualifiedNamespace = '${serviceBusNamespaceName}.${environment().suffixes.serviceBusDns}'
 
 resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: functionPlanName

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -75,7 +75,7 @@ module functionPlaceholder './function-placeholder.bicep' = {
     functionPlanName: functionPlanName
     deploymentContainerUrl: functionDeploymentContainerUrl
     storageAccountName: storage.outputs.storageAccountName
-    serviceBusNamespaceName: serviceBusNamespaceName
+    serviceBusFullyQualifiedNamespace: serviceBus.outputs.namespaceFqdn
     upstreamQueueName: upstreamQueueName
     downstreamQueueName: downstreamQueueName
     nodeStateTableName: storage.outputs.nodeStateTableName


### PR DESCRIPTION
## Summary
- fix the bundled Azure bootstrap Bicep so the placeholder Function App uses the Service Bus FQDN exported by the Service Bus module
- remove the invalid `environment().suffixes.serviceBusDns` reference that breaks bootstrap compilation inside the bootstrap image

## Validation
- docker build --file .github/docker/Dockerfile.azure-bootstrap --tag sonde-azure-bootstrap:bootstrap-fix .
- docker run --rm --entrypoint sh sonde-azure-bootstrap:bootstrap-fix -c "az bicep build --file /opt/sonde/deploy/bicep/main.bicep >/tmp/main.json"