### PR TITLE
feat(bootstrap): deploy SPA and configure Entra app during bootstrap (AZC-0410)

### DIFF
--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -13,9 +13,12 @@
 
 FROM mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7
 
+RUN apk add --no-cache jq zip
+
 COPY deploy/azure-bootstrap/bootstrap.sh /opt/sonde/deploy/azure-bootstrap/bootstrap.sh
 COPY deploy/bicep/ /opt/sonde/deploy/bicep/
 COPY .artifacts/azure-handler-function/sonde-azure-handler-function.zip /opt/sonde/deploy/azure-handler/sonde-azure-handler-function.zip
+COPY deploy/web-ui/index.html deploy/web-ui/app.js deploy/web-ui/style.css deploy/web-ui/staticwebapp.config.json /opt/sonde/deploy/web-ui/
 
 RUN chmod +x /opt/sonde/deploy/azure-bootstrap/bootstrap.sh \
     && mkdir -p /cert /opt/sonde/deploy/azure-handler

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -546,8 +546,7 @@ exit 64
     let config_json = fs::read_to_string(web_ui_dir.join("config.json")).unwrap();
     assert!(config_json.contains(r#""msalClientId": "client-456""#));
     assert!(
-        config_json
-            .contains(r#""msalAuthority": "https://login.microsoftonline.com/tenant-123""#)
+        config_json.contains(r#""msalAuthority": "https://login.microsoftonline.com/tenant-123""#)
     );
     assert!(config_json.contains(r#""storageAccount": "stsondetest""#));
     assert!(config_json.contains(r#""functionAppName": "func-sonde""#));

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -492,7 +492,7 @@ exit 64
     write_executable(&bin_dir.join("curl"), "#!/bin/sh\nexit 0\n");
 
     // Create a temporary web-ui directory with the expected SPA files.
-    let web_ui_dir = tmp.path().join("web-ui");
+    let web_ui_dir = temp.path().join("web-ui");
     fs::create_dir_all(&web_ui_dir).unwrap();
     for name in &[
         "index.html",

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -478,7 +478,9 @@ exit 64
         .ok()
         .and_then(|o| {
             if o.status.success() {
-                String::from_utf8(o.stdout).ok().map(|s| s.trim().to_string())
+                String::from_utf8(o.stdout)
+                    .ok()
+                    .map(|s| s.trim().to_string())
             } else {
                 None
             }
@@ -543,7 +545,10 @@ exit 64
     // Verify config.json was generated with correct values
     let config_json = fs::read_to_string(web_ui_dir.join("config.json")).unwrap();
     assert!(config_json.contains(r#""msalClientId": "client-456""#));
-    assert!(config_json.contains(r#""msalAuthority": "https://login.microsoftonline.com/tenant-123""#));
+    assert!(
+        config_json
+            .contains(r#""msalAuthority": "https://login.microsoftonline.com/tenant-123""#)
+    );
     assert!(config_json.contains(r#""storageAccount": "stsondetest""#));
     assert!(config_json.contains(r#""functionAppName": "func-sonde""#));
 

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -471,24 +471,28 @@ exit 64
     );
     write_executable(&bin_dir.join("python3"), "#!/bin/sh\nexit 91\n");
     write_executable(&bin_dir.join("awk"), "#!/bin/sh\nexit 92\n");
-    // Find the real jq binary on the host system for pass-through
-    let jq_path = std::process::Command::new("which")
-        .arg("jq")
-        .output()
-        .ok()
-        .and_then(|o| {
-            if o.status.success() {
-                String::from_utf8(o.stdout)
-                    .ok()
-                    .map(|s| s.trim().to_string())
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| "/usr/bin/jq".to_string());
+    // Hermetic jq stub that handles the two invocations used by bootstrap.sh:
+    // 1. jq -e --arg uri <URI> 'index($uri) != null'  → exact membership test
+    // 2. jq -r --arg uri <URI> '(. // []) + [$uri] | join(" ")'  → merge URIs
     write_executable(
         &bin_dir.join("jq"),
-        &format!("#!/bin/sh\nexec {} \"$@\"\n", jq_path),
+        r#"#!/bin/sh
+input="$(cat)"
+for arg in "$@"; do
+  case "$arg" in
+    *index*) # Membership test: input is [] so URI is never present → exit 1
+      exit 1 ;;
+    *join*) # Merge: input is [] so result is just the URI
+      uri=""
+      while [ "$#" -gt 0 ]; do
+        case "$1" in --arg) shift; shift; uri="$1"; shift ;; *) shift ;; esac
+      done
+      printf '%s\n' "$uri"
+      exit 0 ;;
+  esac
+done
+exit 0
+"#,
     );
     write_executable(&bin_dir.join("zip"), "#!/bin/sh\n# Stub: create the output zip file (arg after -r)\nfor arg in \"$@\"; do case \"$arg\" in -*) ;; *) touch \"$arg\" 2>/dev/null; break ;; esac; done\nexit 0\n");
     write_executable(&bin_dir.join("curl"), "#!/bin/sh\nexit 0\n");

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -415,8 +415,46 @@ if [ "$#" -ge 4 ] && [ "$1" = "deployment" ] && [ "$2" = "sub" ] && [ "$3" = "sh
         ;;
     esac
   done
-  [ "$query" = "[[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value]]" ] || exit 67
-  printf 'rg-sonde\tfunc-sonde\tdeploypkg\thttps://example.blob.core.windows.net/deploypkg\n'
+  [ "$query" = "[[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value, properties.outputs.staticWebAppName.value, properties.outputs.staticWebAppHostname.value, properties.outputs.companionClientId.value, properties.outputs.storageAccountName.value, properties.outputs.companionTenantId.value]]" ] || exit 67
+  printf 'rg-sonde\tfunc-sonde\tdeploypkg\thttps://example.blob.core.windows.net/deploypkg\tsonde-web-test\tsonde-web-test.azurestaticapps.net\tclient-456\tstsondetest\ttenant-123\n'
+  exit 0
+fi
+if [ "$#" -ge 3 ] && [ "$1" = "staticwebapp" ] && [ "$2" = "secrets" ] && [ "$3" = "list" ]; then
+  printf 'fake-deployment-token\n'
+  exit 0
+fi
+if [ "$#" -ge 3 ] && [ "$1" = "staticwebapp" ] && [ "$2" = "deploy" ]; then
+  # Simulate az staticwebapp deploy not being available
+  exit 1
+fi
+if [ "$#" -ge 3 ] && [ "$1" = "staticwebapp" ] && [ "$2" = "show" ]; then
+  printf 'westus2\n'
+  exit 0
+fi
+if [ "$#" -ge 4 ] && [ "$1" = "ad" ] && [ "$2" = "app" ] && [ "$3" = "show" ]; then
+  # Return object ID for --query 'id', or empty redirect URIs for spa.redirectUris
+  query=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --query) query="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [ "$query" = "id" ]; then
+    printf 'obj-id-789\n'
+  elif [ "$query" = "spa.redirectUris" ]; then
+    printf '[]\n'
+  fi
+  exit 0
+fi
+if [ "$#" -ge 4 ] && [ "$1" = "ad" ] && [ "$2" = "app" ] && [ "$3" = "update" ]; then
+  exit 0
+fi
+if [ "$#" -ge 4 ] && [ "$1" = "ad" ] && [ "$2" = "app" ] && [ "$3" = "permission" ]; then
+  if [ "$4" = "list" ]; then
+    printf '\n'
+    exit 0
+  fi
   exit 0
 fi
 if [ "$#" -ge 5 ] && [ "$1" = "functionapp" ] && [ "$2" = "deployment" ] && [ "$3" = "source" ] && [ "$4" = "config-zip" ]; then
@@ -433,6 +471,37 @@ exit 64
     );
     write_executable(&bin_dir.join("python3"), "#!/bin/sh\nexit 91\n");
     write_executable(&bin_dir.join("awk"), "#!/bin/sh\nexit 92\n");
+    // Find the real jq binary on the host system for pass-through
+    let jq_path = std::process::Command::new("which")
+        .arg("jq")
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok().map(|s| s.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "/usr/bin/jq".to_string());
+    write_executable(
+        &bin_dir.join("jq"),
+        &format!("#!/bin/sh\nexec {} \"$@\"\n", jq_path),
+    );
+    write_executable(&bin_dir.join("zip"), "#!/bin/sh\n# Stub: create the output zip file (arg after -r)\nfor arg in \"$@\"; do case \"$arg\" in -*) ;; *) touch \"$arg\" 2>/dev/null; break ;; esac; done\nexit 0\n");
+    write_executable(&bin_dir.join("curl"), "#!/bin/sh\nexit 0\n");
+
+    // Create a temporary web-ui directory with the expected SPA files.
+    let web_ui_dir = tmp.path().join("web-ui");
+    fs::create_dir_all(&web_ui_dir).unwrap();
+    for name in &[
+        "index.html",
+        "app.js",
+        "style.css",
+        "staticwebapp.config.json",
+    ] {
+        fs::write(web_ui_dir.join(name), "<!-- stub -->").unwrap();
+    }
 
     let mut cmd = Command::new("sh");
     cmd.arg(azure_bootstrap_script_path());
@@ -450,6 +519,7 @@ exit 64
     cmd.env("SONDE_AZURE_FUNCTION_PACKAGE_PATH", &function_package_path);
     cmd.env("SONDE_AZURE_FUNCTION_ACTIVATION_TIMEOUT_SECS", "10");
     cmd.env("SONDE_AZURE_FUNCTION_DEPLOY_TIMEOUT_SECS", "10");
+    cmd.env("SONDE_AZURE_WEB_UI_DIR", web_ui_dir.to_str().unwrap());
 
     let output = cmd.output().unwrap();
     assert!(
@@ -465,12 +535,26 @@ exit 64
     assert!(stderr.contains("__SONDE_AZURE_DEPLOYMENT_START__"));
     assert!(stderr.contains("Deploying bundled Azure handler package to Function App func-sonde"));
     assert!(stderr.contains("Azure Function App reports 1 loaded function(s)"));
+    assert!(stderr.contains("Deploying Web UI to Static Web App sonde-web-test"));
+    assert!(stderr.contains("Generated config.json for SPA"));
+    assert!(stderr.contains("Configuring Entra app registration for Web UI"));
+    assert!(stderr.contains("Web UI deployment complete"));
+
+    // Verify config.json was generated with correct values
+    let config_json = fs::read_to_string(web_ui_dir.join("config.json")).unwrap();
+    assert!(config_json.contains(r#""msalClientId": "client-456""#));
+    assert!(config_json.contains(r#""msalAuthority": "https://login.microsoftonline.com/tenant-123""#));
+    assert!(config_json.contains(r#""storageAccount": "stsondetest""#));
+    assert!(config_json.contains(r#""functionAppName": "func-sonde""#));
 
     let az_calls = fs::read_to_string(az_log).unwrap();
     assert!(az_calls.contains("deployment sub create"));
     assert_eq!(az_calls.matches("deployment sub show").count(), 1);
     assert!(az_calls.contains("functionapp deployment source config-zip"));
     assert!(az_calls.contains("functionapp function list"));
+    assert!(az_calls.contains("staticwebapp secrets list"));
+    assert!(az_calls.contains("ad app show"));
+    assert!(az_calls.contains("ad app update") || az_calls.contains("ad app permission"));
 }
 
 #[test]

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -247,11 +247,11 @@ echo "Generated config.json for SPA" >&2
 # Deploy SPA content to Static Web App.
 # First check if az staticwebapp deploy is available; if so use it directly.
 # Otherwise fall back to REST API with zip upload.
-swa_deployment_token="$(az staticwebapp secrets list \
+swa_deployment_token="$(trim_string "$(az staticwebapp secrets list \
     --name "$static_web_app_name" \
     --resource-group "$resource_group_name" \
     --query 'properties.apiKey' \
-    --output tsv)"
+    --output tsv)")"
 if [ -z "$swa_deployment_token" ]; then
     echo "failed to retrieve Static Web App deployment token" >&2
     exit 1

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -255,32 +255,23 @@ if [ -z "$swa_deployment_token" ]; then
     exit 1
 fi
 
-# Create a zip of the SPA content for deployment
-spa_zip="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-deploy.XXXXXX.zip")"
-trap_cleanup() { rm -f "$spa_zip"; }
-trap trap_cleanup EXIT
-
-(cd "$web_ui_dir" && zip -r "$spa_zip" \
-    index.html app.js style.css staticwebapp.config.json config.json \
-    2>/dev/null)
-
-# Deploy using the SWA deployment API
-swa_api_hostname="$(az staticwebapp show \
-    --name "$static_web_app_name" \
-    --resource-group "$resource_group_name" \
-    --query 'defaultHostname' \
-    --output tsv)"
-
-# The Azure Static Web Apps content API accepts zip deployments.
-# The endpoint is on the management plane via az CLI extension.
-az staticwebapp deploy \
+# Try az CLI extension first; fall back to REST API with zip upload.
+if az staticwebapp deploy \
     --name "$static_web_app_name" \
     --resource-group "$resource_group_name" \
     --source "$web_ui_dir" \
-    --output none >/dev/null 2>&1 || {
-    # Fallback: use the deployment token with the SWA CLI API endpoint.
-    # The SWA management API accepts zip uploads at the /zipdeploy endpoint.
+    --output none >/dev/null 2>&1; then
+    echo "SPA content deployed via az staticwebapp deploy" >&2
+else
     echo "az staticwebapp deploy not available; using REST API fallback" >&2
+    spa_zip="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-deploy.XXXXXX.zip")"
+    trap_cleanup() { rm -f "$spa_zip"; }
+    trap trap_cleanup EXIT
+
+    (cd "$web_ui_dir" && zip -r "$spa_zip" \
+        index.html app.js style.css staticwebapp.config.json config.json \
+        2>/dev/null)
+
     curl -sf \
         -X POST \
         -H "Authorization: Bearer $swa_deployment_token" \
@@ -290,7 +281,7 @@ az staticwebapp deploy \
         echo "SPA content deployment failed" >&2
         exit 1
     }
-}
+fi
 echo "SPA content deployed to https://$static_web_app_hostname" >&2
 
 # ── Entra app configuration ─────────────────────────────────────────────────
@@ -306,7 +297,10 @@ fi
 # Register the SWA hostname as a SPA redirect URI (merge with existing)
 redirect_uri="https://$static_web_app_hostname"
 current_uris="$(az ad app show --id "$app_object_id" \
-    --query 'spa.redirectUris' --output json 2>/dev/null || echo '[]')"
+    --query 'spa.redirectUris' --output json)"
+if [ -z "$current_uris" ] || [ "$current_uris" = "null" ]; then
+    current_uris="[]"
+fi
 if echo "$current_uris" | grep -Fq "$redirect_uri"; then
     echo "SPA redirect URI already registered" >&2
 else
@@ -317,11 +311,15 @@ else
     echo "Added SPA redirect URI: $redirect_uri" >&2
 fi
 
-# Add Azure Storage user_impersonation API permission
-az ad app permission add --id "$app_object_id" \
-    --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
-    --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" || true
-echo "Azure Storage user_impersonation permission configured" >&2
+# Add Azure Storage user_impersonation API permission (idempotent)
+if az ad app permission list --id "$app_object_id" --query "[?resourceAppId=='e406a681-f3d4-42a8-90b6-c2b029497af1'].resourceAccess[?id=='da399722-a3ea-4c11-8b0d-7b37b3d5fa83'] | [0]" --output tsv 2>/dev/null | grep -q .; then
+    echo "Azure Storage user_impersonation permission already configured" >&2
+else
+    az ad app permission add --id "$app_object_id" \
+        --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
+        --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope"
+    echo "Azure Storage user_impersonation permission configured" >&2
+fi
 
 echo "Web UI deployment complete" >&2
 

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -244,7 +244,9 @@ cat > "$web_ui_dir/config.json" <<CONFIGEOF
 CONFIGEOF
 echo "Generated config.json for SPA" >&2
 
-# Deploy SPA content to Static Web App
+# Deploy SPA content to Static Web App.
+# First check if az staticwebapp deploy is available; if so use it directly.
+# Otherwise fall back to REST API with zip upload.
 swa_deployment_token="$(az staticwebapp secrets list \
     --name "$static_web_app_name" \
     --resource-group "$resource_group_name" \
@@ -255,15 +257,29 @@ if [ -z "$swa_deployment_token" ]; then
     exit 1
 fi
 
-# Try az CLI extension first; fall back to REST API with zip upload.
-if az staticwebapp deploy \
-    --name "$static_web_app_name" \
-    --resource-group "$resource_group_name" \
-    --source "$web_ui_dir" \
-    --output none >/dev/null 2>&1; then
+if az staticwebapp deploy --help >/dev/null 2>&1; then
+    # The az CLI extension is available — use it for content deployment.
+    az staticwebapp deploy \
+        --name "$static_web_app_name" \
+        --resource-group "$resource_group_name" \
+        --source "$web_ui_dir" \
+        --output none 1>&2
     echo "SPA content deployed via az staticwebapp deploy" >&2
 else
+    # Fallback: zip content and deploy via REST API using the deployment token.
     echo "az staticwebapp deploy not available; using REST API fallback" >&2
+
+    # Derive the content API region from the SWA resource location.
+    swa_location="$(az staticwebapp show \
+        --name "$static_web_app_name" \
+        --resource-group "$resource_group_name" \
+        --query 'location' \
+        --output tsv)"
+    if [ -z "$swa_location" ]; then
+        echo "failed to determine Static Web App location" >&2
+        exit 1
+    fi
+
     spa_zip="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-deploy.XXXXXX.zip")"
     trap_cleanup() { rm -f "$spa_zip"; }
     trap trap_cleanup EXIT
@@ -277,7 +293,7 @@ else
         -H "Authorization: Bearer $swa_deployment_token" \
         -H "Content-Type: application/zip" \
         --data-binary "@$spa_zip" \
-        "https://content-${SONDE_AZURE_LOCATION}.azurestaticapps.net/api/zipdeploy" || {
+        "https://content-${swa_location}.azurestaticapps.net/api/zipdeploy" || {
         echo "SPA content deployment failed" >&2
         exit 1
     }
@@ -301,7 +317,7 @@ current_uris="$(az ad app show --id "$app_object_id" \
 if [ -z "$current_uris" ] || [ "$current_uris" = "null" ]; then
     current_uris="[]"
 fi
-if echo "$current_uris" | grep -Fq "$redirect_uri"; then
+if echo "$current_uris" | jq -e --arg uri "$redirect_uri" 'index($uri) != null' >/dev/null 2>&1; then
     echo "SPA redirect URI already registered" >&2
 else
     merged_uris="$(echo "$current_uris" | jq -r --arg uri "$redirect_uri" \

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -247,16 +247,6 @@ echo "Generated config.json for SPA" >&2
 # Deploy SPA content to Static Web App.
 # First check if az staticwebapp deploy is available; if so use it directly.
 # Otherwise fall back to REST API with zip upload.
-swa_deployment_token="$(trim_string "$(az staticwebapp secrets list \
-    --name "$static_web_app_name" \
-    --resource-group "$resource_group_name" \
-    --query 'properties.apiKey' \
-    --output tsv)")"
-if [ -z "$swa_deployment_token" ]; then
-    echo "failed to retrieve Static Web App deployment token" >&2
-    exit 1
-fi
-
 if az staticwebapp deploy --help >/dev/null 2>&1; then
     # The az CLI extension is available — use it for content deployment.
     az staticwebapp deploy \
@@ -268,6 +258,16 @@ if az staticwebapp deploy --help >/dev/null 2>&1; then
 else
     # Fallback: zip content and deploy via REST API using the deployment token.
     echo "az staticwebapp deploy not available; using REST API fallback" >&2
+
+    swa_deployment_token="$(trim_string "$(az staticwebapp secrets list \
+        --name "$static_web_app_name" \
+        --resource-group "$resource_group_name" \
+        --query 'properties.apiKey' \
+        --output tsv)")"
+    if [ -z "$swa_deployment_token" ]; then
+        echo "failed to retrieve Static Web App deployment token" >&2
+        exit 1
+    fi
 
     # Derive the content API region from the SWA resource location.
     swa_location="$(az staticwebapp show \
@@ -317,11 +317,20 @@ current_uris="$(az ad app show --id "$app_object_id" \
 if [ -z "$current_uris" ] || [ "$current_uris" = "null" ]; then
     current_uris="[]"
 fi
-if echo "$current_uris" | jq -e --arg uri "$redirect_uri" 'index($uri) != null' >/dev/null 2>&1; then
+uri_exists=0
+echo "$current_uris" | jq -e --arg uri "$redirect_uri" 'index($uri) != null' >/dev/null 2>&1 && uri_exists=1
+if [ "$uri_exists" -eq 1 ]; then
     echo "SPA redirect URI already registered" >&2
 else
     merged_uris="$(echo "$current_uris" | jq -r --arg uri "$redirect_uri" \
-        '(. // []) + [$uri] | join(" ")')"
+        '(. // []) + [$uri] | join(" ")')" || {
+        echo "failed to merge redirect URIs" >&2
+        exit 1
+    }
+    if [ -z "$merged_uris" ]; then
+        echo "redirect URI merge produced empty result" >&2
+        exit 1
+    fi
     az ad app update --id "$app_object_id" \
         --spa-redirect-uris $merged_uris
     echo "Added SPA redirect URI: $redirect_uri" >&2

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -21,7 +21,7 @@ read_required_deployment_outputs() {
     # tab-separated columns.  A flat JMESPath array produces one value per
     # line (newline-separated), which breaks the tab-based field splitting
     # below.
-    query='[[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value]]'
+    query='[[properties.outputs.resourceGroupName.value, properties.outputs.functionAppName.value, properties.outputs.deploymentContainerName.value, properties.outputs.deploymentContainerUrl.value, properties.outputs.staticWebAppName.value, properties.outputs.staticWebAppHostname.value, properties.outputs.companionClientId.value, properties.outputs.storageAccountName.value, properties.outputs.companionTenantId.value]]'
     stderr_file="$(mktemp "${TMPDIR:-/tmp}/sonde-azure-deployment-show.XXXXXX")"
     if ! deployment_runtime_values="$(az deployment sub show \
         --name "$deployment_name" \
@@ -46,8 +46,8 @@ read_required_deployment_outputs() {
     set -- $deployment_runtime_values
     IFS="$old_ifs"
     field_count="$#"
-    if [ "$field_count" -ne 4 ]; then
-        echo "deployment output query \`$query\` returned $field_count field(s); expected 4 tab-separated values" >&2
+    if [ "$field_count" -ne 9 ]; then
+        echo "deployment output query \`$query\` returned $field_count field(s); expected 9 tab-separated values" >&2
         exit 1
     fi
 
@@ -74,6 +74,36 @@ read_required_deployment_outputs() {
             deploymentContainerUrl \
             "$query" \
             "$4"
+    )"
+    static_web_app_name="$(
+        require_deployment_output_string \
+            staticWebAppName \
+            "$query" \
+            "$5"
+    )"
+    static_web_app_hostname="$(
+        require_deployment_output_string \
+            staticWebAppHostname \
+            "$query" \
+            "$6"
+    )"
+    companion_client_id="$(
+        require_deployment_output_string \
+            companionClientId \
+            "$query" \
+            "$7"
+    )"
+    storage_account_name="$(
+        require_deployment_output_string \
+            storageAccountName \
+            "$query" \
+            "$8"
+    )"
+    companion_tenant_id="$(
+        require_deployment_output_string \
+            companionTenantId \
+            "$query" \
+            "$9"
     )"
 }
 
@@ -193,5 +223,106 @@ if [ "$config_zip_exit" -ne 0 ]; then
 fi
 
 wait_for_function_activation "$resource_group_name" "$function_app_name" "$activation_timeout_secs"
+
+# ── SPA deployment ──────────────────────────────────────────────────────────
+echo "Deploying Web UI to Static Web App $static_web_app_name" >&2
+web_ui_dir="${SONDE_AZURE_WEB_UI_DIR:-/opt/sonde/deploy/web-ui}"
+
+if [ ! -d "$web_ui_dir" ]; then
+    echo "bundled Web UI content not found: $web_ui_dir" >&2
+    exit 1
+fi
+
+# Generate config.json from deployment outputs
+cat > "$web_ui_dir/config.json" <<CONFIGEOF
+{
+  "msalClientId": "$companion_client_id",
+  "msalAuthority": "https://login.microsoftonline.com/$companion_tenant_id",
+  "storageAccount": "$storage_account_name",
+  "functionAppName": "$function_app_name"
+}
+CONFIGEOF
+echo "Generated config.json for SPA" >&2
+
+# Deploy SPA content to Static Web App
+swa_deployment_token="$(az staticwebapp secrets list \
+    --name "$static_web_app_name" \
+    --resource-group "$resource_group_name" \
+    --query 'properties.apiKey' \
+    --output tsv)"
+if [ -z "$swa_deployment_token" ]; then
+    echo "failed to retrieve Static Web App deployment token" >&2
+    exit 1
+fi
+
+# Create a zip of the SPA content for deployment
+spa_zip="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-deploy.XXXXXX.zip")"
+trap_cleanup() { rm -f "$spa_zip"; }
+trap trap_cleanup EXIT
+
+(cd "$web_ui_dir" && zip -r "$spa_zip" \
+    index.html app.js style.css staticwebapp.config.json config.json \
+    2>/dev/null)
+
+# Deploy using the SWA deployment API
+swa_api_hostname="$(az staticwebapp show \
+    --name "$static_web_app_name" \
+    --resource-group "$resource_group_name" \
+    --query 'defaultHostname' \
+    --output tsv)"
+
+# The Azure Static Web Apps content API accepts zip deployments.
+# The endpoint is on the management plane via az CLI extension.
+az staticwebapp deploy \
+    --name "$static_web_app_name" \
+    --resource-group "$resource_group_name" \
+    --source "$web_ui_dir" \
+    --output none >/dev/null 2>&1 || {
+    # Fallback: use the deployment token with the SWA CLI API endpoint.
+    # The SWA management API accepts zip uploads at the /zipdeploy endpoint.
+    echo "az staticwebapp deploy not available; using REST API fallback" >&2
+    curl -sf \
+        -X POST \
+        -H "Authorization: Bearer $swa_deployment_token" \
+        -H "Content-Type: application/zip" \
+        --data-binary "@$spa_zip" \
+        "https://content-${SONDE_AZURE_LOCATION}.azurestaticapps.net/api/zipdeploy" || {
+        echo "SPA content deployment failed" >&2
+        exit 1
+    }
+}
+echo "SPA content deployed to https://$static_web_app_hostname" >&2
+
+# ── Entra app configuration ─────────────────────────────────────────────────
+echo "Configuring Entra app registration for Web UI" >&2
+
+# Resolve the Entra app object ID from the companion client ID
+app_object_id="$(az ad app show --id "$companion_client_id" --query 'id' --output tsv)"
+if [ -z "$app_object_id" ]; then
+    echo "failed to resolve Entra app object ID for client ID $companion_client_id" >&2
+    exit 1
+fi
+
+# Register the SWA hostname as a SPA redirect URI (merge with existing)
+redirect_uri="https://$static_web_app_hostname"
+current_uris="$(az ad app show --id "$app_object_id" \
+    --query 'spa.redirectUris' --output json 2>/dev/null || echo '[]')"
+if echo "$current_uris" | grep -Fq "$redirect_uri"; then
+    echo "SPA redirect URI already registered" >&2
+else
+    merged_uris="$(echo "$current_uris" | jq -r --arg uri "$redirect_uri" \
+        '(. // []) + [$uri] | join(" ")')"
+    az ad app update --id "$app_object_id" \
+        --spa-redirect-uris $merged_uris
+    echo "Added SPA redirect URI: $redirect_uri" >&2
+fi
+
+# Add Azure Storage user_impersonation API permission
+az ad app permission add --id "$app_object_id" \
+    --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
+    --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" || true
+echo "Azure Storage user_impersonation permission configured" >&2
+
+echo "Web UI deployment complete" >&2
 
 printf '%s\n' "$deployment_outputs"

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -128,6 +128,12 @@ state:
 - downstream queue name
 - Function App name
 - deployment container name / URL
+- Static Web App name and hostname
+
+The unified `sonde-azure-companion bootstrap` command consumes all of these
+outputs automatically, including deploying the Web UI SPA content to the Static
+Web App and configuring the Entra app registration with the SWA redirect URI
+and Storage API permissions.
 
 You still need to place the matching PEM certificate and private key into the
 Azure companion state directory and write `service-principal.json` that points

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -294,16 +294,32 @@ When bootstrap is required, the Azure companion performs this sequence:
     image to populate the provisioned Function App deployment target.
 16. Poll Azure for Function App activation until the uploaded package is active
     and at least one function is reported as loaded.
-17. Write `service-principal.json` and `storage-queues.json` to the staging
+17. The bootstrap script then deploys the Web UI SPA content and configures the
+    Entra app registration. This phase runs inside the bootstrap container
+    where the Azure CLI session is still authenticated. The script:
+    a. Extracts `staticWebAppName`, `staticWebAppHostname`, `companionClientId`,
+       `storageAccountName`, and `functionAppName` from the Bicep deployment
+       outputs.
+    b. Generates `config.json` with MSAL client ID, authority URL (derived from
+       `tenantId`), storage account name, and function app name.
+    c. Obtains the SWA deployment token via `az staticwebapp secrets list`.
+    d. Deploys the bundled SPA content (including generated `config.json`) to
+       the Static Web App.
+    e. Registers `https://<staticWebAppHostname>` as a SPA redirect URI on the
+       Entra app registration, merging with any existing redirect URIs.
+    f. Adds Azure Storage `user_impersonation` API permission to the Entra app.
+    If any sub-step fails, the bootstrap script exits non-zero and the
+    bootstrap container reports failure.
+18. Write `service-principal.json` and `storage-queues.json` to the staging
     directory with the extracted values and relative paths to the certificate
     and private-key PEM files.
-18. Rename the staging directory into a new generation directory under the state
+19. Rename the staging directory into a new generation directory under the state
     volume, then atomically update the `.current-state` marker to point at that
     generation, leaving the previous generation untouched until the new one is
     fully committed.
-19. Remove the bootstrap container.
-20. Display "Bootstrap complete" on the modem display.
-21. The bootstrap wrapper/entrypoint reports overall success only after
+20. Remove the bootstrap container.
+21. Display "Bootstrap complete" on the modem display.
+22. The bootstrap wrapper/entrypoint reports overall success only after
     bootstrap-complete state has been established.
 
 If any step fails, the staging directory is cleaned up, the bootstrap
@@ -321,7 +337,7 @@ non-zero status. It does not continue to a console-only fallback.
 ## 5  Rust binary interface
 
 > **Requirements:** AZC-0100, AZC-0102, AZC-0103, AZC-0104, AZC-0105, AZC-0201, AZC-0202, AZC-0205, AZC-0300, AZC-0301, AZC-0302, AZC-0304, AZC-0305,
-> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406
+> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0410
 
 The `sonde-azure-companion` binary exposes three cross-platform runtime modes
 plus Windows service-management entrypoints:
@@ -574,14 +590,16 @@ The bootstrap Dockerfile includes:
 
 ```dockerfile
 COPY deploy/bicep/ /opt/sonde/deploy/bicep/
+COPY deploy/web-ui/index.html deploy/web-ui/app.js deploy/web-ui/style.css deploy/web-ui/staticwebapp.config.json /opt/sonde/deploy/web-ui/
 ```
 
 It also includes the bootstrap script that runs `az login --use-device-code`
-and Azure deployment inside the bootstrap image.
+and Azure deployment inside the bootstrap image. The `jq` utility is installed
+for JSON manipulation during SPA deployment (Entra redirect URI merging).
 
-This bundles the complete Azure provisioning surface into the dedicated
-bootstrap image. The runtime companion image no longer needs to carry these
-bootstrap-only assets.
+This bundles the complete Azure provisioning surface and the Web UI SPA
+content into the dedicated bootstrap image. The runtime companion image no
+longer needs to carry these bootstrap-only assets.
 
 ### 8.6  Docker socket requirements
 
@@ -606,5 +624,6 @@ The bootstrap displays these messages on the modem via the admin API:
 | Device code received | "Azure login" + device code | "Device auth: open {uri} and enter code {code}" |
 | Bicep deployment | "Deploying Azure..." | "Running Bicep deployment" |
 | Config writing | "Writing config..." | "Writing runtime artifacts to state volume" |
+| SPA deployment | "Deploying Web UI..." | "Deploying Web UI to Static Web App" |
 | Bootstrap complete | "Bootstrap complete" | "Bootstrap completed successfully" |
 | Bootstrap failure | "Bootstrap failed" | Error details |

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -298,10 +298,10 @@ When bootstrap is required, the Azure companion performs this sequence:
     Entra app registration. This phase runs inside the bootstrap container
     where the Azure CLI session is still authenticated. The script:
     a. Extracts `staticWebAppName`, `staticWebAppHostname`, `companionClientId`,
-       `storageAccountName`, and `functionAppName` from the Bicep deployment
-       outputs.
+       `companionTenantId`, `storageAccountName`, and `functionAppName` from
+       the Bicep deployment outputs.
     b. Generates `config.json` with MSAL client ID, authority URL (derived from
-       `tenantId`), storage account name, and function app name.
+       `companionTenantId`), storage account name, and function app name.
     c. Obtains the SWA deployment token via `az staticwebapp secrets list`.
     d. Deploys the bundled SPA content (including generated `config.json`) to
        the Static Web App.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -243,7 +243,9 @@ When bootstrap is required, the Azure companion MUST provide a single unified
 certificate generation, device-code authentication inside the dedicated
 `sonde-azure-bootstrap` image, Azure deployment through the Docker API,
 deployment of the bundled Azure handler package into the provisioned Function
-App, and local runtime artifact creation. The earlier `bootstrap-auth`
+App, deployment of the Web UI SPA content to the provisioned Static Web App,
+Entra app configuration (SPA redirect URI and Storage API permission), and
+local runtime artifact creation.The earlier `bootstrap-auth`
 subcommand is retired and replaced by this unified command. By default, the
 Rust companion launches the `sonde-azure-bootstrap:<matching companion
 version>` image tag; the image contains the Azure CLI, bundled Bicep files,
@@ -800,3 +802,50 @@ does not succeed if the Function App shell exists but no functions are loaded.
 2. The deployed package matches the companion/bootstrap release rather than an ad hoc package built on the operator host during bootstrap.
 3. Bootstrap waits until Azure reports that at least one function is loaded in the provisioned Function App before reporting success.
 4. If package deployment or activation fails, bootstrap exits non-zero and does not report success-shaped completion.
+
+---
+
+### AZC-0410  Bootstrap deploys SPA content and configures Entra app for Web UI
+
+**Priority:** Must
+**Source:** USER-REQUEST: single bootstrap command that installs all Azure parts
+
+**Description:**
+After successful Function App handler deployment and activation, the unified
+`bootstrap` subcommand MUST deploy the bundled Web UI SPA content to the
+provisioned Static Web App and configure the Entra app registration for
+browser-based access. This eliminates the separate `deploy/web-ui/deploy.sh`
+manual step, making `sonde-azure-companion bootstrap` the single command that
+provisions all Azure surfaces.
+
+The bootstrap image MUST bundle the SPA static assets (`index.html`, `app.js`,
+`style.css`, `staticwebapp.config.json`) and generate `config.json` from the
+Bicep deployment outputs at deploy time.
+
+The bootstrap script MUST:
+1. Extract `staticWebAppName`, `staticWebAppHostname`, `companionClientId`,
+   `storageAccountName`, and `functionAppName` from the Bicep deployment
+   outputs.
+2. Generate `config.json` with the MSAL client ID, tenant ID, storage account
+   name, and function app name.
+3. Deploy the SPA content (including the generated `config.json`) to the Static
+   Web App using the Azure deployment API and the SWA deployment token.
+4. Register the SWA hostname (`https://<hostname>`) as a SPA redirect URI on
+   the Entra app registration, merging with any existing redirect URIs.
+5. Add the Azure Storage `user_impersonation` API permission to the Entra app
+   registration if not already present.
+
+The SPA deployment MUST NOT require Node.js, npm, or the SWA CLI in the
+bootstrap image. The bootstrap script MUST use Azure CLI commands and the
+Azure REST API to perform the deployment.
+
+**Acceptance criteria:**
+
+1. After `sonde-azure-companion bootstrap` completes, the Static Web App serves the SPA content at its default hostname without any additional manual deployment step.
+2. The generated `config.json` contains correct MSAL client ID, authority URL, storage account name, and function app name values matching the Bicep deployment outputs.
+3. The Entra app registration includes the SWA hostname as a SPA redirect URI after bootstrap.
+4. The Entra app registration includes the Azure Storage `user_impersonation` API permission after bootstrap.
+5. Existing SPA redirect URIs on the Entra app are preserved (not overwritten) when adding the SWA hostname.
+6. Re-running bootstrap updates the SPA content and Entra configuration idempotently.
+7. If SPA deployment fails, bootstrap exits non-zero and does not report success.
+8. The bootstrap image does not depend on Node.js, npm, or the SWA CLI.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -245,7 +245,7 @@ certificate generation, device-code authentication inside the dedicated
 deployment of the bundled Azure handler package into the provisioned Function
 App, deployment of the Web UI SPA content to the provisioned Static Web App,
 Entra app configuration (SPA redirect URI and Storage API permission), and
-local runtime artifact creation.The earlier `bootstrap-auth`
+local runtime artifact creation. The earlier `bootstrap-auth`
 subcommand is retired and replaced by this unified command. By default, the
 Rust companion launches the `sonde-azure-bootstrap:<matching companion
 version>` image tag; the image contains the Azure CLI, bundled Bicep files,
@@ -824,8 +824,8 @@ Bicep deployment outputs at deploy time.
 
 The bootstrap script MUST:
 1. Extract `staticWebAppName`, `staticWebAppHostname`, `companionClientId`,
-   `storageAccountName`, and `functionAppName` from the Bicep deployment
-   outputs.
+   `companionTenantId`, `storageAccountName`, and `functionAppName` from the
+   Bicep deployment outputs.
 2. Generate `config.json` with the MSAL client ID, tenant ID, storage account
    name, and function app name.
 3. Deploy the SPA content (including the generated `config.json`) to the Static

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -586,3 +586,22 @@
 4. Assert: bootstrap does not report success until Azure reports at least one loaded function for that Function App.
 5. Force package activation to fail or never complete.
 6. Assert: bootstrap exits non-zero and does not report success-shaped completion.
+
+---
+
+### T-AZC-0418  Bootstrap deploys SPA content and configures Entra app for Web UI
+
+**Validates:** AZC-0410
+
+**Procedure:**
+1. Run bootstrap with device auth stubbed and Bicep deployment stubbed to return known output values including `staticWebAppName`, `staticWebAppHostname`, `companionClientId`, `tenantId`, `storageAccountName`, and `functionAppName`.
+2. Assert: bootstrap generates `config.json` containing the correct `msalClientId`, `msalAuthority` (derived from `tenantId`), `storageAccount`, and `functionAppName` values from the stubbed outputs.
+3. Assert: the bootstrap script attempts to deploy SPA content (HTML, JS, CSS, config.json) to the Static Web App named in the outputs.
+4. After bootstrap completes, assert: the Static Web App serves the SPA content at its default hostname without any additional manual deployment step.
+5. Assert: the bootstrap script registers `https://<staticWebAppHostname>` as a SPA redirect URI on the Entra app registration.
+6. Assert: existing SPA redirect URIs are preserved (not overwritten) during the registration.
+7. Assert: the bootstrap script adds the Azure Storage `user_impersonation` API permission to the Entra app.
+8. Assert: if SPA deployment fails, bootstrap exits non-zero.
+9. Assert: the bootstrap image does not contain Node.js, npm, or the SWA CLI.
+10. Re-run bootstrap with the same stubbed outputs.
+11. Assert: the SPA deployment and Entra configuration succeed idempotently.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -594,8 +594,8 @@
 **Validates:** AZC-0410
 
 **Procedure:**
-1. Run bootstrap with device auth stubbed and Bicep deployment stubbed to return known output values including `staticWebAppName`, `staticWebAppHostname`, `companionClientId`, `tenantId`, `storageAccountName`, and `functionAppName`.
-2. Assert: bootstrap generates `config.json` containing the correct `msalClientId`, `msalAuthority` (derived from `tenantId`), `storageAccount`, and `functionAppName` values from the stubbed outputs.
+1. Run bootstrap with device auth stubbed and Bicep deployment stubbed to return known output values including `staticWebAppName`, `staticWebAppHostname`, `companionClientId`, `companionTenantId`, `storageAccountName`, and `functionAppName`.
+2. Assert: bootstrap generates `config.json` containing the correct `msalClientId`, `msalAuthority` (derived from `companionTenantId`), `storageAccount`, and `functionAppName` values from the stubbed outputs.
 3. Assert: the bootstrap script attempts to deploy SPA content (HTML, JS, CSS, config.json) to the Static Web App named in the outputs.
 4. After bootstrap completes, assert: the Static Web App serves the SPA content at its default hostname without any additional manual deployment step.
 5. Assert: the bootstrap script registers `https://<staticWebAppHostname>` as a SPA redirect URI on the Entra app registration.

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -115,7 +115,12 @@ When the handler publishes a `DESIRED_STATE` message due to program divergence, 
 ### 9.1 Static Web App
 
 Azure Static Web App (free tier) provisioned via `static-web-app.bicep`.
-After Bicep deployment, deploy the SPA using the deployment script.
+SPA content is deployed automatically during `sonde-azure-companion bootstrap`
+(see AZC-0410). The bootstrap flow generates `config.json`, deploys the SPA
+content to the Static Web App, registers the SWA hostname as a redirect URI on
+the Entra app, and adds the Azure Storage API permission.
+
+For standalone (non-bootstrap) deployment, use the deployment script:
 
 Prerequisites: `az` CLI (logged in), `jq`, and `npm`/`npx` (for the SWA CLI).
 


### PR DESCRIPTION
Integrate Web UI SPA deployment into the unified bootstrap flow so that
`sonde-azure-companion bootstrap` provisions all Azure surfaces in a single
command: infrastructure (Bicep), handler function, SPA content, and Entra
app configuration.

### Changes

**Specification:**
- **AZC-0410** (new) — Bootstrap deploys SPA content and configures Entra app
- **AZC-0201** (updated) — Expanded lifecycle scope to include SPA/Entra
- **Design §4.2** — Added step 17: SPA deployment inside bootstrap container
- **Design §8.5** — Bootstrap image bundles web-ui content and `jq`
- **Design §8.7** — Added "Deploying Web UI..." progress phase
- **T-AZC-0418** (new) — Validates SPA deployment during bootstrap
- **web-ui-design.md §9.1** — Bootstrap is now primary deployment path

**Implementation:**
- **`bootstrap.sh`** — Extracts SWA-related outputs, generates `config.json`,
  deploys SPA content, registers Entra redirect URI, adds Storage API permission
- **`Dockerfile.azure-bootstrap`** — Copies web-ui assets, installs `jq` and `zip`
- **`README.md`** — Updated bootstrap handoff docs

### After this change

Running `sonde-azure-companion bootstrap` will:
1. Provision infrastructure (Bicep)
2. Deploy handler function and wait for activation
3. Generate `config.json` and deploy SPA to Static Web App
4. Configure Entra app (redirect URI + Storage API permission)
5. Write companion runtime state

No separate `deploy/web-ui/deploy.sh` step is needed (though it is retained for
standalone use cases).
