### PR TITLE
fix: bootstrap JMESPath query returns newline-separated TSV instead of tab-separated

### DIFF
--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -415,7 +415,7 @@ if [ "$#" -ge 4 ] && [ "$1" = "deployment" ] && [ "$2" = "sub" ] && [ "$3" = "sh
         ;;
     esac
   done
-  [ "$query" = "[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value]" ] || exit 67
+  [ "$query" = "[[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value]]" ] || exit 67
   printf 'rg-sonde\tfunc-sonde\tdeploypkg\thttps://example.blob.core.windows.net/deploypkg\n'
   exit 0
 fi

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -17,7 +17,11 @@ require_deployment_output_string() {
 }
 
 read_required_deployment_outputs() {
-    query='[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value]'
+    # Wrap in an outer array so `--output tsv` emits a single row with
+    # tab-separated columns.  A flat JMESPath array produces one value per
+    # line (newline-separated), which breaks the tab-based field splitting
+    # below.
+    query='[[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value]]'
     stderr_file="$(mktemp "${TMPDIR:-/tmp}/sonde-azure-deployment-show.XXXXXX")"
     if ! deployment_runtime_values="$(az deployment sub show \
         --name "$deployment_name" \

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -135,11 +135,6 @@ module functionRbac './function-rbac.bicep' = {
     nodeStateTableName: storage.outputs.nodeStateTableName
     programRouteTableName: storage.outputs.programRouteTableName
   }
-  dependsOn: [
-    serviceBus
-    storage
-    functionPlaceholder
-  ]
 }
 
 output serviceBusNamespaceName string = serviceBus.outputs.namespaceName

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -128,10 +128,10 @@ module functionRbac './function-rbac.bicep' = {
   name: 'functionRbac'
   params: {
     functionPrincipalId: functionPlaceholder.outputs.principalId
-    serviceBusNamespaceName: serviceBusNamespaceName
-    upstreamQueueName: upstreamQueueName
-    downstreamQueueName: downstreamQueueName
-    storageAccountName: storageAccountName
+    serviceBusNamespaceName: serviceBus.outputs.namespaceName
+    upstreamQueueName: serviceBus.outputs.upstreamQueueName
+    downstreamQueueName: serviceBus.outputs.downstreamQueueName
+    storageAccountName: storage.outputs.storageAccountName
     nodeStateTableName: storage.outputs.nodeStateTableName
     programRouteTableName: storage.outputs.programRouteTableName
   }


### PR DESCRIPTION
## Problem

Running `sonde-azure-companion bootstrap` fails with:

\\\
deployment output query \[properties.outputs.resourceGroupName.value, ...]\ returned 1 field(s); expected 4 tab-separated values
\\\

## Root cause

Azure CLI \\--output tsv\\ renders a flat JMESPath array \\[a, b, c, d]\\ as **one value per line** (newline-separated). The bootstrap script sets \\IFS\\ to tab-only and uses \\set --\\ to split, so the entire multi-line output collapses into a single field.

## Fix

- **\\ootstrap.sh\\**: Wrap the JMESPath query in an outer array \\[[...]]\\ so Azure CLI emits a single row with tab-separated columns, matching the existing IFS-based parser.
- **\\stack.bicep\\**: Remove redundant \\dependsOn\\ entries that Bicep warns about — the implicit dependencies through \\params\\ output references are sufficient.