### PR TITLE
fix(web-ui): preserve status messages, configure CORS and role in deploy

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -545,7 +545,9 @@ async function renderDesiredState() {
     return;
   }
 
+  const savedMessage = APP.viewMessage;
   renderCard('Desired State', '<p class="muted">Loading desired state…</p>');
+  APP.viewMessage = savedMessage;
 
   try {
     const [programs, desiredRows] = await Promise.all([
@@ -664,7 +666,9 @@ async function renderPrograms() {
     return;
   }
 
+  const savedMessage = APP.viewMessage;
   renderCard('Programs', '<p class="muted">Loading programs…</p>');
+  APP.viewMessage = savedMessage;
 
   try {
     const programs = await listPrograms();
@@ -794,7 +798,9 @@ async function renderRoutes() {
     return;
   }
 
+  const savedMessage = APP.viewMessage;
   renderCard('Routes', '<p class="muted">Loading routes…</p>');
+  APP.viewMessage = savedMessage;
 
   try {
     const [programs, routes] = await Promise.all([

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -124,6 +124,39 @@ az ad app permission grant \
 echo "  Azure Storage user_impersonation permission granted"
 
 echo ""
+echo "=== Configuring Function App CORS ==="
+# The web UI calls the Function App ingest endpoint from the browser.
+# Without CORS, the preflight request is rejected and fetch() fails.
+EXISTING_CORS="$(az functionapp cors show --name "$FUNCTION_APP" \
+  --resource-group "$RESOURCE_GROUP" --query 'allowedOrigins' -o json 2>/dev/null || echo '[]')"
+SWA_ORIGIN="https://$SWA_HOSTNAME"
+HAS_ORIGIN=0
+echo "$EXISTING_CORS" | jq -e --arg o "$SWA_ORIGIN" 'index($o) != null' >/dev/null 2>&1 && HAS_ORIGIN=1
+if [ "$HAS_ORIGIN" -eq 1 ]; then
+  echo "  CORS origin already registered"
+else
+  az functionapp cors add --name "$FUNCTION_APP" \
+    --resource-group "$RESOURCE_GROUP" \
+    --allowed-origins "$SWA_ORIGIN" --output none
+  echo "  Added CORS origin: $SWA_ORIGIN"
+fi
+
+echo ""
+echo "=== Assigning Storage Table Data Contributor to deploying user ==="
+DEPLOYER_PRINCIPAL="$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)"
+if [ -z "$DEPLOYER_PRINCIPAL" ]; then
+  echo "  WARNING: Could not determine signed-in user. Skipping role assignment."
+  echo "  Grant 'Storage Table Data Contributor' manually — see instructions below."
+else
+  STORAGE_SCOPE="/subscriptions/$(az account show --query id -o tsv)/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$STORAGE_ACCOUNT"
+  az role assignment create --assignee "$DEPLOYER_PRINCIPAL" \
+    --role "Storage Table Data Contributor" \
+    --scope "$STORAGE_SCOPE" \
+    --output none 2>/dev/null || true
+  echo "  Assigned 'Storage Table Data Contributor' to deploying user"
+fi
+
+echo ""
 echo "=== Deploying SPA content ==="
 DEPLOYMENT_TOKEN="$(az staticwebapp secrets list --name "$SWA_NAME" \
   --resource-group "$RESOURCE_GROUP" \


### PR DESCRIPTION
## Problem

Uploading programs via the web UI at `https://ashy-smoke-0644bc710.7.azurestaticapps.net/#programs` silently failed — the page blinked briefly and returned to the upload form with no feedback.

## Root Cause

Three issues combined:

1. **Status messages consumed by loading placeholder** — `renderDesiredState`, `renderPrograms`, and `renderRoutes` each call `renderCard()` twice: once for a "Loading..." placeholder and again for the final content. Because `renderCard()` calls `consumeViewMessage()`, the loading render consumed the pending success/error message before the final render could display it.

2. **Function App CORS not configured** — The web UI calls the Function App `programs/ingest` endpoint from the browser, but no CORS origin was registered on the Function App. The browser blocked the preflight `OPTIONS` request, causing `fetch()` to fail with a network error ("Failed to fetch").

3. **Storage Table Data Contributor not auto-assigned** — After deployment, the deploying admin had to manually grant themselves the `Storage Table Data Contributor` role before the web UI could access Azure Table Storage.

## Fix

- **`app.js`**: Save `APP.viewMessage` before the loading `renderCard` call and restore it afterward, so the final render displays the message. Applied to all three affected views (Programs, Desired State, Routes).
- **`deploy.sh`**: Added a CORS configuration step that registers the SWA origin on the Function App (idempotent — skips if already present).
- **`deploy.sh`**: Added auto-assignment of `Storage Table Data Contributor` to the deploying user (via `az ad signed-in-user`), with a fallback warning if the principal cannot be determined.

## Note

The `ProgramIngest` Azure Function endpoint (`POST /api/programs/ingest`) has a `function.json` route definition but no handler implementation in the custom handler binary. The upload will now show a clear server error instead of silently failing. Implementing the ingest handler is tracked separately.
