### PR TITLE
fix(azure-handler): use axum 0.7+ wildcard route syntax

### DIFF
--- a/crates/sonde-azure-handler/src/main.rs
+++ b/crates/sonde-azure-handler/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let app = Router::new()
         .route("/", post(invoke))
-        .route("/*path", post(invoke))
+        .route("/{*path}", post(invoke))
         .with_state(state);
     let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;


### PR DESCRIPTION
## Problem

The custom handler binary panics on startup in Azure Functions with:

\\\
thread 'main' panicked at crates/sonde-azure-handler/src/main.rs:62:10:
Path segments must not start with \*\. For wildcard capture, use \{*wildcard}\.
\\\

This was observed via App Insights after deploying \sonde-decoder-our7bn66\. The Functions host repeatedly restarted the worker process (\Exceeded http worker restart retry count. Shutting down Functions Host\), preventing queue messages from being processed.

## Root Cause

axum 0.7+ changed wildcard route syntax from \/*path\ to \/{*path}\. The route definition on line 62 of \main.rs\ used the old syntax.

## Fix

Single-character change: \/*path\ → \/{*path}\.

## Testing

All 31 existing tests pass (\cargo test -p sonde-azure-handler\).