### PR TITLE
fix: build Azure handler in Alpine container for static musl linkage

### DIFF
--- a/.github/docker/Dockerfile.azure-handler-builder
+++ b/.github/docker/Dockerfile.azure-handler-builder
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Builder image for the Azure handler function package.  Produces a
+# statically-linked musl binary inside an Alpine container so the
+# resulting artifact runs on any Linux host regardless of glibc version.
+#
+# Usage (via build-function-package.sh):
+#   docker build \
+#       -f .github/docker/Dockerfile.azure-handler-builder \
+#       -o type=local,dest=.artifacts/azure-handler-function .
+
+# ── Stage 1: build ──────────────────────────────────────────────────────────
+# rust:alpine — same base image used by the companion builder.
+FROM rust:alpine@sha256:ef7b340d4201444fa2757dfddfd4c03be9d2bde468de7b7a68b0e9fabb794334 AS builder
+
+RUN apk add --no-cache build-base musl-dev openssl-dev openssl-libs-static protobuf pkgconf zip
+
+WORKDIR /sonde
+COPY . .
+RUN cargo build --locked --release -p sonde-azure-handler
+
+RUN mkdir -p /out/UpstreamConnector /pkg \
+    && cp target/release/sonde-azure-handler /out/sonde-azure-handler \
+    && chmod 0755 /out/sonde-azure-handler \
+    && cp crates/sonde-azure-handler/function-app/host.json /out/host.json \
+    && cp crates/sonde-azure-handler/function-app/UpstreamConnector/function.json \
+       /out/UpstreamConnector/function.json \
+    && cd /out && zip -q -r /pkg/sonde-azure-handler-function.zip .
+
+# ── Stage 2: export ─────────────────────────────────────────────────────────
+# Scratch stage so `docker build -o` exports only the zip artifact.
+FROM scratch
+COPY --from=builder /pkg/sonde-azure-handler-function.zip /sonde-azure-handler-function.zip

--- a/.github/docker/Dockerfile.azure-handler-builder.dockerignore
+++ b/.github/docker/Dockerfile.azure-handler-builder.dockerignore
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Exclude large/unnecessary directories from the Azure handler builder
+# Docker build context.
+target/
+hw/
+docs/
+sensor-data/
+logs/
+rfcxml/
+prevail-rust/tests/upstream/external/
+.git/
+.artifacts/
+firmware/
+firmware-modem/
+bin/
+apk/
+apk-nightly/
+installer/windows/CustomActions/bin/
+installer/windows/CustomActions/obj/
+*.etl
+*.xlsx
+*.wprp

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -25,13 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-
-      - name: Install protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
 
       - name: Build bundled Azure handler package
         run: sh deploy/azure-bootstrap/build-function-package.sh

--- a/deploy/azure-bootstrap/build-function-package.sh
+++ b/deploy/azure-bootstrap/build-function-package.sh
@@ -4,39 +4,21 @@ set -eu
 script_dir="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
 repo_root="$(CDPATH= cd -- "$script_dir/../.." && pwd)"
 artifact_dir="${1:-$repo_root/.artifacts/azure-handler-function}"
-target_dir="${CARGO_TARGET_DIR:-$repo_root/target}"
 package_path="$artifact_dir/sonde-azure-handler-function.zip"
-staging_dir="$(mktemp -d "${TMPDIR:-/tmp}/sonde-azure-handler-package.XXXXXX")"
-build_target="${CARGO_BUILD_TARGET:-}"
 
-cleanup() {
-    rm -rf "$staging_dir"
-}
-trap cleanup EXIT INT TERM
+mkdir -p "$artifact_dir"
 
-mkdir -p "$artifact_dir" "$staging_dir/UpstreamConnector"
+# Build the handler binary inside an Alpine container to produce a
+# statically-linked musl binary that runs on any Linux host (including
+# the Azure Functions Consumption runtime, which ships an older glibc).
+docker build \
+    -f "$repo_root/.github/docker/Dockerfile.azure-handler-builder" \
+    -o "type=local,dest=$artifact_dir" \
+    "$repo_root"
 
-cargo build --locked --release -p sonde-azure-handler --manifest-path "$repo_root/Cargo.toml"
-
-binary_path="$target_dir/release/sonde-azure-handler"
-if [ -n "$build_target" ]; then
-    binary_path="$target_dir/$build_target/release/sonde-azure-handler"
-fi
-if [ ! -f "$binary_path" ]; then
-    echo "built handler binary not found: $binary_path" >&2
+if [ ! -f "$package_path" ]; then
+    echo "built handler package not found: $package_path" >&2
     exit 1
 fi
-
-cp "$repo_root/crates/sonde-azure-handler/function-app/host.json" "$staging_dir/host.json"
-cp "$repo_root/crates/sonde-azure-handler/function-app/UpstreamConnector/function.json" \
-    "$staging_dir/UpstreamConnector/function.json"
-cp "$binary_path" "$staging_dir/sonde-azure-handler"
-chmod 0755 "$staging_dir/sonde-azure-handler"
-
-rm -f "$package_path"
-(
-    cd "$staging_dir"
-    zip -q -r "$package_path" .
-)
 
 printf '%s\n' "$package_path"

--- a/deploy/azure-bootstrap/build-function-package.sh
+++ b/deploy/azure-bootstrap/build-function-package.sh
@@ -11,7 +11,12 @@ mkdir -p "$artifact_dir"
 # Build the handler binary inside an Alpine container to produce a
 # statically-linked musl binary that runs on any Linux host (including
 # the Azure Functions Consumption runtime, which ships an older glibc).
-docker build \
+# Use `docker buildx build` explicitly so BuildKit output export works
+# regardless of the host Docker configuration.  Pin --platform to
+# linux/amd64 so the binary matches the Azure Functions x86_64 runtime
+# even when the script is run on ARM hosts.
+docker buildx build \
+    --platform linux/amd64 \
     -f "$repo_root/.github/docker/Dockerfile.azure-handler-builder" \
     -o "type=local,dest=$artifact_dir" \
     "$repo_root"


### PR DESCRIPTION
## Problem

The Azure handler binary was built on `ubuntu-latest` (glibc 2.39), but the Azure Functions Linux Consumption runtime ships an older glibc. This caused the handler process to crash immediately on startup:

\\\
/home/site/wwwroot/sonde-azure-handler: /lib/x86_64-linux-gnu/libc.so.6:
version `GLIBC_2.39` not found (required by /home/site/wwwroot/sonde-azure-handler)
\\\

## Fix

Build the handler inside an Alpine Docker container with `openssl-libs-static`, matching the existing `sonde-azure-companion` pattern. The resulting binary is statically linked against musl and has no host glibc dependency.

## Changes

- **New** `Dockerfile.azure-handler-builder` — multi-stage Alpine build (`rust:alpine` + `openssl-libs-static`), exports only the zip artifact via a scratch stage
- **New** `Dockerfile.azure-handler-builder.dockerignore` — excludes `target/`, docs, etc. from build context
- **Simplified** `build-function-package.sh` — delegates to `docker build -o` instead of building locally
- **Updated** `azure-bootstrap-container.yml` — replaced Rust toolchain / protoc install steps with Docker Buildx setup
