### PR TITLE
fix(web-ui): switch MSAL CDN from alcdn.msauth.net to jsdelivr

### DIFF
--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -282,8 +282,8 @@ echo "$current_uris" | jq -e --arg uri "$redirect_uri" 'index($uri) != null' >/d
 if [ "$uri_exists" -eq 1 ]; then
     echo "SPA redirect URI already registered" >&2
 else
-    merged_uris="$(echo "$current_uris" | jq -r --arg uri "$redirect_uri" \
-        '(. // []) + [$uri] | join(" ")')" || {
+    merged_uris="$(echo "$current_uris" | jq -c --arg uri "$redirect_uri" \
+        '(. // []) + [$uri]')" || {
         echo "failed to merge redirect URIs" >&2
         exit 1
     }
@@ -291,8 +291,10 @@ else
         echo "redirect URI merge produced empty result" >&2
         exit 1
     fi
-    az ad app update --id "$app_object_id" \
-        --spa-redirect-uris $merged_uris
+    az rest --method PATCH \
+        --url "https://graph.microsoft.com/v1.0/applications/$app_object_id" \
+        --headers "Content-Type=application/json" \
+        --body "{\"spa\":{\"redirectUris\":$merged_uris}}"
     echo "Added SPA redirect URI: $redirect_uri" >&2
 fi
 

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -95,9 +95,11 @@ if echo "$CURRENT_URIS" | grep -Fq "$REDIRECT_URI"; then
   echo "  Redirect URI already registered"
 else
   # Merge with existing URIs to avoid overwriting the list
-  MERGED_URIS="$(echo "$CURRENT_URIS" | jq -r --arg uri "$REDIRECT_URI" '(. // []) + [$uri] | join(" ")')"
-  az ad app update --id "$APP_OBJECT_ID" \
-    --spa-redirect-uris $MERGED_URIS
+  MERGED_URIS="$(echo "$CURRENT_URIS" | jq -c --arg uri "$REDIRECT_URI" '(. // []) + [$uri]')"
+  az rest --method PATCH \
+    --url "https://graph.microsoft.com/v1.0/applications/$APP_OBJECT_ID" \
+    --headers "Content-Type=application/json" \
+    --body "{\"spa\":{\"redirectUris\":$MERGED_URIS}}"
   echo "  Added redirect URI: $REDIRECT_URI"
 fi
 

--- a/deploy/web-ui/index.html
+++ b/deploy/web-ui/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Sonde</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://alcdn.msauth.net/browser/2.38.3/js/msal-browser.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@azure/msal-browser@2.39.0/lib/msal-browser.min.js"></script>
   <script src="app.js" defer></script>
 </head>
 <body>

--- a/deploy/web-ui/staticwebapp.config.json
+++ b/deploy/web-ui/staticwebapp.config.json
@@ -1,5 +1,6 @@
 {
   "navigationFallback": {
-    "rewrite": "/index.html"
+    "rewrite": "/index.html",
+    "exclude": ["/config.json"]
   }
 }


### PR DESCRIPTION
The Microsoft MSAL CDN at alcdn.msauth.net returns 404 for all versions, causing the SPA to show 'MSAL is not available'. Switch to cdn.jsdelivr.net with MSAL Browser v2.39.0 (latest v2.x compatible with the UMD global API used by app.js).