### PR TITLE
Deploy Azure handler during bootstrap

### DIFF
--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -1,15 +1,23 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 sonde contributors
 #
-# Bootstrap image for Azure companion provisioning. Contains Azure CLI plus the
-# bundled Bicep deployment surface and bootstrap script.
+# Bootstrap image for Azure companion provisioning. Contains Azure CLI, the
+# bundled Bicep deployment surface, the prebuilt Azure handler package, and the
+# bootstrap script.
+#
+# Build:
+#   sh deploy/azure-bootstrap/build-function-package.sh
+#   docker build -f .github/docker/Dockerfile.azure-bootstrap -t sonde-azure-bootstrap .
+#   # Requires:
+#   #   .artifacts/azure-handler-function/sonde-azure-handler-function.zip
 
 FROM mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7
 
 COPY deploy/azure-bootstrap/bootstrap.sh /opt/sonde/deploy/azure-bootstrap/bootstrap.sh
 COPY deploy/bicep/ /opt/sonde/deploy/bicep/
+COPY .artifacts/azure-handler-function/sonde-azure-handler-function.zip /opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip
 
 RUN chmod +x /opt/sonde/deploy/azure-bootstrap/bootstrap.sh \
-    && mkdir -p /cert
+    && mkdir -p /cert /opt/sonde/deploy/azure-handler
 
 ENTRYPOINT ["/opt/sonde/deploy/azure-bootstrap/bootstrap.sh"]

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -232,6 +232,26 @@ jobs:
             assert outputs["companionBootstrapValues"]["value"]["functionAppName"] == "func-test"
             assert outputs["companionBootstrapValues"]["value"]["deploymentContainerName"] == "app-package-test"
             PY
+
+            if PATH="/tmp/fakebin:$PATH" \
+              SONDE_AZURE_LOCATION=eastus \
+              SONDE_AZURE_PROJECT_NAME=sonde \
+              SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS=abc \
+              COMPANION_CERT_BASE64=dummy-cert \
+              /opt/sonde/deploy/azure-bootstrap/bootstrap.sh >/tmp/invalid-activation-stdout.txt 2>/tmp/invalid-activation-stderr.txt; then
+              exit 1
+            fi
+            grep -q "SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS must be a positive integer" /tmp/invalid-activation-stderr.txt
+
+            if PATH="/tmp/fakebin:$PATH" \
+              SONDE_AZURE_LOCATION=eastus \
+              SONDE_AZURE_PROJECT_NAME=sonde \
+              SONDE_AZURE_FUNCTION_DEPLOY_TIMEOUT_SECS=0 \
+              COMPANION_CERT_BASE64=dummy-cert \
+              /opt/sonde/deploy/azure-bootstrap/bootstrap.sh >/tmp/invalid-deploy-stdout.txt 2>/tmp/invalid-deploy-stderr.txt; then
+              exit 1
+            fi
+            grep -q "SONDE_AZURE_FUNCTION_DEPLOY_TIMEOUT_SECS must be greater than zero" /tmp/invalid-deploy-stderr.txt
           '
 
       - name: Smoke test — bootstrap image entrypoint

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -186,6 +186,7 @@ jobs:
                     count="$((count + 1))"
                     printf "%s" "$count" > "$count_file"
                     if [ "$count" -eq 1 ]; then
+                      printf "warning: warm-up in progress\n" >&2
                       printf "[]"
                     else
                       printf "[{\"name\":\"UpstreamConnector\"}]"
@@ -217,6 +218,7 @@ jobs:
 
             grep -q "__SONDE_AZURE_DEPLOYMENT_START__" /tmp/bootstrap-stderr.txt
             grep -q "Deploying bundled Azure handler package" /tmp/bootstrap-stderr.txt
+            grep -q "warning: warm-up in progress" /tmp/bootstrap-stderr.txt
             grep -q "Waiting for Azure Function App to load functions" /tmp/bootstrap-stderr.txt
             grep -q "Azure Function App reports 1 loaded function(s)" /tmp/bootstrap-stderr.txt
             grep -q "functionapp deployment source config-zip" /tmp/az-calls.log

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -18,7 +18,29 @@ env:
   IMAGE_NAME: alan-jowett/sonde-azure-bootstrap
 
 jobs:
+  function-package:
+    name: Build Azure handler package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - name: Build bundled Azure handler package
+        run: sh deploy/azure-bootstrap/build-function-package.sh
+
+      - name: Upload Azure handler package artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: azure-handler-function-package
+          path: .artifacts/azure-handler-function/sonde-azure-handler-function.zip
+          if-no-files-found: error
+          retention-days: 7
+
   build:
+    needs: [function-package]
     strategy:
       matrix:
         include:
@@ -34,6 +56,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download Azure handler package artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: azure-handler-function-package
+          path: .artifacts/azure-handler-function
 
       - name: Log in to GitHub Container Registry
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
@@ -60,11 +88,149 @@ jobs:
       - name: Smoke test — Azure CLI and bundled assets
         run: |
           docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
-            'az version >/dev/null \
-             && test -x /opt/sonde/deploy/azure-bootstrap/bootstrap.sh \
-             && test -r /opt/sonde/deploy/bicep/main.bicep \
-             && test -r /opt/sonde/deploy/bicep/bicepconfig.json \
-             && test -d /opt/sonde/deploy/bicep/modules'
+             'az version >/dev/null \
+              && test -x /opt/sonde/deploy/azure-bootstrap/bootstrap.sh \
+              && test -r /opt/sonde/deploy/bicep/main.bicep \
+              && test -r /opt/sonde/deploy/bicep/bicepconfig.json \
+              && test -d /opt/sonde/deploy/bicep/modules \
+              && test -r /opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip'
+
+      - name: Smoke test — bundled handler package contents
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'python3 - <<'"'"'PY'"'"'
+          import zipfile
+
+          package_path = "/opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip"
+          with zipfile.ZipFile(package_path) as archive:
+              names = set(archive.namelist())
+              expected = {
+                  "host.json",
+                  "UpstreamConnector/function.json",
+                  "sonde-azure-handler",
+              }
+              missing = expected.difference(names)
+              if missing:
+                  raise SystemExit(f"missing packaged files: {sorted(missing)}")
+              mode = (archive.getinfo("sonde-azure-handler").external_attr >> 16) & 0o777
+              if (mode & 0o111) == 0:
+                  raise SystemExit(f"sonde-azure-handler is not executable in zip metadata: {oct(mode)}")
+          PY'
+
+      - name: Smoke test — bootstrap script deploy flow
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c '
+            set -eu
+            mkdir -p /tmp/fakebin
+            cat > /tmp/fakebin/az <<'"'"'SH'"'"'
+            #!/bin/sh
+            set -eu
+
+            log_file=/tmp/az-calls.log
+            count_file=/tmp/function-list-count
+            printf "%s\n" "$*" >> "$log_file"
+
+            case "$1" in
+              login)
+                exit 0
+                ;;
+              account)
+                [ "${2:-}" = "set" ] || exit 1
+                exit 0
+                ;;
+              deployment)
+                [ "${2:-}" = "sub" ] && [ "${3:-}" = "create" ] || exit 1
+                cat <<'"'"'JSON'"'"'
+            {"resourceGroupName":{"value":"rg-test"},"companionBootstrapValues":{"value":{"tenantId":"11111111-1111-1111-1111-111111111111","clientId":"22222222-2222-2222-2222-222222222222","serviceBusNamespace":"example.servicebus.windows.net","upstreamQueue":"upstream","downstreamQueue":"downstream","functionAppName":"func-test","deploymentContainerName":"app-package-test","deploymentContainerUrl":"https://example.blob.core.windows.net/app-package-test"}}}
+            JSON
+                ;;
+              functionapp)
+                case "${2:-}" in
+                  deployment)
+                    [ "${3:-}" = "source" ] && [ "${4:-}" = "config-zip" ] || exit 1
+                    src=
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --src)
+                          src="$2"
+                          shift 2
+                          ;;
+                        --timeout)
+                          timeout="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+                    [ "$src" = "/opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip" ] || exit 1
+                    [ "${timeout:-}" = "600" ] || exit 1
+                    python3 - <<'"'"'PY'"'"'
+            import zipfile
+
+            with zipfile.ZipFile("/opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip") as archive:
+                names = set(archive.namelist())
+                assert "host.json" in names
+                assert "UpstreamConnector/function.json" in names
+                assert "sonde-azure-handler" in names
+            PY
+                    exit 0
+                    ;;
+                  function)
+                    [ "${3:-}" = "list" ] || exit 1
+                    count=0
+                    if [ -f "$count_file" ]; then
+                      count="$(cat "$count_file")"
+                    fi
+                    count="$((count + 1))"
+                    printf "%s" "$count" > "$count_file"
+                    if [ "$count" -eq 1 ]; then
+                      printf "[]"
+                    else
+                      printf "[{\"name\":\"UpstreamConnector\"}]"
+                    fi
+                    ;;
+                  *)
+                    exit 1
+                    ;;
+                esac
+                ;;
+              *)
+                exit 1
+                ;;
+            esac
+            SH
+            chmod +x /tmp/fakebin/az
+
+            cat > /tmp/fakebin/sleep <<'"'"'SH'"'"'
+            #!/bin/sh
+            exit 0
+            SH
+            chmod +x /tmp/fakebin/sleep
+
+            PATH="/tmp/fakebin:$PATH" \
+            SONDE_AZURE_LOCATION=eastus \
+            SONDE_AZURE_PROJECT_NAME=sonde \
+            COMPANION_CERT_BASE64=dummy-cert \
+            /opt/sonde/deploy/azure-bootstrap/bootstrap.sh >/tmp/bootstrap-stdout.json 2>/tmp/bootstrap-stderr.txt
+
+            grep -q "__SONDE_AZURE_DEPLOYMENT_START__" /tmp/bootstrap-stderr.txt
+            grep -q "Deploying bundled Azure handler package" /tmp/bootstrap-stderr.txt
+            grep -q "Waiting for Azure Function App to load functions" /tmp/bootstrap-stderr.txt
+            grep -q "Azure Function App reports 1 loaded function(s)" /tmp/bootstrap-stderr.txt
+            grep -q "functionapp deployment source config-zip" /tmp/az-calls.log
+            test "$(cat /tmp/function-list-count)" = "2"
+
+            python3 - <<'"'"'PY'"'"'
+            import json
+
+            with open("/tmp/bootstrap-stdout.json", "r", encoding="utf-8") as fh:
+                outputs = json.load(fh)
+            assert outputs["companionBootstrapValues"]["value"]["functionAppName"] == "func-test"
+            assert outputs["companionBootstrapValues"]["value"]["deploymentContainerName"] == "app-package-test"
+            PY
+          '
 
       - name: Smoke test — bootstrap image entrypoint
         run: |

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -246,6 +246,16 @@ jobs:
             if PATH="/tmp/fakebin:$PATH" \
               SONDE_AZURE_LOCATION=eastus \
               SONDE_AZURE_PROJECT_NAME=sonde \
+              SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS=08 \
+              COMPANION_CERT_BASE64=dummy-cert \
+              /opt/sonde/deploy/azure-bootstrap/bootstrap.sh >/tmp/leading-zero-stdout.txt 2>/tmp/leading-zero-stderr.txt; then
+              exit 1
+            fi
+            grep -q "SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS must not contain leading zeros" /tmp/leading-zero-stderr.txt
+
+            if PATH="/tmp/fakebin:$PATH" \
+              SONDE_AZURE_LOCATION=eastus \
+              SONDE_AZURE_PROJECT_NAME=sonde \
               SONDE_AZURE_FUNCTION_DEPLOY_TIMEOUT_SECS=0 \
               COMPANION_CERT_BASE64=dummy-cert \
               /opt/sonde/deploy/azure-bootstrap/bootstrap.sh >/tmp/invalid-deploy-stdout.txt 2>/tmp/invalid-deploy-stderr.txt; then

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -10,10 +10,33 @@ import sys
 field = sys.argv[1]
 data = json.load(sys.stdin)
 
-if field == "resourceGroupName":
-    value = data["resourceGroupName"]["value"]
-else:
-    value = data["companionBootstrapValues"]["value"][field]
+try:
+    if field == "resourceGroupName":
+        value = data["resourceGroupName"]["value"]
+    else:
+        companion_values = data["companionBootstrapValues"]["value"]
+        value = companion_values[field]
+except (KeyError, TypeError):
+    if not isinstance(data, dict):
+        raise SystemExit("deployment outputs must be a JSON object")
+    if field == "resourceGroupName":
+        available_keys = ", ".join(sorted(data.keys())) or "(none)"
+        raise SystemExit(
+            f"missing deployment output `{field}`; available top-level outputs: {available_keys}"
+        )
+    companion_output = data.get("companionBootstrapValues")
+    if isinstance(companion_output, dict):
+        companion_values = companion_output.get("value")
+    else:
+        companion_values = None
+    available_keys = (
+        ", ".join(sorted(companion_values.keys()))
+        if isinstance(companion_values, dict)
+        else "(none)"
+    )
+    raise SystemExit(
+        f"missing deployment output `{field}` in companionBootstrapValues; available keys: {available_keys}"
+    )
 
 if not isinstance(value, str) or not value.strip():
     raise SystemExit(f"deployment output `{field}` must be a non-empty string")
@@ -29,10 +52,15 @@ wait_for_function_activation() {
     deadline="$(( $(date +%s) + timeout_secs ))"
 
     while :; do
+        function_list_stderr="$(mktemp "${TMPDIR:-/tmp}/sonde-azure-function-list.XXXXXX")"
         if function_list_json="$(az functionapp function list \
             --name "$function_app_name" \
             --resource-group "$resource_group_name" \
-            --output json 2>&1)"; then
+            --output json 2>"$function_list_stderr")"; then
+            if [ -s "$function_list_stderr" ]; then
+                cat "$function_list_stderr" >&2
+            fi
+            rm -f "$function_list_stderr"
             loaded_count="$(printf '%s' "$function_list_json" | python3 - <<'PY'
 import json
 import sys
@@ -54,7 +82,13 @@ PY
 
             echo "Waiting for Azure Function App to load functions..." >&2
         else
-            echo "Azure Function activation probe failed: $function_list_json" >&2
+            if [ -s "$function_list_stderr" ]; then
+                function_list_error="$(cat "$function_list_stderr")"
+                echo "Azure Function activation probe failed: $function_list_error" >&2
+            else
+                echo "Azure Function activation probe failed" >&2
+            fi
+            rm -f "$function_list_stderr"
         fi
 
         if [ "$(date +%s)" -ge "$deadline" ]; then

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -1,16 +1,106 @@
 #!/bin/sh
 set -eu
 
+json_output_string() {
+    field="$1"
+    printf '%s' "$deployment_outputs" | python3 - "$field" <<'PY'
+import json
+import sys
+
+field = sys.argv[1]
+data = json.load(sys.stdin)
+
+if field == "resourceGroupName":
+    value = data["resourceGroupName"]["value"]
+else:
+    value = data["companionBootstrapValues"]["value"][field]
+
+if not isinstance(value, str) or not value.strip():
+    raise SystemExit(f"deployment output `{field}` must be a non-empty string")
+
+print(value.strip())
+PY
+}
+
+wait_for_function_activation() {
+    resource_group_name="$1"
+    function_app_name="$2"
+    timeout_secs="${SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS:-300}"
+    deadline="$(( $(date +%s) + timeout_secs ))"
+
+    while :; do
+        if function_list_json="$(az functionapp function list \
+            --name "$function_app_name" \
+            --resource-group "$resource_group_name" \
+            --output json 2>&1)"; then
+            loaded_count="$(printf '%s' "$function_list_json" | python3 - <<'PY'
+import json
+import sys
+
+print(len(json.load(sys.stdin)))
+PY
+)"
+            case "$loaded_count" in
+                ''|*[!0-9]*)
+                    echo "invalid Azure function-list response while waiting for activation" >&2
+                    exit 1
+                    ;;
+            esac
+
+            if [ "$loaded_count" -gt 0 ]; then
+                echo "Azure Function App reports $loaded_count loaded function(s)" >&2
+                return 0
+            fi
+
+            echo "Waiting for Azure Function App to load functions..." >&2
+        else
+            echo "Azure Function activation probe failed: $function_list_json" >&2
+        fi
+
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+            echo "timed out waiting for Azure Function App activation" >&2
+            return 1
+        fi
+
+        sleep 5
+    done
+}
+
 az login --use-device-code --output none >&2
 if [ -n "${SONDE_AZURE_SUBSCRIPTION_ID:-}" ]; then
     az account set --subscription "$SONDE_AZURE_SUBSCRIPTION_ID" >&2
 fi
 echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2
-az deployment sub create \
+deployment_outputs="$(az deployment sub create \
     --location "$SONDE_AZURE_LOCATION" \
     --template-file /opt/sonde/deploy/bicep/main.bicep \
     --parameters companionCertificateBase64="$COMPANION_CERT_BASE64" \
     --parameters location="$SONDE_AZURE_LOCATION" \
     --parameters project_name="$SONDE_AZURE_PROJECT_NAME" \
     --query 'properties.outputs' \
-    --output json
+    --output json)"
+
+resource_group_name="$(json_output_string resourceGroupName)"
+function_app_name="$(json_output_string functionAppName)"
+deployment_container_name="$(json_output_string deploymentContainerName)"
+deployment_container_url="$(json_output_string deploymentContainerUrl)"
+function_package_path='/opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip'
+deployment_timeout_secs="${SONDE_AZURE_FUNCTION_DEPLOY_TIMEOUT_SECS:-600}"
+
+if [ ! -r "$function_package_path" ]; then
+    echo "bundled Azure handler package not found: $function_package_path" >&2
+    exit 1
+fi
+
+echo "Deploying bundled Azure handler package to Function App $function_app_name" >&2
+echo "Using deployment target $deployment_container_name ($deployment_container_url)" >&2
+az functionapp deployment source config-zip \
+    --src "$function_package_path" \
+    --name "$function_app_name" \
+    --resource-group "$resource_group_name" \
+    --timeout "$deployment_timeout_secs" \
+    --output none 1>&2
+
+wait_for_function_activation "$resource_group_name" "$function_app_name"
+
+printf '%s\n' "$deployment_outputs"

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -45,10 +45,25 @@ print(value.strip())
 PY
 }
 
+validate_positive_integer() {
+    name="$1"
+    value="$2"
+    case "$value" in
+        ''|*[!0-9]*)
+            echo "$name must be a positive integer; got: $value" >&2
+            exit 1
+            ;;
+        0)
+            echo "$name must be greater than zero; got: $value" >&2
+            exit 1
+            ;;
+    esac
+}
+
 wait_for_function_activation() {
     resource_group_name="$1"
     function_app_name="$2"
-    timeout_secs="${SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS:-300}"
+    timeout_secs="$3"
     deadline="$(( $(date +%s) + timeout_secs ))"
 
     while :; do
@@ -100,6 +115,11 @@ PY
     done
 }
 
+activation_timeout_secs="${SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS:-300}"
+deployment_timeout_secs="${SONDE_AZURE_FUNCTION_DEPLOY_TIMEOUT_SECS:-600}"
+validate_positive_integer "SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS" "$activation_timeout_secs"
+validate_positive_integer "SONDE_AZURE_FUNCTION_DEPLOY_TIMEOUT_SECS" "$deployment_timeout_secs"
+
 az login --use-device-code --output none >&2
 if [ -n "${SONDE_AZURE_SUBSCRIPTION_ID:-}" ]; then
     az account set --subscription "$SONDE_AZURE_SUBSCRIPTION_ID" >&2
@@ -119,7 +139,6 @@ function_app_name="$(json_output_string functionAppName)"
 deployment_container_name="$(json_output_string deploymentContainerName)"
 deployment_container_url="$(json_output_string deploymentContainerUrl)"
 function_package_path='/opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip'
-deployment_timeout_secs="${SONDE_AZURE_FUNCTION_DEPLOY_TIMEOUT_SECS:-600}"
 
 if [ ! -r "$function_package_path" ]; then
     echo "bundled Azure handler package not found: $function_package_path" >&2
@@ -135,6 +154,6 @@ az functionapp deployment source config-zip \
     --timeout "$deployment_timeout_secs" \
     --output none 1>&2
 
-wait_for_function_activation "$resource_group_name" "$function_app_name"
+wait_for_function_activation "$resource_group_name" "$function_app_name" "$activation_timeout_secs"
 
 printf '%s\n' "$deployment_outputs"

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -57,6 +57,10 @@ validate_positive_integer() {
             echo "$name must be greater than zero; got: $value" >&2
             exit 1
             ;;
+        0[0-9]*)
+            echo "$name must not contain leading zeros; got: $value" >&2
+            exit 1
+            ;;
     esac
 }
 

--- a/deploy/azure-bootstrap/build-function-package.sh
+++ b/deploy/azure-bootstrap/build-function-package.sh
@@ -7,6 +7,7 @@ artifact_dir="${1:-$repo_root/.artifacts/azure-handler-function}"
 target_dir="${CARGO_TARGET_DIR:-$repo_root/target}"
 package_path="$artifact_dir/sonde-azure-handler-function.zip"
 staging_dir="$(mktemp -d "${TMPDIR:-/tmp}/sonde-azure-handler-package.XXXXXX")"
+build_target="${CARGO_BUILD_TARGET:-}"
 
 cleanup() {
     rm -rf "$staging_dir"
@@ -17,10 +18,19 @@ mkdir -p "$artifact_dir" "$staging_dir/UpstreamConnector"
 
 cargo build --locked --release -p sonde-azure-handler --manifest-path "$repo_root/Cargo.toml"
 
+binary_path="$target_dir/release/sonde-azure-handler"
+if [ -n "$build_target" ]; then
+    binary_path="$target_dir/$build_target/release/sonde-azure-handler"
+fi
+if [ ! -f "$binary_path" ]; then
+    echo "built handler binary not found: $binary_path" >&2
+    exit 1
+fi
+
 cp "$repo_root/crates/sonde-azure-handler/function-app/host.json" "$staging_dir/host.json"
 cp "$repo_root/crates/sonde-azure-handler/function-app/UpstreamConnector/function.json" \
     "$staging_dir/UpstreamConnector/function.json"
-cp "$target_dir/release/sonde-azure-handler" "$staging_dir/sonde-azure-handler"
+cp "$binary_path" "$staging_dir/sonde-azure-handler"
 chmod 0755 "$staging_dir/sonde-azure-handler"
 
 rm -f "$package_path"

--- a/deploy/azure-bootstrap/build-function-package.sh
+++ b/deploy/azure-bootstrap/build-function-package.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+script_dir="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+repo_root="$(CDPATH= cd -- "$script_dir/../.." && pwd)"
+artifact_dir="${1:-$repo_root/.artifacts/azure-handler-function}"
+target_dir="${CARGO_TARGET_DIR:-$repo_root/target}"
+package_path="$artifact_dir/sonde-azure-handler-function.zip"
+staging_dir="$(mktemp -d "${TMPDIR:-/tmp}/sonde-azure-handler-package.XXXXXX")"
+
+cleanup() {
+    rm -rf "$staging_dir"
+}
+trap cleanup EXIT INT TERM
+
+mkdir -p "$artifact_dir" "$staging_dir/UpstreamConnector"
+
+cargo build --locked --release -p sonde-azure-handler --manifest-path "$repo_root/Cargo.toml"
+
+cp "$repo_root/crates/sonde-azure-handler/function-app/host.json" "$staging_dir/host.json"
+cp "$repo_root/crates/sonde-azure-handler/function-app/UpstreamConnector/function.json" \
+    "$staging_dir/UpstreamConnector/function.json"
+cp "$target_dir/release/sonde-azure-handler" "$staging_dir/sonde-azure-handler"
+chmod 0755 "$staging_dir/sonde-azure-handler"
+
+rm -f "$package_path"
+(
+    cd "$staging_dir"
+    zip -q -r "$package_path" .
+)
+
+printf '%s\n' "$package_path"

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -94,21 +94,26 @@ az deployment sub create `
 ## Custom handler package deployment
 
 The Bicep stack provisions the Azure handler Function App shell and the storage-backed
-deployment configuration, but it does **not** upload the runnable custom-handler package
-by itself. After provisioning, you still need to publish a package containing:
+deployment configuration. The supported `sonde-azure-companion bootstrap` flow now
+uses those deployment outputs to upload the bundled runnable custom-handler package
+automatically.
+
+If you run the Bicep deployment manually without the repository-owned bootstrap
+image, you still need to publish a package containing:
 
 - the `sonde-azure-handler` binary
 - `host.json`
 - `UpstreamConnector/function.json`
 
-The deployment outputs `deploymentContainerName` and `deploymentContainerUrl` so automation
-can discover the blob container that must receive that package.
+The deployment outputs `functionAppName`, `deploymentContainerName`, and
+`deploymentContainerUrl` so automation can discover the target used by that
+package deployment.
 Build the `sonde-azure-handler` executable for the Function App's Linux runtime, not
 for your local host OS. If you package from Windows or macOS, cross-compile or build
 the binary in a Linux environment before uploading it.
 
-Until that package is uploaded to the configured deployment container, the Function App
-is provisioned but not yet runnable.
+Until that package is uploaded and Azure loads at least one function, the
+Function App is provisioned but not yet runnable.
 
 ## Bootstrap handoff
 
@@ -120,6 +125,8 @@ state:
 - Service Bus namespace
 - upstream queue name
 - downstream queue name
+- Function App name
+- deployment container name / URL
 
 You still need to place the matching PEM certificate and private key into the
 Azure companion state directory and write `service-principal.json` that points

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -136,6 +136,7 @@ output companionBootstrapValues object = {
   serviceBusNamespace: stack.outputs.serviceBusNamespaceFqdn
   upstreamQueue: stack.outputs.upstreamQueueName
   downstreamQueue: stack.outputs.downstreamQueueName
+  functionAppName: stack.outputs.functionAppName
   deploymentContainerName: stack.outputs.deploymentContainerName
   deploymentContainerUrl: stack.outputs.deploymentContainerUrl
   nodeStateTable: stack.outputs.nodeStateTableName

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -232,7 +232,7 @@ transport and the runtime bridge semantics already defined in section 5.
 ## 4  Bootstrap flow
 
 > **Requirements:** AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204, AZC-0205, AZC-0300,
-> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0407, AZC-0408
+> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0407, AZC-0408, AZC-0409
 
 ### 4.1  Bootstrap trigger
 
@@ -288,18 +288,22 @@ When bootstrap is required, the Azure companion performs this sequence:
 13. Display "Deploying Azure…" on the modem display (transitions from auth to
     deployment phase may overlap in the single container session).
 14. Capture and parse the JSON outputs to extract `tenantId`, `clientId`,
-    Service Bus namespace, and queue names from the `companionBootstrapValues`
-    output object.
-15. Write `service-principal.json` and `service-bus.json` to the staging
+    Service Bus namespace, queue names, Function App name, and deployment
+    container values from the `companionBootstrapValues` output object.
+15. Use the bundled prebuilt `sonde-azure-handler` package from the bootstrap
+    image to populate the provisioned Function App deployment target.
+16. Poll Azure for Function App activation until the uploaded package is active
+    and at least one function is reported as loaded.
+17. Write `service-principal.json` and `service-bus.json` to the staging
     directory with the extracted values and relative paths to the certificate
     and private-key PEM files.
-16. Rename the staging directory into a new generation directory under the state
+18. Rename the staging directory into a new generation directory under the state
     volume, then atomically update the `.current-state` marker to point at that
     generation, leaving the previous generation untouched until the new one is
     fully committed.
-17. Remove the bootstrap container.
-18. Display "Bootstrap complete" on the modem display.
-19. The bootstrap wrapper/entrypoint reports overall success only after
+19. Remove the bootstrap container.
+20. Display "Bootstrap complete" on the modem display.
+21. The bootstrap wrapper/entrypoint reports overall success only after
     bootstrap-complete state has been established.
 
 If any step fails, the staging directory is cleaned up, the bootstrap
@@ -443,7 +447,7 @@ a detected bridge failure.
 ## 8  Provisioning orchestration internals
 
 > **Requirements:** AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405,
-> AZC-0406, AZC-0407, AZC-0408
+> AZC-0406, AZC-0407, AZC-0408, AZC-0409
 
 ### 8.1  Certificate generation
 
@@ -510,6 +514,9 @@ that:
      parameter overrides from environment variables
    - `--query properties.outputs` to extract only the deployment outputs
    - `--output json` for machine-parseable output
+4. Materializes the bundled prebuilt `sonde-azure-handler` package and deploys
+   it into the Function App deployment target described by the Bicep outputs.
+5. Polls Azure until the Function App reports at least one loaded function.
 
 The deployment outputs JSON is emitted on stdout. All other `az` output
 (device-code prompt, login confirmation, deployment progress) goes to stderr,

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -786,7 +786,7 @@ deployment SHOULD use the default subscription from the device-login session.
 ### AZC-0409  Bootstrap deploys and activates the bundled Azure handler package
 
 **Priority:** Must
-**Source:** USER-REQUEST: implement "Function code deployment" in azure funciton, AZP-0105
+**Source:** USER-REQUEST: implement "Function code deployment" in azure function, AZP-0105
 
 **Description:**
 After successful Azure deployment, the unified `bootstrap` subcommand MUST

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -241,11 +241,13 @@ instead of normal runtime mode.
 When bootstrap is required, the Azure companion MUST provide a single unified
 `bootstrap` subcommand that performs the entire provisioning lifecycle:
 certificate generation, device-code authentication inside the dedicated
-`sonde-azure-bootstrap` image, Azure deployment through the Docker API, and
-local runtime artifact creation. The earlier `bootstrap-auth` subcommand is
-retired and replaced by this unified command. By default, the Rust companion
-launches the `sonde-azure-bootstrap:<matching companion version>` image tag;
-the image contains the Azure CLI, bundled Bicep files, and bootstrap script.
+`sonde-azure-bootstrap` image, Azure deployment through the Docker API,
+deployment of the bundled Azure handler package into the provisioned Function
+App, and local runtime artifact creation. The earlier `bootstrap-auth`
+subcommand is retired and replaced by this unified command. By default, the
+Rust companion launches the `sonde-azure-bootstrap:<matching companion
+version>` image tag; the image contains the Azure CLI, bundled Bicep files,
+bundled Azure handler package, and bootstrap script.
 The Rust companion monitors the bootstrap image output to extract the device
 code and display it on the modem. The same explicit `bootstrap` subcommand MUST
 be supported by the Windows native binary when invoked manually by an operator;
@@ -255,7 +257,7 @@ AZC-0205.
 **Acceptance criteria:**
 
 1. Missing bootstrap-complete state causes the companion bootstrap path to invoke the unified `bootstrap` subcommand.
-2. The `bootstrap` subcommand performs device-code login, certificate generation, Bicep deployment, and runtime artifact creation in sequence.
+2. The `bootstrap` subcommand performs device-code login, certificate generation, Bicep deployment, Azure handler package deployment/activation, and runtime artifact creation in sequence.
 3. If any phase of the unified bootstrap fails, the subcommand exits with a non-zero status and does not report success.
 4. Successful device-code login alone is not treated as bootstrap completion; the bootstrap path reports success only after bootstrap-complete state has been established.
 5. The earlier `bootstrap-auth` subcommand name is no longer accepted.
@@ -644,7 +646,9 @@ crate.
 **Description:**
 The dedicated `sonde-azure-bootstrap` image MUST bundle the Azure provisioning
 assets needed for bootstrap at build time so the bootstrap workflow does not
-rely on runtime-image internals or host-side Bicep files.
+rely on runtime-image internals or host-side Bicep files. The same image MUST
+also bundle the prebuilt Azure handler package needed to make the Function App
+runnable during bootstrap.
 
 **Acceptance criteria:**
 
@@ -652,6 +656,7 @@ rely on runtime-image internals or host-side Bicep files.
 2. The bundled provisioning assets include the top-level `main.bicep`, all module files, and `bicepconfig.json`.
 3. The bootstrap image includes the script that runs `az login --use-device-code` followed by Azure deployment.
 4. Bootstrap references the bundled path inside the bootstrap image rather than copying Bicep files out of the runtime companion image.
+5. The bootstrap image bundles the prebuilt `sonde-azure-handler` package that bootstrap deploys into the Function App.
 
 ---
 
@@ -693,8 +698,6 @@ supply them.
 1. Bootstrap extracts the Service Bus namespace, upstream queue name, and downstream queue name from the Bicep deployment outputs.
 2. Bootstrap writes or persists these values so they are available at the next container startup.
 3. The runtime can read the persisted queue configuration without requiring the operator to re-enter it manually.
-
----
 
 ### AZC-0405  Bootstrap progress display
 
@@ -777,3 +780,23 @@ deployment SHOULD use the default subscription from the device-login session.
 1. Bootstrap accepts an optional Azure subscription ID via environment variable.
 2. If specified, the Bicep deployment targets that subscription.
 3. If not specified, the Bicep deployment uses the device-login session's default subscription.
+
+---
+
+### AZC-0409  Bootstrap deploys and activates the bundled Azure handler package
+
+**Priority:** Must
+**Source:** USER-REQUEST: implement "Function code deployment" in azure funciton, AZP-0105
+
+**Description:**
+After successful Azure deployment, the unified `bootstrap` subcommand MUST
+deploy the bundled prebuilt `sonde-azure-handler` package into the provisioned
+Azure Function App and wait until Azure reports the package active. Bootstrap
+does not succeed if the Function App shell exists but no functions are loaded.
+
+**Acceptance criteria:**
+
+1. Bootstrap deploys the bundled `sonde-azure-handler` package without requiring a manual operator upload step.
+2. The deployed package matches the companion/bootstrap release rather than an ad hoc package built on the operator host during bootstrap.
+3. Bootstrap waits until Azure reports that at least one function is loaded in the provisioned Function App before reporting success.
+4. If package deployment or activation fails, bootstrap exits non-zero and does not report success-shaped completion.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -387,6 +387,7 @@
 2. Run `docker run --rm <image> ls /opt/sonde/deploy/bicep/`.
 3. Assert: the listing includes `main.bicep`, `bicepconfig.json`, and the `modules/` directory.
 4. Assert: the `modules/` directory contains the expected Bicep module files.
+5. Assert: the image also contains the bundled prebuilt Azure handler package intended for Function App deployment.
 
 ---
 
@@ -571,3 +572,17 @@
 2. Start bootstrap with a mock Docker API server (or equivalent traceable test double).
 3. Assert: the Docker API requests use the configured override image reference rather than the default version-matched release tag.
 4. Assert: bootstrap reaches the container-creation path using the override image reference when the override image is available.
+
+---
+
+### T-AZC-0417  Bootstrap deploys the bundled Azure handler package and waits for activation
+
+**Validates:** AZC-0409, AZC-0402
+
+**Procedure:**
+1. Run bootstrap with device auth and Azure deployment stubbed or directed at a disposable Azure test stack whose Function App can be queried after deployment.
+2. Assert: bootstrap uses the prebuilt `sonde-azure-handler` package bundled in the version-matched bootstrap image rather than requiring a separate operator-supplied upload or an ad hoc local build.
+3. After the package-deployment phase, query Azure for the provisioned Function App.
+4. Assert: bootstrap does not report success until Azure reports at least one loaded function for that Function App.
+5. Force package activation to fail or never complete.
+6. Assert: bootstrap exits non-zero and does not report success-shaped completion.

--- a/docs/azure-provisioning-design.md
+++ b/docs/azure-provisioning-design.md
@@ -46,7 +46,7 @@ The design assumes this layout:
 | `deploy/bicep/main.bicep` | Top-level deployment entrypoint. |
 | `deploy/bicep/modules/service-bus.bicep` | Service Bus namespace and queue provisioning. |
 | `deploy/bicep/modules/storage.bicep` | Storage Account and Table resource provisioning. |
-| `deploy/bicep/modules/function-placeholder.bicep` | Placeholder Function hosting resources for the later decoder issue. |
+| `deploy/bicep/modules/function-placeholder.bicep` | Function hosting resources and deployment target for the Azure handler package. |
 | `deploy/bicep/modules/identity.*` | Runtime identity provisioning artifacts or wrappers used by the Bicep-driven workflow. |
 | `deploy/bicep/README.md` or equivalent inline deployment documentation | Operator-facing description of inputs, outputs, and post-deploy handoff. |
 
@@ -119,10 +119,14 @@ outputs.
 ### 3.5  Azure handler Function App resources
 
 The function-placeholder module provisions the hosting resources used by the
-Azure handler Function App. This module may create the Function App shell, a
-consumption hosting plan, storage linkage, and baseline app settings, but it
-must not depend on the handler function code package being deployed by the
-provisioning workflow itself.
+Azure handler Function App. This module creates the Function App shell, the
+consumption hosting plan, storage linkage, and baseline app settings required
+for the repository-owned bootstrap path to deploy the runnable handler package.
+
+The runnable package itself is not compiled during bootstrap. Instead, the
+bootstrap image carries a prebuilt Linux package for the matching Sonde
+release, uploads it into the provisioned deployment target, and waits until
+Azure reports that at least one function is loaded before reporting success.
 
 ---
 
@@ -218,6 +222,8 @@ The handoff contract includes:
 | Service Bus namespace | Azure companion runtime configuration |
 | Upstream queue name | Azure companion runtime configuration |
 | Downstream queue name | Azure companion runtime configuration |
+| Function App name | bootstrap package activation checks |
+| Deployment container name / URL | bootstrap package upload target |
 
 ### 5.2  Local artifact compatibility
 
@@ -248,8 +254,8 @@ The top-level workflow exposes or documents the following outputs:
 3. upstream queue name,
 4. downstream queue name,
 5. Storage Account name,
-6. Table resource name,
-7. Function placeholder resource identity, and
+6. deployment container name / URL,
+7. Function App name and identity, and
 8. the runtime identity / bootstrap handoff values described in section 5.
 
 ### 6.2  Idempotency

--- a/docs/azure-provisioning-requirements.md
+++ b/docs/azure-provisioning-requirements.md
@@ -138,16 +138,38 @@ the tables' logical schema.
 
 **Description:**
 The provisioning workflow MUST create the Azure Function hosting resources used
-by the Sonde Azure handler without requiring the function code package to be
-deployed by the Bicep workflow itself. The Function App uses a consumption plan
-unless a later specification explicitly changes that hosting model.
+by the Sonde Azure handler and the deployment target that the repository-owned
+bootstrap path populates with the runnable handler package. The Function App
+uses a consumption plan unless a later specification explicitly changes that
+hosting model.
 
 **Acceptance criteria:**
 
 1. The workflow provisions the Azure resources needed to host the Azure handler Function App.
-2. The workflow does not require the handler function code package to exist in order to deploy the hosting resources.
+2. The workflow provisions or documents the deployment target consumed by the repository-owned handler package deployment step.
 3. The Function App resources use a consumption-plan hosting model.
 4. The deployment outputs or documentation identify the Function App resources used by the Azure handler path.
+
+---
+
+### AZP-0105  Repository-owned Azure handler package deployment
+
+**Priority:** Must
+**Source:** USER-REQUEST: implement "Function code deployment" in azure funciton, reviewed discovery output
+
+**Description:**
+The repository-owned Azure provisioning/bootstrap workflow MUST deploy a
+prebuilt `sonde-azure-handler` package into the provisioned Function App rather
+than leaving a manual post-provision upload step to the operator. Successful
+bootstrap MUST make the Function App runnable.
+
+**Acceptance criteria:**
+
+1. The deployed package is a prebuilt repository-owned artifact for the Function App's Linux runtime rather than a package built ad hoc during bootstrap.
+2. The package contents include the `sonde-azure-handler` executable, `host.json`, and the function metadata required for Azure Functions to load at least one function.
+3. The bootstrap workflow deploys that package without requiring the operator to upload a separate handler artifact manually.
+4. Bootstrap does not report overall success until Azure reports the package active and at least one function is loaded in the Function App.
+5. Re-running bootstrap may replace the deployed package, but it does not require manual cleanup of the prior package first.
 
 ---
 
@@ -229,7 +251,7 @@ and private-key PEM.
 **Acceptance criteria:**
 
 1. The workflow documents which values and artifacts must be handed off to bootstrap for runtime starts.
-2. The handoff contract includes the tenant ID, client ID, certificate reference or material, private-key reference or material, and Service Bus namespace/queue configuration.
+2. The handoff contract includes the tenant ID, client ID, certificate reference or material, private-key reference or material, Service Bus namespace/queue configuration, and the Function App / deployment-target values needed for package deployment and activation checks.
 3. The handoff contract is compatible with the current Azure companion runtime expectations in `azure-companion-requirements.md`.
 
 ---

--- a/docs/azure-provisioning-requirements.md
+++ b/docs/azure-provisioning-requirements.md
@@ -155,7 +155,7 @@ hosting model.
 ### AZP-0105  Repository-owned Azure handler package deployment
 
 **Priority:** Must
-**Source:** USER-REQUEST: implement "Function code deployment" in azure funciton, reviewed discovery output
+**Source:** USER-REQUEST: implement "Function code deployment" in azure function, reviewed discovery output
 
 **Description:**
 The repository-owned Azure provisioning/bootstrap workflow MUST deploy a

--- a/docs/azure-provisioning-validation.md
+++ b/docs/azure-provisioning-validation.md
@@ -69,16 +69,32 @@
 
 ---
 
-### T-AZP-0104  Azure handler Function App resources deploy without handler code
+### T-AZP-0104  Azure handler Function App resources and deployment target are provisioned
 
 **Validates:** AZP-0104
 
 **Procedure:**
-1. Run the deployment without supplying any Azure handler function package.
+1. Run the deployment.
 2. Inspect the resulting Function hosting resources.
 3. Assert: the Azure handler Function App resources exist.
 4. Assert: the Function App uses a consumption hosting plan.
-5. Assert: the deployment did not require the handler implementation package to be present.
+5. Assert: the deployment target used by the repository-owned package deployment step is present or explicitly surfaced by deployment outputs/documentation.
+
+---
+
+### T-AZP-0105  Repository-owned bootstrap deploys runnable Azure handler package
+
+**Validates:** AZP-0105
+
+**Procedure:**
+1. Run the repository-owned bootstrap workflow against a disposable Azure test stack.
+2. Inspect the bootstrap image contents or documented build outputs.
+3. Assert: the bundled handler package includes the `sonde-azure-handler` executable, `host.json`, and the function metadata required by the Function App host.
+4. After bootstrap completes, query Azure for the Function App.
+5. Assert: Azure reports at least one loaded function for the provisioned Function App.
+6. Assert: the operator did not need to upload a separate handler package manually.
+7. Re-run bootstrap against the same stack.
+8. Assert: bootstrap can replace or refresh the deployed handler package without requiring manual cleanup first.
 
 ---
 
@@ -116,7 +132,7 @@
 1. Run the provisioning workflow.
 2. Collect the documented outputs and artifacts from the handoff contract.
 3. Compare them against the runtime-state inputs expected by `sonde-azure-companion`.
-4. Assert: the handoff includes tenant ID, client ID, certificate material or reference, private-key material or reference, and Service Bus namespace/queue values.
+4. Assert: the handoff includes tenant ID, client ID, certificate material or reference, private-key material or reference, Service Bus namespace/queue values, and the Function App / deployment-target values needed by bootstrap package deployment.
 5. Assert: the handoff can be translated into `service-principal.json`, certificate PEM, and private-key PEM without inventing extra undocumented values.
 
 ---

--- a/docs/deployment-sop.md
+++ b/docs/deployment-sop.md
@@ -243,6 +243,8 @@ sonde-azure-companion.exe bootstrap
 Bootstrap:
 - pulls `ghcr.io/alan-jowett/sonde-azure-bootstrap:<matching companion version>` by default
 - runs Azure device-code authentication inside the bootstrap container
+- deploys the bundled prebuilt `sonde-azure-handler` package into the provisioned Function App
+- waits until Azure reports at least one loaded function before reporting success
 - displays the device code and progress messages on the modem via the gateway admin pipe
 - writes runtime state under `%ProgramData%\sonde-azure-companion\`
 


### PR DESCRIPTION
## Summary
- bundle a prebuilt Linux `sonde-azure-handler` package into `sonde-azure-bootstrap`
- deploy that package during Azure bootstrap and wait for Azure to report loaded functions
- update the approved provisioning/companion specs, bootstrap-image workflow coverage, and operator docs for the runnable Function App contract

## Traceability
### Requirements / spec changes
- `AZP-0104` now treats the Function App deployment target as part of the provisioned surface
- new `AZP-0105` requires the repository-owned bootstrap path to deploy a runnable handler package
- `AZP-0203` now includes the Function App / deployment-target handoff values
- `AZC-0201`, `AZC-0402`, and new `AZC-0409` require bundled-package deployment and activation during bootstrap

### Implementation
- adds `deploy/azure-bootstrap/build-function-package.sh` to build the bundled handler zip
- updates `.github/workflows/azure-bootstrap-container.yml` to build/download the package artifact and smoke-test both package contents and the scripted deploy flow
- updates `.github/docker/Dockerfile.azure-bootstrap` to bundle the prebuilt handler package
- updates `deploy/azure-bootstrap/bootstrap.sh` to run `az functionapp deployment source config-zip --timeout ...` and then poll `az functionapp function list` until at least one function loads
- adds `functionAppName` to `companionBootstrapValues` in `deploy/bicep/main.bicep`
- updates `deploy/bicep/README.md` and `docs/deployment-sop.md` for the new bootstrap behavior

## Audit outcomes
- Phase 3 spec audit: PASS
- Phase 6 implementation audit: PASS

## Validation
- `cargo build --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- workflow YAML parse
- bootstrap shell syntax check