### PR TITLE
feat(azure-handler): implement ProgramIngest HTTP trigger endpoint

### DIFF
--- a/.github/docker/Dockerfile.azure-handler-builder
+++ b/.github/docker/Dockerfile.azure-handler-builder
@@ -20,12 +20,14 @@ WORKDIR /sonde
 COPY . .
 RUN cargo build --locked --release -p sonde-azure-handler
 
-RUN mkdir -p /out/UpstreamConnector /pkg \
+RUN mkdir -p /out/UpstreamConnector /out/ProgramIngest /pkg \
     && cp target/release/sonde-azure-handler /out/sonde-azure-handler \
     && chmod 0755 /out/sonde-azure-handler \
     && cp crates/sonde-azure-handler/function-app/host.json /out/host.json \
     && cp crates/sonde-azure-handler/function-app/UpstreamConnector/function.json \
        /out/UpstreamConnector/function.json \
+    && cp crates/sonde-azure-handler/function-app/ProgramIngest/function.json \
+       /out/ProgramIngest/function.json \
     && cd /out && zip -q -r /pkg/sonde-azure-handler-function.zip .
 
 # ── Stage 2: export ─────────────────────────────────────────────────────────

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -107,6 +107,7 @@ jobs:
               expected = {
                   "host.json",
                   "UpstreamConnector/function.json",
+                  "ProgramIngest/function.json",
                   "sonde-azure-handler",
               }
               missing = expected.difference(names)
@@ -173,6 +174,7 @@ jobs:
                 names = set(archive.namelist())
                 assert "host.json" in names
                 assert "UpstreamConnector/function.json" in names
+                assert "ProgramIngest/function.json" in names
                 assert "sonde-azure-handler" in names
             PY
                     exit 0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "sarif-viewer.connectToGithubCodeScanning": "off"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "sarif-viewer.connectToGithubCodeScanning": "off"
-}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6514,6 +6514,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sonde-gateway",
+ "sonde-protocol",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/sonde-azure-handler/Cargo.toml
+++ b/crates/sonde-azure-handler/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 sonde-gateway = { path = "../sonde-gateway", default-features = false }
+sonde-protocol = { path = "../sonde-protocol", default-features = false }
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/crates/sonde-azure-handler/function-app/ProgramIngest/function.json
+++ b/crates/sonde-azure-handler/function-app/ProgramIngest/function.json
@@ -11,7 +11,7 @@
     {
       "type": "http",
       "direction": "out",
-      "name": "$return"
+      "name": "res"
     }
   ]
 }

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -19,8 +19,13 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use sonde_gateway::connector::{MSG_TYPE_ACTUAL_STATE, MSG_TYPE_APP_DATA, MSG_TYPE_DESIRED_STATE};
+use sonde_gateway::program::{ProgramLibrary, VerificationProfile};
+use sonde_protocol::normalize_display_filename;
 use thiserror::Error;
 use tracing::warn;
+
+/// Maximum uploaded ELF size (1 MB) — defense-in-depth before verification.
+const MAX_ELF_UPLOAD_SIZE: usize = 1_048_576;
 
 static HISTORY_ROW_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 static HISTORY_ROW_PROCESS_NONCE: OnceLock<u64> = OnceLock::new();
@@ -124,6 +129,17 @@ pub struct ProgramRouteRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgramImageRow {
+    pub program_hash: Vec<u8>,
+    pub cbor_image: Vec<u8>,
+    pub source_filename: Option<String>,
+    pub abi_version: Option<u32>,
+    pub size_bytes: u32,
+    pub verification_profile: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActualStateMessage {
     pub entity_kind: String,
     pub entity_id: String,
@@ -170,6 +186,7 @@ pub trait HandlerStore: Send + Sync {
         &self,
         program_hash: &[u8],
     ) -> Result<Option<Vec<u8>>, HandlerError>;
+    async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), HandlerError>;
 }
 
 #[async_trait]
@@ -322,6 +339,281 @@ where
             .publish(&route.handler_queue, raw_payload.to_vec())
             .await
     }
+
+    /// Handle a ProgramIngest HTTP trigger invocation (WEB-0300).
+    ///
+    /// Accepts JSON: `{"elf": "base64...", "source_filename": "...",
+    /// "abi_version": N, "verification_profile": "resident"|"ephemeral"}`
+    ///
+    /// Returns a JSON response with the program hash and metadata, or an error.
+    pub async fn handle_program_ingest(
+        &self,
+        body: &serde_json::Value,
+    ) -> Result<IngestResponse, IngestError> {
+        let elf_b64 = body
+            .get("elf")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| IngestError::bad_request("missing or non-string `elf` field"))?;
+
+        // Pre-decode length check: base64 encodes 3 bytes → 4 chars, so
+        // MAX_ELF_UPLOAD_SIZE decoded bytes ≈ ceil(n/3)*4 encoded chars.
+        let max_encoded_len = (MAX_ELF_UPLOAD_SIZE / 3 + 1) * 4;
+        if elf_b64.len() > max_encoded_len {
+            return Err(IngestError::payload_too_large(format!(
+                "base64 `elf` field length {} exceeds maximum; \
+                 decoded ELF must not exceed {} bytes",
+                elf_b64.len(),
+                MAX_ELF_UPLOAD_SIZE
+            )));
+        }
+
+        let elf_bytes = base64::engine::general_purpose::STANDARD
+            .decode(elf_b64)
+            .map_err(|e| IngestError::bad_request(format!("`elf` field is not valid base64: {e}")))?;
+
+        if elf_bytes.is_empty() {
+            return Err(IngestError::bad_request("`elf` field must not be empty"));
+        }
+        if elf_bytes.len() > MAX_ELF_UPLOAD_SIZE {
+            return Err(IngestError::payload_too_large(format!(
+                "ELF size {} bytes exceeds limit of {} bytes",
+                elf_bytes.len(),
+                MAX_ELF_UPLOAD_SIZE
+            )));
+        }
+
+        let profile_str = body
+            .get("verification_profile")
+            .and_then(|v| v.as_str())
+            .unwrap_or("resident");
+        let profile = match profile_str {
+            "resident" => VerificationProfile::Resident,
+            "ephemeral" => VerificationProfile::Ephemeral,
+            other => {
+                return Err(IngestError::bad_request(format!(
+                    "unknown `verification_profile`: `{other}`; \
+                     expected `resident` or `ephemeral`"
+                )));
+            }
+        };
+
+        let source_filename_raw = body
+            .get("source_filename")
+            .and_then(|v| v.as_str())
+            .map(|s| Some(s.to_string()))
+            .unwrap_or(None);
+        let source_filename = normalize_display_filename(&source_filename_raw);
+
+        let abi_version = match body.get("abi_version") {
+            Some(serde_json::Value::Null) | None => None,
+            Some(v) => {
+                let raw = v.as_u64().ok_or_else(|| {
+                    IngestError::bad_request(
+                        "`abi_version` must be a non-negative integer",
+                    )
+                })?;
+                let val = u32::try_from(raw).map_err(|_| {
+                    IngestError::bad_request(format!(
+                        "`abi_version` value {raw} exceeds maximum ({})",
+                        u32::MAX
+                    ))
+                })?;
+                Some(val)
+            }
+        };
+
+        let lib = ProgramLibrary::new();
+        let mut record = lib.ingest_elf(&elf_bytes, profile).map_err(|e| {
+            IngestError::unprocessable(format!(
+                "program verification/ingestion failed: {e}"
+            ))
+        })?;
+        record.abi_version = abi_version;
+        record.source_filename = source_filename.clone();
+
+        let now = chrono_iso8601_utc_now();
+        let profile_name = match record.verification_profile {
+            VerificationProfile::Resident => "resident",
+            VerificationProfile::Ephemeral => "ephemeral",
+        };
+        let row = ProgramImageRow {
+            program_hash: record.hash.clone(),
+            cbor_image: record.image,
+            source_filename: record.source_filename.clone(),
+            abi_version: record.abi_version,
+            size_bytes: record.size,
+            verification_profile: profile_name.to_string(),
+            created_at: now,
+        };
+        self.store
+            .store_program_image(&row)
+            .await
+            .map_err(|e| IngestError::internal(format!("store program failed: {e}")))?;
+
+        Ok(IngestResponse {
+            program_hash: hex::encode(&record.hash),
+            size: record.size,
+            abi_version: record.abi_version,
+            source_filename: record.source_filename,
+        })
+    }
+}
+
+/// Successful response from program ingestion.
+#[derive(Debug, Clone, Serialize)]
+pub struct IngestResponse {
+    pub program_hash: String,
+    pub size: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub abi_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_filename: Option<String>,
+}
+
+/// Error from program ingestion with HTTP status code.
+#[derive(Debug)]
+pub struct IngestError {
+    pub status_code: u16,
+    pub message: String,
+}
+
+impl IngestError {
+    fn bad_request(msg: impl Into<String>) -> Self {
+        Self {
+            status_code: 400,
+            message: msg.into(),
+        }
+    }
+
+    fn payload_too_large(msg: impl Into<String>) -> Self {
+        Self {
+            status_code: 413,
+            message: msg.into(),
+        }
+    }
+
+    fn unprocessable(msg: impl Into<String>) -> Self {
+        Self {
+            status_code: 422,
+            message: msg.into(),
+        }
+    }
+
+    fn internal(msg: impl Into<String>) -> Self {
+        Self {
+            status_code: 500,
+            message: msg.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for IngestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HTTP {}: {}", self.status_code, self.message)
+    }
+}
+
+fn chrono_iso8601_utc_now() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Compute year/month/day from days since epoch (1970-01-01).
+    let mut y = 1970i64;
+    let mut remaining = days as i64;
+    loop {
+        let days_in_year = if y % 4 == 0 && (y % 100 != 0 || y % 400 == 0) {
+            366
+        } else {
+            365
+        };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        y += 1;
+    }
+    let leap = y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+    let month_days: [i64; 12] = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut m = 0;
+    for &md in &month_days {
+        if remaining < md {
+            break;
+        }
+        remaining -= md;
+        m += 1;
+    }
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y,
+        m + 1,
+        remaining + 1,
+        hours,
+        minutes,
+        seconds
+    )
+}
+
+/// Extract the JSON body from an Azure Functions HTTP trigger invocation
+/// envelope. The envelope is the outer JSON sent by the Functions host when
+/// `enableForwardingHttpRequest` is `false`.
+///
+/// Returns the parsed body as a `serde_json::Value`.
+pub fn extract_http_trigger_body(
+    request_body: &[u8],
+) -> Result<serde_json::Value, HandlerError> {
+    let envelope: serde_json::Value = serde_json::from_slice(request_body)?;
+    let body_str = envelope
+        .get("Data")
+        .or_else(|| envelope.get("data"))
+        .and_then(|data| data.get("req").or_else(|| data.get("Req")))
+        .and_then(|req| req.get("Body").or_else(|| req.get("body")))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            HandlerError::Decode(
+                "HTTP trigger envelope missing `Data.req.Body`".to_string(),
+            )
+        })?;
+    serde_json::from_str(body_str).map_err(|e| {
+        HandlerError::Decode(format!("HTTP trigger body is not valid JSON: {e}"))
+    })
+}
+
+/// Format an `IngestResponse` as an Azure Functions HTTP output binding
+/// response envelope. The binding name `res` matches
+/// `ProgramIngest/function.json`.
+pub fn format_ingest_response(
+    status_code: u16,
+    body: &serde_json::Value,
+) -> serde_json::Value {
+    serde_json::json!({
+        "Outputs": {
+            "res": {
+                "statusCode": status_code,
+                "headers": {"Content-Type": "application/json"},
+                "body": serde_json::to_string(body).unwrap_or_default()
+            }
+        }
+    })
 }
 
 pub struct AzureTablesStore {
@@ -457,6 +749,32 @@ impl HandlerStore for AzureTablesStore {
                 "query program image failed: {e}"
             ))),
         }
+    }
+
+    async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), HandlerError> {
+        let row_key = hex::encode(&row.program_hash);
+        let entity = ProgramImageEntity {
+            partition_key: "program".to_string(),
+            row_key: row_key.clone(),
+            cbor_image: base64::engine::general_purpose::STANDARD.encode(&row.cbor_image),
+            source_filename: row.source_filename.clone(),
+            abi_version: row.abi_version,
+            size_bytes: Some(row.size_bytes),
+            verification_profile: Some(row.verification_profile.clone()),
+            created_at: Some(row.created_at.clone()),
+        };
+        let entity_client = self
+            .programs_table
+            .partition_key_client("program")
+            .entity_client(row_key);
+        entity_client
+            .insert_or_replace(entity)
+            .map_err(|e| {
+                HandlerError::Store(format!("prepare program-image upsert failed: {e}"))
+            })?
+            .await
+            .map_err(|e| HandlerError::Store(format!("upsert program-image row failed: {e}")))?;
+        Ok(())
     }
 }
 
@@ -611,6 +929,16 @@ struct ProgramImageEntity {
     #[serde(rename = "RowKey")]
     row_key: String,
     cbor_image: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    source_filename: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    abi_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    size_bytes: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    verification_profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    created_at: Option<String>,
 }
 
 impl TryFrom<ActualStateEntity> for ActualStateRow {
@@ -1152,6 +1480,14 @@ mod tests {
                 .get(&hex::encode(program_hash))
                 .cloned())
         }
+
+        async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), HandlerError> {
+            self.program_images
+                .lock()
+                .await
+                .insert(hex::encode(&row.program_hash), row.cbor_image.clone());
+            Ok(())
+        }
     }
 
     #[derive(Default)]
@@ -1249,6 +1585,10 @@ mod tests {
                 None => Ok(None),
             }
         }
+
+        async fn store_program_image(&self, _row: &ProgramImageRow) -> Result<(), HandlerError> {
+            Ok(())
+        }
     }
 
     struct SameTimestampDifferentLatestStore {
@@ -1290,6 +1630,10 @@ mod tests {
             _program_hash: &[u8],
         ) -> Result<Option<Vec<u8>>, HandlerError> {
             Ok(None)
+        }
+
+        async fn store_program_image(&self, _row: &ProgramImageRow) -> Result<(), HandlerError> {
+            Ok(())
         }
     }
 
@@ -1333,6 +1677,10 @@ mod tests {
             _program_hash: &[u8],
         ) -> Result<Option<Vec<u8>>, HandlerError> {
             Ok(None)
+        }
+
+        async fn store_program_image(&self, _row: &ProgramImageRow) -> Result<(), HandlerError> {
+            Ok(())
         }
     }
 
@@ -2165,5 +2513,332 @@ mod tests {
         });
         let err = serde_json::from_value::<ActualStateEntity>(json).unwrap_err();
         assert!(err.to_string().contains("not a valid u64"));
+    }
+
+    // ── Program Ingest tests (T-WEB-0301 through T-WEB-0308) ──
+
+    /// Build a minimal valid BPF ELF with a `sonde` section containing the
+    /// given BPF bytecode. This mirrors `make_sonde_elf` from
+    /// `crates/sonde-gateway/src/program.rs` (test-only).
+    fn make_test_elf(bpf_code: &[u8]) -> Vec<u8> {
+        let shstrtab: &[u8] = b"\0sonde\0.shstrtab\0";
+
+        let text_offset: u64 = 64;
+        let shstrtab_offset: u64 = text_offset + bpf_code.len() as u64;
+        let shdr_offset: u64 = shstrtab_offset + shstrtab.len() as u64;
+
+        let mut elf = Vec::new();
+        elf.extend_from_slice(&[0x7f, b'E', b'L', b'F']);
+        elf.push(2); // ELFCLASS64
+        elf.push(1); // ELFDATA2LSB
+        elf.push(1); // EI_VERSION
+        elf.extend_from_slice(&[0; 9]);
+        elf.extend_from_slice(&1u16.to_le_bytes()); // ET_REL
+        elf.extend_from_slice(&247u16.to_le_bytes()); // EM_BPF
+        elf.extend_from_slice(&1u32.to_le_bytes());
+        elf.extend_from_slice(&0u64.to_le_bytes()); // e_entry
+        elf.extend_from_slice(&0u64.to_le_bytes()); // e_phoff
+        elf.extend_from_slice(&shdr_offset.to_le_bytes());
+        elf.extend_from_slice(&0u32.to_le_bytes());
+        elf.extend_from_slice(&64u16.to_le_bytes()); // e_ehsize
+        elf.extend_from_slice(&0u16.to_le_bytes());
+        elf.extend_from_slice(&0u16.to_le_bytes());
+        elf.extend_from_slice(&64u16.to_le_bytes()); // e_shentsize
+        elf.extend_from_slice(&3u16.to_le_bytes()); // e_shnum
+        elf.extend_from_slice(&2u16.to_le_bytes()); // e_shstrndx
+        assert_eq!(elf.len(), 64);
+        elf.extend_from_slice(bpf_code);
+        elf.extend_from_slice(shstrtab);
+
+        // Null section header
+        elf.extend_from_slice(&[0u8; 64]);
+
+        // sonde section header
+        let mut sh = [0u8; 64];
+        sh[0..4].copy_from_slice(&1u32.to_le_bytes());
+        sh[4..8].copy_from_slice(&1u32.to_le_bytes()); // SHT_PROGBITS
+        let flags: u64 = 0x6; // SHF_ALLOC | SHF_EXECINSTR
+        sh[8..16].copy_from_slice(&flags.to_le_bytes());
+        sh[24..32].copy_from_slice(&text_offset.to_le_bytes());
+        sh[32..40].copy_from_slice(&(bpf_code.len() as u64).to_le_bytes());
+        sh[48..56].copy_from_slice(&8u64.to_le_bytes());
+        elf.extend_from_slice(&sh);
+
+        // .shstrtab section header
+        let mut sh2 = [0u8; 64];
+        sh2[0..4].copy_from_slice(&7u32.to_le_bytes());
+        sh2[4..8].copy_from_slice(&3u32.to_le_bytes()); // SHT_STRTAB
+        sh2[24..32].copy_from_slice(&shstrtab_offset.to_le_bytes());
+        sh2[32..40].copy_from_slice(&(shstrtab.len() as u64).to_le_bytes());
+        sh2[48..56].copy_from_slice(&1u64.to_le_bytes());
+        elf.extend_from_slice(&sh2);
+
+        elf
+    }
+
+    fn minimal_bpf_code() -> [u8; 16] {
+        [
+            0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mov r0, 0
+            0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+        ]
+    }
+
+    fn make_ingest_handler() -> (
+        Arc<MemoryStore>,
+        AzureHandler<MemoryStore, RecordingPublisher>,
+    ) {
+        let store = Arc::new(MemoryStore::default());
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler =
+            AzureHandler::new(store.clone(), publisher, "downstream-queue");
+        (store, handler)
+    }
+
+    fn make_ingest_body(
+        elf: &[u8],
+        source_filename: Option<&str>,
+        abi_version: Option<u32>,
+        verification_profile: Option<&str>,
+    ) -> serde_json::Value {
+        let mut body = serde_json::json!({
+            "elf": base64::engine::general_purpose::STANDARD.encode(elf),
+        });
+        if let Some(name) = source_filename {
+            body["source_filename"] = serde_json::json!(name);
+        }
+        if let Some(abi) = abi_version {
+            body["abi_version"] = serde_json::json!(abi);
+        }
+        if let Some(profile) = verification_profile {
+            body["verification_profile"] = serde_json::json!(profile);
+        }
+        body
+    }
+
+    // T-WEB-0301: ProgramIngest accepts ELF + metadata via JSON POST
+    #[tokio::test]
+    async fn program_ingest_accepts_valid_elf() {
+        let (store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let body = make_ingest_body(&elf, Some("sensor.o"), Some(1), Some("resident"));
+        let resp = handler.handle_program_ingest(&body).await.unwrap();
+
+        assert!(!resp.program_hash.is_empty());
+        assert!(resp.size > 0);
+        assert_eq!(resp.abi_version, Some(1));
+        assert_eq!(resp.source_filename.as_deref(), Some("sensor.o"));
+
+        // Verify the image was stored and can be loaded back.
+        let hash_bytes = hex::decode(&resp.program_hash).unwrap();
+        let stored = store.load_program_image(&hash_bytes).await.unwrap();
+        assert!(stored.is_some());
+    }
+
+    // T-WEB-0302: Prevail verification runs; invalid ELF rejected
+    #[tokio::test]
+    async fn program_ingest_rejects_invalid_elf() {
+        let (_store, handler) = make_ingest_handler();
+        let body = make_ingest_body(&[0xDE, 0xAD, 0xBE, 0xEF], None, None, None);
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 422);
+        assert!(err.message.contains("verification/ingestion failed"));
+    }
+
+    // T-WEB-0303: Program hash matches gateway computation
+    #[tokio::test]
+    async fn program_ingest_hash_matches_gateway() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let body = make_ingest_body(&elf, None, None, None);
+        let resp = handler.handle_program_ingest(&body).await.unwrap();
+
+        // Independently compute the hash via ProgramLibrary.
+        let lib = sonde_gateway::program::ProgramLibrary::new();
+        let record = lib
+            .ingest_elf(&elf, sonde_gateway::program::VerificationProfile::Resident)
+            .unwrap();
+        assert_eq!(resp.program_hash, hex::encode(&record.hash));
+    }
+
+    // T-WEB-0305: Success returns hash+metadata; failure returns diagnostics
+    #[tokio::test]
+    async fn program_ingest_success_returns_metadata() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let body = make_ingest_body(&elf, Some("my-prog.o"), Some(42), Some("resident"));
+        let resp = handler.handle_program_ingest(&body).await.unwrap();
+        assert_eq!(resp.abi_version, Some(42));
+        assert_eq!(resp.source_filename.as_deref(), Some("my-prog.o"));
+        assert_eq!(resp.program_hash.len(), 64); // SHA-256 hex = 64 chars
+    }
+
+    #[tokio::test]
+    async fn program_ingest_failure_returns_diagnostics() {
+        let (_store, handler) = make_ingest_handler();
+        let body = make_ingest_body(&[0x7f, b'E', b'L', b'F'], None, None, None);
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 422);
+        assert!(!err.message.is_empty());
+    }
+
+    // T-WEB-0306: Oversized programs rejected
+    #[tokio::test]
+    async fn program_ingest_rejects_oversized_elf() {
+        let (_store, handler) = make_ingest_handler();
+        let big_elf = vec![0u8; MAX_ELF_UPLOAD_SIZE + 1];
+        let body = make_ingest_body(&big_elf, None, None, None);
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 413);
+        assert!(err.message.contains("exceeds limit"));
+    }
+
+    // T-WEB-0307: Empty ELF rejected
+    #[tokio::test]
+    async fn program_ingest_rejects_empty_elf() {
+        let (_store, handler) = make_ingest_handler();
+        let body = make_ingest_body(&[], None, None, None);
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("must not be empty"));
+    }
+
+    // T-WEB-0308: source_filename normalized to basename
+    #[tokio::test]
+    async fn program_ingest_normalizes_source_filename() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let body = make_ingest_body(
+            &elf,
+            Some("/path/to/sensor.o"),
+            None,
+            None,
+        );
+        let resp = handler.handle_program_ingest(&body).await.unwrap();
+        assert_eq!(resp.source_filename.as_deref(), Some("sensor.o"));
+    }
+
+    #[tokio::test]
+    async fn program_ingest_missing_elf_field() {
+        let (_store, handler) = make_ingest_handler();
+        let body = serde_json::json!({"source_filename": "test.o"});
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("`elf` field"));
+    }
+
+    #[tokio::test]
+    async fn program_ingest_invalid_base64() {
+        let (_store, handler) = make_ingest_handler();
+        let body = serde_json::json!({"elf": "not-valid-base64!!!"});
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("base64"));
+    }
+
+    #[tokio::test]
+    async fn program_ingest_invalid_verification_profile() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let body = make_ingest_body(&elf, None, None, Some("unknown-profile"));
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("verification_profile"));
+    }
+
+    #[tokio::test]
+    async fn program_ingest_rejects_invalid_abi_version() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let mut body = make_ingest_body(&elf, None, None, None);
+        body["abi_version"] = serde_json::json!("not-a-number");
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("abi_version"));
+    }
+
+    #[tokio::test]
+    async fn program_ingest_defaults_to_resident_profile() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        // No verification_profile in body — should default to resident.
+        let body = make_ingest_body(&elf, None, None, None);
+        let resp = handler.handle_program_ingest(&body).await.unwrap();
+        assert!(!resp.program_hash.is_empty());
+    }
+
+    #[tokio::test]
+    async fn program_ingest_is_idempotent() {
+        let (store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let body = make_ingest_body(&elf, Some("v1.o"), Some(1), None);
+
+        let resp1 = handler.handle_program_ingest(&body).await.unwrap();
+        let body2 = make_ingest_body(&elf, Some("v2.o"), Some(2), None);
+        let resp2 = handler.handle_program_ingest(&body2).await.unwrap();
+
+        // Same hash (same ELF = same CBOR image).
+        assert_eq!(resp1.program_hash, resp2.program_hash);
+
+        // Stored image is still valid.
+        let hash_bytes = hex::decode(&resp1.program_hash).unwrap();
+        let stored = store.load_program_image(&hash_bytes).await.unwrap();
+        assert!(stored.is_some());
+    }
+
+    // Test the HTTP trigger envelope extraction.
+    #[test]
+    fn extract_http_trigger_body_parses_envelope() {
+        let inner_json = serde_json::json!({"elf": "AAAA", "source_filename": "test.o"});
+        let envelope = serde_json::json!({
+            "Data": {
+                "req": {
+                    "Body": serde_json::to_string(&inner_json).unwrap(),
+                    "Headers": {"Content-Type": "application/json"}
+                }
+            }
+        });
+        let body = extract_http_trigger_body(
+            serde_json::to_string(&envelope).unwrap().as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(body.get("elf").unwrap().as_str().unwrap(), "AAAA");
+        assert_eq!(
+            body.get("source_filename").unwrap().as_str().unwrap(),
+            "test.o"
+        );
+    }
+
+    #[test]
+    fn extract_http_trigger_body_rejects_missing_body() {
+        let envelope = serde_json::json!({"Data": {"req": {}}});
+        let err = extract_http_trigger_body(
+            serde_json::to_string(&envelope).unwrap().as_bytes(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Data.req.Body"));
+    }
+
+    #[test]
+    fn format_ingest_response_has_correct_structure() {
+        let body = serde_json::json!({"program_hash": "abcd", "size": 42});
+        let resp = format_ingest_response(200, &body);
+        let ret = resp
+            .get("Outputs")
+            .unwrap()
+            .get("res")
+            .unwrap();
+        assert_eq!(ret.get("statusCode").unwrap().as_u64().unwrap(), 200);
+        assert_eq!(
+            ret.get("headers")
+                .unwrap()
+                .get("Content-Type")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "application/json"
+        );
+        let body_str = ret.get("body").unwrap().as_str().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+        assert_eq!(parsed.get("program_hash").unwrap().as_str().unwrap(), "abcd");
     }
 }

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -382,10 +382,15 @@ where
             )));
         }
 
-        let profile_str = body
-            .get("verification_profile")
-            .and_then(|v| v.as_str())
-            .unwrap_or("resident");
+        let profile_str = match body.get("verification_profile") {
+            Some(serde_json::Value::Null) | None => "resident",
+            Some(serde_json::Value::String(s)) => s.as_str(),
+            Some(_) => {
+                return Err(IngestError::bad_request(
+                    "`verification_profile` must be a string (`resident` or `ephemeral`)",
+                ));
+            }
+        };
         let profile = match profile_str {
             "resident" => VerificationProfile::Resident,
             "ephemeral" => VerificationProfile::Ephemeral,
@@ -424,9 +429,15 @@ where
 
         let lib = ProgramLibrary::new();
         let mut record = lib.ingest_elf(&elf_bytes, profile).map_err(|e| {
-            IngestError::unprocessable(format!(
-                "program verification/ingestion failed: {e}"
-            ))
+            use sonde_gateway::program::ProgramError;
+            match &e {
+                ProgramError::Internal(_) => IngestError::internal(format!(
+                    "program ingestion internal error: {e}"
+                )),
+                _ => IngestError::unprocessable(format!(
+                    "program verification/ingestion failed: {e}"
+                )),
+            }
         })?;
         record.abi_version = abi_version;
         record.source_filename = source_filename.clone();
@@ -1380,6 +1391,7 @@ mod tests {
         desired_rows: Mutex<HashMap<String, Vec<DesiredStateRow>>>,
         routes: Mutex<HashMap<String, ProgramRouteRow>>,
         program_images: Mutex<HashMap<String, Vec<u8>>>,
+        stored_program_rows: Mutex<Vec<ProgramImageRow>>,
     }
 
     impl MemoryStore {
@@ -1486,6 +1498,7 @@ mod tests {
                 .lock()
                 .await
                 .insert(hex::encode(&row.program_hash), row.cbor_image.clone());
+            self.stored_program_rows.lock().await.push(row.clone());
             Ok(())
         }
     }
@@ -2616,6 +2629,7 @@ mod tests {
     }
 
     // T-WEB-0301: ProgramIngest accepts ELF + metadata via JSON POST
+    // T-WEB-0304: Program stored in programs table with all fields
     #[tokio::test]
     async fn program_ingest_accepts_valid_elf() {
         let (store, handler) = make_ingest_handler();
@@ -2632,6 +2646,18 @@ mod tests {
         let hash_bytes = hex::decode(&resp.program_hash).unwrap();
         let stored = store.load_program_image(&hash_bytes).await.unwrap();
         assert!(stored.is_some());
+
+        // T-WEB-0304: Assert all metadata fields were passed to storage.
+        let rows = store.stored_program_rows.lock().await;
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(hex::encode(&row.program_hash), resp.program_hash);
+        assert_eq!(row.source_filename.as_deref(), Some("sensor.o"));
+        assert_eq!(row.abi_version, Some(1));
+        assert_eq!(row.size_bytes, resp.size);
+        assert_eq!(row.verification_profile, "resident");
+        assert!(!row.created_at.is_empty());
+        assert!(!row.cbor_image.is_empty());
     }
 
     // T-WEB-0302: Prevail verification runs; invalid ELF rejected
@@ -2690,6 +2716,17 @@ mod tests {
         let err = handler.handle_program_ingest(&body).await.unwrap_err();
         assert_eq!(err.status_code, 413);
         assert!(err.message.contains("exceeds limit"));
+    }
+
+    #[tokio::test]
+    async fn program_ingest_exact_size_limit_not_rejected_as_too_large() {
+        let (_store, handler) = make_ingest_handler();
+        // Exactly at the limit — should NOT be rejected as 413.
+        // It will fail later as invalid ELF (422), but that's expected.
+        let at_limit_elf = vec![0u8; MAX_ELF_UPLOAD_SIZE];
+        let body = make_ingest_body(&at_limit_elf, None, None, None);
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_ne!(err.status_code, 413, "exact-boundary upload must not be rejected as too large");
     }
 
     // T-WEB-0307: Empty ELF rejected
@@ -2764,6 +2801,30 @@ mod tests {
         let body = make_ingest_body(&elf, None, None, None);
         let resp = handler.handle_program_ingest(&body).await.unwrap();
         assert!(!resp.program_hash.is_empty());
+    }
+
+    #[tokio::test]
+    async fn program_ingest_ephemeral_profile() {
+        let (store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let body = make_ingest_body(&elf, None, None, Some("ephemeral"));
+        let resp = handler.handle_program_ingest(&body).await.unwrap();
+        assert!(!resp.program_hash.is_empty());
+
+        let rows = store.stored_program_rows.lock().await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].verification_profile, "ephemeral");
+    }
+
+    #[tokio::test]
+    async fn program_ingest_non_string_verification_profile_rejected() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let mut body = make_ingest_body(&elf, None, None, None);
+        body["verification_profile"] = serde_json::json!(42);
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("verification_profile"));
     }
 
     #[tokio::test]

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -404,11 +404,15 @@ where
             }
         };
 
-        let source_filename_raw = body
-            .get("source_filename")
-            .and_then(|v| v.as_str())
-            .map(|s| Some(s.to_string()))
-            .unwrap_or(None);
+        let source_filename_raw = match body.get("source_filename") {
+            Some(serde_json::Value::String(s)) => Some(s.clone()),
+            Some(serde_json::Value::Null) | None => None,
+            Some(_) => {
+                return Err(IngestError::bad_request(
+                    "`source_filename` must be a string",
+                ));
+            }
+        };
         let source_filename = normalize_display_filename(&source_filename_raw);
 
         let abi_version = match body.get("abi_version") {
@@ -417,13 +421,14 @@ where
                 let raw = v.as_u64().ok_or_else(|| {
                     IngestError::bad_request("`abi_version` must be a non-negative integer")
                 })?;
-                let val = u32::try_from(raw).map_err(|_| {
-                    IngestError::bad_request(format!(
-                        "`abi_version` value {raw} exceeds maximum ({})",
-                        u32::MAX
-                    ))
-                })?;
-                Some(val)
+                // Azure Tables stores this as Edm.Int32, so cap at i32::MAX.
+                let max_abi = i32::MAX as u64;
+                if raw > max_abi {
+                    return Err(IngestError::bad_request(format!(
+                        "`abi_version` value {raw} exceeds Edm.Int32 maximum ({max_abi})"
+                    )));
+                }
+                Some(raw as u32)
             }
         };
 
@@ -2831,6 +2836,74 @@ mod tests {
         let hash_bytes = hex::decode(&resp1.program_hash).unwrap();
         let stored = store.load_program_image(&hash_bytes).await.unwrap();
         assert!(stored.is_some());
+    }
+
+    #[tokio::test]
+    async fn program_ingest_store_failure_returns_500() {
+        struct FailingProgramStore;
+
+        #[async_trait]
+        impl HandlerStore for FailingProgramStore {
+            async fn append_actual_state(&self, _: &ActualStateRow) -> Result<(), HandlerError> {
+                Ok(())
+            }
+            async fn load_latest_actual_state(
+                &self,
+                _: &str,
+            ) -> Result<Option<ActualStateRow>, HandlerError> {
+                Ok(None)
+            }
+            async fn load_latest_desired_state(
+                &self,
+                _: &str,
+            ) -> Result<Option<DesiredStateRow>, HandlerError> {
+                Ok(None)
+            }
+            async fn load_program_route(
+                &self,
+                _: &[u8],
+            ) -> Result<Option<ProgramRouteRow>, HandlerError> {
+                Ok(None)
+            }
+            async fn load_program_image(&self, _: &[u8]) -> Result<Option<Vec<u8>>, HandlerError> {
+                Ok(None)
+            }
+            async fn store_program_image(&self, _: &ProgramImageRow) -> Result<(), HandlerError> {
+                Err(HandlerError::Store("simulated storage failure".to_string()))
+            }
+        }
+
+        let store = Arc::new(FailingProgramStore);
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler = AzureHandler::new(store, publisher, "downstream-queue");
+
+        let elf = make_test_elf(&minimal_bpf_code());
+        let body = make_ingest_body(&elf, None, None, None);
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 500);
+        assert!(err.message.contains("store program failed"));
+    }
+
+    #[tokio::test]
+    async fn program_ingest_rejects_non_string_source_filename() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let mut body = make_ingest_body(&elf, None, None, None);
+        body["source_filename"] = serde_json::json!(123);
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("source_filename"));
+    }
+
+    #[tokio::test]
+    async fn program_ingest_rejects_abi_version_above_i32_max() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let mut body = make_ingest_body(&elf, None, None, None);
+        body["abi_version"] = serde_json::json!(i32::MAX as u64 + 1);
+        let err = handler.handle_program_ingest(&body).await.unwrap_err();
+        assert_eq!(err.status_code, 400);
+        assert!(err.message.contains("abi_version"));
     }
 
     // Test the HTTP trigger envelope extraction.

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -369,7 +369,9 @@ where
 
         let elf_bytes = base64::engine::general_purpose::STANDARD
             .decode(elf_b64)
-            .map_err(|e| IngestError::bad_request(format!("`elf` field is not valid base64: {e}")))?;
+            .map_err(|e| {
+                IngestError::bad_request(format!("`elf` field is not valid base64: {e}"))
+            })?;
 
         if elf_bytes.is_empty() {
             return Err(IngestError::bad_request("`elf` field must not be empty"));
@@ -413,9 +415,7 @@ where
             Some(serde_json::Value::Null) | None => None,
             Some(v) => {
                 let raw = v.as_u64().ok_or_else(|| {
-                    IngestError::bad_request(
-                        "`abi_version` must be a non-negative integer",
-                    )
+                    IngestError::bad_request("`abi_version` must be a non-negative integer")
                 })?;
                 let val = u32::try_from(raw).map_err(|_| {
                     IngestError::bad_request(format!(
@@ -431,9 +431,9 @@ where
         let mut record = lib.ingest_elf(&elf_bytes, profile).map_err(|e| {
             use sonde_gateway::program::ProgramError;
             match &e {
-                ProgramError::Internal(_) => IngestError::internal(format!(
-                    "program ingestion internal error: {e}"
-                )),
+                ProgramError::Internal(_) => {
+                    IngestError::internal(format!("program ingestion internal error: {e}"))
+                }
                 _ => IngestError::unprocessable(format!(
                     "program verification/ingestion failed: {e}"
                 )),
@@ -589,9 +589,7 @@ fn chrono_iso8601_utc_now() -> String {
 /// `enableForwardingHttpRequest` is `false`.
 ///
 /// Returns the parsed body as a `serde_json::Value`.
-pub fn extract_http_trigger_body(
-    request_body: &[u8],
-) -> Result<serde_json::Value, HandlerError> {
+pub fn extract_http_trigger_body(request_body: &[u8]) -> Result<serde_json::Value, HandlerError> {
     let envelope: serde_json::Value = serde_json::from_slice(request_body)?;
     let body_str = envelope
         .get("Data")
@@ -600,22 +598,16 @@ pub fn extract_http_trigger_body(
         .and_then(|req| req.get("Body").or_else(|| req.get("body")))
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            HandlerError::Decode(
-                "HTTP trigger envelope missing `Data.req.Body`".to_string(),
-            )
+            HandlerError::Decode("HTTP trigger envelope missing `Data.req.Body`".to_string())
         })?;
-    serde_json::from_str(body_str).map_err(|e| {
-        HandlerError::Decode(format!("HTTP trigger body is not valid JSON: {e}"))
-    })
+    serde_json::from_str(body_str)
+        .map_err(|e| HandlerError::Decode(format!("HTTP trigger body is not valid JSON: {e}")))
 }
 
 /// Format an `IngestResponse` as an Azure Functions HTTP output binding
 /// response envelope. The binding name `res` matches
 /// `ProgramIngest/function.json`.
-pub fn format_ingest_response(
-    status_code: u16,
-    body: &serde_json::Value,
-) -> serde_json::Value {
+pub fn format_ingest_response(status_code: u16, body: &serde_json::Value) -> serde_json::Value {
     serde_json::json!({
         "Outputs": {
             "res": {
@@ -780,9 +772,7 @@ impl HandlerStore for AzureTablesStore {
             .entity_client(row_key);
         entity_client
             .insert_or_replace(entity)
-            .map_err(|e| {
-                HandlerError::Store(format!("prepare program-image upsert failed: {e}"))
-            })?
+            .map_err(|e| HandlerError::Store(format!("prepare program-image upsert failed: {e}")))?
             .await
             .map_err(|e| HandlerError::Store(format!("upsert program-image row failed: {e}")))?;
         Ok(())
@@ -2602,8 +2592,7 @@ mod tests {
     ) {
         let store = Arc::new(MemoryStore::default());
         let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(store.clone(), publisher, "downstream-queue");
+        let handler = AzureHandler::new(store.clone(), publisher, "downstream-queue");
         (store, handler)
     }
 
@@ -2726,7 +2715,10 @@ mod tests {
         let at_limit_elf = vec![0u8; MAX_ELF_UPLOAD_SIZE];
         let body = make_ingest_body(&at_limit_elf, None, None, None);
         let err = handler.handle_program_ingest(&body).await.unwrap_err();
-        assert_ne!(err.status_code, 413, "exact-boundary upload must not be rejected as too large");
+        assert_ne!(
+            err.status_code, 413,
+            "exact-boundary upload must not be rejected as too large"
+        );
     }
 
     // T-WEB-0307: Empty ELF rejected
@@ -2744,12 +2736,7 @@ mod tests {
     async fn program_ingest_normalizes_source_filename() {
         let (_store, handler) = make_ingest_handler();
         let elf = make_test_elf(&minimal_bpf_code());
-        let body = make_ingest_body(
-            &elf,
-            Some("/path/to/sensor.o"),
-            None,
-            None,
-        );
+        let body = make_ingest_body(&elf, Some("/path/to/sensor.o"), None, None);
         let resp = handler.handle_program_ingest(&body).await.unwrap();
         assert_eq!(resp.source_filename.as_deref(), Some("sensor.o"));
     }
@@ -2858,10 +2845,8 @@ mod tests {
                 }
             }
         });
-        let body = extract_http_trigger_body(
-            serde_json::to_string(&envelope).unwrap().as_bytes(),
-        )
-        .unwrap();
+        let body = extract_http_trigger_body(serde_json::to_string(&envelope).unwrap().as_bytes())
+            .unwrap();
         assert_eq!(body.get("elf").unwrap().as_str().unwrap(), "AAAA");
         assert_eq!(
             body.get("source_filename").unwrap().as_str().unwrap(),
@@ -2872,10 +2857,8 @@ mod tests {
     #[test]
     fn extract_http_trigger_body_rejects_missing_body() {
         let envelope = serde_json::json!({"Data": {"req": {}}});
-        let err = extract_http_trigger_body(
-            serde_json::to_string(&envelope).unwrap().as_bytes(),
-        )
-        .unwrap_err();
+        let err = extract_http_trigger_body(serde_json::to_string(&envelope).unwrap().as_bytes())
+            .unwrap_err();
         assert!(err.to_string().contains("Data.req.Body"));
     }
 
@@ -2883,11 +2866,7 @@ mod tests {
     fn format_ingest_response_has_correct_structure() {
         let body = serde_json::json!({"program_hash": "abcd", "size": 42});
         let resp = format_ingest_response(200, &body);
-        let ret = resp
-            .get("Outputs")
-            .unwrap()
-            .get("res")
-            .unwrap();
+        let ret = resp.get("Outputs").unwrap().get("res").unwrap();
         assert_eq!(ret.get("statusCode").unwrap().as_u64().unwrap(), 200);
         assert_eq!(
             ret.get("headers")
@@ -2900,6 +2879,9 @@ mod tests {
         );
         let body_str = ret.get("body").unwrap().as_str().unwrap();
         let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
-        assert_eq!(parsed.get("program_hash").unwrap().as_str().unwrap(), "abcd");
+        assert_eq!(
+            parsed.get("program_hash").unwrap().as_str().unwrap(),
+            "abcd"
+        );
     }
 }

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -2623,7 +2623,8 @@ mod tests {
     }
 
     // T-WEB-0301: ProgramIngest accepts ELF + metadata via JSON POST
-    // T-WEB-0304: Program stored in programs table with all fields
+    // Also verifies all metadata fields are passed to the store (partial
+    // coverage toward T-WEB-0304; full integration coverage is planned).
     #[tokio::test]
     async fn program_ingest_accepts_valid_elf() {
         let (store, handler) = make_ingest_handler();
@@ -2641,7 +2642,7 @@ mod tests {
         let stored = store.load_program_image(&hash_bytes).await.unwrap();
         assert!(stored.is_some());
 
-        // T-WEB-0304: Assert all metadata fields were passed to storage.
+        // Assert all metadata fields were passed to storage.
         let rows = store.stored_program_rows.lock().await;
         assert_eq!(rows.len(), 1);
         let row = &rows[0];
@@ -2904,6 +2905,32 @@ mod tests {
         let err = handler.handle_program_ingest(&body).await.unwrap_err();
         assert_eq!(err.status_code, 400);
         assert!(err.message.contains("abi_version"));
+    }
+
+    #[tokio::test]
+    async fn program_ingest_accepts_abi_version_at_i32_max() {
+        let (_store, handler) = make_ingest_handler();
+        let elf = make_test_elf(&minimal_bpf_code());
+        let mut body = make_ingest_body(&elf, None, None, None);
+        body["abi_version"] = serde_json::json!(i32::MAX);
+        let resp = handler.handle_program_ingest(&body).await.unwrap();
+        assert_eq!(resp.abi_version, Some(i32::MAX as u32));
+    }
+
+    #[test]
+    fn chrono_iso8601_utc_now_has_valid_format() {
+        let ts = chrono_iso8601_utc_now();
+        // Must match YYYY-MM-DDTHH:MM:SSZ
+        assert_eq!(ts.len(), 20, "unexpected length: {ts}");
+        assert!(ts.ends_with('Z'), "must end with Z: {ts}");
+        assert_eq!(&ts[4..5], "-");
+        assert_eq!(&ts[7..8], "-");
+        assert_eq!(&ts[10..11], "T");
+        assert_eq!(&ts[13..14], ":");
+        assert_eq!(&ts[16..17], ":");
+        // Year must be >= 2025
+        let year: u32 = ts[0..4].parse().unwrap();
+        assert!(year >= 2025, "year {year} too low");
     }
 
     // Test the HTTP trigger envelope extraction.

--- a/crates/sonde-azure-handler/src/main.rs
+++ b/crates/sonde-azure-handler/src/main.rs
@@ -12,8 +12,8 @@ use axum::routing::post;
 use axum::{Json, Router};
 use serde_json::json;
 use sonde_azure_handler::{
-    extract_trigger_payload, AzureHandler, AzureTablesStore, HandlerError, RuntimeConfig,
-    StorageQueuePublisher,
+    extract_http_trigger_body, extract_trigger_payload, format_ingest_response, AzureHandler,
+    AzureTablesStore, HandlerError, RuntimeConfig, StorageQueuePublisher,
 };
 use tokio::net::TcpListener;
 use tracing_subscriber::prelude::*;
@@ -58,6 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or(3000);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     let app = Router::new()
+        .route("/ProgramIngest", post(program_ingest))
         .route("/", post(invoke))
         .route("/{*path}", post(invoke))
         .with_state(state);
@@ -84,4 +85,39 @@ async fn invoke(State(state): State<AppState>, body: Bytes) -> Response {
 async fn handle_invocation(state: &AppState, body: &[u8]) -> Result<(), HandlerError> {
     let payload = extract_trigger_payload(body)?;
     state.handler.handle_payload(&payload).await
+}
+
+async fn program_ingest(State(state): State<AppState>, body: Bytes) -> Response {
+    let json_body = match extract_http_trigger_body(&body) {
+        Ok(body) => body,
+        Err(err) => {
+            let msg = err.to_string();
+            tracing::error!(error = msg, "program ingest: failed to parse HTTP envelope");
+            let resp = format_ingest_response(
+                400,
+                &serde_json::json!({ "error": msg }),
+            );
+            return (StatusCode::OK, Json(resp)).into_response();
+        }
+    };
+
+    match state.handler.handle_program_ingest(&json_body).await {
+        Ok(ingest_resp) => {
+            let resp = format_ingest_response(
+                200,
+                &serde_json::to_value(&ingest_resp).unwrap_or_default(),
+            );
+            (StatusCode::OK, Json(resp)).into_response()
+        }
+        Err(ingest_err) => {
+            let msg = ingest_err.message.clone();
+            let status = ingest_err.status_code;
+            tracing::error!(error = msg, http_status = status, "program ingest failed");
+            let resp = format_ingest_response(
+                status,
+                &serde_json::json!({ "error": msg }),
+            );
+            (StatusCode::OK, Json(resp)).into_response()
+        }
+    }
 }

--- a/crates/sonde-azure-handler/src/main.rs
+++ b/crates/sonde-azure-handler/src/main.rs
@@ -93,10 +93,7 @@ async fn program_ingest(State(state): State<AppState>, body: Bytes) -> Response 
         Err(err) => {
             let msg = err.to_string();
             tracing::error!(error = msg, "program ingest: failed to parse HTTP envelope");
-            let resp = format_ingest_response(
-                400,
-                &serde_json::json!({ "error": msg }),
-            );
+            let resp = format_ingest_response(400, &serde_json::json!({ "error": msg }));
             return (StatusCode::OK, Json(resp)).into_response();
         }
     };
@@ -113,10 +110,7 @@ async fn program_ingest(State(state): State<AppState>, body: Bytes) -> Response 
             let msg = ingest_err.message.clone();
             let status = ingest_err.status_code;
             tracing::error!(error = msg, http_status = status, "program ingest failed");
-            let resp = format_ingest_response(
-                status,
-                &serde_json::json!({ "error": msg }),
-            );
+            let resp = format_ingest_response(status, &serde_json::json!({ "error": msg }));
             (StatusCode::OK, Json(resp)).into_response()
         }
     }

--- a/docs/gateway-companion-api.md
+++ b/docs/gateway-companion-api.md
@@ -184,6 +184,7 @@ unchanged".
 | `assigned_program_hash` | 1 | bstr/null | Desired resident program hash. `null` means no resident program assignment is desired. |
 | `schedule_interval_s` | 2 | uint/null | Desired node wake interval in seconds. `null` means no scheduled interval target is desired in this draft. |
 | `ephemeral_program_hash` | 3 | bstr/null | Desired ephemeral program hash to queue when reconciliation determines one is needed. `null` means no ephemeral run is requested. |
+| `assigned_program_image` | 5 | bstr/null | CBOR program image bytes for the assigned program. Present when the control plane embeds the program image inline so the gateway can ingest it into its local `ProgramLibrary` without a separate fetch. Absent or `null` means no inline image is provided; the gateway must already have the program locally. |
 
 Fields not yet defined by this draft remain reserved for future desired-state
 extension. Receivers MUST ignore unknown integer keys.

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -86,7 +86,7 @@ deploy/web-ui/
   9. On failure: return JSON error with diagnostics
 - The uploaded ELF is verified and transformed; the persisted and delivered artifact is the deterministic CBOR program image, not the raw ELF
 - `programs` table schema: `PartitionKey="program"`, `RowKey=hex(program_hash)`, `source_filename`, `abi_version` (`Edm.Int32`), `cbor_image` (base64-encoded CBOR program image), `size_bytes` (`Edm.Int32`, CBOR image byte length), `verification_profile`, `created_at` (ISO 8601 UTC string)
-- Idempotent: re-ingesting the same ELF produces the same program hash; metadata fields (`source_filename`, `abi_version`) are overwritten on re-ingest
+- Idempotent: re-ingesting the same ELF produces the same program hash; all metadata fields (`source_filename`, `abi_version`, `verification_profile`, `created_at`) are overwritten on re-ingest (last-writer-wins)
 - Error responses use HTTP status codes: 400 (malformed JSON, missing `elf` field, invalid base64), 413 (ELF exceeds size limit), 422 (Prevail verification failure, invalid ELF), 500 (storage/internal error)
 
 #### 6.1.1 Custom Handler Routing
@@ -96,7 +96,7 @@ dedicated `handle_program_ingest` handler, separate from the catch-all
 `/{*path}` route used for queue-triggered connector messages. The handler:
 
 1. Extracts the HTTP trigger envelope from the Azure Functions invocation request
-2. Reads `Data.req.Body` (JSON string) and `Data.req.Headers`
+2. Reads `Data.req.Body` (JSON string)
 3. Parses the JSON body to extract `elf`, `source_filename`, `abi_version`, `verification_profile`
 4. Processes the program through `ProgramLibrary`
 5. Returns an Azure Functions HTTP output binding response:
@@ -132,8 +132,9 @@ async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), Handler
 When the handler publishes a `DESIRED_STATE` message due to program divergence, it fetches the CBOR program image from the `programs` table and embeds it at CBOR key 5 (`assigned_program_image`, `bstr`). The companion forwards this opaque payload to the gateway, which ingests the inline image into its local `ProgramLibrary`.
 
 > **Note**: The gateway's `DESIRED_STATE` handler (`connector.rs`) does not yet
-> read key 5. A follow-up change to `gateway-companion-api.md` and
-> `connector.rs` is required to parse and ingest the inline program image.
+> read key 5. Key 5 (`assigned_program_image`) is now documented in
+> `gateway-companion-api.md` §3.2.2. A follow-up change to `connector.rs` is
+> required to parse and ingest the inline program image.
 
 ---
 

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -85,7 +85,7 @@ deploy/web-ui/
   8. Return JSON: `{"program_hash": "hex", "size": N, "abi_version": N, "source_filename": "name"}`
   9. On failure: return JSON error with diagnostics
 - The uploaded ELF is verified and transformed; the persisted and delivered artifact is the deterministic CBOR program image, not the raw ELF
-- `programs` table schema: `PartitionKey="program"`, `RowKey=hex(program_hash)`, `source_filename`, `abi_version` (`Edm.Int32`), `cbor_image` (base64-encoded CBOR program image), `size_bytes` (`Edm.Int32`, CBOR image byte length), `verification_profile`, `created_at` (`Edm.DateTime`)
+- `programs` table schema: `PartitionKey="program"`, `RowKey=hex(program_hash)`, `source_filename`, `abi_version` (`Edm.Int32`), `cbor_image` (base64-encoded CBOR program image), `size_bytes` (`Edm.Int32`, CBOR image byte length), `verification_profile`, `created_at` (ISO 8601 UTC string)
 - Idempotent: re-ingesting the same ELF produces the same program hash; metadata fields (`source_filename`, `abi_version`) are overwritten on re-ingest
 - Error responses use HTTP status codes: 400 (malformed JSON, missing `elf` field, invalid base64), 413 (ELF exceeds size limit), 422 (Prevail verification failure, invalid ELF), 500 (storage/internal error)
 
@@ -207,7 +207,7 @@ After deployment, grant users the `Storage Table Data Contributor` role on the s
 - `lib.rs` implements `handle_program_ingest()` which reuses
   `ProgramLibrary::ingest_elf()` from `sonde-gateway` for Prevail verification,
   CBOR encoding, and SHA-256 hashing.
-- The HTTP trigger response uses the Azure Functions `$return` output binding
+- The HTTP trigger response uses the Azure Functions `res` output binding
   envelope format with `statusCode`, `headers`, and `body` fields.
 
 > **Note**: The `ProgramIngest` endpoint currently uses `authLevel: "function"`

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -69,15 +69,63 @@ deploy/web-ui/
 ### 6.1 Azure Function: ProgramIngest
 
 - HTTP trigger, `POST`, route `api/programs/ingest`
-- Request: `multipart/form-data` with fields: `elf` (binary), `source_filename` (string), `abi_version` (integer), `verification_profile` (`"resident"|"ephemeral"`, default `"resident"`)
+- Request: `application/json` with fields:
+  - `elf` (string, required): Base64-encoded ELF binary
+  - `source_filename` (string, optional): Original filename for display
+  - `abi_version` (integer, optional): ABI version the program targets
+  - `verification_profile` (string, optional): `"resident"` (default) or `"ephemeral"`
 - Processing (reuses `sonde-gateway` `ProgramLibrary`):
-  1. Parse multipart body
-  2. Call `ProgramLibrary::ingest_elf(elf_bytes, profile)`
-  3. Normalize `source_filename` via `normalize_display_filename()`
-  4. Store in `programs` Azure Table
-  5. Return JSON: `{"program_hash": "hex", "size": N, "abi_version": N, "source_filename": "name"}`
-  6. On failure: return JSON error with Prevail diagnostics
-- `programs` table schema: `PartitionKey="program"`, `RowKey=hex(program_hash)`, `source_filename`, `abi_version` (`Edm.Int32`), `cbor_image` (base64), `size_bytes` (`Edm.Int32`), `verification_profile`, `created_at` (`Edm.DateTime`)
+  1. Parse JSON body from the Azure Functions HTTP trigger envelope (`Data.req.Body`)
+  2. Base64-decode the `elf` field; reject if missing, empty, or invalid base64
+  3. Reject requests where decoded ELF exceeds 1 MB (defense-in-depth before verification)
+  4. Parse `verification_profile`; default to `Resident` if absent
+  5. Call `ProgramLibrary::ingest_elf(elf_bytes, profile)` — this verifies with Prevail, extracts bytecode + maps, encodes deterministic CBOR, and computes SHA-256
+  6. Normalize `source_filename` via `normalize_display_filename()`
+  7. Store in `programs` Azure Table via `HandlerStore::store_program_image()`
+  8. Return JSON: `{"program_hash": "hex", "size": N, "abi_version": N, "source_filename": "name"}`
+  9. On failure: return JSON error with diagnostics
+- The uploaded ELF is verified and transformed; the persisted and delivered artifact is the deterministic CBOR program image, not the raw ELF
+- `programs` table schema: `PartitionKey="program"`, `RowKey=hex(program_hash)`, `source_filename`, `abi_version` (`Edm.Int32`), `cbor_image` (base64-encoded CBOR program image), `size_bytes` (`Edm.Int32`, CBOR image byte length), `verification_profile`, `created_at` (`Edm.DateTime`)
+- Idempotent: re-ingesting the same ELF produces the same program hash; metadata fields (`source_filename`, `abi_version`) are overwritten on re-ingest
+- Error responses use HTTP status codes: 400 (malformed JSON, missing `elf` field, invalid base64), 413 (ELF exceeds size limit), 422 (Prevail verification failure, invalid ELF), 500 (storage/internal error)
+
+#### 6.1.1 Custom Handler Routing
+
+The Azure Functions custom handler (`main.rs`) routes `/ProgramIngest` to a
+dedicated `handle_program_ingest` handler, separate from the catch-all
+`/{*path}` route used for queue-triggered connector messages. The handler:
+
+1. Extracts the HTTP trigger envelope from the Azure Functions invocation request
+2. Reads `Data.req.Body` (JSON string) and `Data.req.Headers`
+3. Parses the JSON body to extract `elf`, `source_filename`, `abi_version`, `verification_profile`
+4. Processes the program through `ProgramLibrary`
+5. Returns an Azure Functions HTTP output binding response:
+   ```json
+   {
+     "Outputs": {
+       "res": {
+         "statusCode": 200,
+         "headers": {"Content-Type": "application/json"},
+         "body": "{\"program_hash\":\"hex\",\"size\":N,\"abi_version\":N,\"source_filename\":\"name\"}"
+       }
+     }
+   }
+   ```
+
+#### 6.1.2 HandlerStore Expansion
+
+The `HandlerStore` trait gains:
+
+```rust
+async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), HandlerError>;
+```
+
+`ProgramImageRow` contains: `program_hash` (`Vec<u8>`), `cbor_image` (`Vec<u8>`),
+`source_filename` (`Option<String>`), `abi_version` (`Option<u32>`), `size_bytes` (`u32`),
+`verification_profile` (`String`), `created_at` (`String`, ISO 8601 UTC).
+
+`AzureTablesStore` implements this as an upsert to the `programs` table, encoding
+`cbor_image` as base64 and `program_hash` as hex for the `RowKey`.
 
 ### 6.2 Inline Program Image in DESIRED_STATE (WEB-0309, WEB-0310)
 
@@ -104,9 +152,11 @@ When the handler publishes a `DESIRED_STATE` message due to program divergence, 
 - Silent token renewal; redirect to login on expiry.
 
 > **Note**: The SPA acquires tokens scoped to `https://storage.azure.com/.default`
-> for Azure Table operations. The ProgramIngest function endpoint is not yet
-> implemented in the custom handler. When it is, a separate token with the
-> function's API scope and appropriate auth configuration will be required.
+> for Azure Table operations. The `ProgramIngest` function endpoint uses
+> `authLevel: "function"` for API key authentication. Browser-based SPA
+> access to this endpoint requires a follow-up to configure Entra/EasyAuth
+> token-based authentication with the function's API scope and appropriate
+> redirect URI configuration.
 
 ---
 
@@ -148,11 +198,19 @@ After deployment, grant users the `Storage Table Data Contributor` role on the s
 
 ### 9.3 Function App Changes
 
-- New `function.json` for `ProgramIngest` HTTP trigger (stub —
-  `authLevel: function`). The custom handler does not yet route or
-  process HTTP-triggered requests; this trigger definition is
-  scaffolding for the follow-up implementation.
-- The HTTP ingest handler implementation in `main.rs` is planned. The
-  current handler routes all POSTs through `extract_trigger_payload` /
-  `handle_payload`. A dedicated route for `/api/programs/ingest` with
-  multipart parsing will be added in a follow-up.
+- `ProgramIngest/function.json` defines the HTTP trigger (`authLevel: function`,
+  route `programs/ingest`).
+- `main.rs` routes `/ProgramIngest` to a dedicated handler that parses the
+  Azure Functions HTTP trigger envelope and delegates to
+  `AzureHandler::handle_program_ingest()`. The catch-all `/{*path}` route
+  continues to handle queue-triggered connector messages.
+- `lib.rs` implements `handle_program_ingest()` which reuses
+  `ProgramLibrary::ingest_elf()` from `sonde-gateway` for Prevail verification,
+  CBOR encoding, and SHA-256 hashing.
+- The HTTP trigger response uses the Azure Functions `$return` output binding
+  envelope format with `statusCode`, `headers`, and `body` fields.
+
+> **Note**: The `ProgramIngest` endpoint currently uses `authLevel: "function"`
+> for Azure Functions-level API key authentication. Browser-based SPA access
+> requires a follow-up to configure Entra/EasyAuth token-based authentication
+> with the function's API scope.

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -25,10 +25,11 @@
 | T-WEB-0301 | WEB-0301 | `ProgramIngest` accepts ELF + metadata via JSON POST | Unit (Rust) | Pass |
 | T-WEB-0302 | WEB-0302 | Prevail verification runs; invalid ELF rejected | Unit (Rust) | Pass |
 | T-WEB-0303 | WEB-0303 | Program hash matches gateway computation | Unit (Rust) | Pass |
-| T-WEB-0304 | WEB-0304 | Program stored in `programs` table with all fields | Unit (Rust) | Pass |
+| T-WEB-0304 | WEB-0304 | Program stored in `programs` table with all fields | Integration | Planned |
 | T-WEB-0305 | WEB-0305 | Success returns hash+metadata; failure returns diagnostics | Unit (Rust) | Pass |
 | T-WEB-0306 | WEB-0306 | Oversized programs rejected | Unit (Rust) | Pass |
-| T-WEB-0307 | WEB-0307 | Empty ELF and multi-program ELF rejected | Unit (Rust) | Pass |
+| T-WEB-0307a | WEB-0307 | Empty ELF rejected | Unit (Rust) | Pass |
+| T-WEB-0307b | WEB-0307 | Multi-program ELF rejected | Unit (Rust) | Planned |
 | T-WEB-0308 | WEB-0308 | `source_filename` normalized to basename | Unit (Rust) | Pass |
 | T-WEB-0309 | WEB-0309 | `DESIRED_STATE` includes inline CBOR image on program divergence | Unit (Rust) | Planned |
 | T-WEB-0310 | WEB-0310 | `DESIRED_STATE` CBOR carries key 5 with program image bytes | Unit (Rust) | Planned |

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -22,14 +22,14 @@
 | T-WEB-0203 | WEB-0203 | RowKey uses reverse-timestamp format | Unit (JS) | Planned |
 | T-WEB-0204 | WEB-0204 | PartitionKey = `n:{SHA-256(node_id)}` | Unit (JS) | Planned |
 | T-WEB-0205 | WEB-0205 | `timestamp_ms` stored as `Edm.Int64` | Integration | Planned |
-| T-WEB-0301 | WEB-0301 | `ProgramIngest` accepts ELF + metadata via JSON POST | Unit (Rust) | Planned |
-| T-WEB-0302 | WEB-0302 | Prevail verification runs; invalid ELF rejected | Unit (Rust) | Planned |
-| T-WEB-0303 | WEB-0303 | Program hash matches gateway computation | Unit (Rust) | Planned |
-| T-WEB-0304 | WEB-0304 | Program stored in `programs` table with all fields | Integration | Planned |
-| T-WEB-0305 | WEB-0305 | Success returns hash+metadata; failure returns diagnostics | Unit (Rust) | Planned |
-| T-WEB-0306 | WEB-0306 | Oversized programs rejected | Unit (Rust) | Planned |
-| T-WEB-0307 | WEB-0307 | Empty ELF and multi-program ELF rejected | Unit (Rust) | Planned |
-| T-WEB-0308 | WEB-0308 | `source_filename` normalized to basename | Unit (Rust) | Planned |
+| T-WEB-0301 | WEB-0301 | `ProgramIngest` accepts ELF + metadata via JSON POST | Unit (Rust) | Pass |
+| T-WEB-0302 | WEB-0302 | Prevail verification runs; invalid ELF rejected | Unit (Rust) | Pass |
+| T-WEB-0303 | WEB-0303 | Program hash matches gateway computation | Unit (Rust) | Pass |
+| T-WEB-0304 | WEB-0304 | Program stored in `programs` table with all fields | Unit (Rust) | Pass |
+| T-WEB-0305 | WEB-0305 | Success returns hash+metadata; failure returns diagnostics | Unit (Rust) | Pass |
+| T-WEB-0306 | WEB-0306 | Oversized programs rejected | Unit (Rust) | Pass |
+| T-WEB-0307 | WEB-0307 | Empty ELF and multi-program ELF rejected | Unit (Rust) | Pass |
+| T-WEB-0308 | WEB-0308 | `source_filename` normalized to basename | Unit (Rust) | Pass |
 | T-WEB-0309 | WEB-0309 | `DESIRED_STATE` includes inline CBOR image on program divergence | Unit (Rust) | Planned |
 | T-WEB-0310 | WEB-0310 | `DESIRED_STATE` CBOR carries key 5 with program image bytes | Unit (Rust) | Planned |
 | T-WEB-0401 | WEB-0401 | SPA lists programs from `programs` table | Manual/E2E | Planned |

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -22,7 +22,7 @@
 | T-WEB-0203 | WEB-0203 | RowKey uses reverse-timestamp format | Unit (JS) | Planned |
 | T-WEB-0204 | WEB-0204 | PartitionKey = `n:{SHA-256(node_id)}` | Unit (JS) | Planned |
 | T-WEB-0205 | WEB-0205 | `timestamp_ms` stored as `Edm.Int64` | Integration | Planned |
-| T-WEB-0301 | WEB-0301 | `ProgramIngest` accepts ELF + metadata via HTTP POST | Unit (Rust) | Planned |
+| T-WEB-0301 | WEB-0301 | `ProgramIngest` accepts ELF + metadata via JSON POST | Unit (Rust) | Planned |
 | T-WEB-0302 | WEB-0302 | Prevail verification runs; invalid ELF rejected | Unit (Rust) | Planned |
 | T-WEB-0303 | WEB-0303 | Program hash matches gateway computation | Unit (Rust) | Planned |
 | T-WEB-0304 | WEB-0304 | Program stored in `programs` table with all fields | Integration | Planned |


### PR DESCRIPTION
## Summary

Implements the `ProgramIngest` Azure Function endpoint (WEB-0300) that accepts ELF binaries via JSON POST, verifies them with Prevail, encodes deterministic CBOR program images, and stores them in Azure Tables for delivery via `DESIRED_STATE` messages.

## Changes

### `sonde-azure-handler` (lib.rs)
- `ProgramImageRow` struct and `HandlerStore::store_program_image()` trait method
- `AzureHandler::handle_program_ingest()` — JSON body parsing, Prevail verification, CBOR encoding, storage
- `IngestResponse`/`IngestError` types with HTTP status mapping (400/413/422/500)
- `extract_http_trigger_body()` and `format_ingest_response()` for Azure Functions envelope handling
- Input validation: base64, empty check, 1 MB ELF limit, `abi_version` type/range, `verification_profile` enum
- Unit tests covering T-WEB-0301 through T-WEB-0306, T-WEB-0307a (empty ELF), and T-WEB-0308. T-WEB-0304 (integration) and T-WEB-0307b (multi-program ELF) remain planned.

### `sonde-azure-handler` (main.rs)
- Dedicated `/ProgramIngest` route

### Specification updates
- `gateway-companion-api.md`: Documented key 5 (`assigned_program_image`) in DESIRED_STATE
- `web-ui-design.md`: Updated sections 6.1 and 9.3 with implementation details
- `web-ui-validation.md`: Updated test statuses

## Test results

66 tests pass, 0 failures. Clippy clean across workspace.