### PR TITLE
Refactor Azure handler to use append-only actual and desired state history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6828,6 +6828,7 @@ dependencies = [
  "azure_identity 0.25.0",
  "base64 0.22.1",
  "ciborium",
+ "futures",
  "hex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6829,6 +6829,7 @@ dependencies = [
  "base64 0.22.1",
  "ciborium",
  "futures",
+ "getrandom 0.3.4",
  "hex",
  "serde",
  "serde_json",

--- a/crates/sonde-azure-handler/Cargo.toml
+++ b/crates/sonde-azure-handler/Cargo.toml
@@ -16,6 +16,7 @@ azure_identity_legacy = { package = "azure_identity", version = "0.21.0", defaul
 base64 = "0.22"
 ciborium = "0.2"
 futures = "0.3"
+getrandom = "0.3"
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/sonde-azure-handler/Cargo.toml
+++ b/crates/sonde-azure-handler/Cargo.toml
@@ -15,6 +15,7 @@ azure_identity = { version = "0.25.0", default-features = false, features = ["re
 azure_identity_legacy = { package = "azure_identity", version = "0.21.0", default-features = false, features = ["enable_reqwest_rustls"] }
 base64 = "0.22"
 ciborium = "0.2"
+futures = "0.3"
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -728,6 +728,9 @@ fn encode_node_partition_key(node_id: &str) -> String {
     format!("n:{}", hex::encode(digest))
 }
 
+// Equal-timestamp ordering is only guaranteed within one handler process
+// lifetime; reconciliation correctness must not depend on cross-process suffix
+// ordering.
 fn next_history_row_key(timestamp_ms: u64) -> Result<String, HandlerError> {
     let sequence = HISTORY_ROW_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     let process_nonce = history_row_process_nonce()?;
@@ -1626,7 +1629,7 @@ mod tests {
     }
 
     #[test]
-    fn history_row_keys_sort_later_appends_first_for_equal_timestamps() {
+    fn history_row_keys_sort_later_appends_first_for_equal_timestamps_within_process() {
         let first = next_history_row_key(1234).unwrap();
         let second = next_history_row_key(1234).unwrap();
         assert!(second < first);

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -216,7 +216,10 @@ where
         }
     }
 
-    async fn handle_actual_state(&self, actual_state: ActualStateMessage) -> Result<(), HandlerError> {
+    async fn handle_actual_state(
+        &self,
+        actual_state: ActualStateMessage,
+    ) -> Result<(), HandlerError> {
         if actual_state.entity_id.is_empty() {
             return Err(HandlerError::Decode(
                 "node-scoped ACTUAL_STATE requires a non-empty entity_id".to_string(),
@@ -251,7 +254,9 @@ where
         let program_diverged = desired_row
             .desired_assigned_program_hash
             .as_ref()
-            .is_some_and(|desired| latest_actual.observed_current_program_hash.as_ref() != Some(desired));
+            .is_some_and(|desired| {
+                latest_actual.observed_current_program_hash.as_ref() != Some(desired)
+            });
         let schedule_diverged = desired_row
             .desired_schedule_interval_s
             .is_some_and(|desired| latest_actual.observed_schedule_interval_s != Some(desired));
@@ -550,7 +555,9 @@ impl TryFrom<ActualStateRow> for ActualStateEntity {
             row_key: value.row_key,
             node_id: value.node_id,
             observed_current_program_hash: encode_optional_hex(value.observed_current_program_hash),
-            observed_assigned_program_hash: encode_optional_hex(value.observed_assigned_program_hash),
+            observed_assigned_program_hash: encode_optional_hex(
+                value.observed_assigned_program_hash,
+            ),
             observed_schedule_interval_s: value.observed_schedule_interval_s,
             battery_mv: value.battery_mv,
             firmware_abi_version: value.firmware_abi_version,
@@ -634,12 +641,12 @@ pub fn extract_trigger_payload(request_body: &[u8]) -> Result<Vec<u8>, HandlerEr
 
 fn extract_json_payload(value: &serde_json::Value) -> Result<Vec<u8>, HandlerError> {
     match value {
-        serde_json::Value::String(text) => match base64::engine::general_purpose::STANDARD
-            .decode(text)
-        {
-            Ok(bytes) => Ok(bytes),
-            Err(_) => Ok(text.as_bytes().to_vec()),
-        },
+        serde_json::Value::String(text) => {
+            match base64::engine::general_purpose::STANDARD.decode(text) {
+                Ok(bytes) => Ok(bytes),
+                Err(_) => Ok(text.as_bytes().to_vec()),
+            }
+        }
         serde_json::Value::Array(values) => values
             .iter()
             .map(|value| {
@@ -948,12 +955,11 @@ mod tests {
             &self,
             node_id: &str,
         ) -> Result<Option<ActualStateRow>, HandlerError> {
-            Ok(self
-                .actual_rows
-                .lock()
-                .await
-                .get(node_id)
-                .and_then(|rows| rows.iter().min_by(|a, b| a.row_key.cmp(&b.row_key)).cloned()))
+            Ok(self.actual_rows.lock().await.get(node_id).and_then(|rows| {
+                rows.iter()
+                    .min_by(|a, b| a.row_key.cmp(&b.row_key))
+                    .cloned()
+            }))
         }
 
         async fn load_latest_desired_state(
@@ -965,7 +971,11 @@ mod tests {
                 .lock()
                 .await
                 .get(node_id)
-                .and_then(|rows| rows.iter().min_by(|a, b| a.row_key.cmp(&b.row_key)).cloned()))
+                .and_then(|rows| {
+                    rows.iter()
+                        .min_by(|a, b| a.row_key.cmp(&b.row_key))
+                        .cloned()
+                }))
         }
 
         async fn load_program_route(
@@ -1296,7 +1306,11 @@ mod tests {
         let rows = store.actual_rows_for("node-1").await;
         assert_eq!(rows.len(), 2);
         assert!(rows.iter().any(|row| row.timestamp_ms == 1234));
-        let latest = store.load_latest_actual_state("node-1").await.unwrap().unwrap();
+        let latest = store
+            .load_latest_actual_state("node-1")
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(latest.timestamp_ms, 5000);
         assert!(publisher.sends.lock().await.is_empty());
     }
@@ -1356,7 +1370,11 @@ mod tests {
 
         let rows = store.actual_rows_for("node-1").await;
         assert_eq!(rows.len(), 2);
-        let latest = store.load_latest_actual_state("node-1").await.unwrap().unwrap();
+        let latest = store
+            .load_latest_actual_state("node-1")
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(latest.timestamp_ms, 1234);
         assert_eq!(latest.observed_current_program_hash, Some(vec![0xAA; 32]));
     }

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -2,7 +2,9 @@
 // Copyright (c) 2026 sonde contributors
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use azservicebus::{
@@ -14,17 +16,20 @@ use azure_core_legacy::auth::TokenCredential as LegacyTokenCredential;
 use azure_core_legacy::error::ErrorKind as LegacyAzureErrorKind;
 use azure_core_legacy::Error as LegacyAzureError;
 use azure_core_legacy::StatusCode as LegacyStatusCode;
-use azure_data_tables::prelude::{IfMatchCondition, TableServiceClient};
+use azure_data_tables::prelude::TableServiceClient;
 use azure_identity::ManagedIdentityCredential;
 use azure_identity_legacy::{AppServiceManagedIdentityCredential, TokenCredentialOptions};
 use base64::Engine as _;
 use ciborium::Value;
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sonde_gateway::connector::{MSG_TYPE_ACTUAL_STATE, MSG_TYPE_APP_DATA, MSG_TYPE_DESIRED_STATE};
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::warn;
+
+static HISTORY_ROW_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Error)]
 pub enum HandlerError {
@@ -48,7 +53,8 @@ pub struct RuntimeConfig {
     pub upstream_queue: String,
     pub downstream_queue: String,
     pub storage_account: String,
-    pub node_state_table: String,
+    pub actual_state_table: String,
+    pub desired_state_table: String,
     pub program_route_table: String,
 }
 
@@ -61,7 +67,8 @@ impl RuntimeConfig {
             upstream_queue: required_env("SONDE_AZURE_HANDLER_UPSTREAM_QUEUE")?,
             downstream_queue: required_env("SONDE_AZURE_HANDLER_DOWNSTREAM_QUEUE")?,
             storage_account: required_env("SONDE_AZURE_HANDLER_STORAGE_ACCOUNT")?,
-            node_state_table: required_env("SONDE_AZURE_HANDLER_NODE_STATE_TABLE")?,
+            actual_state_table: required_env("SONDE_AZURE_HANDLER_ACTUAL_STATE_TABLE")?,
+            desired_state_table: required_env("SONDE_AZURE_HANDLER_DESIRED_STATE_TABLE")?,
             program_route_table: required_env("SONDE_AZURE_HANDLER_PROGRAM_ROUTE_TABLE")?,
         })
     }
@@ -75,42 +82,47 @@ fn required_env(name: &str) -> Result<String, HandlerError> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NodeStateRow {
+pub struct ActualStateRow {
+    pub row_key: String,
     pub node_id: String,
-    pub desired_assigned_program_hash: Option<Vec<u8>>,
-    pub desired_schedule_interval_s: Option<u32>,
     pub observed_current_program_hash: Option<Vec<u8>>,
     pub observed_assigned_program_hash: Option<Vec<u8>>,
     pub observed_schedule_interval_s: Option<u32>,
     pub battery_mv: Option<u32>,
     pub firmware_abi_version: Option<u32>,
     pub firmware_version: Option<String>,
-    pub last_checkin_ms: u64,
+    pub timestamp_ms: u64,
+}
+
+impl ActualStateRow {
+    fn from_message(message: &ActualStateMessage) -> Self {
+        Self {
+            row_key: next_history_row_key(message.timestamp_ms),
+            node_id: message.entity_id.clone(),
+            observed_current_program_hash: message.current_program_hash.clone(),
+            observed_assigned_program_hash: message.assigned_program_hash.clone(),
+            observed_schedule_interval_s: message.schedule_interval_s,
+            battery_mv: message.battery_mv,
+            firmware_abi_version: message.firmware_abi_version,
+            firmware_version: message.firmware_version.clone(),
+            timestamp_ms: message.timestamp_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DesiredStateRow {
+    pub row_key: String,
+    pub node_id: String,
+    pub desired_assigned_program_hash: Option<Vec<u8>>,
+    pub desired_schedule_interval_s: Option<u32>,
+    pub timestamp_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProgramRouteRow {
     pub program_hash: Vec<u8>,
     pub handler_queue: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ObservedStateUpdate {
-    pub node_id: String,
-    pub current_program_hash: Option<Vec<u8>>,
-    pub assigned_program_hash: Option<Vec<u8>>,
-    pub schedule_interval_s: Option<u32>,
-    pub battery_mv: Option<u32>,
-    pub firmware_abi_version: Option<u32>,
-    pub firmware_version: Option<String>,
-    pub timestamp_ms: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ObservedStateWriteResult {
-    Applied(NodeStateRow),
-    Current(NodeStateRow),
-    IgnoredStale,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -143,13 +155,15 @@ pub enum ConnectorMessage {
 
 #[async_trait]
 pub trait HandlerStore: Send + Sync {
-    async fn load_node_state(&self, node_id: &str) -> Result<Option<NodeStateRow>, HandlerError>;
-    async fn save_node_state(&self, row: &NodeStateRow) -> Result<(), HandlerError>;
-    async fn create_node_state_if_absent(&self, row: &NodeStateRow) -> Result<bool, HandlerError>;
-    async fn update_observed_state(
+    async fn append_actual_state(&self, row: &ActualStateRow) -> Result<(), HandlerError>;
+    async fn load_latest_actual_state(
         &self,
-        update: &ObservedStateUpdate,
-    ) -> Result<ObservedStateWriteResult, HandlerError>;
+        node_id: &str,
+    ) -> Result<Option<ActualStateRow>, HandlerError>;
+    async fn load_latest_desired_state(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<DesiredStateRow>, HandlerError>;
     async fn load_program_route(
         &self,
         program_hash: &[u8],
@@ -202,92 +216,50 @@ where
         }
     }
 
-    async fn handle_actual_state(
-        &self,
-        actual_state: ActualStateMessage,
-    ) -> Result<(), HandlerError> {
+    async fn handle_actual_state(&self, actual_state: ActualStateMessage) -> Result<(), HandlerError> {
         if actual_state.entity_id.is_empty() {
             return Err(HandlerError::Decode(
                 "node-scoped ACTUAL_STATE requires a non-empty entity_id".to_string(),
             ));
         }
 
-        let node_id = actual_state.entity_id.clone();
-        let Some(row) = self.store.load_node_state(&node_id).await? else {
-            let seeded = NodeStateRow {
-                node_id: node_id.clone(),
-                desired_assigned_program_hash: actual_state
-                    .current_program_hash
-                    .clone()
-                    .or_else(|| actual_state.assigned_program_hash.clone()),
-                desired_schedule_interval_s: actual_state.schedule_interval_s,
-                observed_current_program_hash: actual_state.current_program_hash.clone(),
-                observed_assigned_program_hash: actual_state.assigned_program_hash.clone(),
-                observed_schedule_interval_s: actual_state.schedule_interval_s,
-                battery_mv: actual_state.battery_mv,
-                firmware_abi_version: actual_state.firmware_abi_version,
-                firmware_version: actual_state.firmware_version.clone(),
-                last_checkin_ms: actual_state.timestamp_ms,
-            };
-            if self.store.create_node_state_if_absent(&seeded).await? {
-                return Ok(());
-            }
-            let Some(row) = self.store.load_node_state(&node_id).await? else {
-                return Err(HandlerError::Store(format!(
-                    "node state row `{node_id}` disappeared during create race"
-                )));
-            };
-            return self
-                .reconcile_existing_actual_state(row, actual_state)
-                .await;
-        };
+        let appended_row = ActualStateRow::from_message(&actual_state);
+        self.store.append_actual_state(&appended_row).await?;
 
-        self.reconcile_existing_actual_state(row, actual_state)
-            .await
-    }
-
-    async fn reconcile_existing_actual_state(
-        &self,
-        row: NodeStateRow,
-        actual_state: ActualStateMessage,
-    ) -> Result<(), HandlerError> {
-        if actual_state.timestamp_ms < row.last_checkin_ms {
+        let latest_actual = self
+            .store
+            .load_latest_actual_state(&actual_state.entity_id)
+            .await?
+            .ok_or_else(|| {
+                HandlerError::Store(format!(
+                    "actual-state row `{}` disappeared after append",
+                    actual_state.entity_id
+                ))
+            })?;
+        if latest_actual.row_key != appended_row.row_key {
             return Ok(());
         }
 
-        let row = if actual_state.timestamp_ms == row.last_checkin_ms {
-            row
-        } else {
-            let update = ObservedStateUpdate {
-                node_id: row.node_id.clone(),
-                current_program_hash: actual_state.current_program_hash,
-                assigned_program_hash: actual_state.assigned_program_hash,
-                schedule_interval_s: actual_state.schedule_interval_s,
-                battery_mv: actual_state.battery_mv,
-                firmware_abi_version: actual_state.firmware_abi_version,
-                firmware_version: actual_state.firmware_version,
-                timestamp_ms: actual_state.timestamp_ms,
-            };
-            match self.store.update_observed_state(&update).await? {
-                ObservedStateWriteResult::Applied(row) | ObservedStateWriteResult::Current(row) => {
-                    row
-                }
-                ObservedStateWriteResult::IgnoredStale => return Ok(()),
-            }
+        let Some(desired_row) = self
+            .store
+            .load_latest_desired_state(&actual_state.entity_id)
+            .await?
+        else {
+            return Ok(());
         };
 
-        let program_diverged = row
+        let program_diverged = desired_row
             .desired_assigned_program_hash
             .as_ref()
-            .is_some_and(|desired| row.observed_current_program_hash.as_ref() != Some(desired));
-        let schedule_diverged = row
+            .is_some_and(|desired| latest_actual.observed_current_program_hash.as_ref() != Some(desired));
+        let schedule_diverged = desired_row
             .desired_schedule_interval_s
-            .is_some_and(|desired| row.observed_schedule_interval_s != Some(desired));
+            .is_some_and(|desired| latest_actual.observed_schedule_interval_s != Some(desired));
         if !program_diverged && !schedule_diverged {
             return Ok(());
         }
 
-        let desired = encode_desired_state(&row)?;
+        let desired = encode_desired_state(&desired_row)?;
         self.publisher
             .publish(&self.downstream_queue, desired)
             .await
@@ -315,7 +287,8 @@ where
 }
 
 pub struct AzureTablesStore {
-    node_state_table: azure_data_tables::clients::TableClient,
+    actual_state_table: azure_data_tables::clients::TableClient,
+    desired_state_table: azure_data_tables::clients::TableClient,
     program_route_table: azure_data_tables::clients::TableClient,
 }
 
@@ -329,7 +302,8 @@ impl AzureTablesStore {
         );
         let service = TableServiceClient::new(config.storage_account.clone(), credential);
         Ok(Self {
-            node_state_table: service.table_client(config.node_state_table.clone()),
+            actual_state_table: service.table_client(config.actual_state_table.clone()),
+            desired_state_table: service.table_client(config.desired_state_table.clone()),
             program_route_table: service.table_client(config.program_route_table.clone()),
         })
     }
@@ -345,163 +319,66 @@ fn is_legacy_not_found(e: &LegacyAzureError) -> bool {
     )
 }
 
-fn node_state_row_key_candidates(node_id: &str) -> Vec<String> {
-    let mut candidates = Vec::with_capacity(3);
-    for row_key in [
-        encode_node_row_key(node_id),
-        encode_legacy_node_row_key(node_id),
-        node_id.to_string(),
-    ] {
-        if !candidates.contains(&row_key) {
-            candidates.push(row_key);
-        }
-    }
-    candidates
-}
-
 #[async_trait]
 impl HandlerStore for AzureTablesStore {
-    async fn load_node_state(&self, node_id: &str) -> Result<Option<NodeStateRow>, HandlerError> {
-        for row_key in node_state_row_key_candidates(node_id) {
-            let entity_client = self
-                .node_state_table
-                .partition_key_client("node")
-                .entity_client(row_key);
-            match entity_client.get::<NodeStateEntity>().await {
-                Ok(response) => return Ok(Some(NodeStateRow::try_from(response.entity)?)),
-                Err(e) if is_legacy_not_found(&e) => {}
-                Err(e) => {
-                    return Err(HandlerError::Store(format!("query node state failed: {e}")));
-                }
-            }
-        }
-        Ok(None)
-    }
-
-    async fn save_node_state(&self, row: &NodeStateRow) -> Result<(), HandlerError> {
-        let entity = NodeStateEntity::try_from(row.clone())?;
-        self.node_state_table
-            .partition_key_client(entity.partition_key.clone())
-            .entity_client(entity.row_key.clone())
-            .insert_or_replace(&entity)
-            .map_err(|e| HandlerError::Store(format!("prepare node state upsert failed: {e}")))?
+    async fn append_actual_state(&self, row: &ActualStateRow) -> Result<(), HandlerError> {
+        let entity = ActualStateEntity::try_from(row.clone())?;
+        self.actual_state_table
+            .insert::<_, ActualStateEntity>(&entity)
+            .map_err(|e| HandlerError::Store(format!("prepare actual-state insert failed: {e}")))?
             .await
-            .map_err(|e| HandlerError::Store(format!("save node state failed: {e}")))?;
+            .map_err(|e| HandlerError::Store(format!("append actual-state row failed: {e}")))?;
         Ok(())
     }
 
-    async fn create_node_state_if_absent(&self, row: &NodeStateRow) -> Result<bool, HandlerError> {
-        let entity = NodeStateEntity::try_from(row.clone())?;
-        match self
-            .node_state_table
-            .insert::<_, NodeStateEntity>(&entity)
-            .map_err(|e| HandlerError::Store(format!("prepare node state insert failed: {e}")))?
-            .await
-        {
-            Ok(_) => Ok(true),
-            Err(e)
-                if matches!(
-                    e.kind(),
-                    LegacyAzureErrorKind::HttpResponse {
-                        status: LegacyStatusCode::Conflict,
-                        ..
-                    }
-                ) =>
-            {
-                Ok(false)
-            }
-            Err(e) => Err(HandlerError::Store(format!(
-                "create node state failed: {e}"
+    async fn load_latest_actual_state(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<ActualStateRow>, HandlerError> {
+        let partition_key = encode_node_partition_key(node_id);
+        let mut stream = self
+            .actual_state_table
+            .query()
+            .filter(partition_filter(&partition_key))
+            .top(1)
+            .into_stream::<ActualStateEntity>();
+        match stream.next().await {
+            Some(Ok(response)) => response
+                .entities
+                .into_iter()
+                .next()
+                .map(ActualStateRow::try_from)
+                .transpose(),
+            Some(Err(e)) => Err(HandlerError::Store(format!(
+                "query latest actual-state row failed: {e}"
             ))),
+            None => Ok(None),
         }
     }
 
-    async fn update_observed_state(
+    async fn load_latest_desired_state(
         &self,
-        update: &ObservedStateUpdate,
-    ) -> Result<ObservedStateWriteResult, HandlerError> {
-        let entity_client = self.node_state_table.partition_key_client("node");
-        let candidate_row_keys = node_state_row_key_candidates(&update.node_id);
-        for _ in 0..4 {
-            let mut response = None;
-            for row_key in &candidate_row_keys {
-                match entity_client
-                    .entity_client(row_key.clone())
-                    .get::<NodeStateEntity>()
-                    .await
-                {
-                    Ok(found) => {
-                        response = Some(found);
-                        break;
-                    }
-                    Err(e) if is_legacy_not_found(&e) => {}
-                    Err(e) => {
-                        return Err(HandlerError::Store(format!(
-                            "load node state for merge failed: {e}"
-                        )));
-                    }
-                }
-            }
-            let Some(response) = response else {
-                return Err(HandlerError::Store(format!(
-                    "missing node `{}` for observed update",
-                    update.node_id
-                )));
-            };
-            let mut entity = response.entity;
-            if update.timestamp_ms <= entity.last_checkin_ms {
-                return if update.timestamp_ms == entity.last_checkin_ms {
-                    Ok(ObservedStateWriteResult::Current(NodeStateRow::try_from(
-                        entity,
-                    )?))
-                } else {
-                    Ok(ObservedStateWriteResult::IgnoredStale)
-                };
-            }
-            entity.observed_current_program_hash =
-                encode_optional_hex(update.current_program_hash.clone());
-            entity.observed_assigned_program_hash =
-                encode_optional_hex(update.assigned_program_hash.clone());
-            entity.observed_schedule_interval_s = update.schedule_interval_s;
-            entity.battery_mv = update.battery_mv;
-            entity.firmware_abi_version = update.firmware_abi_version;
-            entity.firmware_version = update.firmware_version.clone();
-            entity.last_checkin_ms = update.timestamp_ms;
-            match entity_client
-                .entity_client(entity.row_key.clone())
-                .update(&entity, IfMatchCondition::from(response.etag))
-                .map_err(|e| {
-                    HandlerError::Store(format!("prepare observed-state update failed: {e}"))
-                })?
-                .await
-            {
-                Ok(_) => {
-                    return Ok(ObservedStateWriteResult::Applied(NodeStateRow::try_from(
-                        entity,
-                    )?))
-                }
-                Err(e)
-                    if matches!(
-                        e.kind(),
-                        LegacyAzureErrorKind::HttpResponse {
-                            status: LegacyStatusCode::PreconditionFailed,
-                            ..
-                        }
-                    ) =>
-                {
-                    continue;
-                }
-                Err(e) => {
-                    return Err(HandlerError::Store(format!(
-                        "update observed state failed: {e}"
-                    )));
-                }
-            }
+        node_id: &str,
+    ) -> Result<Option<DesiredStateRow>, HandlerError> {
+        let partition_key = encode_node_partition_key(node_id);
+        let mut stream = self
+            .desired_state_table
+            .query()
+            .filter(partition_filter(&partition_key))
+            .top(1)
+            .into_stream::<DesiredStateEntity>();
+        match stream.next().await {
+            Some(Ok(response)) => response
+                .entities
+                .into_iter()
+                .next()
+                .map(DesiredStateRow::try_from)
+                .transpose(),
+            Some(Err(e)) => Err(HandlerError::Store(format!(
+                "query latest desired-state row failed: {e}"
+            ))),
+            None => Ok(None),
         }
-        Err(HandlerError::Store(format!(
-            "update observed state for node `{}` failed after concurrent retries",
-            update.node_id
-        )))
     }
 
     async fn load_program_route(
@@ -515,17 +392,7 @@ impl HandlerStore for AzureTablesStore {
             .entity_client(row_key);
         match entity_client.get::<ProgramRouteEntity>().await {
             Ok(response) => Ok(Some(ProgramRouteRow::try_from(response.entity)?)),
-            Err(e)
-                if matches!(
-                    e.kind(),
-                    LegacyAzureErrorKind::HttpResponse {
-                        status: LegacyStatusCode::NotFound,
-                        ..
-                    }
-                ) =>
-            {
-                Ok(None)
-            }
+            Err(e) if is_legacy_not_found(&e) => Ok(None),
             Err(e) => Err(HandlerError::Store(format!(
                 "query program route failed: {e}"
             ))),
@@ -614,21 +481,31 @@ async fn send_with_cached_sender(
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
-struct NodeStateEntity {
+struct ActualStateEntity {
     #[serde(rename = "PartitionKey")]
     partition_key: String,
     #[serde(rename = "RowKey")]
     row_key: String,
-    node_id: Option<String>,
-    desired_assigned_program_hash: Option<String>,
-    desired_schedule_interval_s: Option<u32>,
+    node_id: String,
     observed_current_program_hash: Option<String>,
     observed_assigned_program_hash: Option<String>,
     observed_schedule_interval_s: Option<u32>,
     battery_mv: Option<u32>,
     firmware_abi_version: Option<u32>,
     firmware_version: Option<String>,
-    last_checkin_ms: u64,
+    timestamp_ms: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct DesiredStateEntity {
+    #[serde(rename = "PartitionKey")]
+    partition_key: String,
+    #[serde(rename = "RowKey")]
+    row_key: String,
+    node_id: String,
+    desired_assigned_program_hash: Option<String>,
+    desired_schedule_interval_s: Option<u32>,
+    timestamp_ms: u64,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -640,20 +517,13 @@ struct ProgramRouteEntity {
     handler_queue: String,
 }
 
-impl TryFrom<NodeStateEntity> for NodeStateRow {
+impl TryFrom<ActualStateEntity> for ActualStateRow {
     type Error = HandlerError;
 
-    fn try_from(value: NodeStateEntity) -> Result<Self, Self::Error> {
+    fn try_from(value: ActualStateEntity) -> Result<Self, Self::Error> {
         Ok(Self {
-            node_id: match value.node_id {
-                Some(node_id) => node_id,
-                None => decode_legacy_node_row_key(&value.row_key)?,
-            },
-            desired_assigned_program_hash: decode_optional_program_hash(
-                value.desired_assigned_program_hash,
-                "desired_assigned_program_hash",
-            )?,
-            desired_schedule_interval_s: value.desired_schedule_interval_s,
+            row_key: value.row_key,
+            node_id: value.node_id,
             observed_current_program_hash: decode_optional_program_hash(
                 value.observed_current_program_hash,
                 "observed_current_program_hash",
@@ -666,30 +536,58 @@ impl TryFrom<NodeStateEntity> for NodeStateRow {
             battery_mv: value.battery_mv,
             firmware_abi_version: value.firmware_abi_version,
             firmware_version: value.firmware_version,
-            last_checkin_ms: value.last_checkin_ms,
+            timestamp_ms: value.timestamp_ms,
         })
     }
 }
 
-impl TryFrom<NodeStateRow> for NodeStateEntity {
+impl TryFrom<ActualStateRow> for ActualStateEntity {
     type Error = HandlerError;
 
-    fn try_from(value: NodeStateRow) -> Result<Self, Self::Error> {
+    fn try_from(value: ActualStateRow) -> Result<Self, Self::Error> {
         Ok(Self {
-            partition_key: "node".to_string(),
-            row_key: encode_node_row_key(&value.node_id),
-            node_id: Some(value.node_id),
-            desired_assigned_program_hash: encode_optional_hex(value.desired_assigned_program_hash),
-            desired_schedule_interval_s: value.desired_schedule_interval_s,
+            partition_key: encode_node_partition_key(&value.node_id),
+            row_key: value.row_key,
+            node_id: value.node_id,
             observed_current_program_hash: encode_optional_hex(value.observed_current_program_hash),
-            observed_assigned_program_hash: encode_optional_hex(
-                value.observed_assigned_program_hash,
-            ),
+            observed_assigned_program_hash: encode_optional_hex(value.observed_assigned_program_hash),
             observed_schedule_interval_s: value.observed_schedule_interval_s,
             battery_mv: value.battery_mv,
             firmware_abi_version: value.firmware_abi_version,
             firmware_version: value.firmware_version,
-            last_checkin_ms: value.last_checkin_ms,
+            timestamp_ms: value.timestamp_ms,
+        })
+    }
+}
+
+impl TryFrom<DesiredStateEntity> for DesiredStateRow {
+    type Error = HandlerError;
+
+    fn try_from(value: DesiredStateEntity) -> Result<Self, Self::Error> {
+        Ok(Self {
+            row_key: value.row_key,
+            node_id: value.node_id,
+            desired_assigned_program_hash: decode_optional_program_hash(
+                value.desired_assigned_program_hash,
+                "desired_assigned_program_hash",
+            )?,
+            desired_schedule_interval_s: value.desired_schedule_interval_s,
+            timestamp_ms: value.timestamp_ms,
+        })
+    }
+}
+
+impl TryFrom<DesiredStateRow> for DesiredStateEntity {
+    type Error = HandlerError;
+
+    fn try_from(value: DesiredStateRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            partition_key: encode_node_partition_key(&value.node_id),
+            row_key: value.row_key,
+            node_id: value.node_id,
+            desired_assigned_program_hash: encode_optional_hex(value.desired_assigned_program_hash),
+            desired_schedule_interval_s: value.desired_schedule_interval_s,
+            timestamp_ms: value.timestamp_ms,
         })
     }
 }
@@ -736,12 +634,12 @@ pub fn extract_trigger_payload(request_body: &[u8]) -> Result<Vec<u8>, HandlerEr
 
 fn extract_json_payload(value: &serde_json::Value) -> Result<Vec<u8>, HandlerError> {
     match value {
-        serde_json::Value::String(text) => {
-            match base64::engine::general_purpose::STANDARD.decode(text) {
-                Ok(bytes) => Ok(bytes),
-                Err(_) => Ok(text.as_bytes().to_vec()),
-            }
-        }
+        serde_json::Value::String(text) => match base64::engine::general_purpose::STANDARD
+            .decode(text)
+        {
+            Ok(bytes) => Ok(bytes),
+            Err(_) => Ok(text.as_bytes().to_vec()),
+        },
         serde_json::Value::Array(values) => values
             .iter()
             .map(|value| {
@@ -788,7 +686,7 @@ fn decode_connector_message(bytes: &[u8]) -> Result<ConnectorMessage, HandlerErr
     }
 }
 
-pub fn encode_desired_state(row: &NodeStateRow) -> Result<Vec<u8>, HandlerError> {
+pub fn encode_desired_state(row: &DesiredStateRow) -> Result<Vec<u8>, HandlerError> {
     let desired_state = Value::Map(vec![
         map_entry(
             1,
@@ -812,24 +710,28 @@ fn encode_optional_hex(value: Option<Vec<u8>>) -> Option<String> {
     value.map(hex::encode)
 }
 
-fn encode_node_row_key(node_id: &str) -> String {
+fn encode_node_partition_key(node_id: &str) -> String {
     let digest = Sha256::digest(node_id.as_bytes());
     format!("n:{}", hex::encode(digest))
 }
 
-fn encode_legacy_node_row_key(node_id: &str) -> String {
-    format!("n:{}", hex::encode(node_id.as_bytes()))
+fn next_history_row_key(timestamp_ms: u64) -> String {
+    let ingested_at_ns = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let ingested_at_ns = u64::try_from(ingested_at_ns).unwrap_or(u64::MAX);
+    let sequence = HISTORY_ROW_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!(
+        "{:016x}:{:016x}:{:016x}",
+        u64::MAX - timestamp_ms,
+        u64::MAX - ingested_at_ns,
+        u64::MAX - sequence
+    )
 }
 
-fn decode_legacy_node_row_key(row_key: &str) -> Result<String, HandlerError> {
-    let Some(encoded) = row_key.strip_prefix("n:") else {
-        return Ok(row_key.to_string());
-    };
-    let bytes = hex::decode(encoded).map_err(|e| {
-        HandlerError::Store(format!("NodeState.RowKey must contain valid hex: {e}"))
-    })?;
-    String::from_utf8(bytes)
-        .map_err(|e| HandlerError::Store(format!("NodeState.RowKey must contain valid UTF-8: {e}")))
+fn partition_filter(partition_key: &str) -> String {
+    format!("PartitionKey eq '{partition_key}'")
 }
 
 fn decode_optional_program_hash(
@@ -996,65 +898,74 @@ mod tests {
 
     #[derive(Default)]
     struct MemoryStore {
-        nodes: Mutex<HashMap<String, NodeStateRow>>,
+        actual_rows: Mutex<HashMap<String, Vec<ActualStateRow>>>,
+        desired_rows: Mutex<HashMap<String, Vec<DesiredStateRow>>>,
         routes: Mutex<HashMap<String, ProgramRouteRow>>,
+    }
+
+    impl MemoryStore {
+        async fn desired_writes(&self) -> usize {
+            self.desired_rows
+                .lock()
+                .await
+                .values()
+                .map(Vec::len)
+                .sum::<usize>()
+        }
+
+        async fn append_desired(&self, row: DesiredStateRow) {
+            self.desired_rows
+                .lock()
+                .await
+                .entry(row.node_id.clone())
+                .or_default()
+                .push(row);
+        }
+
+        async fn actual_rows_for(&self, node_id: &str) -> Vec<ActualStateRow> {
+            self.actual_rows
+                .lock()
+                .await
+                .get(node_id)
+                .cloned()
+                .unwrap_or_default()
+        }
     }
 
     #[async_trait]
     impl HandlerStore for MemoryStore {
-        async fn load_node_state(
-            &self,
-            node_id: &str,
-        ) -> Result<Option<NodeStateRow>, HandlerError> {
-            Ok(self.nodes.lock().await.get(node_id).cloned())
-        }
-
-        async fn save_node_state(&self, row: &NodeStateRow) -> Result<(), HandlerError> {
-            self.nodes
+        async fn append_actual_state(&self, row: &ActualStateRow) -> Result<(), HandlerError> {
+            self.actual_rows
                 .lock()
                 .await
-                .insert(row.node_id.clone(), row.clone());
+                .entry(row.node_id.clone())
+                .or_default()
+                .push(row.clone());
             Ok(())
         }
 
-        async fn create_node_state_if_absent(
+        async fn load_latest_actual_state(
             &self,
-            row: &NodeStateRow,
-        ) -> Result<bool, HandlerError> {
-            let mut nodes = self.nodes.lock().await;
-            if nodes.contains_key(&row.node_id) {
-                return Ok(false);
-            }
-            nodes.insert(row.node_id.clone(), row.clone());
-            Ok(true)
+            node_id: &str,
+        ) -> Result<Option<ActualStateRow>, HandlerError> {
+            Ok(self
+                .actual_rows
+                .lock()
+                .await
+                .get(node_id)
+                .and_then(|rows| rows.iter().min_by(|a, b| a.row_key.cmp(&b.row_key)).cloned()))
         }
 
-        async fn update_observed_state(
+        async fn load_latest_desired_state(
             &self,
-            update: &ObservedStateUpdate,
-        ) -> Result<ObservedStateWriteResult, HandlerError> {
-            let mut nodes = self.nodes.lock().await;
-            let row = nodes.get_mut(&update.node_id).ok_or_else(|| {
-                HandlerError::Store(format!(
-                    "missing node `{}` for observed update",
-                    update.node_id
-                ))
-            })?;
-            if update.timestamp_ms <= row.last_checkin_ms {
-                return if update.timestamp_ms == row.last_checkin_ms {
-                    Ok(ObservedStateWriteResult::Current(row.clone()))
-                } else {
-                    Ok(ObservedStateWriteResult::IgnoredStale)
-                };
-            }
-            row.observed_current_program_hash = update.current_program_hash.clone();
-            row.observed_assigned_program_hash = update.assigned_program_hash.clone();
-            row.observed_schedule_interval_s = update.schedule_interval_s;
-            row.battery_mv = update.battery_mv;
-            row.firmware_abi_version = update.firmware_abi_version;
-            row.firmware_version = update.firmware_version.clone();
-            row.last_checkin_ms = update.timestamp_ms;
-            Ok(ObservedStateWriteResult::Applied(row.clone()))
+            node_id: &str,
+        ) -> Result<Option<DesiredStateRow>, HandlerError> {
+            Ok(self
+                .desired_rows
+                .lock()
+                .await
+                .get(node_id)
+                .and_then(|rows| rows.iter().min_by(|a, b| a.row_key.cmp(&b.row_key)).cloned()))
         }
 
         async fn load_program_route(
@@ -1105,58 +1016,43 @@ mod tests {
     }
 
     struct FailingStore {
-        load_node_error: Option<String>,
-        save_error: Option<String>,
+        append_actual_error: Option<String>,
+        load_desired_error: Option<String>,
         load_route_error: Option<String>,
+        latest_actual: Mutex<Option<ActualStateRow>>,
     }
 
     #[async_trait]
     impl HandlerStore for FailingStore {
-        async fn load_node_state(
+        async fn append_actual_state(&self, _row: &ActualStateRow) -> Result<(), HandlerError> {
+            match &self.append_actual_error {
+                Some(error) => Err(HandlerError::Store(error.clone())),
+                None => {
+                    *self.latest_actual.lock().await = Some(_row.clone());
+                    Ok(())
+                }
+            }
+        }
+
+        async fn load_latest_actual_state(
             &self,
             _node_id: &str,
-        ) -> Result<Option<NodeStateRow>, HandlerError> {
-            match &self.load_node_error {
-                Some(error) => Err(HandlerError::Store(error.clone())),
-                None => Ok(None),
-            }
+        ) -> Result<Option<ActualStateRow>, HandlerError> {
+            Ok(self.latest_actual.lock().await.clone())
         }
 
-        async fn save_node_state(&self, _row: &NodeStateRow) -> Result<(), HandlerError> {
-            match &self.save_error {
-                Some(error) => Err(HandlerError::Store(error.clone())),
-                None => Ok(()),
-            }
-        }
-
-        async fn create_node_state_if_absent(
+        async fn load_latest_desired_state(
             &self,
-            _row: &NodeStateRow,
-        ) -> Result<bool, HandlerError> {
-            match &self.save_error {
+            node_id: &str,
+        ) -> Result<Option<DesiredStateRow>, HandlerError> {
+            match &self.load_desired_error {
                 Some(error) => Err(HandlerError::Store(error.clone())),
-                None => Ok(true),
-            }
-        }
-
-        async fn update_observed_state(
-            &self,
-            _update: &ObservedStateUpdate,
-        ) -> Result<ObservedStateWriteResult, HandlerError> {
-            match &self.save_error {
-                Some(error) => Err(HandlerError::Store(error.clone())),
-                None => Ok(ObservedStateWriteResult::Applied(NodeStateRow {
-                    node_id: "node-1".to_string(),
-                    desired_assigned_program_hash: None,
-                    desired_schedule_interval_s: None,
-                    observed_current_program_hash: None,
-                    observed_assigned_program_hash: None,
-                    observed_schedule_interval_s: None,
-                    battery_mv: None,
-                    firmware_abi_version: None,
-                    firmware_version: None,
-                    last_checkin_ms: 0,
-                })),
+                None => Ok(Some(desired_row(
+                    node_id,
+                    Some(vec![0xBB; 32]),
+                    Some(60),
+                    1234,
+                ))),
             }
         }
 
@@ -1171,70 +1067,27 @@ mod tests {
         }
     }
 
-    struct FailingPublisher {
-        error: String,
-    }
-
-    #[async_trait]
-    impl QueuePublisher for FailingPublisher {
-        async fn publish(&self, _queue: &str, _payload: Vec<u8>) -> Result<(), HandlerError> {
-            Err(HandlerError::Publish(self.error.clone()))
+    fn desired_row(
+        node_id: &str,
+        desired_assigned_program_hash: Option<Vec<u8>>,
+        desired_schedule_interval_s: Option<u32>,
+        timestamp_ms: u64,
+    ) -> DesiredStateRow {
+        DesiredStateRow {
+            row_key: next_history_row_key(timestamp_ms),
+            node_id: node_id.to_string(),
+            desired_assigned_program_hash,
+            desired_schedule_interval_s,
+            timestamp_ms,
         }
     }
 
-    struct UpdateReturnsAppliedRowStore {
-        initial_row: NodeStateRow,
-        applied_row: NodeStateRow,
-        load_count: Mutex<u32>,
-    }
-
-    #[async_trait]
-    impl HandlerStore for UpdateReturnsAppliedRowStore {
-        async fn load_node_state(
-            &self,
-            node_id: &str,
-        ) -> Result<Option<NodeStateRow>, HandlerError> {
-            let mut load_count = self.load_count.lock().await;
-            *load_count += 1;
-            if *load_count == 1 && node_id == self.initial_row.node_id {
-                return Ok(Some(self.initial_row.clone()));
-            }
-            Err(HandlerError::Store(
-                "load_node_state should not be called after update_observed_state".to_string(),
-            ))
-        }
-
-        async fn save_node_state(&self, _row: &NodeStateRow) -> Result<(), HandlerError> {
-            Ok(())
-        }
-
-        async fn create_node_state_if_absent(
-            &self,
-            _row: &NodeStateRow,
-        ) -> Result<bool, HandlerError> {
-            Ok(false)
-        }
-
-        async fn update_observed_state(
-            &self,
-            _update: &ObservedStateUpdate,
-        ) -> Result<ObservedStateWriteResult, HandlerError> {
-            Ok(ObservedStateWriteResult::Applied(self.applied_row.clone()))
-        }
-
-        async fn load_program_route(
-            &self,
-            _program_hash: &[u8],
-        ) -> Result<Option<ProgramRouteRow>, HandlerError> {
-            Ok(None)
-        }
-    }
-
-    fn sample_actual_state(
+    fn sample_actual_state_with_timestamp(
         node_id: &str,
         current_program_hash: Option<&[u8]>,
         assigned_program_hash: Option<&[u8]>,
         schedule_interval_s: Option<u32>,
+        timestamp_ms: u64,
     ) -> Vec<u8> {
         let value = Value::Map(vec![
             map_entry(1, Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
@@ -1245,13 +1098,28 @@ mod tests {
             map_entry(6, Value::Integer(3300u64.into())),
             map_entry(7, Value::Integer(1u64.into())),
             map_entry(8, Value::Text("1.2.3".to_string())),
-            map_entry(9, Value::Integer(1234u64.into())),
+            map_entry(9, Value::Integer(timestamp_ms.into())),
             map_entry(10, Value::Map(Vec::new())),
             map_entry(11, opt_u32_value(schedule_interval_s)),
         ]);
         let mut bytes = Vec::new();
         ciborium::into_writer(&value, &mut bytes).unwrap();
         bytes
+    }
+
+    fn sample_actual_state(
+        node_id: &str,
+        current_program_hash: Option<&[u8]>,
+        assigned_program_hash: Option<&[u8]>,
+        schedule_interval_s: Option<u32>,
+    ) -> Vec<u8> {
+        sample_actual_state_with_timestamp(
+            node_id,
+            current_program_hash,
+            assigned_program_hash,
+            schedule_interval_s,
+            1234,
+        )
     }
 
     fn sample_app_data(program_hash: &[u8], payload: &[u8]) -> Vec<u8> {
@@ -1279,7 +1147,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn first_actual_state_seeds_row_without_publish() {
+    async fn first_actual_state_appends_row_without_publish_when_desired_is_absent() {
         let store = Arc::new(MemoryStore::default());
         let publisher = Arc::new(RecordingPublisher::default());
         let handler =
@@ -1295,65 +1163,28 @@ mod tests {
             .await
             .unwrap();
 
-        let row = store.load_node_state("node-1").await.unwrap().unwrap();
-        assert_eq!(row.desired_assigned_program_hash, Some(vec![0xAA; 32]));
-        assert_eq!(row.desired_schedule_interval_s, Some(60));
-        assert_eq!(row.observed_current_program_hash, Some(vec![0xAA; 32]));
-        assert_eq!(row.observed_assigned_program_hash, None);
-        assert_eq!(row.observed_schedule_interval_s, Some(60));
-        assert_eq!(row.battery_mv, Some(3300));
-        assert_eq!(row.firmware_abi_version, Some(1));
-        assert_eq!(row.firmware_version.as_deref(), Some("1.2.3"));
-        assert_eq!(row.last_checkin_ms, 1234);
-        assert!(publisher.sends.lock().await.is_empty());
-    }
-
-    #[tokio::test]
-    async fn first_actual_state_seeds_from_assigned_program_when_current_is_missing() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        handler
-            .handle_payload(&sample_actual_state(
-                "node-1",
-                None,
-                Some(&[0xCC; 32]),
-                Some(60),
-            ))
-            .await
-            .unwrap();
-
-        let row = store.load_node_state("node-1").await.unwrap().unwrap();
-        assert_eq!(row.desired_assigned_program_hash, Some(vec![0xCC; 32]));
-        assert_eq!(row.observed_current_program_hash, None);
-        assert_eq!(row.observed_assigned_program_hash, Some(vec![0xCC; 32]));
+        let rows = store.actual_rows_for("node-1").await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].observed_current_program_hash, Some(vec![0xAA; 32]));
+        assert_eq!(rows[0].observed_assigned_program_hash, None);
+        assert_eq!(rows[0].observed_schedule_interval_s, Some(60));
+        assert_eq!(rows[0].battery_mv, Some(3300));
+        assert_eq!(rows[0].firmware_abi_version, Some(1));
+        assert_eq!(rows[0].firmware_version.as_deref(), Some("1.2.3"));
+        assert_eq!(rows[0].timestamp_ms, 1234);
+        assert_eq!(store.desired_writes().await, 0);
         assert!(publisher.sends.lock().await.is_empty());
     }
 
     #[tokio::test]
     async fn divergence_publishes_full_desired_state_without_ephemeral() {
         let store = Arc::new(MemoryStore::default());
+        store
+            .append_desired(desired_row("node-1", Some(vec![0xBB; 32]), Some(120), 100))
+            .await;
         let publisher = Arc::new(RecordingPublisher::default());
         let handler =
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        store
-            .save_node_state(&NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0xBB; 32]),
-                desired_schedule_interval_s: Some(120),
-                observed_current_program_hash: Some(vec![0xAA; 32]),
-                observed_assigned_program_hash: Some(vec![0xAA; 32]),
-                observed_schedule_interval_s: Some(60),
-                battery_mv: Some(3200),
-                firmware_abi_version: Some(1),
-                firmware_version: Some("1.0.0".to_string()),
-                last_checkin_ms: 1,
-            })
-            .await
-            .unwrap();
 
         handler
             .handle_payload(&sample_actual_state(
@@ -1386,41 +1217,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unsupported_messages_do_not_mutate_state() {
+    async fn aligned_actual_state_appends_history_without_publish() {
         let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        handler.handle_payload(&sample_unsupported()).await.unwrap();
-
-        assert!(store.nodes.lock().await.is_empty());
-        assert!(store.routes.lock().await.is_empty());
-        assert!(publisher.sends.lock().await.is_empty());
-    }
-
-    #[tokio::test]
-    async fn aligned_actual_state_refreshes_observed_fields_without_publish() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
         store
-            .save_node_state(&NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0xAA; 32]),
-                desired_schedule_interval_s: Some(60),
-                observed_current_program_hash: Some(vec![0x10; 32]),
-                observed_assigned_program_hash: Some(vec![0x20; 32]),
-                observed_schedule_interval_s: Some(30),
-                battery_mv: Some(3100),
-                firmware_abi_version: Some(9),
-                firmware_version: Some("0.9.0".to_string()),
-                last_checkin_ms: 7,
-            })
-            .await
-            .unwrap();
+            .append_desired(desired_row("node-1", Some(vec![0xAA; 32]), Some(60), 100))
+            .await;
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler =
+            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
 
         handler
             .handle_payload(&sample_actual_state(
@@ -1432,82 +1236,77 @@ mod tests {
             .await
             .unwrap();
 
-        let row = store.load_node_state("node-1").await.unwrap().unwrap();
-        assert_eq!(row.desired_assigned_program_hash, Some(vec![0xAA; 32]));
-        assert_eq!(row.desired_schedule_interval_s, Some(60));
-        assert_eq!(row.observed_current_program_hash, Some(vec![0xAA; 32]));
-        assert_eq!(row.observed_assigned_program_hash, Some(vec![0xCC; 32]));
-        assert_eq!(row.observed_schedule_interval_s, Some(60));
-        assert_eq!(row.battery_mv, Some(3300));
-        assert_eq!(row.firmware_abi_version, Some(1));
-        assert_eq!(row.firmware_version.as_deref(), Some("1.2.3"));
-        assert_eq!(row.last_checkin_ms, 1234);
+        let rows = store.actual_rows_for("node-1").await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].observed_assigned_program_hash, Some(vec![0xCC; 32]));
         assert!(publisher.sends.lock().await.is_empty());
     }
 
     #[tokio::test]
-    async fn stale_actual_state_is_ignored() {
+    async fn repeated_actual_state_deliveries_are_all_recorded() {
         let store = Arc::new(MemoryStore::default());
         let publisher = Arc::new(RecordingPublisher::default());
         let handler =
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
+        let payload = sample_actual_state("node-1", Some(&[0xAA; 32]), Some(&[0xAA; 32]), Some(60));
 
+        handler.handle_payload(&payload).await.unwrap();
+        handler.handle_payload(&payload).await.unwrap();
+
+        let rows = store.actual_rows_for("node-1").await;
+        assert_eq!(rows.len(), 2);
+        assert_ne!(rows[0].row_key, rows[1].row_key);
+    }
+
+    #[tokio::test]
+    async fn out_of_order_actual_state_is_retained_without_publish() {
+        let store = Arc::new(MemoryStore::default());
         store
-            .save_node_state(&NodeStateRow {
+            .append_desired(desired_row("node-1", Some(vec![0xAA; 32]), Some(60), 100))
+            .await;
+        store
+            .append_actual_state(&ActualStateRow {
+                row_key: next_history_row_key(5000),
                 node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0xAA; 32]),
-                desired_schedule_interval_s: Some(60),
                 observed_current_program_hash: Some(vec![0xAA; 32]),
                 observed_assigned_program_hash: Some(vec![0xAA; 32]),
                 observed_schedule_interval_s: Some(60),
                 battery_mv: Some(3200),
                 firmware_abi_version: Some(2),
                 firmware_version: Some("2.0.0".to_string()),
-                last_checkin_ms: 5000,
+                timestamp_ms: 5000,
             })
             .await
             .unwrap();
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler =
+            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
 
         handler
-            .handle_payload(&sample_actual_state(
+            .handle_payload(&sample_actual_state_with_timestamp(
                 "node-1",
                 Some(&[0xBB; 32]),
                 Some(&[0xBB; 32]),
                 Some(120),
+                1234,
             ))
             .await
             .unwrap();
 
-        let row = store.load_node_state("node-1").await.unwrap().unwrap();
-        assert_eq!(row.observed_current_program_hash, Some(vec![0xAA; 32]));
-        assert_eq!(row.observed_schedule_interval_s, Some(60));
-        assert_eq!(row.battery_mv, Some(3200));
-        assert_eq!(row.last_checkin_ms, 5000);
+        let rows = store.actual_rows_for("node-1").await;
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().any(|row| row.timestamp_ms == 1234));
+        let latest = store.load_latest_actual_state("node-1").await.unwrap().unwrap();
+        assert_eq!(latest.timestamp_ms, 5000);
         assert!(publisher.sends.lock().await.is_empty());
     }
 
     #[tokio::test]
-    async fn schedule_only_divergence_publishes_one_desired_state() {
+    async fn missing_desired_state_suppresses_publication() {
         let store = Arc::new(MemoryStore::default());
         let publisher = Arc::new(RecordingPublisher::default());
         let handler =
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        store
-            .save_node_state(&NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0xAA; 32]),
-                desired_schedule_interval_s: Some(120),
-                observed_current_program_hash: Some(vec![0xAA; 32]),
-                observed_assigned_program_hash: Some(vec![0xAA; 32]),
-                observed_schedule_interval_s: Some(120),
-                battery_mv: Some(3200),
-                firmware_abi_version: Some(1),
-                firmware_version: Some("1.0.0".to_string()),
-                last_checkin_ms: 1,
-            })
-            .await
-            .unwrap();
 
         handler
             .handle_payload(&sample_actual_state(
@@ -1519,52 +1318,27 @@ mod tests {
             .await
             .unwrap();
 
-        let sends = publisher.sends.lock().await;
-        assert_eq!(sends.len(), 1);
-        let desired = decode_map(&sends[0].1).unwrap();
-        let desired_state = map_get(&desired, 4).unwrap().as_map().unwrap();
-        assert_eq!(
-            optional_bytes_field(desired_state, 1, "assigned_program_hash").unwrap(),
-            Some(vec![0xAA; 32])
-        );
-        assert_eq!(
-            optional_u32_field(desired_state, 2, "schedule_interval_s").unwrap(),
-            Some(120)
-        );
+        assert!(publisher.sends.lock().await.is_empty());
     }
 
     #[tokio::test]
-    async fn program_only_divergence_publishes_one_desired_state() {
+    async fn duplicate_actual_state_redelivery_retries_divergence_publish() {
         let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
+        store
+            .append_desired(desired_row("node-1", Some(vec![0xBB; 32]), Some(60), 10))
+            .await;
+        let publisher = Arc::new(FailOncePublisher {
+            sends: Mutex::new(Vec::new()),
+            failed: Mutex::new(false),
+        });
         let handler =
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
+        let payload = sample_actual_state("node-1", Some(&[0xAA; 32]), Some(&[0xAA; 32]), Some(30));
 
-        store
-            .save_node_state(&NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0xBB; 32]),
-                desired_schedule_interval_s: Some(60),
-                observed_current_program_hash: Some(vec![0xAA; 32]),
-                observed_assigned_program_hash: Some(vec![0xAA; 32]),
-                observed_schedule_interval_s: Some(60),
-                battery_mv: Some(3200),
-                firmware_abi_version: Some(1),
-                firmware_version: Some("1.0.0".to_string()),
-                last_checkin_ms: 1,
-            })
-            .await
-            .unwrap();
+        let err = handler.handle_payload(&payload).await.unwrap_err();
+        assert!(err.to_string().contains("simulated first publish failure"));
 
-        handler
-            .handle_payload(&sample_actual_state(
-                "node-1",
-                Some(&[0xAA; 32]),
-                Some(&[0xAA; 32]),
-                Some(60),
-            ))
-            .await
-            .unwrap();
+        handler.handle_payload(&payload).await.unwrap();
 
         let sends = publisher.sends.lock().await;
         assert_eq!(sends.len(), 1);
@@ -1578,6 +1352,28 @@ mod tests {
             optional_u32_field(desired_state, 2, "schedule_interval_s").unwrap(),
             Some(60)
         );
+        drop(sends);
+
+        let rows = store.actual_rows_for("node-1").await;
+        assert_eq!(rows.len(), 2);
+        let latest = store.load_latest_actual_state("node-1").await.unwrap().unwrap();
+        assert_eq!(latest.timestamp_ms, 1234);
+        assert_eq!(latest.observed_current_program_hash, Some(vec![0xAA; 32]));
+    }
+
+    #[tokio::test]
+    async fn unsupported_messages_do_not_mutate_state() {
+        let store = Arc::new(MemoryStore::default());
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler =
+            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
+
+        handler.handle_payload(&sample_unsupported()).await.unwrap();
+
+        assert!(store.actual_rows.lock().await.is_empty());
+        assert!(store.desired_rows.lock().await.is_empty());
+        assert!(store.routes.lock().await.is_empty());
+        assert!(publisher.sends.lock().await.is_empty());
     }
 
     #[tokio::test]
@@ -1708,242 +1504,53 @@ mod tests {
     }
 
     #[test]
-    fn node_state_row_key_candidates_are_unique_and_ordered() {
-        let candidates = node_state_row_key_candidates("node-1");
-        assert_eq!(candidates.len(), 3);
-        assert_eq!(candidates[0], encode_node_row_key("node-1"));
-        assert_eq!(candidates[1], encode_legacy_node_row_key("node-1"));
-        assert_eq!(candidates[2], "node-1");
-        assert_eq!(
-            candidates
-                .iter()
-                .collect::<std::collections::HashSet<_>>()
-                .len(),
-            candidates.len()
-        );
+    fn history_row_keys_sort_newer_timestamps_first() {
+        let newer = next_history_row_key(200);
+        let older = next_history_row_key(100);
+        assert!(newer < older);
     }
 
     #[test]
-    fn node_state_entity_round_trips_table_safe_row_key() {
-        let row = NodeStateRow {
+    fn history_row_keys_sort_later_appends_first_for_equal_timestamps() {
+        let first = next_history_row_key(1234);
+        let second = next_history_row_key(1234);
+        assert!(second < first);
+    }
+
+    #[test]
+    fn actual_state_entity_round_trips_table_safe_partition_key() {
+        let row = ActualStateRow {
+            row_key: next_history_row_key(1234),
             node_id: "node/with?#unsafe\\chars".to_string(),
-            desired_assigned_program_hash: Some(vec![0x11; 32]),
-            desired_schedule_interval_s: Some(60),
             observed_current_program_hash: Some(vec![0x22; 32]),
             observed_assigned_program_hash: Some(vec![0x33; 32]),
             observed_schedule_interval_s: Some(30),
             battery_mv: Some(3300),
             firmware_abi_version: Some(1),
             firmware_version: Some("1.2.3".to_string()),
-            last_checkin_ms: 1234,
+            timestamp_ms: 1234,
         };
 
-        let entity = NodeStateEntity::try_from(row.clone()).unwrap();
+        let entity = ActualStateEntity::try_from(row.clone()).unwrap();
         assert_eq!(
-            entity.row_key,
+            entity.partition_key,
             "n:6a096929d88b3094bc781fbd0fb8dc060aa75ba06339ac3a706aa06f5ac9fedd"
         );
-        assert_eq!(entity.node_id.as_deref(), Some("node/with?#unsafe\\chars"));
-        assert_eq!(NodeStateRow::try_from(entity).unwrap(), row);
+        assert_eq!(ActualStateRow::try_from(entity).unwrap(), row);
     }
 
     #[test]
-    fn node_state_entity_accepts_legacy_raw_row_key() {
-        let row = NodeStateRow::try_from(NodeStateEntity {
-            partition_key: "node".to_string(),
-            row_key: "node-1".to_string(),
-            node_id: None,
-            desired_assigned_program_hash: None,
-            desired_schedule_interval_s: None,
-            observed_current_program_hash: None,
-            observed_assigned_program_hash: None,
-            observed_schedule_interval_s: None,
-            battery_mv: None,
-            firmware_abi_version: None,
-            firmware_version: None,
-            last_checkin_ms: 1,
-        })
-        .unwrap();
-        assert_eq!(row.node_id, "node-1");
+    fn desired_state_entity_round_trips() {
+        let row = desired_row("node-1", Some(vec![0x11; 32]), Some(60), 1234);
+        let entity = DesiredStateEntity::try_from(row.clone()).unwrap();
+        assert_eq!(DesiredStateRow::try_from(entity).unwrap(), row);
     }
 
     #[test]
-    fn long_node_ids_still_produce_bounded_row_keys() {
+    fn long_node_ids_still_produce_bounded_partition_keys() {
         let node_id = "a".repeat(4096);
-        let row_key = encode_node_row_key(&node_id);
-        assert_eq!(row_key.len(), 66);
-    }
-
-    #[tokio::test]
-    async fn actual_state_uses_applied_row_without_post_update_reload() {
-        let store = Arc::new(UpdateReturnsAppliedRowStore {
-            initial_row: NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0x42; 32]),
-                desired_schedule_interval_s: Some(120),
-                observed_current_program_hash: Some(vec![0x42; 32]),
-                observed_assigned_program_hash: Some(vec![0x42; 32]),
-                observed_schedule_interval_s: Some(120),
-                battery_mv: Some(3300),
-                firmware_abi_version: Some(1),
-                firmware_version: Some("1.2.3".to_string()),
-                last_checkin_ms: 1200,
-            },
-            applied_row: NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0x42; 32]),
-                desired_schedule_interval_s: Some(120),
-                observed_current_program_hash: Some(vec![0x99; 32]),
-                observed_assigned_program_hash: Some(vec![0x99; 32]),
-                observed_schedule_interval_s: Some(60),
-                battery_mv: Some(3300),
-                firmware_abi_version: Some(1),
-                firmware_version: Some("1.2.3".to_string()),
-                last_checkin_ms: 1234,
-            },
-            load_count: Mutex::new(0),
-        });
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        handler
-            .handle_payload(&sample_actual_state(
-                "node-1",
-                Some(&[0x99; 32]),
-                Some(&[0x99; 32]),
-                Some(60),
-            ))
-            .await
-            .unwrap();
-
-        let sends = publisher.sends.lock().await;
-        assert_eq!(sends.len(), 1);
-        assert_eq!(sends[0].0, "desired-state");
-        assert_eq!(*store.load_count.lock().await, 1);
-    }
-
-    #[tokio::test]
-    async fn duplicate_actual_state_timestamp_is_ignored() {
-        let store = Arc::new(MemoryStore::default());
-        store.nodes.lock().await.insert(
-            "node-1".to_string(),
-            NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0x42; 32]),
-                desired_schedule_interval_s: Some(120),
-                observed_current_program_hash: Some(vec![0x42; 32]),
-                observed_assigned_program_hash: Some(vec![0x42; 32]),
-                observed_schedule_interval_s: Some(120),
-                battery_mv: Some(3300),
-                firmware_abi_version: Some(1),
-                firmware_version: Some("1.2.3".to_string()),
-                last_checkin_ms: 1234,
-            },
-        );
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        handler
-            .handle_payload(&sample_actual_state(
-                "node-1",
-                Some(&[0x99; 32]),
-                Some(&[0x99; 32]),
-                Some(60),
-            ))
-            .await
-            .unwrap();
-
-        assert!(publisher.sends.lock().await.is_empty());
-        let row = store.nodes.lock().await.get("node-1").cloned().unwrap();
-        assert_eq!(row.last_checkin_ms, 1234);
-        assert_eq!(row.observed_current_program_hash, Some(vec![0x42; 32]));
-    }
-
-    #[tokio::test]
-    async fn duplicate_actual_state_redelivery_retries_divergence_publish() {
-        let store = Arc::new(MemoryStore::default());
-        store.nodes.lock().await.insert(
-            "node-1".to_string(),
-            NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0xBB; 32]),
-                desired_schedule_interval_s: Some(60),
-                observed_current_program_hash: Some(vec![0x11; 32]),
-                observed_assigned_program_hash: Some(vec![0x11; 32]),
-                observed_schedule_interval_s: Some(30),
-                battery_mv: Some(3300),
-                firmware_abi_version: Some(1),
-                firmware_version: Some("1.2.3".to_string()),
-                last_checkin_ms: 1,
-            },
-        );
-        let publisher = Arc::new(FailOncePublisher {
-            sends: Mutex::new(Vec::new()),
-            failed: Mutex::new(false),
-        });
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-        let payload = sample_actual_state("node-1", Some(&[0xAA; 32]), Some(&[0xAA; 32]), Some(30));
-
-        let err = handler.handle_payload(&payload).await.unwrap_err();
-        assert!(err.to_string().contains("simulated first publish failure"));
-
-        handler.handle_payload(&payload).await.unwrap();
-
-        let sends = publisher.sends.lock().await;
-        assert_eq!(sends.len(), 1);
-        let desired = decode_map(&sends[0].1).unwrap();
-        let desired_state = map_get(&desired, 4).unwrap().as_map().unwrap();
-        assert_eq!(
-            optional_bytes_field(desired_state, 1, "assigned_program_hash").unwrap(),
-            Some(vec![0xBB; 32])
-        );
-        assert_eq!(
-            optional_u32_field(desired_state, 2, "schedule_interval_s").unwrap(),
-            Some(60)
-        );
-        drop(sends);
-
-        let row = store.nodes.lock().await.get("node-1").cloned().unwrap();
-        assert_eq!(row.last_checkin_ms, 1234);
-        assert_eq!(row.observed_current_program_hash, Some(vec![0xAA; 32]));
-    }
-
-    #[tokio::test]
-    async fn cleared_desired_targets_do_not_republish_forever() {
-        let store = Arc::new(MemoryStore::default());
-        store.nodes.lock().await.insert(
-            "node-1".to_string(),
-            NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: None,
-                desired_schedule_interval_s: None,
-                observed_current_program_hash: Some(vec![0x42; 32]),
-                observed_assigned_program_hash: Some(vec![0x42; 32]),
-                observed_schedule_interval_s: Some(120),
-                battery_mv: Some(3300),
-                firmware_abi_version: Some(1),
-                firmware_version: Some("1.2.3".to_string()),
-                last_checkin_ms: 1200,
-            },
-        );
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        handler
-            .handle_payload(&sample_actual_state(
-                "node-1",
-                Some(&[0x42; 32]),
-                Some(&[0x42; 32]),
-                Some(120),
-            ))
-            .await
-            .unwrap();
-
-        assert!(publisher.sends.lock().await.is_empty());
+        let partition_key = encode_node_partition_key(&node_id);
+        assert_eq!(partition_key.len(), 66);
     }
 
     #[test]
@@ -1980,20 +1587,14 @@ mod tests {
     }
 
     #[test]
-    fn node_state_row_decode_fails_closed_on_invalid_hex() {
-        let err = NodeStateRow::try_from(NodeStateEntity {
-            partition_key: "node".to_string(),
-            row_key: "node-1".to_string(),
-            node_id: None,
+    fn desired_state_row_decode_fails_closed_on_invalid_hex() {
+        let err = DesiredStateRow::try_from(DesiredStateEntity {
+            partition_key: encode_node_partition_key("node-1"),
+            row_key: next_history_row_key(1234),
+            node_id: "node-1".to_string(),
             desired_assigned_program_hash: Some("not-hex".to_string()),
             desired_schedule_interval_s: Some(60),
-            observed_current_program_hash: None,
-            observed_assigned_program_hash: None,
-            observed_schedule_interval_s: Some(60),
-            battery_mv: Some(3300),
-            firmware_abi_version: Some(1),
-            firmware_version: Some("1.2.3".to_string()),
-            last_checkin_ms: 1234,
+            timestamp_ms: 1234,
         })
         .unwrap_err();
         assert!(err
@@ -2002,11 +1603,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn table_write_failures_are_surfaced() {
+    async fn actual_state_table_write_failures_are_surfaced() {
         let store = Arc::new(FailingStore {
-            load_node_error: None,
-            save_error: Some("save failed".to_string()),
+            append_actual_error: Some("append failed".to_string()),
+            load_desired_error: None,
             load_route_error: None,
+            latest_actual: Mutex::new(None),
         });
         let publisher = Arc::new(RecordingPublisher::default());
         let handler =
@@ -2022,69 +1624,51 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(err.to_string().contains("save failed"));
+        assert!(err.to_string().contains("append failed"));
     }
 
     #[tokio::test]
-    async fn downstream_publish_failures_are_surfaced() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(FailingPublisher {
-            error: "downstream publish failed".to_string(),
+    async fn desired_state_read_failures_are_surfaced() {
+        let store = Arc::new(FailingStore {
+            append_actual_error: None,
+            load_desired_error: Some("desired read failed".to_string()),
+            load_route_error: None,
+            latest_actual: Mutex::new(None),
         });
+        let publisher = Arc::new(RecordingPublisher::default());
         let handler =
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        store
-            .save_node_state(&NodeStateRow {
-                node_id: "node-1".to_string(),
-                desired_assigned_program_hash: Some(vec![0xBB; 32]),
-                desired_schedule_interval_s: Some(120),
-                observed_current_program_hash: Some(vec![0xAA; 32]),
-                observed_assigned_program_hash: Some(vec![0xAA; 32]),
-                observed_schedule_interval_s: Some(60),
-                battery_mv: Some(3200),
-                firmware_abi_version: Some(1),
-                firmware_version: Some("1.0.0".to_string()),
-                last_checkin_ms: 1,
-            })
-            .await
-            .unwrap();
 
         let err = handler
             .handle_payload(&sample_actual_state(
                 "node-1",
                 Some(&[0xAA; 32]),
-                Some(&[0xAA; 32]),
+                None,
                 Some(60),
             ))
             .await
             .unwrap_err();
 
-        assert!(err.to_string().contains("downstream publish failed"));
+        assert!(err.to_string().contains("desired read failed"));
     }
 
     #[tokio::test]
-    async fn handler_queue_publish_failures_are_surfaced() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(FailingPublisher {
-            error: "handler queue publish failed".to_string(),
+    async fn program_route_read_failures_are_surfaced() {
+        let store = Arc::new(FailingStore {
+            append_actual_error: None,
+            load_desired_error: None,
+            load_route_error: Some("route read failed".to_string()),
+            latest_actual: Mutex::new(None),
         });
+        let publisher = Arc::new(RecordingPublisher::default());
         let handler =
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        store.routes.lock().await.insert(
-            hex::encode([0x44; 32]),
-            ProgramRouteRow {
-                program_hash: vec![0x44; 32],
-                handler_queue: "handler-q".to_string(),
-            },
-        );
 
         let err = handler
             .handle_payload(&sample_app_data(&[0x44; 32], &[1, 2, 3]))
             .await
             .unwrap_err();
 
-        assert!(err.to_string().contains("handler queue publish failed"));
+        assert!(err.to_string().contains("route read failed"));
     }
 }

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -239,9 +239,10 @@ where
                     actual_state.entity_id
                 ))
             })?;
-        if latest_actual.row_key != appended_row.row_key {
+        if latest_actual.timestamp_ms > appended_row.timestamp_ms {
             return Ok(());
         }
+        let actual_state_for_evaluation = appended_row;
 
         let Some(desired_row) = self
             .store
@@ -255,11 +256,16 @@ where
             .desired_assigned_program_hash
             .as_ref()
             .is_some_and(|desired| {
-                latest_actual.observed_current_program_hash.as_ref() != Some(desired)
+                actual_state_for_evaluation
+                    .observed_current_program_hash
+                    .as_ref()
+                    != Some(desired)
             });
         let schedule_diverged = desired_row
             .desired_schedule_interval_s
-            .is_some_and(|desired| latest_actual.observed_schedule_interval_s != Some(desired));
+            .is_some_and(|desired| {
+                actual_state_for_evaluation.observed_schedule_interval_s != Some(desired)
+            });
         if !program_diverged && !schedule_diverged {
             return Ok(());
         }
@@ -1048,11 +1054,11 @@ mod tests {
 
     #[async_trait]
     impl HandlerStore for FailingStore {
-        async fn append_actual_state(&self, _row: &ActualStateRow) -> Result<(), HandlerError> {
+        async fn append_actual_state(&self, row: &ActualStateRow) -> Result<(), HandlerError> {
             match &self.append_actual_error {
                 Some(error) => Err(HandlerError::Store(error.clone())),
                 None => {
-                    *self.latest_actual.lock().await = Some(_row.clone());
+                    *self.latest_actual.lock().await = Some(row.clone());
                     Ok(())
                 }
             }
@@ -1088,6 +1094,41 @@ mod tests {
                 Some(error) => Err(HandlerError::Store(error.clone())),
                 None => Ok(None),
             }
+        }
+    }
+
+    struct SameTimestampDifferentLatestStore {
+        latest_actual: ActualStateRow,
+        desired: DesiredStateRow,
+        appended_rows: Mutex<Vec<ActualStateRow>>,
+    }
+
+    #[async_trait]
+    impl HandlerStore for SameTimestampDifferentLatestStore {
+        async fn append_actual_state(&self, row: &ActualStateRow) -> Result<(), HandlerError> {
+            self.appended_rows.lock().await.push(row.clone());
+            Ok(())
+        }
+
+        async fn load_latest_actual_state(
+            &self,
+            _node_id: &str,
+        ) -> Result<Option<ActualStateRow>, HandlerError> {
+            Ok(Some(self.latest_actual.clone()))
+        }
+
+        async fn load_latest_desired_state(
+            &self,
+            _node_id: &str,
+        ) -> Result<Option<DesiredStateRow>, HandlerError> {
+            Ok(Some(self.desired.clone()))
+        }
+
+        async fn load_program_route(
+            &self,
+            _program_hash: &[u8],
+        ) -> Result<Option<ProgramRouteRow>, HandlerError> {
+            Ok(None)
         }
     }
 
@@ -1391,6 +1432,48 @@ mod tests {
             .unwrap();
         assert_eq!(latest.timestamp_ms, 1234);
         assert_eq!(latest.observed_current_program_hash, Some(vec![0xAA; 32]));
+    }
+
+    #[tokio::test]
+    async fn same_timestamp_row_key_mismatch_still_evaluates_current_delivery() {
+        let store = Arc::new(SameTimestampDifferentLatestStore {
+            latest_actual: ActualStateRow {
+                row_key: next_history_row_key(1234).unwrap(),
+                node_id: "node-1".to_string(),
+                observed_current_program_hash: Some(vec![0xBB; 32]),
+                observed_assigned_program_hash: Some(vec![0xBB; 32]),
+                observed_schedule_interval_s: Some(60),
+                battery_mv: Some(3200),
+                firmware_abi_version: Some(1),
+                firmware_version: Some("1.2.3".to_string()),
+                timestamp_ms: 1234,
+            },
+            desired: desired_row("node-1", Some(vec![0xCC; 32]), Some(60), 100),
+            appended_rows: Mutex::new(Vec::new()),
+        });
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler =
+            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
+
+        handler
+            .handle_payload(&sample_actual_state(
+                "node-1",
+                Some(&[0xAA; 32]),
+                Some(&[0xAA; 32]),
+                Some(60),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(store.appended_rows.lock().await.len(), 1);
+        let sends = publisher.sends.lock().await;
+        assert_eq!(sends.len(), 1);
+        let desired = decode_map(&sends[0].1).unwrap();
+        let desired_state = map_get(&desired, 4).unwrap().as_map().unwrap();
+        assert_eq!(
+            optional_bytes_field(desired_state, 1, "assigned_program_hash").unwrap(),
+            Some(vec![0xCC; 32])
+        );
     }
 
     #[tokio::test]

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -3,8 +3,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use azservicebus::{
@@ -30,6 +29,7 @@ use tokio::sync::Mutex;
 use tracing::warn;
 
 static HISTORY_ROW_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static HISTORY_ROW_PROCESS_NONCE: OnceLock<u64> = OnceLock::new();
 
 #[derive(Debug, Error)]
 pub enum HandlerError {
@@ -95,9 +95,9 @@ pub struct ActualStateRow {
 }
 
 impl ActualStateRow {
-    fn from_message(message: &ActualStateMessage) -> Self {
-        Self {
-            row_key: next_history_row_key(message.timestamp_ms),
+    fn from_message(message: &ActualStateMessage) -> Result<Self, HandlerError> {
+        Ok(Self {
+            row_key: next_history_row_key(message.timestamp_ms)?,
             node_id: message.entity_id.clone(),
             observed_current_program_hash: message.current_program_hash.clone(),
             observed_assigned_program_hash: message.assigned_program_hash.clone(),
@@ -106,7 +106,7 @@ impl ActualStateRow {
             firmware_abi_version: message.firmware_abi_version,
             firmware_version: message.firmware_version.clone(),
             timestamp_ms: message.timestamp_ms,
-        }
+        })
     }
 }
 
@@ -226,7 +226,7 @@ where
             ));
         }
 
-        let appended_row = ActualStateRow::from_message(&actual_state);
+        let appended_row = ActualStateRow::from_message(&actual_state)?;
         self.store.append_actual_state(&appended_row).await?;
 
         let latest_actual = self
@@ -722,19 +722,33 @@ fn encode_node_partition_key(node_id: &str) -> String {
     format!("n:{}", hex::encode(digest))
 }
 
-fn next_history_row_key(timestamp_ms: u64) -> String {
-    let ingested_at_ns = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let ingested_at_ns = u64::try_from(ingested_at_ns).unwrap_or(u64::MAX);
+fn next_history_row_key(timestamp_ms: u64) -> Result<String, HandlerError> {
     let sequence = HISTORY_ROW_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    format!(
+    let process_nonce = history_row_process_nonce()?;
+    Ok(format!(
         "{:016x}:{:016x}:{:016x}",
         u64::MAX - timestamp_ms,
-        u64::MAX - ingested_at_ns,
-        u64::MAX - sequence
-    )
+        u64::MAX - sequence,
+        process_nonce
+    ))
+}
+
+fn history_row_process_nonce() -> Result<u64, HandlerError> {
+    if let Some(nonce) = HISTORY_ROW_PROCESS_NONCE.get() {
+        return Ok(*nonce);
+    }
+
+    let mut bytes = [0u8; 8];
+    getrandom::fill(&mut bytes)
+        .map_err(|e| HandlerError::Store(format!("generate row-key nonce failed: {e}")))?;
+    let nonce = u64::from_be_bytes(bytes);
+    if HISTORY_ROW_PROCESS_NONCE.set(nonce).is_ok() {
+        return Ok(nonce);
+    }
+    HISTORY_ROW_PROCESS_NONCE
+        .get()
+        .copied()
+        .ok_or_else(|| HandlerError::Store("row-key nonce initialization lost race".to_string()))
 }
 
 fn partition_filter(partition_key: &str) -> String {
@@ -1084,7 +1098,7 @@ mod tests {
         timestamp_ms: u64,
     ) -> DesiredStateRow {
         DesiredStateRow {
-            row_key: next_history_row_key(timestamp_ms),
+            row_key: next_history_row_key(timestamp_ms).unwrap(),
             node_id: node_id.to_string(),
             desired_assigned_program_hash,
             desired_schedule_interval_s,
@@ -1276,7 +1290,7 @@ mod tests {
             .await;
         store
             .append_actual_state(&ActualStateRow {
-                row_key: next_history_row_key(5000),
+                row_key: next_history_row_key(5000).unwrap(),
                 node_id: "node-1".to_string(),
                 observed_current_program_hash: Some(vec![0xAA; 32]),
                 observed_assigned_program_hash: Some(vec![0xAA; 32]),
@@ -1523,22 +1537,22 @@ mod tests {
 
     #[test]
     fn history_row_keys_sort_newer_timestamps_first() {
-        let newer = next_history_row_key(200);
-        let older = next_history_row_key(100);
+        let newer = next_history_row_key(200).unwrap();
+        let older = next_history_row_key(100).unwrap();
         assert!(newer < older);
     }
 
     #[test]
     fn history_row_keys_sort_later_appends_first_for_equal_timestamps() {
-        let first = next_history_row_key(1234);
-        let second = next_history_row_key(1234);
+        let first = next_history_row_key(1234).unwrap();
+        let second = next_history_row_key(1234).unwrap();
         assert!(second < first);
     }
 
     #[test]
     fn actual_state_entity_round_trips_table_safe_partition_key() {
         let row = ActualStateRow {
-            row_key: next_history_row_key(1234),
+            row_key: next_history_row_key(1234).unwrap(),
             node_id: "node/with?#unsafe\\chars".to_string(),
             observed_current_program_hash: Some(vec![0x22; 32]),
             observed_assigned_program_hash: Some(vec![0x33; 32]),
@@ -1608,7 +1622,7 @@ mod tests {
     fn desired_state_row_decode_fails_closed_on_invalid_hex() {
         let err = DesiredStateRow::try_from(DesiredStateEntity {
             partition_key: encode_node_partition_key("node-1"),
-            row_key: next_history_row_key(1234),
+            row_key: next_history_row_key(1234).unwrap(),
             node_id: "node-1".to_string(),
             desired_assigned_program_hash: Some("not-hex".to_string()),
             desired_schedule_interval_s: Some(60),

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -251,6 +251,12 @@ where
         else {
             return Ok(());
         };
+        if desired_row.node_id != actual_state.entity_id {
+            return Err(HandlerError::Store(format!(
+                "desired-state row node_id `{}` did not match requested node `{}`",
+                desired_row.node_id, actual_state.entity_id
+            )));
+        }
 
         let program_diverged = desired_row
             .desired_assigned_program_hash
@@ -1135,6 +1141,42 @@ mod tests {
         }
     }
 
+    struct MismatchedDesiredNodeStore {
+        desired: DesiredStateRow,
+        latest_actual: Mutex<Option<ActualStateRow>>,
+        appended_rows: Mutex<Vec<ActualStateRow>>,
+    }
+
+    #[async_trait]
+    impl HandlerStore for MismatchedDesiredNodeStore {
+        async fn append_actual_state(&self, row: &ActualStateRow) -> Result<(), HandlerError> {
+            self.appended_rows.lock().await.push(row.clone());
+            *self.latest_actual.lock().await = Some(row.clone());
+            Ok(())
+        }
+
+        async fn load_latest_actual_state(
+            &self,
+            _node_id: &str,
+        ) -> Result<Option<ActualStateRow>, HandlerError> {
+            Ok(self.latest_actual.lock().await.clone())
+        }
+
+        async fn load_latest_desired_state(
+            &self,
+            _node_id: &str,
+        ) -> Result<Option<DesiredStateRow>, HandlerError> {
+            Ok(Some(self.desired.clone()))
+        }
+
+        async fn load_program_route(
+            &self,
+            _program_hash: &[u8],
+        ) -> Result<Option<ProgramRouteRow>, HandlerError> {
+            Ok(None)
+        }
+    }
+
     fn desired_row(
         node_id: &str,
         desired_assigned_program_hash: Option<Vec<u8>>,
@@ -1477,6 +1519,34 @@ mod tests {
             optional_bytes_field(desired_state, 1, "assigned_program_hash").unwrap(),
             Some(vec![0xCC; 32])
         );
+    }
+
+    #[tokio::test]
+    async fn mismatched_desired_row_node_id_is_rejected() {
+        let store = Arc::new(MismatchedDesiredNodeStore {
+            desired: desired_row("other-node", Some(vec![0xBB; 32]), Some(60), 100),
+            latest_actual: Mutex::new(None),
+            appended_rows: Mutex::new(Vec::new()),
+        });
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler =
+            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
+
+        let err = handler
+            .handle_payload(&sample_actual_state(
+                "node-1",
+                Some(&[0xAA; 32]),
+                Some(&[0xAA; 32]),
+                Some(30),
+            ))
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains(
+            "desired-state row node_id `other-node` did not match requested node `node-1`"
+        ));
+        assert_eq!(store.appended_rows.lock().await.len(), 1);
+        assert!(publisher.sends.lock().await.is_empty());
     }
 
     #[tokio::test]

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -118,7 +118,7 @@ The design uses three Azure Tables:
 Each row uses:
 
 - `PartitionKey = "n:" + lowercase hex-encoded SHA-256(node_id UTF-8 bytes)`
-- `RowKey = <reverse_tick_ms as fixed-width lowercase hex> + ":" + <implementation-defined suffix that orders later appends first within the same timestamp>`
+- `RowKey = <reverse_tick_ms as fixed-width lowercase hex> + ":" + <implementation-defined suffix that preserves append uniqueness and orders later appends first within the same timestamp for one handler process lifetime>`
 
 The row contains the following logical columns:
 
@@ -136,15 +136,18 @@ The row contains the following logical columns:
 The node-scoped `PartitionKey` keeps each node's history in one queryable
 partition. The reverse-tick `RowKey` prefix makes newer timestamps sort first.
 The suffix preserves append-only behavior when multiple deliveries share the
-same `timestamp_ms`, and it must order later appends before earlier appends
-within that timestamp so `Top(1)` remains deterministic.
+same `timestamp_ms`, and it orders later appends before earlier appends only
+within one handler process lifetime. Across restarts or concurrent handler
+instances, equal-timestamp row ordering is intentionally unspecified, so the
+reconciliation path must not depend on `Top(1)` returning the most recently
+appended equal-timestamp row.
 
 ### 4.2  `DesiredNodeState` schema
 
 Each row uses:
 
 - `PartitionKey = "n:" + lowercase hex-encoded SHA-256(node_id UTF-8 bytes)`
-- `RowKey = <reverse_tick_ms as fixed-width lowercase hex> + ":" + <implementation-defined suffix that orders later appends first within the same timestamp>`
+- `RowKey = <reverse_tick_ms as fixed-width lowercase hex> + ":" + <implementation-defined suffix that preserves append uniqueness and orders later appends first within the same timestamp for one handler process lifetime>`
 
 The row contains:
 

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -198,21 +198,24 @@ For each node-scoped `GW-0812`, the handler performs the following sequence:
 5. Query `Top(1)` from `DesiredNodeState` for the same node partition.
 6. If no desired-state row exists, complete the invocation without downstream
    publication.
-7. If `desired_assigned_program_hash` is non-null, compare it to
+7. If the desired-state row's `node_id` payload does not exactly match the
+   current `entity_id`, fail the invocation rather than publishing a command
+   for potentially corrupted cross-node state.
+8. If `desired_assigned_program_hash` is non-null, compare it to
    `observed_current_program_hash` from the appended row selected for
    evaluation.
-8. If `desired_schedule_interval_s` is non-null, compare it to
+9. If `desired_schedule_interval_s` is non-null, compare it to
    `observed_schedule_interval_s` from the appended row selected for
    evaluation.
-9. If neither comparison diverges, complete the invocation with no downstream
+10. If neither comparison diverges, complete the invocation with no downstream
    publication.
-10. If either comparison diverges, build one complete `GW-0811`
+11. If either comparison diverges, build one complete `GW-0811`
    `DESIRED_STATE` payload using:
    1. `entity_kind = "node"`,
    2. `entity_id = node_id`,
    3. `assigned_program_hash = desired_assigned_program_hash` from the latest desired row, and
    4. `schedule_interval_s = desired_schedule_interval_s` from the latest desired row.
-11. Publish that payload to the downstream queue.
+12. Publish that payload to the downstream queue.
 
 `ephemeral_program_hash` is intentionally omitted in v1. The gateway connector
 schema already defines it, but this design does not add Azure-side ownership or

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -184,25 +184,32 @@ For each node-scoped `GW-0812`, the handler performs the following sequence:
 
 1. Append one `ActualNodeState` row for the received `GW-0812`.
 2. Query `Top(1)` from `ActualNodeState` for the node's partition.
-3. If the newest actual-state row is not the row that was just appended, treat
-   the incoming message as out-of-order and complete the invocation without
-   downstream publication.
-4. Query `Top(1)` from `DesiredNodeState` for the same node partition.
-5. If no desired-state row exists, complete the invocation without downstream
+3. If the newest actual-state row has a `timestamp_ms` greater than the
+   appended row's `timestamp_ms`, treat the incoming message as out-of-order and
+   complete the invocation without downstream publication.
+4. Otherwise, use the appended row as the actual-state input for this
+   invocation's divergence evaluation. Equal-timestamp ordering among history
+   rows is retained for diagnostics, but reconciliation correctness does not
+   depend on `Top(1)` choosing the just-appended row when multiple rows share
+   the same `timestamp_ms`.
+5. Query `Top(1)` from `DesiredNodeState` for the same node partition.
+6. If no desired-state row exists, complete the invocation without downstream
    publication.
-6. If `desired_assigned_program_hash` is non-null, compare it to
-   `observed_current_program_hash` from the newest actual-state row.
-7. If `desired_schedule_interval_s` is non-null, compare it to
-   `observed_schedule_interval_s` from the newest actual-state row.
-8. If neither comparison diverges, complete the invocation with no downstream
+7. If `desired_assigned_program_hash` is non-null, compare it to
+   `observed_current_program_hash` from the appended row selected for
+   evaluation.
+8. If `desired_schedule_interval_s` is non-null, compare it to
+   `observed_schedule_interval_s` from the appended row selected for
+   evaluation.
+9. If neither comparison diverges, complete the invocation with no downstream
    publication.
-9. If either comparison diverges, build one complete `GW-0811`
+10. If either comparison diverges, build one complete `GW-0811`
    `DESIRED_STATE` payload using:
    1. `entity_kind = "node"`,
    2. `entity_id = node_id`,
    3. `assigned_program_hash = desired_assigned_program_hash` from the latest desired row, and
    4. `schedule_interval_s = desired_schedule_interval_s` from the latest desired row.
-10. Publish that payload to the downstream queue.
+11. Publish that payload to the downstream queue.
 
 `ephemeral_program_hash` is intentionally omitted in v1. The gateway connector
 schema already defines it, but this design does not add Azure-side ownership or

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -24,10 +24,9 @@ adapter between the gateway's local connector socket and Azure Service Bus. The
 Azure handler owns the first Sonde-aware cloud logic:
 
 1. consume upstream connector messages from the upstream queue,
-2. reconcile node-scoped `GW-0812` actual-state messages into a combined
-   desired/observed Azure Table row,
-3. publish a complete node-scoped `GW-0811` desired-state message when desired
-   and observed node state diverge, and
+2. append node-scoped `GW-0812` actual-state messages to actual-state history,
+3. compare the latest eligible actual-state row against the latest desired-state
+   row and publish a complete node-scoped `GW-0811` when they diverge, and
 4. route `GW-0813` application-data messages to handler queues by `program_hash`.
 
 The handler does not replace the gateway's reconciler model. It expresses cloud
@@ -44,7 +43,8 @@ stack. The Function App uses a system-assigned managed identity with:
 
 1. receive permission on the upstream queue,
 2. send permission on the downstream queue,
-3. read/write permission on the Azure Tables used by the handler, and
+3. append permission on `ActualNodeState`, read permission on
+   `DesiredNodeState`, and read permission on `ProgramRoute`, and
 4. send permission on each pre-provisioned handler queue referenced by the
    program route table.
 
@@ -105,44 +105,60 @@ inside the `GW-0813` message body.
 
 ## 4  Azure Table schemas
 
-> **Requirements:** AZH-0200, AZH-0300
+> **Requirements:** AZH-0200, AZH-0205, AZH-0206, AZH-0300
 
-The design uses two Azure Tables:
+The design uses three Azure Tables:
 
-1. **`NodeState`** — combined desired/observed state keyed by `node_id`.
-2. **`ProgramRoute`** — `program_hash` to handler queue mapping.
+1. **`ActualNodeState`** — append-only actual-state history keyed for latest-per-node queries.
+2. **`DesiredNodeState`** — append-only desired-state history keyed for latest-per-node queries.
+3. **`ProgramRoute`** — `program_hash` to handler queue mapping.
 
-### 4.1  `NodeState` schema
+### 4.1  `ActualNodeState` schema
 
 Each row uses:
 
-- `PartitionKey = "node"`
-- `RowKey = "n:" + lowercase hex-encoded SHA-256(node_id UTF-8 bytes)`
+- `PartitionKey = "n:" + lowercase hex-encoded SHA-256(node_id UTF-8 bytes)`
+- `RowKey = <reverse_tick_ms as fixed-width lowercase hex> + ":" + <implementation-defined suffix that orders later appends first within the same timestamp>`
 
 The row contains the following logical columns:
 
 | Column | Purpose |
 |--------|---------|
 | `node_id` | Original opaque node identifier used by gateway and handlers. |
-| `desired_assigned_program_hash` | Cloud-authored desired resident program hash, nullable. |
-| `desired_schedule_interval_s` | Cloud-authored desired schedule interval, nullable. |
 | `observed_current_program_hash` | Node-reported current resident program hash, nullable. |
 | `observed_assigned_program_hash` | Gateway-reported assigned resident program hash, nullable. |
 | `observed_schedule_interval_s` | Gateway-reported node schedule interval, nullable. |
 | `battery_mv` | Latest battery reading from `GW-0812`, nullable. |
 | `firmware_abi_version` | Latest firmware ABI version, nullable. |
 | `firmware_version` | Latest firmware version, nullable. |
-| `last_checkin_ms` | Most recent `timestamp_ms` accepted for the node. |
+| `timestamp_ms` | Check-in time carried by the source `GW-0812`. |
 
-The row deliberately separates desired and observed columns so that Azure-side
-control-plane intent is not overwritten by the next `GW-0812`.
-The hashed `RowKey` is only a storage-safe lookup key. The logical node
-identifier remains the original opaque `node_id`, which is stored in the row and
-returned unchanged when the handler loads rows. For backward compatibility, the
-handler also tolerates legacy rows whose `RowKey` used the older reversible
-hex-encoding or the literal raw node ID.
+The node-scoped `PartitionKey` keeps each node's history in one queryable
+partition. The reverse-tick `RowKey` prefix makes newer timestamps sort first.
+The suffix preserves append-only behavior when multiple deliveries share the
+same `timestamp_ms`, and it must order later appends before earlier appends
+within that timestamp so `Top(1)` remains deterministic.
 
-### 4.2  `ProgramRoute` schema
+### 4.2  `DesiredNodeState` schema
+
+Each row uses:
+
+- `PartitionKey = "n:" + lowercase hex-encoded SHA-256(node_id UTF-8 bytes)`
+- `RowKey = <reverse_tick_ms as fixed-width lowercase hex> + ":" + <implementation-defined suffix that orders later appends first within the same timestamp>`
+
+The row contains:
+
+| Column | Purpose |
+|--------|---------|
+| `node_id` | Original opaque node identifier used by gateway and handlers. |
+| `desired_assigned_program_hash` | Cloud-authored desired resident program hash, nullable. |
+| `desired_schedule_interval_s` | Cloud-authored desired schedule interval, nullable. |
+| `timestamp_ms` | Time associated with the desired-state request. |
+
+The Azure handler reads this table but does not write it. Admin/control-plane
+surfaces append desired-state rows when requested state changes.
+
+### 4.3  `ProgramRoute` schema
 
 Each row uses:
 
@@ -162,32 +178,31 @@ policy lifecycle.
 
 ## 5  Node-state reconciliation algorithm
 
-> **Requirements:** AZH-0201, AZH-0202, AZH-0203, AZH-0204
+> **Requirements:** AZH-0201, AZH-0202, AZH-0203, AZH-0204, AZH-0207
 
 For each node-scoped `GW-0812`, the handler performs the following sequence:
 
-1. Load the `NodeState` row for `node_id`.
-2. If the row is missing:
-   1. create a new row,
-   2. copy the observed fields from `GW-0812`,
-   3. seed `desired_assigned_program_hash` from `current_program_hash` when
-      present, otherwise from `assigned_program_hash`, and
-   4. seed `desired_schedule_interval_s` from `schedule_interval_s`.
-3. If the row exists:
-    1. update all observed fields from `GW-0812`,
-    2. if `desired_assigned_program_hash` is non-null, compare it to
-       `observed_current_program_hash`, and
-    3. if `desired_schedule_interval_s` is non-null, compare it to
-       `observed_schedule_interval_s`.
-4. If neither comparison diverges, complete the invocation with no downstream
+1. Append one `ActualNodeState` row for the received `GW-0812`.
+2. Query `Top(1)` from `ActualNodeState` for the node's partition.
+3. If the newest actual-state row is not the row that was just appended, treat
+   the incoming message as out-of-order and complete the invocation without
+   downstream publication.
+4. Query `Top(1)` from `DesiredNodeState` for the same node partition.
+5. If no desired-state row exists, complete the invocation without downstream
    publication.
-5. If either comparison diverges, build one complete `GW-0811`
+6. If `desired_assigned_program_hash` is non-null, compare it to
+   `observed_current_program_hash` from the newest actual-state row.
+7. If `desired_schedule_interval_s` is non-null, compare it to
+   `observed_schedule_interval_s` from the newest actual-state row.
+8. If neither comparison diverges, complete the invocation with no downstream
+   publication.
+9. If either comparison diverges, build one complete `GW-0811`
    `DESIRED_STATE` payload using:
    1. `entity_kind = "node"`,
    2. `entity_id = node_id`,
-   3. `assigned_program_hash = desired_assigned_program_hash`, and
-   4. `schedule_interval_s = desired_schedule_interval_s`.
-6. Publish that payload to the downstream queue.
+   3. `assigned_program_hash = desired_assigned_program_hash` from the latest desired row, and
+   4. `schedule_interval_s = desired_schedule_interval_s` from the latest desired row.
+10. Publish that payload to the downstream queue.
 
 `ephemeral_program_hash` is intentionally omitted in v1. The gateway connector
 schema already defines it, but this design does not add Azure-side ownership or
@@ -196,7 +211,8 @@ comparison rules for it yet.
 A null desired program or schedule field means the cloud is intentionally not
 asserting a target for that field. The reconciliation algorithm therefore skips
 that comparison instead of republishing `GW-0811` forever against a non-null
-observed value.
+observed value. Because desired-state history is admin-authored, the handler
+never seeds or updates desired-state rows while processing `GW-0812`.
 
 ---
 

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -185,6 +185,7 @@ message for that node using the latest desired-state row's fields.
 5. The emitted desired-state payload does not invent `ephemeral_program_hash` state owned by this document.
 6. A null desired resident-program or null desired schedule field does not, by itself, trigger divergence or downstream publication for that field.
 7. Absence of any desired-state row for a node suppresses downstream publication for that node.
+8. If the latest desired-state row returned for a node partition carries a different `node_id` payload, the handler fails the reconciliation attempt rather than publishing a `GW-0811` for either node.
 
 ---
 

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -25,11 +25,12 @@
 | Term | Definition |
 |------|------------|
 | **Azure handler** | The Azure-hosted control-plane process that consumes upstream Sonde connector traffic from Service Bus and produces downstream desired-state messages or handler-queue deliveries. |
-| **Node state row** | One Azure Table row keyed by Sonde `node_id` that contains both desired fields and the latest observed fields derived from `GW-0812`. |
+| **Actual state row** | One append-only Azure Table row that records a received node-scoped `GW-0812` observation for a Sonde `node_id`. |
+| **Desired state row** | One append-only Azure Table row that records a requested desired state for a Sonde `node_id`. Desired rows are authored by admin/control-plane surfaces, not by the Azure handler reconciliation path. |
 | **Program route row** | One Azure Table row keyed by `program_hash` that names the Azure Service Bus queue that should receive `GW-0813` application-data messages for that program. |
-| **Observed fields** | The subset of node state reported by `GW-0812` and copied into the node state row, including current program state, observed schedule as reported by the gateway, firmware data, battery, and last check-in time. |
-| **Desired fields** | The cloud-authored fields stored in the node state row and used to build a complete `GW-0811` `DESIRED_STATE` payload for the node. In v1 this document defines `assigned_program_hash` and `schedule_interval_s`. |
-| **Last check-in time** | The most recent `timestamp_ms` carried by a node-scoped `GW-0812` message accepted by the Azure handler for that node. |
+| **Observed fields** | The subset of node state reported by `GW-0812` and copied into an actual state row, including current program state, observed schedule as reported by the gateway, firmware data, battery, and check-in time. |
+| **Desired fields** | The cloud-authored fields stored in a desired state row and used to build a complete `GW-0811` `DESIRED_STATE` payload for the node. In v1 this document defines `assigned_program_hash` and `schedule_interval_s`. |
+| **Reverse-tick key** | A row-key prefix derived from `u64::MAX - timestamp_ms`, so newer timestamps sort before older timestamps for `Top(1)` queries within one node partition. |
 
 ---
 
@@ -65,7 +66,7 @@ logic.
 1. The Azure handler accepts raw connector payload bytes from the configured upstream queue.
 2. A node-scoped `GW-0812` message is routed to node-state reconciliation logic.
 3. A `GW-0813` message is routed to application-data delivery logic.
-4. Unsupported or out-of-scope connector messages do not mutate node-state or program-route tables.
+4. Unsupported or out-of-scope connector messages do not mutate actual-state, desired-state, or program-route tables.
 
 ---
 
@@ -84,75 +85,76 @@ desired-state view for that node.
 
 1. Each emitted message is encoded as one complete node-scoped `GW-0811` desired-state payload.
 2. The payload targets exactly one node by `node_id`.
-3. The payload includes the desired fields owned by the node-state row.
+3. The payload includes the desired fields owned by the latest desired-state row.
 4. The Azure handler does not emit imperative gateway commands outside the `GW-0811` desired-state contract.
 
 ---
 
 ## 4  Node-state table ownership and reconciliation
 
-### AZH-0200  Combined desired and observed node-state rows
+### AZH-0200  Append-only actual-state and desired-state history tables
 
 **Priority:** Must
 **Source:** Azure handler discovery review
 
 **Description:**
-The Azure handler MUST own an Azure Table that stores one node state row per
-`node_id`. Each row MUST contain both desired fields and the latest observed
-fields derived from node-scoped `GW-0812` messages. In v1, the desired fields
-owned by this document are `assigned_program_hash` and `schedule_interval_s`.
+The Azure handler integration MUST use separate append-only Azure Tables for
+node actual-state history and node desired-state history. `ActualNodeState`
+records every received node-scoped `GW-0812`. `DesiredNodeState` records each
+requested node desired state. In v1, the desired fields owned by this document
+are `assigned_program_hash` and `schedule_interval_s`.
 `ephemeral_program_hash` remains out of scope for this document.
 
 **Acceptance criteria:**
 
-1. The table stores one row per `node_id`.
-2. Each row contains desired `assigned_program_hash` and desired `schedule_interval_s` fields.
-3. Each row contains observed `current_program_hash`, observed gateway-assigned program hash, observed `schedule_interval_s`, `battery_mv`, firmware ABI/version fields, and last check-in time.
-4. The row shape distinguishes desired fields from observed fields rather than collapsing them into one set of columns.
+1. `ActualNodeState` stores append-only actual-state rows for each `node_id`.
+2. `DesiredNodeState` stores append-only desired-state rows for each `node_id`.
+3. Actual-state rows contain observed `current_program_hash`, observed gateway-assigned program hash, observed `schedule_interval_s`, `battery_mv`, firmware ABI/version fields, and `timestamp_ms`.
+4. Desired-state rows contain desired `assigned_program_hash` and desired `schedule_interval_s`.
+5. The schema distinguishes actual-state history from desired-state history rather than collapsing them into one mutable row shape.
 
 ---
 
-### AZH-0201  Seed missing rows from `GW-0812`
+### AZH-0201  First `GW-0812` appends actual-state history without seeding desired state
 
 **Priority:** Must
 **Source:** Azure handler discovery review, GW-0812
 
 **Description:**
-If the node-state table does not contain a row for the `node_id` named by a
-node-scoped `GW-0812` message, the Azure handler MUST create one using values
-from that message. The seed operation MUST initialize the desired resident
-program from the node's observed current program when present, otherwise from
-the gateway-assigned program hash. It MUST initialize the desired schedule from
-the observed `schedule_interval_s`. The seed operation MUST NOT emit `GW-0811`
-for that first-seen node.
+If the handler receives a node-scoped `GW-0812` for a `node_id` that has no
+prior actual-state history, it MUST append one `ActualNodeState` row using the
+message fields. It MUST NOT synthesize or append a `DesiredNodeState` row for
+that first-seen node. It MUST NOT emit `GW-0811` solely because the node has no
+desired-state history yet.
 
 **Acceptance criteria:**
 
-1. The first node-scoped `GW-0812` for an unseen `node_id` creates exactly one new row.
-2. The new row copies the observed fields from the message.
-3. The new row initializes desired `assigned_program_hash` from observed `current_program_hash` when non-null, otherwise from observed gateway-assigned program hash.
-4. The new row initializes desired `schedule_interval_s` from the observed `schedule_interval_s`.
-5. The seed path does not emit a downstream `GW-0811` message.
+1. The first node-scoped `GW-0812` for an unseen `node_id` creates exactly one new actual-state row.
+2. The new actual-state row copies the observed fields from the message.
+3. The handler does not create or mutate any desired-state row on that path.
+4. The first-seen path does not emit a downstream `GW-0811` message solely because desired state is absent.
 
 ---
 
-### AZH-0202  Observed-state refresh on every `GW-0812`
+### AZH-0202  Append-only actual-state recording on every `GW-0812`
 
 **Priority:** Must
 **Source:** Azure handler discovery review, GW-0812
 
 **Description:**
-For every node-scoped `GW-0812` message, the Azure handler MUST refresh the
-row's observed fields from the message before evaluating divergence. The update
-must include the latest check-in time, battery, firmware data, observed current
+For every node-scoped `GW-0812` message, the Azure handler MUST append a new
+actual-state history row before evaluating divergence. The appended row MUST
+capture the message's check-in time, battery, firmware data, observed current
 program state, observed gateway-assigned program state, and observed schedule.
+The handler MUST retain repeated deliveries and older deliveries as history
+rather than overwriting or discarding them at write time.
 
 **Acceptance criteria:**
 
-1. Existing rows are updated in place when a later `GW-0812` for that node arrives.
-2. The row's last check-in time matches the message timestamp after the update.
-3. The row's observed `battery_mv`, firmware ABI/version fields, current program, assigned program, and schedule fields match the message after the update.
-4. Divergence evaluation uses the refreshed observed values rather than stale values from an older row version.
+1. Each node-scoped `GW-0812` appends exactly one new actual-state row.
+2. The appended row's `timestamp_ms`, `battery_mv`, firmware ABI/version fields, current program, assigned program, and schedule fields match the message.
+3. Repeated delivery of the same logical check-in results in multiple history rows rather than in-place replacement.
+4. Older deliveries may still be appended for diagnostics and audit history.
 
 ---
 
@@ -162,25 +164,27 @@ program state, observed gateway-assigned program state, and observed schedule.
 **Source:** Azure handler discovery review, GW-0811, GW-0812
 
 **Description:**
-After refreshing an existing node-state row from `GW-0812`, the Azure handler
-MUST compare the row's desired fields against the observed fields reported by
-that message. In v1, divergence is present when desired
+After appending an actual-state row from `GW-0812`, the Azure handler MUST load
+the latest desired-state row for that `node_id` and compare the latest eligible
+actual-state row against it. In v1, divergence is present when desired
 `assigned_program_hash` is non-null and differs from the observed current
 program hash, or when desired `schedule_interval_s` is non-null and differs
 from the observed schedule interval. A null desired field means the Azure
 handler is not asserting a cloud target for that field and therefore MUST NOT
-treat that field as divergent by itself. When either active comparison
+treat that field as divergent by itself. If no desired-state row exists for the
+node, the handler MUST NOT emit `GW-0811`. When either active comparison
 diverges, the Azure handler MUST emit one complete `GW-0811` `DESIRED_STATE`
-message for that node using the row's desired fields.
+message for that node using the latest desired-state row's fields.
 
 **Acceptance criteria:**
 
-1. A resident-program mismatch causes one downstream `GW-0811` message for that `GW-0812`.
-2. A schedule mismatch causes one downstream `GW-0811` message for that `GW-0812`.
-3. When both resident-program and schedule mismatch, the Azure handler still emits exactly one complete `GW-0811` message for that `GW-0812`.
-4. The emitted desired-state payload includes the row's desired `assigned_program_hash` and desired `schedule_interval_s`.
+1. A resident-program mismatch between the latest eligible actual-state row and the latest desired-state row causes one downstream `GW-0811` message for that evaluation.
+2. A schedule mismatch between the latest eligible actual-state row and the latest desired-state row causes one downstream `GW-0811` message for that evaluation.
+3. When both resident-program and schedule mismatch, the Azure handler still emits exactly one complete `GW-0811` message for that evaluation.
+4. The emitted desired-state payload includes the latest desired-state row's `assigned_program_hash` and `schedule_interval_s`.
 5. The emitted desired-state payload does not invent `ephemeral_program_hash` state owned by this document.
 6. A null desired resident-program or null desired schedule field does not, by itself, trigger divergence or downstream publication for that field.
+7. Absence of any desired-state row for a node suppresses downstream publication for that node.
 
 ---
 
@@ -190,14 +194,75 @@ message for that node using the row's desired fields.
 **Source:** Azure handler discovery review
 
 **Description:**
-If the desired fields stored in a node-state row match the corresponding
-observed fields reported by `GW-0812`, the Azure handler MUST update the row and
-MUST NOT emit a downstream `GW-0811` message for that event.
+If the latest desired-state row for a node matches the latest eligible
+actual-state row derived from `GW-0812`, the Azure handler MUST retain the
+appended actual-state history row and MUST NOT emit a downstream `GW-0811`
+message for that event.
 
 **Acceptance criteria:**
 
-1. An aligned `GW-0812` updates the node-state row.
+1. An aligned `GW-0812` appends an actual-state row.
 2. An aligned `GW-0812` does not enqueue a downstream desired-state message.
+
+---
+
+### AZH-0205  Reverse-tick latest-row lookup
+
+**Priority:** Must
+**Source:** Azure handler discovery review
+
+**Description:**
+The actual-state and desired-state history tables MUST optimize the common query
+pattern "latest row for one node". Each table MUST use a node-scoped partition
+key and a reverse-tick row-key prefix derived from `u64::MAX - timestamp_ms`,
+so that the newest row for a node sorts first for `Top(1)` retrieval.
+
+**Acceptance criteria:**
+
+1. Actual-state and desired-state rows for one node can be queried by a node-scoped partition key.
+2. Within one node partition, newer timestamps sort before older timestamps by row key.
+3. A `Top(1)` query scoped to one node returns that node's newest row without a full partition scan.
+4. The row key format permits multiple rows with the same `timestamp_ms` without overwriting history.
+5. For rows that share the same `timestamp_ms`, the row key still provides deterministic newest-first ordering within that timestamp.
+
+---
+
+### AZH-0206  Desired-state history is admin-authored
+
+**Priority:** Must
+**Source:** Azure handler discovery review
+
+**Description:**
+The Azure handler reconciliation path MUST treat `DesiredNodeState` as an
+admin-authored control-plane history surface. It MUST read the latest desired
+row for a node when evaluating divergence, but it MUST NOT create, replace, or
+append desired-state rows while processing `GW-0812`.
+
+**Acceptance criteria:**
+
+1. Node reconciliation reads desired-state history but does not write it.
+2. First-seen nodes do not cause synthetic desired-state rows to be created.
+3. Desired-state table mutations are owned by external admin or control-plane surfaces.
+
+---
+
+### AZH-0207  Out-of-order actual-state retention without stale control decisions
+
+**Priority:** Must
+**Source:** Azure handler discovery review
+
+**Description:**
+If a node-scoped `GW-0812` arrives with `timestamp_ms` older than the latest
+actual-state row already stored for that node, the Azure handler MUST still
+append the older actual-state row for diagnostics. However, it MUST NOT let
+that out-of-order row displace the latest eligible actual state for divergence
+evaluation or downstream `GW-0811` publication.
+
+**Acceptance criteria:**
+
+1. An older `GW-0812` still produces an appended actual-state history row.
+2. The latest actual-state row used for control decisions remains the newest row by timestamp for that node.
+3. An out-of-order row does not trigger downstream publication solely because it differs from the latest desired state.
 
 ---
 
@@ -284,13 +349,16 @@ document's scope does not include queue creation or lifecycle management.
 **Source:** Azure handler discovery review, GW-0815
 
 **Description:**
-If the Azure handler cannot read or write the node-state table, cannot read the
-program route table, cannot publish `GW-0811`, or cannot publish a mapped
-`GW-0813`, it MUST surface the failure and fail closed for the affected message.
+If the Azure handler cannot append to the actual-state table, cannot read the
+desired-state table, cannot read the program route table, cannot publish
+`GW-0811`, or cannot publish a mapped `GW-0813`, it MUST surface the failure
+and fail closed for the affected message.
 
 **Acceptance criteria:**
 
-1. Table read/write failures are surfaced through logging, function failure, or both.
-2. Downstream `GW-0811` publish failures are surfaced through logging, function failure, or both.
-3. Mapped handler-queue publish failures are surfaced through logging, function failure, or both.
-4. The Azure handler does not silently claim success after a detected storage or broker failure.
+1. Actual-state table append failures are surfaced through logging, function failure, or both.
+2. Desired-state table read failures are surfaced through logging, function failure, or both.
+3. Program route table read failures are surfaced through logging, function failure, or both.
+4. Downstream `GW-0811` publish failures are surfaced through logging, function failure, or both.
+5. Mapped handler-queue publish failures are surfaced through logging, function failure, or both.
+6. The Azure handler does not silently claim success after a detected storage or broker failure.

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -223,7 +223,7 @@ so that the newest row for a node sorts first for `Top(1)` retrieval.
 2. Within one node partition, newer timestamps sort before older timestamps by row key.
 3. A `Top(1)` query scoped to one node returns that node's newest row without a full partition scan.
 4. The row key format permits multiple rows with the same `timestamp_ms` without overwriting history.
-5. For rows that share the same `timestamp_ms`, the row key still provides deterministic newest-first ordering within that timestamp.
+5. For rows that share the same `timestamp_ms`, the row key still provides deterministic uniqueness, and within one handler process lifetime later appends sort before earlier appends. Reconciliation correctness MUST NOT depend on a globally newest-first order across restarts or concurrent handler instances.
 
 ---
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -199,6 +199,18 @@ published when both desired fields diverge simultaneously.
 
 ---
 
+### T-AZH-0212  Mismatched desired-state `node_id` fails closed
+
+**Validates:** AZH-0203
+
+**Procedure:**
+1. Arrange a desired-state lookup for node `A` that returns a row from node `A`'s partition but with a stored `node_id` payload of node `B`.
+2. Deliver a node-scoped `GW-0812` for node `A` that would otherwise diverge from the desired row.
+3. Assert: the handler surfaces an error instead of publishing a downstream `GW-0811`.
+4. Assert: no downstream desired-state message is sent for either node.
+
+---
+
 ### T-AZH-0300  ProgramRoute rows map `program_hash` to handler queue name
 
 **Validates:** AZH-0300

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -174,7 +174,20 @@ published when both desired fields diverge simultaneously.
 
 ---
 
-### T-AZH-0210  Handler never writes desired-state history during reconciliation
+### T-AZH-0210  Equal-timestamp deliveries still evaluate the current append
+
+**Validates:** AZH-0203, AZH-0205, AZH-0207
+
+**Procedure:**
+1. Seed a latest desired-state row for a test node.
+2. Arrange the latest-row lookup to return a different actual-state history row with the same `timestamp_ms` as the delivery being tested.
+3. Deliver a node-scoped `GW-0812` whose observed state diverges from the desired state.
+4. Assert: the handler still evaluates the current appended delivery rather than suppressing it as stale solely because another equal-timestamp row sorts first.
+5. Assert: downstream `GW-0811` publication still occurs when the current delivery diverges.
+
+---
+
+### T-AZH-0211  Handler never writes desired-state history during reconciliation
 
 **Validates:** AZH-0206
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -157,7 +157,7 @@ published when both desired fields diverge simultaneously.
 3. Assert: the returned row is the one with the greatest `timestamp_ms`.
 4. Repeat for desired-state rows.
 5. Assert: repeated timestamps can coexist without overwriting one another.
-6. Assert: when two rows share the same `timestamp_ms`, the later-appended row sorts ahead of the earlier one for `Top(1)`.
+6. Assert: when two rows share the same `timestamp_ms` within one handler process lifetime, the later-appended row sorts ahead of the earlier one for `Top(1)`.
 
 ---
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -25,7 +25,7 @@
 2. Deliver one node-scoped `GW-0812`, one `GW-0813`, and one unsupported connector payload through the upstream trigger path.
 3. Assert: the `GW-0812` is routed to node-state reconciliation.
 4. Assert: the `GW-0813` is routed to application-data delivery.
-5. Assert: the unsupported message does not mutate the node-state or program-route tables.
+5. Assert: the unsupported message does not mutate the actual-state, desired-state, or program-route tables.
 
 ---
 
@@ -34,7 +34,7 @@
 **Validates:** AZH-0101, AZH-0203
 
 **Procedure:**
-1. Seed an existing `NodeState` row whose desired resident program hash and desired schedule differ from the observed values that will be carried by the test `GW-0812`.
+1. Seed a latest desired-state row whose desired resident program hash and desired schedule differ from the observed values that will be carried by the test `GW-0812`.
 2. Deliver that node-scoped `GW-0812` through the upstream trigger path.
 3. Assert: exactly one downstream message is published.
 4. Assert: the published payload is a node-scoped `GW-0811` `DESIRED_STATE` message.
@@ -43,41 +43,43 @@
 
 ---
 
-### T-AZH-0200  NodeState table stores separate desired and observed columns
+### T-AZH-0200  Actual-state and desired-state tables are separate append-only histories
 
 **Validates:** AZH-0200
 
 **Procedure:**
-1. Create or update a `NodeState` row through the handler's reconciliation path.
-2. Inspect the stored row.
-3. Assert: desired resident program and desired schedule fields are stored separately from the observed fields.
-4. Assert: the row also stores observed current program, observed assigned program, observed schedule, battery, firmware data, and last check-in time.
+1. Trigger the reconciliation path for one node-scoped `GW-0812`.
+2. Inspect the actual-state table and desired-state table through test doubles.
+3. Assert: the actual-state table receives an appended row for the node.
+4. Assert: the desired-state table is not mutated by the handler.
+5. Assert: actual-state rows store observed current program, observed assigned program, observed schedule, battery, firmware data, and `timestamp_ms`.
+6. Assert: desired-state rows, when pre-seeded by the test, store desired resident program and desired schedule separately from actual-state rows.
 
 ---
 
-### T-AZH-0201  First `GW-0812` seeds a missing row without publishing `GW-0811`
+### T-AZH-0201  First `GW-0812` appends actual-state history without publishing `GW-0811`
 
 **Validates:** AZH-0201
 
 **Procedure:**
-1. Start with no `NodeState` row for a test node.
+1. Start with no actual-state rows and no desired-state rows for a test node.
 2. Deliver one node-scoped `GW-0812` containing current program, assigned program, schedule, battery, firmware data, and timestamp.
-3. Assert: exactly one new row is created for that node.
-4. Assert: the row's desired resident program is initialized from current program when present, otherwise from assigned program.
-5. Assert: the row's desired schedule is initialized from the observed schedule.
-6. Assert: no downstream `GW-0811` message is published.
+3. Assert: exactly one new actual-state row is created for that node.
+4. Assert: no desired-state row is created for that node.
+5. Assert: no downstream `GW-0811` message is published.
 
 ---
 
-### T-AZH-0202  Existing rows refresh observed state before divergence evaluation
+### T-AZH-0202  Every `GW-0812` appends a new actual-state row
 
 **Validates:** AZH-0202
 
 **Procedure:**
-1. Seed a `NodeState` row with stale observed values.
-2. Deliver a later node-scoped `GW-0812` for the same node with different battery, firmware, schedule, and timestamp values.
-3. Assert: the stored observed values are replaced by the new values from the message.
-4. Assert: the divergence decision for that invocation uses the new observed values.
+1. Deliver two node-scoped `GW-0812` messages for the same node.
+2. Assert: two distinct actual-state rows exist for that node afterward.
+3. Assert: each row retains the battery, firmware, schedule, and timestamp values from its source message.
+4. Deliver the same logical `GW-0812` again.
+5. Assert: a third actual-state row is appended rather than merged into an existing row.
 
 ---
 
@@ -86,7 +88,7 @@
 **Validates:** AZH-0203
 
 **Procedure:**
-1. Seed a `NodeState` row whose desired resident program hash differs from the current program hash that will be reported by the next `GW-0812`.
+1. Seed a latest desired-state row whose desired resident program hash differs from the current program hash that will be reported by the next `GW-0812`.
 2. Deliver the node-scoped `GW-0812`.
 3. Assert: exactly one downstream `GW-0811` message is published.
 4. Assert: the emitted message targets the correct `node_id`.
@@ -98,9 +100,9 @@
 **Validates:** AZH-0204
 
 **Procedure:**
-1. Seed a `NodeState` row whose desired resident program and desired schedule match the observed values that will be carried by the next `GW-0812`.
+1. Seed a latest desired-state row whose desired resident program and desired schedule match the observed values that will be carried by the next `GW-0812`.
 2. Deliver that node-scoped `GW-0812`.
-3. Assert: the row is updated with the latest observed battery, firmware, and timestamp values.
+3. Assert: a new actual-state row is appended with the latest observed battery, firmware, and timestamp values.
 4. Assert: no downstream `GW-0811` message is published.
 
 ---
@@ -110,7 +112,7 @@
 **Validates:** AZH-0203
 
 **Procedure:**
-1. Seed a `NodeState` row whose desired schedule differs from the observed schedule that will be carried by the next `GW-0812`, while the desired and observed resident program hashes match.
+1. Seed a latest desired-state row whose desired schedule differs from the observed schedule that will be carried by the next `GW-0812`, while the desired and observed resident program hashes match.
 2. Deliver the node-scoped `GW-0812`.
 3. Assert: exactly one downstream `GW-0811` message is published.
 4. Assert: the emitted payload carries the row's desired `schedule_interval_s`.
@@ -126,10 +128,61 @@ published when both desired fields diverge simultaneously.
 **Validates:** AZH-0203, AZH-0204
 
 **Procedure:**
-1. Seed a `NodeState` row whose desired resident program hash and desired schedule are both `null`, while the observed values that will be carried by the next `GW-0812` are non-null.
+1. Seed a latest desired-state row whose desired resident program hash and desired schedule are both `null`, while the observed values that will be carried by the next `GW-0812` are non-null.
 2. Deliver that node-scoped `GW-0812`.
-3. Assert: the handler refreshes the stored observed fields.
+3. Assert: the handler appends a new actual-state row.
 4. Assert: no downstream `GW-0811` message is published solely because the desired field is `null`.
+
+---
+
+### T-AZH-0207  Missing desired-state history suppresses divergence publication
+
+**Validates:** AZH-0201, AZH-0203, AZH-0206
+
+**Procedure:**
+1. Start with no desired-state row for a test node.
+2. Deliver a node-scoped `GW-0812` with non-null observed program and schedule values.
+3. Assert: an actual-state row is appended.
+4. Assert: no downstream `GW-0811` message is published.
+
+---
+
+### T-AZH-0208  Reverse-tick row keys return the newest row with `Top(1)`
+
+**Validates:** AZH-0205
+
+**Procedure:**
+1. Seed multiple actual-state rows for one node with different `timestamp_ms` values.
+2. Query the node partition with `Top(1)`.
+3. Assert: the returned row is the one with the greatest `timestamp_ms`.
+4. Repeat for desired-state rows.
+5. Assert: repeated timestamps can coexist without overwriting one another.
+6. Assert: when two rows share the same `timestamp_ms`, the later-appended row sorts ahead of the earlier one for `Top(1)`.
+
+---
+
+### T-AZH-0209  Out-of-order `GW-0812` is retained but does not drive publication
+
+**Validates:** AZH-0202, AZH-0203, AZH-0207
+
+**Procedure:**
+1. Seed a newer actual-state row and a latest desired-state row for a test node.
+2. Deliver an older node-scoped `GW-0812` whose timestamp is less than the latest actual-state row.
+3. Assert: the older delivery is appended as a new actual-state row.
+4. Assert: the newest actual-state row used for control decisions remains the pre-existing newer row.
+5. Assert: the older delivery does not trigger downstream publication by itself.
+
+---
+
+### T-AZH-0210  Handler never writes desired-state history during reconciliation
+
+**Validates:** AZH-0206
+
+**Procedure:**
+1. Start the Azure handler against test doubles that record writes separately for actual-state and desired-state tables.
+2. Deliver one or more node-scoped `GW-0812` messages.
+3. Assert: actual-state writes occur as expected.
+4. Assert: no desired-state write is attempted by the reconciliation path.
 
 ---
 
@@ -187,7 +240,7 @@ published when both desired fields diverge simultaneously.
 **Validates:** AZH-0400
 
 **Procedure:**
-1. Inject one table write failure, one downstream `GW-0811` send failure, and one mapped handler-queue send failure in separate sub-cases.
+1. Inject one actual-state table append failure, one desired-state table read failure, one program-route table read failure, one downstream `GW-0811` send failure, and one mapped handler-queue send failure in separate sub-cases.
 2. Trigger the corresponding handler path in each sub-case.
 3. Assert: each failure is surfaced through logging, function failure, or both.
 4. Assert: the handler does not report success for the failed message path.


### PR DESCRIPTION
## Summary

This change replaces the Azure handler's mutable per-node \NodeState\ model with
append-only \ActualNodeState\ and \DesiredNodeState\ history tables.

The handler now:
- appends every node-scoped \GW-0812\ check-in to actual-state history
- reads the latest desired-state row without writing desired history itself
- compares the latest eligible actual row with the latest desired row
- suppresses stale or out-of-order control decisions while still retaining history
- uses reverse-tick row keys plus durable tie-breakers for cheap latest-row queries

## Spec changes

Updated:
- \docs/azure-handler-requirements.md\
- \docs/azure-handler-design.md\
- \docs/azure-handler-validation.md\

These now define:
- append-only actual and desired state history
- admin-owned desired-state writes
- reverse-tick newest-first lookup
- out-of-order actual-state retention without stale publication

## Implementation changes

Updated:
- \crates/sonde-azure-handler/src/lib.rs\
- \crates/sonde-azure-handler/Cargo.toml\
- \Cargo.lock\

Highlights:
- replaced the mutable node-state store API with append/read-latest history operations
- refactored reconciliation around append actual -> load latest actual -> load latest desired
- kept \ProgramRoute\ behavior unchanged
- required distinct actual/desired table configuration
- added durable row-key suffixing to avoid same-timestamp collisions across restarts

## Validation

- \cargo test -p sonde-azure-handler\
- \cargo build -p sonde-azure-handler\
- \cargo clippy -p sonde-azure-handler --all-targets -- -D warnings\

## Audit

Phase 6 implementation audit verdict: **PASS**

Notable issue found during audit and fixed before deliverable:
- removed the legacy \SONDE_AZURE_HANDLER_NODE_STATE_TABLE\ fallback because the
  old mutable \NodeState\ schema is incompatible with the new append-only
  actual-state table layout