### PR TITLE
Add Docker Compose deployment for gateway + Azure stack

### DIFF
--- a/.github/docker/Dockerfile.gateway
+++ b/.github/docker/Dockerfile.gateway
@@ -51,10 +51,11 @@ FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d650
 # Non-root user for the gateway process (GW-1802 AC3).
 RUN addgroup -S sonde && adduser -S sonde -G sonde \
     && mkdir -p /var/lib/sonde \
+       /var/run/sonde \
        /usr/local/share/sonde/test-programs \
        /usr/local/share/sonde/firmware/modem/default \
        /usr/local/share/sonde/firmware/modem/verbose \
-    && chown sonde:sonde /var/lib/sonde
+    && chown sonde:sonde /var/lib/sonde /var/run/sonde
 
 COPY --from=builder /opt/espflash/bin/espflash             /usr/local/bin/
 COPY --from=builder /src/target/release/sonde-gateway      /usr/local/bin/

--- a/.github/workflows/azure-companion-container.yml
+++ b/.github/workflows/azure-companion-container.yml
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Build and publish the sonde-azure-companion multi-arch container image
+# to GHCR.  Produces linux/amd64 and linux/arm64 images using native
+# GitHub runners, then combines them into a single multi-arch manifest.
+#
+# Triggered by nightly-release.yml (workflow_call) and on release tags.
+# Can also be run manually via workflow_dispatch.
+
+name: Azure Companion Container
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: azure-companion-container-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: alan-jowett/sonde-azure-companion
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    name: Build (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GitHub Container Registry
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
+
+      - name: Build container image
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: .github/docker/Dockerfile.azure-companion
+          push: false
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }}
+
+      - name: Smoke test — binary version
+        run: |
+          docker run --rm --entrypoint sonde-azure-companion \
+            ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --version
+
+      - name: Smoke test — entrypoint and scripts
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'test -x /opt/sonde/deploy/azure-companion/entrypoint.sh \
+             && test -x /opt/sonde/deploy/azure-companion/bootstrap.sh \
+             && test -x /usr/local/bin/sonde-azure-companion'
+
+      - name: Smoke test — runtime image excludes Rust toolchain and source tree
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            '! command -v cargo >/dev/null 2>&1 \
+             && ! command -v rustc >/dev/null 2>&1 \
+             && ! test -d /root/.cargo \
+             && ! test -d /usr/local/cargo \
+             && ! test -d /sonde/target'
+
+      - name: Smoke test — subcommands available
+        run: |
+          docker run --rm --entrypoint sonde-azure-companion \
+            ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} --help \
+            | grep -q 'bootstrap'
+
+      - name: Push per-arch image
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        run: |
+          ARCH_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-${{ github.sha }}-${{ github.run_id }}-${{ matrix.arch }}"
+          docker tag "${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }}" "$ARCH_TAG"
+          docker push "$ARCH_TAG"
+
+  manifest:
+    name: Publish multi-arch manifest
+    needs: [build]
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
+
+      - name: Determine tags
+        id: tags
+        run: |
+          set -euo pipefail
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          TAGS="sha-${SHORT_SHA}"
+
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+            TAGS="${TAGS},${VERSION},latest"
+          else
+            DATE=$(date -u +%Y%m%d)
+            TAGS="${TAGS},nightly,nightly-${DATE}"
+          fi
+
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push multi-arch manifest
+        run: |
+          set -euo pipefail
+          BASE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          AMD64="${BASE}:build-${{ github.sha }}-${{ github.run_id }}-amd64"
+          ARM64="${BASE}:build-${{ github.sha }}-${{ github.run_id }}-arm64"
+
+          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          for TAG in "${TAG_ARRAY[@]}"; do
+            docker buildx imagetools create \
+              --tag "${BASE}:${TAG}" \
+              "${AMD64}" "${ARM64}"
+          done
+
+      - name: Clean up temporary per-arch tags
+        run: |
+          echo "Manifest published successfully."

--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -173,6 +173,11 @@ jobs:
           docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
             'whoami | grep -q sonde && touch /var/lib/sonde/test && rm /var/lib/sonde/test'
 
+      - name: Smoke test — runtime directory writable by non-root user
+        run: |
+          docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \
+            'whoami | grep -q sonde && touch /var/run/sonde/test && rm /var/run/sonde/test'
+
       - name: Smoke test — bundled modem images
         run: |
           docker run --rm --entrypoint sh ${{ env.IMAGE_NAME }}:smoke-${{ matrix.arch }} -c \

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -173,6 +173,15 @@ jobs:
       contents: read
       packages: write
 
+  azure-companion-container:
+    name: Azure companion container
+    needs: [should_run]
+    if: needs.should_run.outputs.run_builds == 'true'
+    uses: ./.github/workflows/azure-companion-container.yml
+    permissions:
+      contents: read
+      packages: write
+
   node-firmware:
     name: Node firmware
     needs: [should_run]
@@ -344,7 +353,7 @@ jobs:
   # ── Publish release ────────────────────────────────────────────────
   release:
     name: Publish nightly
-    needs: [should_run, gateway, bpf-test-programs, sensor-handlers, gateway-container, azure-bootstrap-container, node-firmware, modem-firmware, desktop, android, installer-linux, installer-linux-arm64, installer-windows]
+    needs: [should_run, gateway, bpf-test-programs, sensor-handlers, gateway-container, azure-bootstrap-container, azure-companion-container, node-firmware, modem-firmware, desktop, android, installer-linux, installer-linux-arm64, installer-windows]
     if: needs.should_run.outputs.run_builds == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -433,6 +442,7 @@ jobs:
           | Installer — Linux (arm64) | `sonde_*_arm64.deb` |
           | Container (multi-arch) | `ghcr.io/alan-jowett/sonde-gateway` |
           | Azure bootstrap container (multi-arch) | `ghcr.io/alan-jowett/sonde-azure-bootstrap` |
+          | Azure companion container (multi-arch) | `ghcr.io/alan-jowett/sonde-azure-companion` |
 
           ### Flashing firmware
 

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -18,7 +18,7 @@
 # Host group ID (numeric) that owns the modem device.  The gateway
 # container is added to this group so the non-root user can open the
 # serial port.  Find it with: stat -c '%g' /dev/ttyACM0
-SONDE_MODEM_GID=20
+# SONDE_MODEM_GID=
 
 # ESP-NOW radio channel (1–14).
 # SONDE_ESPNOW_CHANNEL=1

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Environment variables for the Sonde Docker Compose stack.
+# Copy this file to .env and edit the values below.
+#
+#   cp .env.example .env
+
+# ── Image version ────────────────────────────────────────────────────
+# Tag applied to all GHCR images.  Use "latest", "nightly", or a
+# specific version like "0.5.0".
+# SONDE_IMAGE_TAG=latest
+
+# ── Gateway ──────────────────────────────────────────────────────────
+# Serial port for the ESP-NOW modem (host device path).
+# SONDE_MODEM_PORT=/dev/ttyACM0
+
+# Host group ID (or name) that owns the modem device.  The gateway
+# container is added to this group so the non-root user can open the
+# serial port.  Find it with: stat -c '%g' /dev/ttyACM0
+# SONDE_MODEM_GID=dialout
+
+# ESP-NOW radio channel (1–14).
+# SONDE_ESPNOW_CHANNEL=1
+
+# ── Azure bootstrap ─────────────────────────────────────────────────
+# Azure region for Bicep deployment (e.g., eastus, westeurope).
+# SONDE_AZURE_LOCATION=eastus
+
+# Project name used as a prefix for Azure resources.
+# SONDE_AZURE_PROJECT_NAME=sonde
+
+# (Optional) Azure subscription ID.  If unset, the Azure CLI uses the
+# default subscription from `az login`.
+# SONDE_AZURE_SUBSCRIPTION_ID=
+
+# (Optional) Override the bootstrap container image.  Defaults to the
+# same tag as the other images (SONDE_IMAGE_TAG).
+# SONDE_AZURE_BOOTSTRAP_IMAGE=ghcr.io/alan-jowett/sonde-azure-bootstrap:latest
+
+# ── Azure companion (optional overrides) ─────────────────────────────
+# These are normally populated by the bootstrap step and read from
+# the companion state volume.  Set them here only if you need to
+# override the bootstrapped values.
+# SONDE_AZURE_STORAGE_QUEUE_ENDPOINT=
+# SONDE_AZURE_STORAGE_UPSTREAM_QUEUE=
+# SONDE_AZURE_STORAGE_DOWNSTREAM_QUEUE=

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -15,10 +15,10 @@
 # Serial port for the ESP-NOW modem (host device path).
 # SONDE_MODEM_PORT=/dev/ttyACM0
 
-# Host group ID (or name) that owns the modem device.  The gateway
+# Host group ID (numeric) that owns the modem device.  The gateway
 # container is added to this group so the non-root user can open the
 # serial port.  Find it with: stat -c '%g' /dev/ttyACM0
-# SONDE_MODEM_GID=dialout
+SONDE_MODEM_GID=20
 
 # ESP-NOW radio channel (1–14).
 # SONDE_ESPNOW_CHANNEL=1

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -18,7 +18,7 @@ cd deploy/docker-compose
 
 # 1. Create your environment file
 cp .env.example .env
-# Edit .env — at minimum set SONDE_MODEM_PORT if it differs from /dev/ttyACM0
+# Edit .env — set SONDE_MODEM_GID to: stat -c '%g' /dev/ttyACM0
 
 # 2. Start the stack
 docker compose up -d
@@ -100,7 +100,7 @@ See [`.env.example`](.env.example) for the full list with documentation.
 | Variable | Description |
 |----------|-------------|
 | `SONDE_IMAGE_TAG` | Container image tag (default: `latest`) |
-| `SONDE_MODEM_GID` | Host group for modem device access (default: `dialout`) |
+| `SONDE_MODEM_GID` | Numeric host group ID for modem device access (find with `stat -c '%g' /dev/ttyACM0`) |
 | `SONDE_ESPNOW_CHANNEL` | ESP-NOW radio channel 1–14 (default: `1`) |
 | `SONDE_AZURE_SUBSCRIPTION_ID` | Azure subscription override |
 | `SONDE_AZURE_BOOTSTRAP_IMAGE` | Bootstrap container image override |
@@ -128,11 +128,13 @@ docker compose down -v
 
 ### Gateway fails to start
 
-- **Permission denied on serial port**: Check `SONDE_MODEM_GID` matches
-  the host group that owns the modem device:
+- **Permission denied on serial port**: `SONDE_MODEM_GID` must be the
+  **numeric** group ID that owns the modem device on the host, not a
+  group name (container group names may not match the host). Find it with:
   ```bash
-  stat -c '%G (%g)' /dev/ttyACM0
+  stat -c '%g' /dev/ttyACM0
   ```
+  Set the result in your `.env` file as `SONDE_MODEM_GID=<number>`.
 - **Modem not found**: Verify the device path in `SONDE_MODEM_PORT` and
   that the modem is plugged in.
 

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -91,6 +91,7 @@ See [`.env.example`](.env.example) for the full list with documentation.
 
 | Variable | Description |
 |----------|-------------|
+| `SONDE_MODEM_GID` | Numeric host group ID for modem device access (find with `stat -c '%g' /dev/ttyACM0`) |
 | `SONDE_MODEM_PORT` | Host serial port for the modem (default: `/dev/ttyACM0`) |
 | `SONDE_AZURE_LOCATION` | Azure region (default: `eastus`) |
 | `SONDE_AZURE_PROJECT_NAME` | Azure resource prefix (default: `sonde`) |
@@ -100,7 +101,6 @@ See [`.env.example`](.env.example) for the full list with documentation.
 | Variable | Description |
 |----------|-------------|
 | `SONDE_IMAGE_TAG` | Container image tag (default: `latest`) |
-| `SONDE_MODEM_GID` | Numeric host group ID for modem device access (find with `stat -c '%g' /dev/ttyACM0`) |
 | `SONDE_ESPNOW_CHANNEL` | ESP-NOW radio channel 1–14 (default: `1`) |
 | `SONDE_AZURE_SUBSCRIPTION_ID` | Azure subscription override |
 | `SONDE_AZURE_BOOTSTRAP_IMAGE` | Bootstrap container image override |

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -1,0 +1,162 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright (c) 2026 sonde contributors -->
+
+# Sonde Docker Compose Deployment
+
+Single-command deployment of the sonde-gateway and Azure companion stack.
+
+## Prerequisites
+
+- **Docker Engine** ≥ 24.0 with Compose V2 (`docker compose`)
+- **USB modem** (ESP32-S3) connected to the host
+- **Azure subscription** (for the bootstrap step)
+
+## Quick Start
+
+```bash
+cd deploy/docker-compose
+
+# 1. Create your environment file
+cp .env.example .env
+# Edit .env — at minimum set SONDE_MODEM_PORT if it differs from /dev/ttyACM0
+
+# 2. Start the stack
+docker compose up -d
+
+# 3. Follow the bootstrap progress
+docker compose logs -f bootstrap
+```
+
+On first run, the bootstrap service will:
+1. Wait for the gateway to become healthy
+2. Generate an ECDSA certificate for Azure authentication
+3. Display an Azure device-code login prompt on the modem's screen
+4. Deploy Azure infrastructure via Bicep templates
+5. Write state files for the companion service
+
+Once bootstrap completes, the companion service starts automatically and
+maintains the cloud connection.
+
+## Architecture
+
+```
+┌─────────────────────┐
+│      gateway        │  ← Manages sensor nodes over ESP-NOW radio
+│  (sonde-gateway)    │
+│                     │
+│  UDS: admin.sock    │──┐
+│  UDS: connector.sock│──┤
+└─────────────────────┘  │
+                         │  shared via sonde-runtime volume
+┌─────────────────────┐  │
+│     bootstrap       │──┘ (reads admin.sock)
+│  (one-shot)         │
+│                     │──── Docker socket (runs azure-bootstrap container)
+│  Writes state to:   │
+│  sonde-companion-   │
+│  state volume       │
+└─────────────────────┘
+         │
+         │ service_completed_successfully
+         ▼
+┌─────────────────────┐
+│     companion       │──── connector.sock (from sonde-runtime volume)
+│  (long-running)     │
+│                     │──── state files (from sonde-companion-state volume)
+│  Azure queue bridge │
+└─────────────────────┘
+```
+
+## Services
+
+| Service | Image | Role |
+|---------|-------|------|
+| `gateway` | `ghcr.io/alan-jowett/sonde-gateway` | ESP-NOW radio gateway, gRPC admin API |
+| `bootstrap` | `ghcr.io/alan-jowett/sonde-azure-companion` | One-shot Azure provisioning |
+| `companion` | `ghcr.io/alan-jowett/sonde-azure-companion` | Long-running Azure queue bridge |
+
+## Volumes
+
+| Volume | Purpose |
+|--------|---------|
+| `sonde-data` | Gateway database and master key (persistent) |
+| `sonde-runtime` | Unix domain sockets for inter-service IPC |
+| `sonde-companion-state` | Bootstrap output (certs, queue config) |
+
+## Environment Variables
+
+See [`.env.example`](.env.example) for the full list with documentation.
+
+### Required for first run
+
+| Variable | Description |
+|----------|-------------|
+| `SONDE_MODEM_PORT` | Host serial port for the modem (default: `/dev/ttyACM0`) |
+| `SONDE_AZURE_LOCATION` | Azure region (default: `eastus`) |
+| `SONDE_AZURE_PROJECT_NAME` | Azure resource prefix (default: `sonde`) |
+
+### Optional
+
+| Variable | Description |
+|----------|-------------|
+| `SONDE_IMAGE_TAG` | Container image tag (default: `latest`) |
+| `SONDE_MODEM_GID` | Host group for modem device access (default: `dialout`) |
+| `SONDE_ESPNOW_CHANNEL` | ESP-NOW radio channel 1–14 (default: `1`) |
+| `SONDE_AZURE_SUBSCRIPTION_ID` | Azure subscription override |
+| `SONDE_AZURE_BOOTSTRAP_IMAGE` | Bootstrap container image override |
+
+## Common Operations
+
+```bash
+# View all service logs
+docker compose logs -f
+
+# Restart the gateway (companion reconnects automatically)
+docker compose restart gateway
+
+# Re-run bootstrap (e.g., after Azure config changes)
+docker compose up bootstrap
+
+# Stop everything
+docker compose down
+
+# Stop and remove all data (fresh start)
+docker compose down -v
+```
+
+## Troubleshooting
+
+### Gateway fails to start
+
+- **Permission denied on serial port**: Check `SONDE_MODEM_GID` matches
+  the host group that owns the modem device:
+  ```bash
+  stat -c '%G (%g)' /dev/ttyACM0
+  ```
+- **Modem not found**: Verify the device path in `SONDE_MODEM_PORT` and
+  that the modem is plugged in.
+
+### Bootstrap hangs
+
+- The bootstrap step requires interactive Azure login via device code.
+  The device code is displayed on the modem's screen. Check
+  `docker compose logs bootstrap` for the URL and code if needed.
+
+### Security: Docker socket access
+
+The bootstrap service mounts `/var/run/docker.sock` because it needs to
+pull and run the `sonde-azure-bootstrap` container internally. This grants
+the bootstrap process host-level Docker control. For locked-down
+environments, consider running the bootstrap step manually outside of
+Compose and then starting only the gateway + companion services.
+
+### Companion fails to connect
+
+- Ensure bootstrap completed successfully:
+  ```bash
+  docker compose ps bootstrap
+  ```
+- Check that the companion state volume has the expected files:
+  ```bash
+  docker compose exec companion ls -la /var/lib/sonde-azure-companion/
+  ```

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - "--azure-project-name"
       - "${SONDE_AZURE_PROJECT_NAME:-sonde}"
     environment:
-      - SONDE_AZURE_SUBSCRIPTION_ID=${SONDE_AZURE_SUBSCRIPTION_ID:-}
+      - SONDE_AZURE_SUBSCRIPTION_ID
       - SONDE_AZURE_BOOTSTRAP_IMAGE=${SONDE_AZURE_BOOTSTRAP_IMAGE:-ghcr.io/alan-jowett/sonde-azure-bootstrap:${SONDE_IMAGE_TAG:-latest}}
     volumes:
       - sonde-runtime:/var/run/sonde:ro
@@ -97,9 +97,9 @@ services:
       - "/var/lib/sonde-azure-companion"
       - "run"
     environment:
-      - SONDE_AZURE_STORAGE_QUEUE_ENDPOINT=${SONDE_AZURE_STORAGE_QUEUE_ENDPOINT:-}
-      - SONDE_AZURE_STORAGE_UPSTREAM_QUEUE=${SONDE_AZURE_STORAGE_UPSTREAM_QUEUE:-}
-      - SONDE_AZURE_STORAGE_DOWNSTREAM_QUEUE=${SONDE_AZURE_STORAGE_DOWNSTREAM_QUEUE:-}
+      - SONDE_AZURE_STORAGE_QUEUE_ENDPOINT
+      - SONDE_AZURE_STORAGE_UPSTREAM_QUEUE
+      - SONDE_AZURE_STORAGE_DOWNSTREAM_QUEUE
     volumes:
       - sonde-runtime:/var/run/sonde:ro
       - sonde-companion-state:/var/lib/sonde-azure-companion

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     devices:
       - "${SONDE_MODEM_PORT:-/dev/ttyACM0}:${SONDE_MODEM_PORT:-/dev/ttyACM0}"
     group_add:
-      - "${SONDE_MODEM_GID:-dialout}"
+      - "${SONDE_MODEM_GID}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "sonde-admin", "--socket", "/var/run/sonde/admin.sock", "node", "list"]

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Docker Compose for sonde-gateway + Azure companion stack.
+#
+# Brings up the gateway, runs Azure bootstrap (provisioning), then starts
+# the companion for steady-state cloud connectivity.
+#
+# Quick start:
+#   cp .env.example .env   # edit required values
+#   docker compose up -d
+#
+# See README.md for full documentation.
+
+services:
+  # ── sonde-gateway ──────────────────────────────────────────────────
+  # The gateway manages sensor nodes over ESP-NOW radio via the USB modem.
+  gateway:
+    image: ghcr.io/alan-jowett/sonde-gateway:${SONDE_IMAGE_TAG:-latest}
+    container_name: sonde-gateway
+    command:
+      - "--db"
+      - "/var/lib/sonde/sonde.db"
+      - "--port"
+      - "${SONDE_MODEM_PORT:-/dev/ttyACM0}"
+      - "--key-provider"
+      - "file"
+      - "--generate-master-key"
+      - "--master-key-file"
+      - "/var/lib/sonde/master-key.hex"
+      - "--admin-socket"
+      - "/var/run/sonde/admin.sock"
+      - "--connector-socket"
+      - "/var/run/sonde/connector.sock"
+      - "--channel"
+      - "${SONDE_ESPNOW_CHANNEL:-1}"
+    volumes:
+      - sonde-data:/var/lib/sonde
+      - sonde-runtime:/var/run/sonde
+    devices:
+      - "${SONDE_MODEM_PORT:-/dev/ttyACM0}:${SONDE_MODEM_PORT:-/dev/ttyACM0}"
+    group_add:
+      - "${SONDE_MODEM_GID:-dialout}"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "sonde-admin", "--socket", "/var/run/sonde/admin.sock", "node", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+
+  # ── bootstrap ──────────────────────────────────────────────────────
+  # One-shot Azure infrastructure provisioning.  Uses the companion
+  # image's `bootstrap` subcommand, which internally pulls and runs the
+  # azure-bootstrap container via Docker API.
+  #
+  # On first run this performs interactive Azure device-code login,
+  # deploys Bicep templates, and writes state files consumed by the
+  # companion service.
+  bootstrap:
+    image: ghcr.io/alan-jowett/sonde-azure-companion:${SONDE_IMAGE_TAG:-latest}
+    container_name: sonde-bootstrap
+    entrypoint: ["sonde-azure-companion"]
+    command:
+      - "--admin-socket"
+      - "/var/run/sonde/admin.sock"
+      - "--state-dir"
+      - "/var/lib/sonde-azure-companion"
+      - "bootstrap"
+      - "--azure-location"
+      - "${SONDE_AZURE_LOCATION:-eastus}"
+      - "--azure-project-name"
+      - "${SONDE_AZURE_PROJECT_NAME:-sonde}"
+    environment:
+      - SONDE_AZURE_SUBSCRIPTION_ID=${SONDE_AZURE_SUBSCRIPTION_ID:-}
+      - SONDE_AZURE_BOOTSTRAP_IMAGE=${SONDE_AZURE_BOOTSTRAP_IMAGE:-ghcr.io/alan-jowett/sonde-azure-bootstrap:${SONDE_IMAGE_TAG:-latest}}
+    volumes:
+      - sonde-runtime:/var/run/sonde:ro
+      - sonde-companion-state:/var/lib/sonde-azure-companion
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      gateway:
+        condition: service_healthy
+    restart: "no"
+
+  # ── companion ──────────────────────────────────────────────────────
+  # Long-running Azure connector.  Bridges the gateway to Azure Storage
+  # Queues for cloud-based program distribution and telemetry.
+  companion:
+    image: ghcr.io/alan-jowett/sonde-azure-companion:${SONDE_IMAGE_TAG:-latest}
+    container_name: sonde-companion
+    entrypoint: ["sonde-azure-companion"]
+    command:
+      - "--connector-socket"
+      - "/var/run/sonde/connector.sock"
+      - "--state-dir"
+      - "/var/lib/sonde-azure-companion"
+      - "run"
+    environment:
+      - SONDE_AZURE_STORAGE_QUEUE_ENDPOINT=${SONDE_AZURE_STORAGE_QUEUE_ENDPOINT:-}
+      - SONDE_AZURE_STORAGE_UPSTREAM_QUEUE=${SONDE_AZURE_STORAGE_UPSTREAM_QUEUE:-}
+      - SONDE_AZURE_STORAGE_DOWNSTREAM_QUEUE=${SONDE_AZURE_STORAGE_DOWNSTREAM_QUEUE:-}
+    volumes:
+      - sonde-runtime:/var/run/sonde:ro
+      - sonde-companion-state:/var/lib/sonde-azure-companion
+    depends_on:
+      gateway:
+        condition: service_healthy
+      bootstrap:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+volumes:
+  sonde-data:
+    driver: local
+  sonde-runtime:
+    driver: local
+  sonde-companion-state:
+    driver: local


### PR DESCRIPTION
## Summary

Adds a single-command Docker Compose setup that brings up the full sonde-gateway + Azure companion stack. Resolves #852.

## What changed

### New files
- **\deploy/docker-compose/docker-compose.yml\** — Three-service Compose with proper dependency ordering: gateway (healthy) → bootstrap (one-shot) → companion (steady-state). Includes healthchecks, UDS socket sharing via named volume, and USB modem device passthrough.
- **\deploy/docker-compose/.env.example\** — Documented environment variables for all configurable options.
- **\deploy/docker-compose/README.md\** — Architecture diagram, quick start guide, and troubleshooting.
- **\.github/workflows/azure-companion-container.yml\** — Multi-arch (amd64/arm64) CI workflow to build and publish \ghcr.io/alan-jowett/sonde-azure-companion\ to GHCR. Includes smoke tests for binary version, entrypoint scripts, toolchain exclusion, and subcommand availability.

### Modified files
- **\.github/docker/Dockerfile.gateway\** — Added \/var/run/sonde\ to \mkdir\+\chown\ in the runtime stage so the non-root \sonde\ user can create UDS sockets for the admin and connector APIs.
- **\.github/workflows/gateway-container.yml\** — Added smoke test verifying \/var/run/sonde\ is writable by the non-root user.
- **\.github/workflows/nightly-release.yml\** — Added companion container build job and release notes table entry.

## Key design decisions

- **Bootstrap uses the companion image** running \sonde-azure-companion bootstrap\, which internally orchestrates the \sonde-azure-bootstrap\ container via Docker API (generates certs, runs Bicep deployment, writes state files).
- **Gateway auto-generates master key** via \--key-provider file --generate-master-key\ for zero-config first run.
- **All images default to the same \SONDE_IMAGE_TAG\** to prevent version skew between services.
- **Docker socket mount** is required for the bootstrap service to pull and run the inner bootstrap container; documented as a security consideration in the README.

## Usage

\\\ash
cd deploy/docker-compose
cp .env.example .env   # edit SONDE_MODEM_PORT if needed
docker compose up -d
\\\

## Verification
- All YAML validates via \yaml.safe_load()\
- \cargo build --workspace\ ✅
- \cargo clippy --workspace -- -D warnings\ ✅
- \cargo test --workspace\ ✅

Closes #852