### PR TITLE
fix(azure-handler): fix queue message processing

### DIFF
--- a/crates/sonde-azure-handler/function-app/host.json
+++ b/crates/sonde-azure-handler/function-app/host.json
@@ -9,13 +9,13 @@
       "maxPollingInterval": "00:00:02",
       "batchSize": 1,
       "maxDequeueCount": 5,
-      "messageEncoding": "base64"
+      "messageEncoding": "none"
     }
   },
   "customHandler": {
     "description": {
       "defaultExecutablePath": "sonde-azure-handler"
     },
-    "enableForwardingHttpRequest": true
+    "enableForwardingHttpRequest": false
   }
 }

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -845,6 +845,7 @@ fn optional_bytes_field(
     field: &str,
 ) -> Result<Option<Vec<u8>>, HandlerError> {
     match map_get(map, key) {
+        Some(Value::Bytes(bytes)) if bytes.is_empty() => Ok(None),
         Some(Value::Bytes(bytes)) => Ok(Some(bytes.clone())),
         Some(Value::Null) | None => Ok(None),
         Some(_) => Err(HandlerError::Decode(format!(


### PR DESCRIPTION
## Problem

The Azure handler function consumes queue messages but fails to write to the `actualstate` table. Three issues were identified through live debugging with App Insights:

### 1. `messageEncoding` must be `none`

The companion base64-encodes CBOR into `<MessageText>`, so the stored queue content is valid UTF-8 base64 text. With `messageEncoding: base64` the runtime base64-decodes it back to raw CBOR, which then fails UTF-8 serialization into the JSON envelope for the custom handler.

### 2. `enableForwardingHttpRequest` must be `false`

With forwarding enabled, the runtime sends the raw queue message as the HTTP body instead of wrapping it in the standard `{"Data":{"message":"..."}}` JSON envelope. `extract_trigger_payload` expects JSON, so it fails immediately on the raw base64 string.

### 3. Empty byte strings must be treated as `None`

Nodes send an empty bstr (`b''`) for `current_program_hash` when no program is loaded. `validate_program_hash_length` requires exactly 32 bytes, rejecting the empty value. The fix treats empty byte strings as `None` (no hash present).

## Testing

All 31 `sonde-azure-handler` tests pass. Verified live on `sonde-decoder-our7bn66` with hot-patched `host.json`.
