### PR TITLE
Install protoc in Azure handler package job

### DIFF
--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
+      - name: Install protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build bundled Azure handler package
         run: sh deploy/azure-bootstrap/build-function-package.sh
 


### PR DESCRIPTION
## Summary
- install `protoc` in the Azure bootstrap container `function-package` job
- align that job with the repo's existing Rust build jobs that compile `sonde-gateway` path dependencies
- restore nightly/release Azure handler package builds

## Why this was not caught in PR #857
KNOWN:
- `.github/workflows/azure-bootstrap-container.yml` is only called from `nightly-release.yml`, not from normal PR `ci.yml`.
- `.github/workflows/ci.yml` `pull_request.paths` does not include the bootstrap workflow or `deploy/azure-bootstrap/**`.
- The new `function-package` job therefore was not exercised by standard PR validation.

INFERRED:
- The regression only surfaced once nightly invoked the workflow path that actually builds the Azure handler package on Linux.

## Validation
- workflow YAML parse
- targeted diff review against the existing `setup-protoc` usage in `ci.yml` / `release.yml`