### PR TITLE
fix(bicep): use separate location for Static Web App

### DIFF
--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -51,6 +51,9 @@ param functionPlanName string = ''
 @description('Optional override for the Static Web App name.')
 param staticWebAppName string = ''
 
+@description('Azure region for the Static Web App. Defaults to centralus because Microsoft.Web/staticSites is not available in all regions.')
+param staticWebAppLocation string = 'centralus'
+
 var projectSlug = toLower(replace(replace(replace(replace(replace(project_name, '-', ''), '_', ''), ' ', ''), '.', ''), '/', ''))
 var effectiveProjectSlug = empty(projectSlug) ? 'sonde' : projectSlug
 var effectiveResourceGroupName = empty(resource_group_name) ? '${take(effectiveProjectSlug, 84)}-azure' : resource_group_name
@@ -121,6 +124,7 @@ module stack './modules/stack.bicep' = {
     functionPlanName: effectiveFunctionPlanName
     companionServicePrincipalObjectId: companionIdentity.outputs.servicePrincipalObjectId
     staticWebAppName: effectiveStaticWebAppName
+    staticWebAppLocation: staticWebAppLocation
   }
 }
 

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -42,6 +42,9 @@ param companionServicePrincipalObjectId string
 @description('Static Web App name for the management UI.')
 param staticWebAppName string
 
+@description('Azure region for the Static Web App.')
+param staticWebAppLocation string
+
 var monitoringWorkspaceName = take('${functionAppName}-logs', 63)
 var monitoringAppInsightsName = take('${functionAppName}-insights', 260)
 
@@ -78,7 +81,7 @@ module monitoring './monitoring.bicep' = {
 module staticWebApp './static-web-app.bicep' = {
   name: 'staticWebApp'
   params: {
-    location: location
+    location: staticWebAppLocation
     staticWebAppName: staticWebAppName
     tags: tags
   }


### PR DESCRIPTION
Microsoft.Web/staticSites is only available in a subset of Azure regions (centralus, eastus2, westus2, westeurope, eastasia). The stack was passing the general location parameter (default: eastus) which is not supported, causing bootstrap to fail with LocationNotAvailableForResourceType.

Adds a staticWebAppLocation parameter (default: centralus) threaded through stack.bicep to decouple the SWA region from the main stack location.