### PR TITLE
fix(bootstrap): use SWA CLI for SPA deployment, add live CI coverage

### DIFF
--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -13,7 +13,7 @@
 
 FROM mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7
 
-RUN tdnf install -y jq zip && tdnf clean all
+RUN tdnf install -y jq nodejs npm && tdnf clean all
 
 COPY deploy/azure-bootstrap/bootstrap.sh /opt/sonde/deploy/azure-bootstrap/bootstrap.sh
 COPY deploy/bicep/ /opt/sonde/deploy/bicep/

--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -13,7 +13,8 @@
 
 FROM mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7
 
-RUN tdnf install -y jq nodejs npm && tdnf clean all
+RUN tdnf install -y jq nodejs npm && tdnf clean all \
+    && npm install -g @azure/static-web-apps-cli@2.0.9
 
 COPY deploy/azure-bootstrap/bootstrap.sh /opt/sonde/deploy/azure-bootstrap/bootstrap.sh
 COPY deploy/bicep/ /opt/sonde/deploy/bicep/

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -290,6 +290,81 @@ jobs:
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Deploy SPA to Static Web App
+        shell: bash
+        run: |
+          set -euo pipefail
+          SWA_NAME="$(python3 -c "
+          import json
+          d = json.load(open('.azure-live-state/deployment.json'))
+          print(d['properties']['outputs']['staticWebAppName']['value'])
+          ")"
+          SWA_HOSTNAME="$(python3 -c "
+          import json
+          d = json.load(open('.azure-live-state/deployment.json'))
+          print(d['properties']['outputs']['staticWebAppHostname']['value'])
+          ")"
+          CLIENT_ID="$(python3 -c "
+          import json
+          d = json.load(open('.azure-live-state/deployment.json'))
+          print(d['properties']['outputs']['companionClientId']['value'])
+          ")"
+          TENANT_ID="$(python3 -c "
+          import json
+          d = json.load(open('.azure-live-state/deployment.json'))
+          print(d['properties']['outputs']['companionTenantId']['value'])
+          ")"
+          STORAGE_ACCOUNT="$(python3 -c "
+          import json
+          d = json.load(open('.azure-live-state/deployment.json'))
+          print(d['properties']['outputs']['storageAccountName']['value'])
+          ")"
+          FUNCTION_APP="$(python3 -c "
+          import json
+          d = json.load(open('.azure-live-state/deployment.json'))
+          print(d['properties']['outputs']['functionAppName']['value'])
+          ")"
+
+          echo "Generating config.json for SPA..."
+          cat > deploy/web-ui/config.json <<CFGEOF
+          {
+            "msalClientId": "$CLIENT_ID",
+            "msalAuthority": "https://login.microsoftonline.com/$TENANT_ID",
+            "storageAccount": "$STORAGE_ACCOUNT",
+            "functionAppName": "$FUNCTION_APP"
+          }
+          CFGEOF
+
+          echo "Deploying SPA to $SWA_NAME ($SWA_HOSTNAME)..."
+          DEPLOYMENT_TOKEN="$(az staticwebapp secrets list \
+            --name "$SWA_NAME" \
+            --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+            --query 'properties.apiKey' -o tsv)"
+          npx --yes @azure/static-web-apps-cli deploy ./deploy/web-ui \
+            --deployment-token "$DEPLOYMENT_TOKEN" \
+            --env production
+
+          echo "Verifying SPA is reachable..."
+          for attempt in $(seq 1 12); do
+            http_code="$(curl -s -o /dev/null -w '%{http_code}' "https://$SWA_HOSTNAME" || echo 0)"
+            if [ "$http_code" = "200" ]; then
+              echo "SPA reachable at https://$SWA_HOSTNAME (HTTP $http_code)"
+              break
+            fi
+            echo "  attempt $attempt: HTTP $http_code, waiting..."
+            sleep 10
+          done
+          if [ "$http_code" != "200" ]; then
+            echo "::warning::SPA not reachable after 120s (HTTP $http_code)"
+          fi
+
+      - name: Refresh Azure login before handler health check
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
       - name: Check Azure handler function health
         shell: bash
         run: |

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -340,7 +340,7 @@ jobs:
             --name "$SWA_NAME" \
             --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
             --query 'properties.apiKey' -o tsv)"
-          npx --yes @azure/static-web-apps-cli deploy ./deploy/web-ui \
+          npx --yes @azure/static-web-apps-cli@2.0.9 deploy ./deploy/web-ui \
             --deployment-token "$DEPLOYMENT_TOKEN" \
             --env production
 

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -355,7 +355,8 @@ jobs:
             sleep 10
           done
           if [ "$http_code" != "200" ]; then
-            echo "::warning::SPA not reachable after 120s (HTTP $http_code)"
+            echo "::error::SPA not reachable after 120s (HTTP $http_code)"
+            exit 1
           fi
 
       - name: Refresh Azure login before handler health check

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -494,7 +494,14 @@ done
 exit 0
 "#,
     );
-    write_executable(&bin_dir.join("npx"), "#!/bin/sh\nexit 0\n");
+    let swa_log = temp.path().join("swa.log");
+    write_executable(
+        &bin_dir.join("swa"),
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 0\n",
+            swa_log.display()
+        ),
+    );
 
     // Create a temporary web-ui directory with the expected SPA files.
     let web_ui_dir = temp.path().join("web-ui");
@@ -562,6 +569,17 @@ exit 0
     assert!(az_calls.contains("staticwebapp secrets list"));
     assert!(az_calls.contains("ad app show"));
     assert!(az_calls.contains("ad app update") || az_calls.contains("ad app permission"));
+
+    // Verify swa deploy was invoked with the web-ui directory and deployment token
+    let swa_calls = fs::read_to_string(swa_log).unwrap();
+    assert!(
+        swa_calls.contains("deploy"),
+        "swa deploy was not invoked: {swa_calls}"
+    );
+    assert!(
+        swa_calls.contains("--deployment-token"),
+        "swa deploy missing --deployment-token: {swa_calls}"
+    );
 }
 
 #[test]

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -571,7 +571,8 @@ exit 0
     assert!(az_calls.contains("ad app update") || az_calls.contains("ad app permission"));
 
     // Verify swa deploy was invoked with the web-ui directory and deployment token
-    let swa_calls = fs::read_to_string(swa_log).unwrap();
+    let swa_calls = fs::read_to_string(&swa_log)
+        .expect("swa log file not found — swa was never invoked by bootstrap");
     assert!(
         swa_calls.contains("deploy"),
         "swa deploy was not invoked: {swa_calls}"

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -494,8 +494,7 @@ done
 exit 0
 "#,
     );
-    write_executable(&bin_dir.join("zip"), "#!/bin/sh\n# Stub: create the output zip file (arg after -r)\nfor arg in \"$@\"; do case \"$arg\" in -*) ;; *) touch \"$arg\" 2>/dev/null; break ;; esac; done\nexit 0\n");
-    write_executable(&bin_dir.join("curl"), "#!/bin/sh\nexit 0\n");
+    write_executable(&bin_dir.join("npx"), "#!/bin/sh\nexit 0\n");
 
     // Create a temporary web-ui directory with the expected SPA files.
     let web_ui_dir = temp.path().join("web-ui");

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -255,7 +255,7 @@ if [ -z "$swa_deployment_token" ]; then
     exit 1
 fi
 
-npx --yes @azure/static-web-apps-cli deploy "$web_ui_dir" \
+swa deploy "$web_ui_dir" \
     --deployment-token "$swa_deployment_token" \
     --env production 1>&2
 echo "SPA content deployed to https://$static_web_app_hostname" >&2

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -244,60 +244,20 @@ cat > "$web_ui_dir/config.json" <<CONFIGEOF
 CONFIGEOF
 echo "Generated config.json for SPA" >&2
 
-# Deploy SPA content to Static Web App.
-# First check if az staticwebapp deploy is available; if so use it directly.
-# Otherwise fall back to REST API with zip upload.
-if az staticwebapp deploy --help >/dev/null 2>&1; then
-    # The az CLI extension is available — use it for content deployment.
-    az staticwebapp deploy \
-        --name "$static_web_app_name" \
-        --resource-group "$resource_group_name" \
-        --source "$web_ui_dir" \
-        --output none 1>&2
-    echo "SPA content deployed via az staticwebapp deploy" >&2
-else
-    # Fallback: zip content and deploy via REST API using the deployment token.
-    echo "az staticwebapp deploy not available; using REST API fallback" >&2
-
-    swa_deployment_token="$(trim_string "$(az staticwebapp secrets list \
-        --name "$static_web_app_name" \
-        --resource-group "$resource_group_name" \
-        --query 'properties.apiKey' \
-        --output tsv)")"
-    if [ -z "$swa_deployment_token" ]; then
-        echo "failed to retrieve Static Web App deployment token" >&2
-        exit 1
-    fi
-
-    # Derive the content API region from the SWA resource location.
-    swa_location="$(az staticwebapp show \
-        --name "$static_web_app_name" \
-        --resource-group "$resource_group_name" \
-        --query 'location' \
-        --output tsv)"
-    if [ -z "$swa_location" ]; then
-        echo "failed to determine Static Web App location" >&2
-        exit 1
-    fi
-
-    spa_zip="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-deploy.XXXXXX.zip")"
-    trap_cleanup() { rm -f "$spa_zip"; }
-    trap trap_cleanup EXIT
-
-    (cd "$web_ui_dir" && zip -r "$spa_zip" \
-        index.html app.js style.css staticwebapp.config.json config.json \
-        2>/dev/null)
-
-    curl -sf \
-        -X POST \
-        -H "Authorization: Bearer $swa_deployment_token" \
-        -H "Content-Type: application/zip" \
-        --data-binary "@$spa_zip" \
-        "https://content-${swa_location}.azurestaticapps.net/api/zipdeploy" || {
-        echo "SPA content deployment failed" >&2
-        exit 1
-    }
+# Deploy SPA content to Static Web App via the SWA CLI.
+swa_deployment_token="$(trim_string "$(az staticwebapp secrets list \
+    --name "$static_web_app_name" \
+    --resource-group "$resource_group_name" \
+    --query 'properties.apiKey' \
+    --output tsv)")"
+if [ -z "$swa_deployment_token" ]; then
+    echo "failed to retrieve Static Web App deployment token" >&2
+    exit 1
 fi
+
+npx --yes @azure/static-web-apps-cli deploy "$web_ui_dir" \
+    --deployment-token "$swa_deployment_token" \
+    --env production 1>&2
 echo "SPA content deployed to https://$static_web_app_hostname" >&2
 
 # ── Entra app configuration ─────────────────────────────────────────────────

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -304,7 +304,7 @@ When bootstrap is required, the Azure companion performs this sequence:
        `companionTenantId`), storage account name, and function app name.
     c. Obtains the SWA deployment token via `az staticwebapp secrets list`.
     d. Deploys the bundled SPA content (including generated `config.json`) to
-       the Static Web App.
+       the Static Web App using the SWA CLI (`npx @azure/static-web-apps-cli`).
     e. Registers `https://<staticWebAppHostname>` as a SPA redirect URI on the
        Entra app registration, merging with any existing redirect URIs.
     f. Adds Azure Storage `user_impersonation` API permission to the Entra app.
@@ -595,7 +595,9 @@ COPY deploy/web-ui/index.html deploy/web-ui/app.js deploy/web-ui/style.css deplo
 
 It also includes the bootstrap script that runs `az login --use-device-code`
 and Azure deployment inside the bootstrap image. The `jq` utility is installed
-for JSON manipulation during SPA deployment (Entra redirect URI merging).
+for JSON manipulation during SPA deployment (Entra redirect URI merging), and
+Node.js/npm is installed for the SWA CLI (`npx @azure/static-web-apps-cli`)
+used to deploy SPA content.
 
 This bundles the complete Azure provisioning surface and the Web UI SPA
 content into the dedicated bootstrap image. The runtime companion image no

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -304,7 +304,7 @@ When bootstrap is required, the Azure companion performs this sequence:
        `companionTenantId`), storage account name, and function app name.
     c. Obtains the SWA deployment token via `az staticwebapp secrets list`.
     d. Deploys the bundled SPA content (including generated `config.json`) to
-       the Static Web App using the SWA CLI (`npx @azure/static-web-apps-cli`).
+       the Static Web App using the pre-installed SWA CLI (`swa deploy`).
     e. Registers `https://<staticWebAppHostname>` as a SPA redirect URI on the
        Entra app registration, merging with any existing redirect URIs.
     f. Adds Azure Storage `user_impersonation` API permission to the Entra app.
@@ -596,8 +596,9 @@ COPY deploy/web-ui/index.html deploy/web-ui/app.js deploy/web-ui/style.css deplo
 It also includes the bootstrap script that runs `az login --use-device-code`
 and Azure deployment inside the bootstrap image. The `jq` utility is installed
 for JSON manipulation during SPA deployment (Entra redirect URI merging), and
-Node.js/npm is installed for the SWA CLI (`npx @azure/static-web-apps-cli`)
-used to deploy SPA content.
+Node.js/npm is installed and a pinned version of the SWA CLI
+(`@azure/static-web-apps-cli`) is pre-installed globally for SPA content
+deployment.
 
 This bundles the complete Azure provisioning surface and the Web UI SPA
 content into the dedicated bootstrap image. The runtime companion image no

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -835,9 +835,9 @@ The bootstrap script MUST:
 5. Add the Azure Storage `user_impersonation` API permission to the Entra app
    registration if not already present.
 
-The bootstrap image bundles Node.js and uses the SWA CLI
-(`@azure/static-web-apps-cli` via `npx`) to deploy SPA content to the Static
-Web App.
+The bootstrap image bundles Node.js and a pinned version of the SWA CLI
+(`@azure/static-web-apps-cli`, installed globally at image build time) to
+deploy SPA content to the Static Web App.
 
 **Acceptance criteria:**
 

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -835,9 +835,9 @@ The bootstrap script MUST:
 5. Add the Azure Storage `user_impersonation` API permission to the Entra app
    registration if not already present.
 
-The SPA deployment MUST NOT require Node.js, npm, or the SWA CLI in the
-bootstrap image. The bootstrap script MUST use Azure CLI commands and the
-Azure REST API to perform the deployment.
+The bootstrap image bundles Node.js and uses the SWA CLI
+(`@azure/static-web-apps-cli` via `npx`) to deploy SPA content to the Static
+Web App.
 
 **Acceptance criteria:**
 
@@ -848,4 +848,3 @@ Azure REST API to perform the deployment.
 5. Existing SPA redirect URIs on the Entra app are preserved (not overwritten) when adding the SWA hostname.
 6. Re-running bootstrap updates the SPA content and Entra configuration idempotently.
 7. If SPA deployment fails, bootstrap exits non-zero and does not report success.
-8. The bootstrap image does not depend on Node.js, npm, or the SWA CLI.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -602,6 +602,5 @@
 6. Assert: existing SPA redirect URIs are preserved (not overwritten) during the registration.
 7. Assert: the bootstrap script adds the Azure Storage `user_impersonation` API permission to the Entra app.
 8. Assert: if SPA deployment fails, bootstrap exits non-zero.
-9. Assert: the bootstrap image does not contain Node.js, npm, or the SWA CLI.
-10. Re-run bootstrap with the same stubbed outputs.
-11. Assert: the SPA deployment and Entra configuration succeed idempotently.
+9. Re-run bootstrap with the same stubbed outputs.
+10. Assert: the SPA deployment and Entra configuration succeed idempotently.


### PR DESCRIPTION
The undocumented REST API fallback for SWA content deployment does not work in practice. Replace with the proven SWA CLI (\
px @azure/static-web-apps-cli\).

### What broke

Bootstrap failed at the SPA deployment step because:
1. \z staticwebapp deploy\ doesn't exist in the azure-cli image
2. The REST API fallback endpoint (\content-{region}.azurestaticapps.net/api/zipdeploy\) is undocumented/internal and does not work

### Fix

- Install Node.js/npm in the bootstrap image via \	dnf\
- Use \
px @azure/static-web-apps-cli deploy\ with the deployment token (the proven, documented approach)
- Remove the broken dual-path az CLI / REST API logic

### Azure Live CI gap

The CI workflow exercises Bicep + handler deployment directly but never tested SPA deployment. Added a new step that:
1. Generates \config.json\ from deployment outputs
2. Deploys SPA content via the SWA CLI
3. Verifies the SPA is reachable at its hostname

### Spec updates

- AZC-0410: removed the no-Node.js constraint (AC8), documented SWA CLI usage
- Design §8.5: updated bootstrap image contents
- T-AZC-0418: removed Node.js absence assertion