### PR TITLE
feat(bicep): add App Insights observability + fix queue messageEncoding

### DIFF
--- a/crates/sonde-azure-handler/function-app/host.json
+++ b/crates/sonde-azure-handler/function-app/host.json
@@ -8,7 +8,8 @@
     "queues": {
       "maxPollingInterval": "00:00:02",
       "batchSize": 1,
-      "maxDequeueCount": 5
+      "maxDequeueCount": 5,
+      "messageEncoding": "base64"
     }
   },
   "customHandler": {

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -36,6 +36,9 @@ param programRouteTableName string
 @description('Tags applied to provisioned resources.')
 param tags object
 
+@description('Application Insights connection string. When non-empty, enables telemetry and backtraces.')
+param appInsightsConnectionString string = ''
+
 resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   name: storageAccountName
 }
@@ -56,20 +59,7 @@ resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   }
 }
 
-resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
-  name: functionAppName
-  location: location
-  kind: 'functionapp,linux'
-  tags: tags
-  identity: {
-    type: 'SystemAssigned'
-  }
-  properties: {
-    httpsOnly: true
-    serverFarmId: hostingPlan.id
-    siteConfig: {
-      minTlsVersion: '1.2'
-      appSettings: [
+var baseAppSettings = [
         {
           name: 'AzureWebJobsStorage'
           value: storageConnectionString
@@ -115,6 +105,32 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           value: programRouteTableName
         }
       ]
+
+var observabilityAppSettings = empty(appInsightsConnectionString) ? [] : [
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsightsConnectionString
+        }
+        {
+          name: 'RUST_BACKTRACE'
+          value: '1'
+        }
+      ]
+
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp,linux'
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    httpsOnly: true
+    serverFarmId: hostingPlan.id
+    siteConfig: {
+      minTlsVersion: '1.2'
+      appSettings: concat(baseAppSettings, observabilityAppSettings)
     }
   }
 }

--- a/deploy/bicep/modules/monitoring.bicep
+++ b/deploy/bicep/modules/monitoring.bicep
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+targetScope = 'resourceGroup'
+
+@description('Azure region for monitoring resources.')
+param location string
+
+@description('Log Analytics workspace name.')
+param workspaceName string
+
+@description('Application Insights component name.')
+param appInsightsName string
+
+@description('Tags applied to provisioned resources.')
+param tags object
+
+// PerGB2018 is the only generally-available SKU and the cheapest option.
+// Daily cap + short retention keep costs near-zero for low-volume workloads.
+resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: workspaceName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+    workspaceCapping: {
+      dailyQuotaGb: 1
+    }
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  tags: tags
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: workspace.id
+    RetentionInDays: 30
+  }
+}
+
+output connectionString string = appInsights.properties.ConnectionString
+output instrumentationKey string = appInsights.properties.InstrumentationKey
+output workspaceId string = workspace.id

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -36,6 +36,9 @@ param functionPlanName string
 @description('Object ID of the Azure companion runtime service principal.')
 param companionServicePrincipalObjectId string
 
+var monitoringWorkspaceName = take('${functionAppName}-logs', 63)
+var monitoringAppInsightsName = take('${functionAppName}-insights', 260)
+
 var storageQueueDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
 var companionQueueContributorAssignmentName = guid('companion-queue-contributor', companionServicePrincipalObjectId, storageQueueDataContributorRoleId, storageAccountName)
 var deploymentStorageContainerName = 'app-package-${take(uniqueString(resourceGroup().id, functionAppName, 'deployment-package'), 20)}'
@@ -55,6 +58,16 @@ module storage './storage.bicep' = {
   }
 }
 
+module monitoring './monitoring.bicep' = {
+  name: 'monitoring'
+  params: {
+    location: location
+    workspaceName: monitoringWorkspaceName
+    appInsightsName: monitoringAppInsightsName
+    tags: tags
+  }
+}
+
 module functionPlaceholder './function-placeholder.bicep' = {
   name: 'functionPlaceholder'
   params: {
@@ -68,6 +81,7 @@ module functionPlaceholder './function-placeholder.bicep' = {
     actualStateTableName: storage.outputs.actualStateTableName
     desiredStateTableName: storage.outputs.desiredStateTableName
     programRouteTableName: storage.outputs.programRouteTableName
+    appInsightsConnectionString: monitoring.outputs.connectionString
     tags: tags
   }
 }


### PR DESCRIPTION
## Changes

### 1. Add Application Insights to Bicep deployment

Deploys a Log Analytics workspace and Application Insights component, wired into the function app via `APPLICATIONINSIGHTS_CONNECTION_STRING`. Also sets `RUST_BACKTRACE=1` for panic diagnostics.

**Cost controls:**
- `PerGB2018` SKU (cheapest pay-as-you-go)
- 30-day retention
- 1 GB/day ingestion cap

The monitoring settings are conditional - when `appInsightsConnectionString` is empty, the function app deploys without them (matching previous behavior).

**Files:** `monitoring.bicep` (new), `function-placeholder.bicep`, `stack.bicep`

### 2. Fix queue `messageEncoding` for binary CBOR messages

The Functions queue extension defaults to `messageEncoding: none`, which causes it to interpret raw CBOR bytes (after base64 transport decoding) as UTF-8 text, failing with:

    Queue message's body cannot be converted to string because it contains non-UTF8 bytes

This caused every queue message to fail all 5 dequeue attempts and land in `connector-upstream-poison`, with zero rows written to the `actualstate` table.

**Fix:** Set `messageEncoding: base64` in `host.json`. This tells the runtime to re-encode raw bytes as base64 in the JSON envelope sent to the custom handler, where `extract_trigger_payload` already handles base64 decoding.

**File:** `host.json`

## Testing

All 31 `sonde-azure-handler` tests pass. Bicep templates validate with `az bicep build`.
