### PR TITLE
fix: tolerate `config-zip` health-check failure on Flex Consumption

### DIFF
--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -177,12 +177,20 @@ fi
 
 echo "Deploying bundled Azure handler package to Function App $function_app_name" >&2
 echo "Using deployment target $deployment_container_name ($deployment_container_url)" >&2
+# The CLI's post-deployment health check ("Failed to fetch host key") can
+# fail on Flex Consumption plans even when the zip upload (HTTP 202)
+# succeeded.  Tolerate this exit code and rely on wait_for_function_activation
+# to confirm the function is actually loaded.
+config_zip_exit=0
 az functionapp deployment source config-zip \
     --src "$function_package_path" \
     --name "$function_app_name" \
     --resource-group "$resource_group_name" \
     --timeout "$deployment_timeout_secs" \
-    --output none 1>&2
+    --output none 1>&2 || config_zip_exit=$?
+if [ "$config_zip_exit" -ne 0 ]; then
+    echo "WARNING: config-zip exited $config_zip_exit; verifying via function activation probe" >&2
+fi
 
 wait_for_function_activation "$resource_group_name" "$function_app_name" "$activation_timeout_secs"
 


### PR DESCRIPTION
## Problem

`az functionapp deployment source config-zip` exits non-zero on Flex Consumption plans with custom runtimes because its post-deployment health check fails with:

\\\
ERROR: Failed to fetch host key to check for function app status
\\\

The zip upload itself succeeds (HTTP 202) and the function loads correctly, but \\set -eu\\ in \\ootstrap.sh\\ kills the script before \\wait_for_function_activation\\ can confirm success.

## Verification

Confirmed against the live deployment (\\sondeprod-decoder-ezdl4pko\\):
- \\z functionapp function list\\ shows \\UpstreamConnector\\ loaded and healthy
- The ARM API rejects \\ersion: ''\\ and requires \\'1.0'\\ — the CLI warning ('Invalid version 1.0 ... Supported versions are [\\'\\']') contradicts the API

## Fix

Capture the \\config-zip\\ exit code instead of letting \\set -eu\\ abort the script. If it fails, log a warning and fall through to the existing \\wait_for_function_activation\\ retry loop, which correctly polls \\z functionapp function list\\ to confirm the function loaded.