### PR TITLE
Replace Flex Consumption plan with Classic Consumption (\Y1\/\Dynamic\)

### DIFF
--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -105,9 +105,16 @@ image, you still need to publish a package containing:
 - `host.json`
 - `UpstreamConnector/function.json`
 
-Deploy the package using `az functionapp deployment source config-zip` or the
-Kudu zip deploy API. The deployment output `functionAppName` identifies the
-target Function App.
+Deploy the package using the zip deploy command. The deployment outputs
+`functionAppName` and the top-level output `resourceGroupName` identify the
+target:
+
+```powershell
+az functionapp deployment source config-zip `
+  --resource-group <resourceGroupName> `
+  --name <functionAppName> `
+  --src handler.zip
+```
 Build the `sonde-azure-handler` executable for the Function App's Linux runtime, not
 for your local host OS. If you package from Windows or macOS, cross-compile or build
 the binary in a Linux environment before uploading it.

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -15,7 +15,7 @@ Azure companion architecture.
 - An Azure Storage Account plus two Azure Table resources for the Azure handler:
   - `decodeddata` (default node-state table name for backward-compatible deployments)
   - `programroute`
-- An Azure handler Function App on a Flex Consumption plan
+- An Azure handler Function App on a Classic Consumption plan (`Y1` / `Dynamic`)
 - A system-assigned managed identity on the Function App with:
   - receive permissions on the upstream queue
   - send permissions on the downstream queue
@@ -93,9 +93,9 @@ az deployment sub create `
 
 ## Custom handler package deployment
 
-The Bicep stack provisions the Azure handler Function App shell and the storage-backed
-deployment configuration. The supported `sonde-azure-companion bootstrap` flow now
-uses those deployment outputs to upload the bundled runnable custom-handler package
+The Bicep stack provisions the Azure handler Function App shell with
+`WEBSITE_RUN_FROM_PACKAGE=1`. The supported `sonde-azure-companion bootstrap`
+flow deploys the bundled runnable custom-handler package via zip deploy
 automatically.
 
 If you run the Bicep deployment manually without the repository-owned bootstrap
@@ -105,14 +105,14 @@ image, you still need to publish a package containing:
 - `host.json`
 - `UpstreamConnector/function.json`
 
-The deployment outputs `functionAppName`, `deploymentContainerName`, and
-`deploymentContainerUrl` so automation can discover the target used by that
-package deployment.
+Deploy the package using `az functionapp deployment source config-zip` or the
+Kudu zip deploy API. The deployment output `functionAppName` identifies the
+target Function App.
 Build the `sonde-azure-handler` executable for the Function App's Linux runtime, not
 for your local host OS. If you package from Windows or macOS, cross-compile or build
 the binary in a Linux environment before uploading it.
 
-Until that package is uploaded and Azure loads at least one function, the
+Until that package is deployed and Azure loads at least one function, the
 Function App is provisioned but not yet runnable.
 
 ## Bootstrap handoff

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -66,7 +66,6 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
     serverFarmId: hostingPlan.id
     siteConfig: {
       minTlsVersion: '1.2'
-      linuxFxVersion: ''
       appSettings: [
         {
           name: 'AzureWebJobsStorage'

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -12,9 +12,6 @@ param functionAppName string
 @description('Function hosting plan name.')
 param functionPlanName string
 
-@description('Blob container URL used by the Function placeholder deployment configuration.')
-param deploymentContainerUrl string
-
 @description('Storage Account name used by the Function placeholder deployment configuration.')
 param storageAccountName string
 
@@ -48,8 +45,8 @@ resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   kind: 'functionapp'
   tags: tags
   sku: {
-    name: 'FC1'
-    tier: 'FlexConsumption'
+    name: 'Y1'
+    tier: 'Dynamic'
   }
   properties: {
     reserved: true
@@ -69,42 +66,54 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
     serverFarmId: hostingPlan.id
     siteConfig: {
       minTlsVersion: '1.2'
-    }
-    functionAppConfig: {
-      deployment: {
-        storage: {
-          type: 'blobContainer'
-          value: deploymentContainerUrl
-          authentication: {
-            type: 'StorageAccountConnectionString'
-            storageAccountConnectionStringName: 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
-          }
+      linuxFxVersion: ''
+      appSettings: [
+        {
+          name: 'AzureWebJobsStorage'
+          value: storageConnectionString
         }
-      }
-      runtime: {
-        name: 'custom'
-        version: '1.0'
-      }
-      scaleAndConcurrency: {
-        maximumInstanceCount: 100
-        instanceMemoryMB: 512
-      }
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'custom'
+        }
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'WEBSITE_RUN_FROM_PACKAGE'
+          value: '1'
+        }
+        {
+          name: 'AzureWebJobsServiceBus__fullyQualifiedNamespace'
+          value: serviceBusFullyQualifiedNamespace
+        }
+        {
+          name: 'SONDE_AZURE_HANDLER_SERVICE_BUS_NAMESPACE'
+          value: serviceBusFullyQualifiedNamespace
+        }
+        {
+          name: 'SONDE_AZURE_HANDLER_UPSTREAM_QUEUE'
+          value: upstreamQueueName
+        }
+        {
+          name: 'SONDE_AZURE_HANDLER_DOWNSTREAM_QUEUE'
+          value: downstreamQueueName
+        }
+        {
+          name: 'SONDE_AZURE_HANDLER_STORAGE_ACCOUNT'
+          value: storageAccountName
+        }
+        {
+          name: 'SONDE_AZURE_HANDLER_NODE_STATE_TABLE'
+          value: nodeStateTableName
+        }
+        {
+          name: 'SONDE_AZURE_HANDLER_PROGRAM_ROUTE_TABLE'
+          value: programRouteTableName
+        }
+      ]
     }
-  }
-}
-
-resource appSettings 'Microsoft.Web/sites/config@2024-04-01' = {
-  parent: functionApp
-  name: 'appsettings'
-  properties: {
-    DEPLOYMENT_STORAGE_CONNECTION_STRING: storageConnectionString
-    AzureWebJobsServiceBus__fullyQualifiedNamespace: serviceBusFullyQualifiedNamespace
-    SONDE_AZURE_HANDLER_SERVICE_BUS_NAMESPACE: serviceBusFullyQualifiedNamespace
-    SONDE_AZURE_HANDLER_UPSTREAM_QUEUE: upstreamQueueName
-    SONDE_AZURE_HANDLER_DOWNSTREAM_QUEUE: downstreamQueueName
-    SONDE_AZURE_HANDLER_STORAGE_ACCOUNT: storageAccountName
-    SONDE_AZURE_HANDLER_NODE_STATE_TABLE: nodeStateTableName
-    SONDE_AZURE_HANDLER_PROGRAM_ROUTE_TABLE: programRouteTableName
   }
 }
 

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -73,7 +73,6 @@ module functionPlaceholder './function-placeholder.bicep' = {
     location: location
     functionAppName: functionAppName
     functionPlanName: functionPlanName
-    deploymentContainerUrl: functionDeploymentContainerUrl
     storageAccountName: storage.outputs.storageAccountName
     serviceBusFullyQualifiedNamespace: serviceBus.outputs.namespaceFqdn
     upstreamQueueName: upstreamQueueName

--- a/docs/azure-provisioning-design.md
+++ b/docs/azure-provisioning-design.md
@@ -120,8 +120,18 @@ outputs.
 
 The function-placeholder module provisions the hosting resources used by the
 Azure handler Function App. This module creates the Function App shell, the
-consumption hosting plan, storage linkage, and baseline app settings required
-for the repository-owned bootstrap path to deploy the runnable handler package.
+Classic Consumption hosting plan (`Y1` / `Dynamic` SKU), storage linkage, and
+baseline app settings required for the repository-owned bootstrap path to
+deploy the runnable handler package.
+
+The Classic Consumption plan is chosen over the Flex Consumption plan so that
+built-in filesystem log streaming is available through the Azure Portal
+without requiring a separate Application Insights resource. The Function App
+uses `WEBSITE_RUN_FROM_PACKAGE=1` so that the Azure Functions host runs the
+handler package deployed via the zip deploy API. The `AzureWebJobsStorage`
+connection string provides the runtime storage backend, and
+`FUNCTIONS_WORKER_RUNTIME=custom` tells the Azure Functions host to use the
+Sonde custom handler binary.
 
 The runnable package itself is not compiled during bootstrap. Instead, the
 bootstrap image carries a prebuilt Linux package for the matching Sonde

--- a/docs/azure-provisioning-requirements.md
+++ b/docs/azure-provisioning-requirements.md
@@ -140,15 +140,17 @@ the tables' logical schema.
 The provisioning workflow MUST create the Azure Function hosting resources used
 by the Sonde Azure handler and the deployment target that the repository-owned
 bootstrap path populates with the runnable handler package. The Function App
-uses a consumption plan unless a later specification explicitly changes that
-hosting model.
+uses the Classic Consumption plan (`Y1` / `Dynamic` SKU) so that built-in
+filesystem log streaming is available through the Azure Portal without
+requiring an Application Insights resource.
 
 **Acceptance criteria:**
 
 1. The workflow provisions the Azure resources needed to host the Azure handler Function App.
 2. The workflow provisions or documents the deployment target consumed by the repository-owned handler package deployment step.
-3. The Function App resources use a consumption-plan hosting model.
+3. The Function App resources use the Classic Consumption plan (`Y1` / `Dynamic` SKU).
 4. The deployment outputs or documentation identify the Function App resources used by the Azure handler path.
+5. The Function App does not require an Application Insights resource for basic log access.
 
 ---
 

--- a/docs/azure-provisioning-validation.md
+++ b/docs/azure-provisioning-validation.md
@@ -77,8 +77,10 @@
 1. Run the deployment.
 2. Inspect the resulting Function hosting resources.
 3. Assert: the Azure handler Function App resources exist.
-4. Assert: the Function App uses a consumption hosting plan.
-5. Assert: the deployment target used by the repository-owned package deployment step is present or explicitly surfaced by deployment outputs/documentation.
+4. Assert: the Function App uses the Classic Consumption hosting plan (`Y1` / `Dynamic` SKU).
+5. Assert: the Function App is configured with `WEBSITE_RUN_FROM_PACKAGE` for package deployment.
+6. Assert: the Function App does not require an Application Insights resource for basic log access.
+7. Assert: the deployment target used by the repository-owned package deployment step is present or explicitly surfaced by deployment outputs/documentation.
 
 ---
 


### PR DESCRIPTION
## Summary

Switch the Azure handler Function App from the Flex Consumption plan (\FC1\/\FlexConsumption\) to the Classic Consumption plan (\Y1\/\Dynamic\) so that built-in filesystem log streaming is available through the Azure Portal without requiring an Application Insights resource.

## Motivation

The Flex Consumption plan routes function logs through Application Insights. Without an App Insights resource provisioned (which this stack intentionally omits), there is no log visibility. Classic Consumption supports built-in filesystem-based log streaming via the Azure Portal and Kudu site without any additional resources.

## Key changes

| Area | Before | After |
|------|--------|-------|
| Hosting plan SKU | \FC1\ / \FlexConsumption\ | \Y1\ / \Dynamic\ |
| Deployment model | Flex-specific \unctionAppConfig\ block | \siteConfig.appSettings\ with \WEBSITE_RUN_FROM_PACKAGE=1\ |
| App settings | Separate \Microsoft.Web/sites/config\ child resource | Inlined into \siteConfig.appSettings\ (avoids race conditions) |
| Runtime config | \unctionAppConfig.runtime.name=custom\ | \FUNCTIONS_WORKER_RUNTIME=custom\ + \FUNCTIONS_EXTENSION_VERSION=~4\ |
| Scale config | \maximumInstanceCount: 100\, \instanceMemoryMB: 512\ | Classic Consumption auto-scaling (up to 200 instances) |
| Unused param | \deploymentContainerUrl\ passed to function-placeholder | Removed (blob container still provisioned for bootstrap handoff) |

## Artifacts updated

- **Requirements:** \AZP-0104\ — specifies Classic Consumption \Y1\/\Dynamic\, no App Insights dependency
- **Design:** §3.5 — Classic Consumption rationale, \WEBSITE_RUN_FROM_PACKAGE=1\, zip deploy model
- **Validation:** \T-AZP-0104\ — verify \Y1\/\Dynamic\ SKU, \WEBSITE_RUN_FROM_PACKAGE\, no App Insights requirement
- **Bicep:** \unction-placeholder.bicep\, \stack.bicep\ — SKU change + deployment model restructure
- **README:** Updated plan name and deployment instructions

## What is NOT changed

- Storage, Service Bus, RBAC, companion identity — all untouched
- Bootstrap handoff outputs (\deploymentContainerUrl\ still surfaced from \stack.bicep\)
- CI workflow unchanged
