### PR TITLE
fix(bootstrap): use Graph API for SPA redirect URI, grant Storage permission

### DIFF
--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -291,10 +291,11 @@ else
         echo "redirect URI merge produced empty result" >&2
         exit 1
     fi
+    patch_body="$(jq -n -c --argjson uris "$merged_uris" '{"spa":{"redirectUris":$uris}}')"
     az rest --method PATCH \
         --url "https://graph.microsoft.com/v1.0/applications/$app_object_id" \
         --headers "Content-Type=application/json" \
-        --body "{\"spa\":{\"redirectUris\":$merged_uris}}"
+        --body "$patch_body"
     echo "Added SPA redirect URI: $redirect_uri" >&2
 fi
 
@@ -305,8 +306,16 @@ else
     az ad app permission add --id "$app_object_id" \
         --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
         --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope"
-    echo "Azure Storage user_impersonation permission configured" >&2
+    echo "Azure Storage user_impersonation permission declared" >&2
 fi
+
+# Grant admin consent for Azure Storage so users don't need to consent individually
+az ad app permission grant \
+    --id "$companion_client_id" \
+    --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
+    --scope "user_impersonation" \
+    --output none 2>/dev/null || true
+echo "Azure Storage user_impersonation permission granted" >&2
 
 echo "Web UI deployment complete" >&2
 

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -91,25 +91,37 @@ REDIRECT_URI="https://$SWA_HOSTNAME"
 # Get current SPA redirect URIs and add ours if not present
 CURRENT_URIS="$(az ad app show --id "$APP_OBJECT_ID" \
   --query 'spa.redirectUris' -o json 2>/dev/null || echo '[]')"
-if echo "$CURRENT_URIS" | grep -Fq "$REDIRECT_URI"; then
+if [ -z "$CURRENT_URIS" ] || [ "$CURRENT_URIS" = "null" ]; then
+  CURRENT_URIS="[]"
+fi
+URI_EXISTS=0
+echo "$CURRENT_URIS" | jq -e --arg uri "$REDIRECT_URI" 'index($uri) != null' >/dev/null 2>&1 && URI_EXISTS=1
+if [ "$URI_EXISTS" -eq 1 ]; then
   echo "  Redirect URI already registered"
 else
   # Merge with existing URIs to avoid overwriting the list
   MERGED_URIS="$(echo "$CURRENT_URIS" | jq -c --arg uri "$REDIRECT_URI" '(. // []) + [$uri]')"
+  PATCH_BODY="$(jq -n -c --argjson uris "$MERGED_URIS" '{"spa":{"redirectUris":$uris}}')"
   az rest --method PATCH \
     --url "https://graph.microsoft.com/v1.0/applications/$APP_OBJECT_ID" \
     --headers "Content-Type=application/json" \
-    --body "{\"spa\":{\"redirectUris\":$MERGED_URIS}}"
+    --body "$PATCH_BODY"
   echo "  Added redirect URI: $REDIRECT_URI"
 fi
 
 echo ""
 echo "=== Adding Azure Storage API permission ==="
-# Grant user_impersonation on Azure Storage (e406a681-f3d4-42a8-90b6-c2b029497af1)
+# Declare user_impersonation on Azure Storage (e406a681-f3d4-42a8-90b6-c2b029497af1)
 az ad app permission add --id "$APP_OBJECT_ID" \
   --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
   --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" || true
-echo "  Azure Storage user_impersonation permission configured"
+# Grant admin consent so users don't need to consent individually
+az ad app permission grant \
+  --id "$COMPANION_CLIENT_ID" \
+  --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
+  --scope "user_impersonation" \
+  --output none 2>/dev/null || true
+echo "  Azure Storage user_impersonation permission granted"
 
 echo ""
 echo "=== Deploying SPA content ==="


### PR DESCRIPTION
az ad app update does not have a --spa-redirect-uris flag. Use the
generic --set syntax with a JSON array value instead:
  --set spa/redirectUris='["uri1","uri2"]'

Fixed in both bootstrap.sh and deploy/web-ui/deploy.sh. Changed jq
output from space-separated (-r + join) to compact JSON array (-c).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
