### PR TITLE
Remove Python from Azure bootstrap

### DIFF
--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -415,23 +415,8 @@ if [ "$#" -ge 4 ] && [ "$1" = "deployment" ] && [ "$2" = "sub" ] && [ "$3" = "sh
         ;;
     esac
   done
-  case "$query" in
-    properties.outputs.resourceGroupName.value)
-      printf 'rg-sonde\n'
-      ;;
-    properties.outputs.functionAppName.value)
-      printf 'func-sonde\n'
-      ;;
-    properties.outputs.deploymentContainerName.value)
-      printf 'deploypkg\n'
-      ;;
-    properties.outputs.deploymentContainerUrl.value)
-      printf 'https://example.blob.core.windows.net/deploypkg\n'
-      ;;
-    *)
-      exit 67
-      ;;
-  esac
+  [ "$query" = "[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value]" ] || exit 67
+  printf 'rg-sonde\tfunc-sonde\tdeploypkg\thttps://example.blob.core.windows.net/deploypkg\n'
   exit 0
 fi
 if [ "$#" -ge 5 ] && [ "$1" = "functionapp" ] && [ "$2" = "deployment" ] && [ "$3" = "source" ] && [ "$4" = "config-zip" ]; then
@@ -482,7 +467,7 @@ exit 64
 
     let az_calls = fs::read_to_string(az_log).unwrap();
     assert!(az_calls.contains("deployment sub create"));
-    assert!(az_calls.contains("deployment sub show"));
+    assert_eq!(az_calls.matches("deployment sub show").count(), 1);
     assert!(az_calls.contains("functionapp deployment source config-zip"));
     assert!(az_calls.contains("functionapp function list"));
 }

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -49,6 +49,13 @@ fn bootstrap_script_path() -> PathBuf {
         .join("bootstrap.sh")
 }
 
+fn azure_bootstrap_script_path() -> PathBuf {
+    repo_root()
+        .join("deploy")
+        .join("azure-bootstrap")
+        .join("bootstrap.sh")
+}
+
 fn prepare_path_dir(temp: &TempDir) -> PathBuf {
     let bin_dir = temp.path().join("bin");
     fs::create_dir_all(&bin_dir).unwrap();
@@ -351,6 +358,133 @@ fn host_bootstrap_does_not_require_removed_device_env() {
         docker_log.exists(),
         "docker should still be invoked by the host wrapper"
     );
+}
+
+#[test]
+fn azure_bootstrap_script_avoids_python_and_uses_cli_queries() {
+    let temp = TempDir::new().unwrap();
+    let bin_dir = prepare_path_dir(&temp);
+    let az_log = temp.path().join("az.log");
+    let function_package_path = temp.path().join("handler.zip");
+    fs::write(&function_package_path, b"zip").unwrap();
+
+    write_executable(
+        &bin_dir.join("az"),
+        &format!(
+            r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "{}"
+if [ "$#" -ge 3 ] && [ "$1" = "login" ] && [ "$2" = "--use-device-code" ] && [ "$3" = "--output" ]; then
+  exit 0
+fi
+if [ "$#" -ge 4 ] && [ "$1" = "deployment" ] && [ "$2" = "sub" ] && [ "$3" = "create" ]; then
+  query=""
+  name=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --name)
+        name="$2"
+        shift 2
+        ;;
+      --query)
+        query="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  [ -n "$name" ] || exit 65
+  [ "$query" = "properties.outputs" ] || exit 66
+  cat <<'EOF'
+{{"resourceGroupName":{{"type":"String","value":"rg-sonde"}},"functionAppName":{{"type":"String","value":"func-sonde"}},"deploymentContainerName":{{"type":"String","value":"deploypkg"}},"deploymentContainerUrl":{{"type":"String","value":"https://example.blob.core.windows.net/deploypkg"}},"companionBootstrapValues":{{"type":"Object","value":{{"tenantId":"tenant-123","clientId":"client-456","serviceBusNamespace":"sonde.servicebus.windows.net","upstreamQueue":"connector-upstream","downstreamQueue":"desired-state"}}}}}}
+EOF
+  exit 0
+fi
+if [ "$#" -ge 4 ] && [ "$1" = "deployment" ] && [ "$2" = "sub" ] && [ "$3" = "show" ]; then
+  query=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --query)
+        query="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  case "$query" in
+    properties.outputs.resourceGroupName.value)
+      printf 'rg-sonde\n'
+      ;;
+    properties.outputs.functionAppName.value)
+      printf 'func-sonde\n'
+      ;;
+    properties.outputs.deploymentContainerName.value)
+      printf 'deploypkg\n'
+      ;;
+    properties.outputs.deploymentContainerUrl.value)
+      printf 'https://example.blob.core.windows.net/deploypkg\n'
+      ;;
+    *)
+      exit 67
+      ;;
+  esac
+  exit 0
+fi
+if [ "$#" -ge 5 ] && [ "$1" = "functionapp" ] && [ "$2" = "deployment" ] && [ "$3" = "source" ] && [ "$4" = "config-zip" ]; then
+  exit 0
+fi
+if [ "$#" -ge 4 ] && [ "$1" = "functionapp" ] && [ "$2" = "function" ] && [ "$3" = "list" ]; then
+  printf '1\n'
+  exit 0
+fi
+exit 64
+"#,
+            az_log.display()
+        ),
+    );
+    write_executable(&bin_dir.join("python3"), "#!/bin/sh\nexit 91\n");
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(azure_bootstrap_script_path());
+    cmd.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            bin_dir.display(),
+            std::env::var("PATH").unwrap_or_default()
+        ),
+    );
+    cmd.env("COMPANION_CERT_BASE64", "ZmFrZWNlcnQ=");
+    cmd.env("SONDE_AZURE_LOCATION", "westus2");
+    cmd.env("SONDE_AZURE_PROJECT_NAME", "sonde-test");
+    cmd.env("SONDE_AZURE_FUNCTION_PACKAGE_PATH", &function_package_path);
+    cmd.env("SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS", "10");
+    cmd.env("SONDE_AZURE_FUNCTION_DEPLOY_TIMEOUT_SECS", "10");
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "azure bootstrap script failed: {output:?}"
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(r#""resourceGroupName":{"type":"String","value":"rg-sonde"}"#));
+    assert!(stdout.contains(r#""companionBootstrapValues":{"type":"Object""#));
+
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("__SONDE_AZURE_DEPLOYMENT_START__"));
+    assert!(stderr.contains("Deploying bundled Azure handler package to Function App func-sonde"));
+    assert!(stderr.contains("Azure Function App reports 1 loaded function(s)"));
+
+    let az_calls = fs::read_to_string(az_log).unwrap();
+    assert!(az_calls.contains("deployment sub create"));
+    assert!(az_calls.contains("deployment sub show"));
+    assert!(az_calls.contains("functionapp deployment source config-zip"));
+    assert!(az_calls.contains("functionapp function list"));
 }
 
 #[test]

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -5,19 +5,29 @@ trim_string() {
     printf '%s' "$1" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
 
-deployment_output_string() {
-    query="$1"
-    field="$2"
+require_deployment_output_string() {
+    field="$1"
+    query="$2"
+    value="$(trim_string "$3")"
+    if [ -z "$value" ] || [ "$value" = "null" ]; then
+        echo "deployment output \`$field\` is missing or null for query \`$query\`" >&2
+        exit 1
+    fi
+    printf '%s\n' "$value"
+}
+
+read_required_deployment_outputs() {
+    query='[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value]'
     stderr_file="$(mktemp "${TMPDIR:-/tmp}/sonde-azure-deployment-show.XXXXXX")"
-    if ! value="$(az deployment sub show \
+    if ! deployment_runtime_values="$(az deployment sub show \
         --name "$deployment_name" \
         --query "$query" \
         --output tsv 2>"$stderr_file")"; then
         if [ -s "$stderr_file" ]; then
             deployment_show_error="$(cat "$stderr_file")"
-            echo "failed to read deployment output \`$field\`: $deployment_show_error" >&2
+            echo "failed to read deployment outputs for query \`$query\`: $deployment_show_error" >&2
         else
-            echo "failed to read deployment output \`$field\`" >&2
+            echo "failed to read deployment outputs for query \`$query\`" >&2
         fi
         rm -f "$stderr_file"
         exit 1
@@ -26,12 +36,38 @@ deployment_output_string() {
         cat "$stderr_file" >&2
     fi
     rm -f "$stderr_file"
-    value="$(trim_string "$value")"
-    if [ -z "$value" ] || [ "$value" = "null" ]; then
-        echo "deployment output \`$field\` must be a non-empty string" >&2
+
+    field_count="$(printf '%s' "$deployment_runtime_values" | awk -F '\t' 'NR == 1 { print NF; exit }')"
+    field_count="${field_count:-0}"
+    if [ "$field_count" -ne 4 ]; then
+        echo "deployment output query \`$query\` returned $field_count field(s); expected 4 tab-separated values" >&2
         exit 1
     fi
-    printf '%s\n' "$value"
+
+    resource_group_name="$(
+        require_deployment_output_string \
+            resourceGroupName \
+            "$query" \
+            "$(printf '%s' "$deployment_runtime_values" | awk -F '\t' 'NR == 1 { print $1; exit }')"
+    )"
+    function_app_name="$(
+        require_deployment_output_string \
+            functionAppName \
+            "$query" \
+            "$(printf '%s' "$deployment_runtime_values" | awk -F '\t' 'NR == 1 { print $2; exit }')"
+    )"
+    deployment_container_name="$(
+        require_deployment_output_string \
+            deploymentContainerName \
+            "$query" \
+            "$(printf '%s' "$deployment_runtime_values" | awk -F '\t' 'NR == 1 { print $3; exit }')"
+    )"
+    deployment_container_url="$(
+        require_deployment_output_string \
+            deploymentContainerUrl \
+            "$query" \
+            "$(printf '%s' "$deployment_runtime_values" | awk -F '\t' 'NR == 1 { print $4; exit }')"
+    )"
 }
 
 validate_positive_integer() {
@@ -124,10 +160,7 @@ deployment_outputs="$(az deployment sub create \
     --query 'properties.outputs' \
     --output json)"
 
-resource_group_name="$(deployment_output_string 'properties.outputs.resourceGroupName.value' resourceGroupName)"
-function_app_name="$(deployment_output_string 'properties.outputs.functionAppName.value' functionAppName)"
-deployment_container_name="$(deployment_output_string 'properties.outputs.deploymentContainerName.value' deploymentContainerName)"
-deployment_container_url="$(deployment_output_string 'properties.outputs.deploymentContainerUrl.value' deploymentContainerUrl)"
+read_required_deployment_outputs
 function_package_path="${SONDE_AZURE_FUNCTION_PACKAGE_PATH:-/opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip}"
 
 if [ ! -r "$function_package_path" ]; then

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -1,48 +1,37 @@
 #!/bin/sh
 set -eu
 
-json_output_string() {
-    field="$1"
-    printf '%s' "$deployment_outputs" | python3 - "$field" <<'PY'
-import json
-import sys
+trim_string() {
+    printf '%s' "$1" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
 
-field = sys.argv[1]
-data = json.load(sys.stdin)
-
-try:
-    if field == "resourceGroupName":
-        value = data["resourceGroupName"]["value"]
-    else:
-        companion_values = data["companionBootstrapValues"]["value"]
-        value = companion_values[field]
-except (KeyError, TypeError):
-    if not isinstance(data, dict):
-        raise SystemExit("deployment outputs must be a JSON object")
-    if field == "resourceGroupName":
-        available_keys = ", ".join(sorted(data.keys())) or "(none)"
-        raise SystemExit(
-            f"missing deployment output `{field}`; available top-level outputs: {available_keys}"
-        )
-    companion_output = data.get("companionBootstrapValues")
-    if isinstance(companion_output, dict):
-        companion_values = companion_output.get("value")
-    else:
-        companion_values = None
-    available_keys = (
-        ", ".join(sorted(companion_values.keys()))
-        if isinstance(companion_values, dict)
-        else "(none)"
-    )
-    raise SystemExit(
-        f"missing deployment output `{field}` in companionBootstrapValues; available keys: {available_keys}"
-    )
-
-if not isinstance(value, str) or not value.strip():
-    raise SystemExit(f"deployment output `{field}` must be a non-empty string")
-
-print(value.strip())
-PY
+deployment_output_string() {
+    query="$1"
+    field="$2"
+    stderr_file="$(mktemp "${TMPDIR:-/tmp}/sonde-azure-deployment-show.XXXXXX")"
+    if ! value="$(az deployment sub show \
+        --name "$deployment_name" \
+        --query "$query" \
+        --output tsv 2>"$stderr_file")"; then
+        if [ -s "$stderr_file" ]; then
+            deployment_show_error="$(cat "$stderr_file")"
+            echo "failed to read deployment output \`$field\`: $deployment_show_error" >&2
+        else
+            echo "failed to read deployment output \`$field\`" >&2
+        fi
+        rm -f "$stderr_file"
+        exit 1
+    fi
+    if [ -s "$stderr_file" ]; then
+        cat "$stderr_file" >&2
+    fi
+    rm -f "$stderr_file"
+    value="$(trim_string "$value")"
+    if [ -z "$value" ] || [ "$value" = "null" ]; then
+        echo "deployment output \`$field\` must be a non-empty string" >&2
+        exit 1
+    fi
+    printf '%s\n' "$value"
 }
 
 validate_positive_integer() {
@@ -72,21 +61,16 @@ wait_for_function_activation() {
 
     while :; do
         function_list_stderr="$(mktemp "${TMPDIR:-/tmp}/sonde-azure-function-list.XXXXXX")"
-        if function_list_json="$(az functionapp function list \
+        if loaded_count="$(az functionapp function list \
             --name "$function_app_name" \
             --resource-group "$resource_group_name" \
-            --output json 2>"$function_list_stderr")"; then
+            --query 'length(@)' \
+            --output tsv 2>"$function_list_stderr")"; then
             if [ -s "$function_list_stderr" ]; then
                 cat "$function_list_stderr" >&2
             fi
             rm -f "$function_list_stderr"
-            loaded_count="$(printf '%s' "$function_list_json" | python3 - <<'PY'
-import json
-import sys
-
-print(len(json.load(sys.stdin)))
-PY
-)"
+            loaded_count="$(trim_string "$loaded_count")"
             case "$loaded_count" in
                 ''|*[!0-9]*)
                     echo "invalid Azure function-list response while waiting for activation" >&2
@@ -129,7 +113,9 @@ if [ -n "${SONDE_AZURE_SUBSCRIPTION_ID:-}" ]; then
     az account set --subscription "$SONDE_AZURE_SUBSCRIPTION_ID" >&2
 fi
 echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2
+deployment_name="sonde-bootstrap-$(date +%Y%m%d%H%M%S)-$$"
 deployment_outputs="$(az deployment sub create \
+    --name "$deployment_name" \
     --location "$SONDE_AZURE_LOCATION" \
     --template-file /opt/sonde/deploy/bicep/main.bicep \
     --parameters companionCertificateBase64="$COMPANION_CERT_BASE64" \
@@ -138,11 +124,11 @@ deployment_outputs="$(az deployment sub create \
     --query 'properties.outputs' \
     --output json)"
 
-resource_group_name="$(json_output_string resourceGroupName)"
-function_app_name="$(json_output_string functionAppName)"
-deployment_container_name="$(json_output_string deploymentContainerName)"
-deployment_container_url="$(json_output_string deploymentContainerUrl)"
-function_package_path='/opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip'
+resource_group_name="$(deployment_output_string 'properties.outputs.resourceGroupName.value' resourceGroupName)"
+function_app_name="$(deployment_output_string 'properties.outputs.functionAppName.value' functionAppName)"
+deployment_container_name="$(deployment_output_string 'properties.outputs.deploymentContainerName.value' deploymentContainerName)"
+deployment_container_url="$(deployment_output_string 'properties.outputs.deploymentContainerUrl.value' deploymentContainerUrl)"
+function_package_path="${SONDE_AZURE_FUNCTION_PACKAGE_PATH:-/opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip}"
 
 if [ ! -r "$function_package_path" ]; then
     echo "bundled Azure handler package not found: $function_package_path" >&2


### PR DESCRIPTION
## Summary\n- replace inline Python parsing in the Azure bootstrap script with Azure CLI-native queries\n- name the subscription deployment and read required outputs back with z deployment sub show\n- add a regression test that proves the bootstrap script works without Python in PATH\n\n## Validation\n- cargo build --workspace\n- cargo clippy --workspace -- -D warnings\n- cargo test --workspace