### PR TITLE
fix(azure-handler): log handler errors to stderr

### DIFF
--- a/crates/sonde-azure-handler/src/main.rs
+++ b/crates/sonde-azure-handler/src/main.rs
@@ -69,11 +69,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn invoke(State(state): State<AppState>, body: Bytes) -> Response {
     match handle_invocation(&state, &body).await {
         Ok(()) => (StatusCode::OK, Json(json!({}))).into_response(),
-        Err(err) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": err.to_string() })),
-        )
-            .into_response(),
+        Err(err) => {
+            let msg = err.to_string();
+            tracing::error!(error = msg, "handler invocation failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": msg })),
+            )
+                .into_response()
+        }
     }
 }
 


### PR DESCRIPTION
The custom handler returns errors in the HTTP 500 response body, but the Functions runtime does not log response bodies. This makes debugging impossible without local reproduction.

Adding `eprintln!` on the error path surfaces the actual error message in App Insights traces via the runtime's stderr capture.
