### PR TITLE
fix(docker): use tdnf instead of apk for azure-cli base image

### DIFF
--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -13,7 +13,7 @@
 
 FROM mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7
 
-RUN apk add --no-cache jq zip
+RUN tdnf install -y jq zip && tdnf clean all
 
 COPY deploy/azure-bootstrap/bootstrap.sh /opt/sonde/deploy/azure-bootstrap/bootstrap.sh
 COPY deploy/bicep/ /opt/sonde/deploy/bicep/


### PR DESCRIPTION
The `mcr.microsoft.com/azure-cli` base image is CBL-Mariner/Azure Linux, not Alpine. The `apk` package manager does not exist — use `tdnf` instead.

Fixes nightly release failure: https://github.com/Alan-Jowett/sonde/actions/runs/25753918747/job/75639053187