### PR TITLE
fix(docker): install nodejs24 + nodejs24-npm as matched set

### DIFF
--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -13,7 +13,7 @@
 
 FROM mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7
 
-RUN tdnf install -y jq nodejs npm && tdnf clean all \
+RUN tdnf install -y jq nodejs24 nodejs24-npm && tdnf clean all \
     && npm install -g @azure/static-web-apps-cli@2.0.9
 
 COPY deploy/azure-bootstrap/bootstrap.sh /opt/sonde/deploy/azure-bootstrap/bootstrap.sh


### PR DESCRIPTION
The generic nodejs and npm packages resolve to mismatched versions on Azure Linux 3.0 (nodejs24-npm requires nodejs24 but nodejs installs a different version). Install the explicit nodejs24 + nodejs24-npm pair.