### PR TITLE
fix(azure-handler): use string dataType for queue trigger

### DIFF
--- a/crates/sonde-azure-handler/function-app/UpstreamConnector/function.json
+++ b/crates/sonde-azure-handler/function-app/UpstreamConnector/function.json
@@ -4,7 +4,7 @@
       "type": "queueTrigger",
       "direction": "in",
       "name": "message",
-      "dataType": "binary",
+      "dataType": "string",
       "queueName": "%SONDE_AZURE_HANDLER_UPSTREAM_QUEUE%",
       "connection": "AzureWebJobsStorage"
     }

--- a/crates/sonde-azure-handler/src/main.rs
+++ b/crates/sonde-azure-handler/src/main.rs
@@ -69,11 +69,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn invoke(State(state): State<AppState>, body: Bytes) -> Response {
     match handle_invocation(&state, &body).await {
         Ok(()) => (StatusCode::OK, Json(json!({}))).into_response(),
-        Err(err) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": err.to_string() })),
-        )
-            .into_response(),
+        Err(err) => {
+            let msg = err.to_string();
+            tracing::error!(error = msg, "handler invocation failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": msg })),
+            )
+                .into_response()
+        }
     }
 }
 


### PR DESCRIPTION
With \\dataType: binary\\ in function.json, the Functions runtime delivers the queue message as a JSON byte array of ASCII codes. The handler reassembles the bytes but gets the base64 **text**, not the CBOR payload, causing:

    connector payload must be a CBOR map

Changing to \\dataType: string\\ delivers the message as a JSON string, which \\xtract_json_payload\\ correctly base64-decodes into raw CBOR.
