### PR TITLE
Fix Azure bootstrap Service Bus host handoff

### DIFF
--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -133,7 +133,7 @@ output companionServicePrincipalObjectId string = companionIdentity.outputs.serv
 output companionBootstrapValues object = {
   tenantId: companionIdentity.outputs.tenantId
   clientId: companionIdentity.outputs.clientId
-  serviceBusNamespace: stack.outputs.serviceBusNamespaceName
+  serviceBusNamespace: stack.outputs.serviceBusNamespaceFqdn
   upstreamQueue: stack.outputs.upstreamQueueName
   downstreamQueue: stack.outputs.downstreamQueueName
   deploymentContainerName: stack.outputs.deploymentContainerName

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -143,6 +143,7 @@ module functionRbac './function-rbac.bicep' = {
 }
 
 output serviceBusNamespaceName string = serviceBus.outputs.namespaceName
+output serviceBusNamespaceFqdn string = serviceBus.outputs.namespaceFqdn
 output upstreamQueueName string = serviceBus.outputs.upstreamQueueName
 output downstreamQueueName string = serviceBus.outputs.downstreamQueueName
 output storageAccountName string = storage.outputs.storageAccountName

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -536,12 +536,12 @@ staging directory:
    }
    ```
 3. **`service-bus.json`** containing:
-   ```json
-   {
-     "namespace": "<from companionBootstrapValues.serviceBusNamespace>",
-     "upstream_queue": "<from companionBootstrapValues.upstreamQueue>",
-     "downstream_queue": "<from companionBootstrapValues.downstreamQueue>"
-   }
+    ```json
+    {
+      "namespace": "<fully qualified host from companionBootstrapValues.serviceBusNamespace>",
+      "upstream_queue": "<from companionBootstrapValues.upstreamQueue>",
+      "downstream_queue": "<from companionBootstrapValues.downstreamQueue>"
+    }
    ```
 
 Only after all staging writes succeed does the bootstrap atomically move the

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -536,12 +536,12 @@ staging directory:
    }
    ```
 3. **`service-bus.json`** containing:
-    ```json
-    {
-      "namespace": "<fully qualified host from companionBootstrapValues.serviceBusNamespace>",
-      "upstream_queue": "<from companionBootstrapValues.upstreamQueue>",
-      "downstream_queue": "<from companionBootstrapValues.downstreamQueue>"
-    }
+   ```json
+   {
+     "namespace": "<fully qualified host from companionBootstrapValues.serviceBusNamespace>",
+     "upstream_queue": "<from companionBootstrapValues.upstreamQueue>",
+     "downstream_queue": "<from companionBootstrapValues.downstreamQueue>"
+   }
    ```
 
 Only after all staging writes succeed does the bootstrap atomically move the


### PR DESCRIPTION
## Summary
- fix the Azure bootstrap handoff so `service-bus.json` receives the Service Bus fully qualified host instead of the bare namespace name
- keep the design doc aligned with the runtime contract for `service-bus.json`

## Validation
- cargo test -p sonde-azure-companion
- docker build --file .github/docker/Dockerfile.azure-bootstrap --tag sonde-azure-bootstrap:bootstrap-host-fix .
- docker run --rm --entrypoint sh sonde-azure-bootstrap:bootstrap-host-fix -c "az bicep build --file /opt/sonde/deploy/bicep/main.bicep >/tmp/main.json"