### PR TITLE
Fix reusable container workflow cancellation

### DIFF
--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: azure-bootstrap-container-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -12,10 +12,22 @@ name: Gateway Container
 
 on:
   workflow_call:
+    inputs:
+      build_same_run_artifacts:
+        description: Build supporting same-run artifacts for standalone execution.
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
+    inputs:
+      build_same_run_artifacts:
+        description: Build supporting same-run artifacts for standalone execution.
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: gateway-container-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -27,14 +39,14 @@ jobs:
   # modem artifacts, so build them here first. workflow_call executions expect
   # the caller to produce modem-firmware and modem-firmware-verbose in the same run.
   modem-firmware:
-    if: github.event_name == 'workflow_dispatch'
+    if: inputs.build_same_run_artifacts
     name: Build modem firmware (same run)
     uses: ./.github/workflows/esp32-modem.yml
 
   # Standalone dispatches also need same-run compiled BPF test-program artifacts.
   # workflow_call executions expect the caller to upload a bpf-test-programs artifact.
   bpf-test-programs:
-    if: github.event_name == 'workflow_dispatch'
+    if: inputs.build_same_run_artifacts
     name: Build BPF test programs (same run)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- give the Azure bootstrap and Gateway container reusable workflows distinct concurrency groups
- gate Gateway container standalone helper jobs on an explicit input instead of inherited event context
- keep standalone manual dispatch behavior while preventing Nightly Release child runs from cancelling each other

## Root cause
workflow_call executions were inheriting caller context for github.workflow and github.event_name in ways that made both reusable container workflows share the same Nightly Release concurrency group. When the Gateway container child workflow started, it cancelled the Azure bootstrap child workflow mid-push.

The inherited event context also caused Gateway container's standalone-only helper jobs to run during Nightly Release.

## Validation
- parsed the edited workflow YAML successfully
- inspected the workflow diff to confirm only the reusable workflow guards and concurrency keys changed