### PR TITLE
fix: assign Storage Table Data Contributor in bootstrap

### DIFF
--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -317,6 +317,21 @@ az ad app permission grant \
     --output none 2>/dev/null || true
 echo "Azure Storage user_impersonation permission granted" >&2
 
+# Assign Storage Table Data Contributor to the deploying user so they can
+# access the programs table via the SPA immediately after bootstrap.
+deployer_principal="$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)"
+if [ -z "$deployer_principal" ]; then
+    echo "WARNING: Could not determine signed-in user. Skipping role assignment." >&2
+    echo "  Grant 'Storage Table Data Contributor' manually on storage account $storage_account_name" >&2
+else
+    storage_scope="/subscriptions/$(az account show --query id -o tsv)/resourceGroups/$resource_group_name/providers/Microsoft.Storage/storageAccounts/$storage_account_name"
+    az role assignment create --assignee "$deployer_principal" \
+        --role "Storage Table Data Contributor" \
+        --scope "$storage_scope" \
+        --output none 2>/dev/null || true
+    echo "Assigned 'Storage Table Data Contributor' to deploying user" >&2
+fi
+
 echo "Web UI deployment complete" >&2
 
 printf '%s\n' "$deployment_outputs"

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -319,17 +319,28 @@ echo "Azure Storage user_impersonation permission granted" >&2
 
 # Assign Storage Table Data Contributor to the deploying user so they can
 # access the programs table via the SPA immediately after bootstrap.
-deployer_principal="$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)"
+deployer_principal="$(az ad signed-in-user show --query id --output tsv 2>/dev/null || true)"
 if [ -z "$deployer_principal" ]; then
     echo "WARNING: Could not determine signed-in user. Skipping role assignment." >&2
     echo "  Grant 'Storage Table Data Contributor' manually on storage account $storage_account_name" >&2
 else
-    storage_scope="/subscriptions/$(az account show --query id -o tsv)/resourceGroups/$resource_group_name/providers/Microsoft.Storage/storageAccounts/$storage_account_name"
-    az role assignment create --assignee "$deployer_principal" \
-        --role "Storage Table Data Contributor" \
-        --scope "$storage_scope" \
-        --output none 2>/dev/null || true
-    echo "Assigned 'Storage Table Data Contributor' to deploying user" >&2
+    subscription_id="$(az account show --query id --output tsv 2>/dev/null || true)"
+    if [ -z "$subscription_id" ]; then
+        echo "WARNING: Could not determine subscription ID. Skipping role assignment." >&2
+        echo "  Grant 'Storage Table Data Contributor' manually on storage account $storage_account_name" >&2
+    else
+        storage_scope="/subscriptions/$subscription_id/resourceGroups/$resource_group_name/providers/Microsoft.Storage/storageAccounts/$storage_account_name"
+        role_assign_exit=0
+        az role assignment create --assignee "$deployer_principal" \
+            --role "Storage Table Data Contributor" \
+            --scope "$storage_scope" \
+            --output none 2>/dev/null || role_assign_exit=$?
+        if [ "$role_assign_exit" -eq 0 ]; then
+            echo "Assigned 'Storage Table Data Contributor' to deploying user" >&2
+        else
+            echo "WARNING: Role assignment failed (exit $role_assign_exit). Grant 'Storage Table Data Contributor' manually." >&2
+        fi
+    fi
 fi
 
 echo "Web UI deployment complete" >&2

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -330,15 +330,29 @@ else
         echo "  Grant 'Storage Table Data Contributor' manually on storage account $storage_account_name" >&2
     else
         storage_scope="/subscriptions/$subscription_id/resourceGroups/$resource_group_name/providers/Microsoft.Storage/storageAccounts/$storage_account_name"
-        role_assign_exit=0
-        az role assignment create --assignee "$deployer_principal" \
+        existing_role="$(az role assignment list \
+            --assignee "$deployer_principal" \
             --role "Storage Table Data Contributor" \
             --scope "$storage_scope" \
-            --output none 2>/dev/null || role_assign_exit=$?
-        if [ "$role_assign_exit" -eq 0 ]; then
-            echo "Assigned 'Storage Table Data Contributor' to deploying user" >&2
+            --query "length(@)" \
+            --output tsv 2>/dev/null || echo 0)"
+        if [ "$existing_role" -gt 0 ] 2>/dev/null; then
+            echo "'Storage Table Data Contributor' already assigned to deploying user" >&2
         else
-            echo "WARNING: Role assignment failed (exit $role_assign_exit). Grant 'Storage Table Data Contributor' manually." >&2
+            role_assign_stderr="$(mktemp "${TMPDIR:-/tmp}/sonde-role-assign.XXXXXX")"
+            role_assign_exit=0
+            az role assignment create --assignee "$deployer_principal" \
+                --role "Storage Table Data Contributor" \
+                --scope "$storage_scope" \
+                --output none 2>"$role_assign_stderr" || role_assign_exit=$?
+            if [ "$role_assign_exit" -eq 0 ]; then
+                echo "Assigned 'Storage Table Data Contributor' to deploying user" >&2
+            else
+                role_assign_error="$(cat "$role_assign_stderr")"
+                echo "WARNING: Role assignment failed (exit $role_assign_exit): $role_assign_error" >&2
+                echo "  Grant 'Storage Table Data Contributor' manually on storage account $storage_account_name" >&2
+            fi
+            rm -f "$role_assign_stderr"
         fi
     fi
 fi

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -42,6 +42,9 @@ param tags object
 @description('Application Insights connection string. When non-empty, enables telemetry and backtraces.')
 param appInsightsConnectionString string = ''
 
+@description('Allowed CORS origins for the Function App (e.g. the SWA hostname). Empty array disables CORS.')
+param corsAllowedOrigins array = []
+
 resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   name: storageAccountName
 }
@@ -138,6 +141,9 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
     siteConfig: {
       minTlsVersion: '1.2'
       appSettings: concat(baseAppSettings, observabilityAppSettings)
+      cors: empty(corsAllowedOrigins) ? null : {
+        allowedOrigins: corsAllowedOrigins
+      }
     }
   }
 }

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -102,6 +102,7 @@ module functionPlaceholder './function-placeholder.bicep' = {
     programRouteTableName: storage.outputs.programRouteTableName
     programsTableName: storage.outputs.programsTableName
     appInsightsConnectionString: monitoring.outputs.connectionString
+    corsAllowedOrigins: ['https://${staticWebApp.outputs.defaultHostname}']
     tags: tags
   }
 }
@@ -133,10 +134,6 @@ module functionRbac './function-rbac.bicep' = {
     programRouteTableName: storage.outputs.programRouteTableName
     programsTableName: storage.outputs.programsTableName
   }
-  dependsOn: [
-    storage
-    functionPlaceholder
-  ]
 }
 
 output storageAccountName string = storage.outputs.storageAccountName

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -728,18 +728,26 @@ async function renderPrograms() {
       try {
         requireConfig('functionAppName', 'Function app name');
         const token = await getToken();
-        const payload = new FormData();
-        payload.append('elf', file, file.name);
-        payload.append('source_filename', String(formData.get('sourceFilename') || file.name));
-        payload.append('abi_version', String(formData.get('abiVersion') || '1'));
-        payload.append('verification_profile', String(formData.get('verificationProfile') || 'resident'));
+        const arrayBuf = await file.arrayBuffer();
+        const bytes = new Uint8Array(arrayBuf);
+        let binary = '';
+        for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+        const elfBase64 = btoa(binary);
+
+        const payload = {
+          elf: elfBase64,
+          source_filename: String(formData.get('sourceFilename') || file.name),
+          abi_version: Number(formData.get('abiVersion') || 1),
+          verification_profile: String(formData.get('verificationProfile') || 'resident'),
+        };
 
         const response = await fetch(`https://${CONFIG.functionAppName}.azurewebsites.net/api/programs/ingest`, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
           },
-          body: payload,
+          body: JSON.stringify(payload),
         });
 
         const responseText = await response.text();

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -730,9 +730,12 @@ async function renderPrograms() {
         const token = await getToken();
         const arrayBuf = await file.arrayBuffer();
         const bytes = new Uint8Array(arrayBuf);
-        let binary = '';
-        for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
-        const elfBase64 = btoa(binary);
+        const chunkSize = 8192;
+        const chunks = [];
+        for (let i = 0; i < bytes.length; i += chunkSize) {
+          chunks.push(String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize)));
+        }
+        const elfBase64 = btoa(chunks.join(''));
 
         const payload = {
           elf: elfBase64,


### PR DESCRIPTION
The bootstrap script deploys the Web UI and configures Entra permissions but is missing two pieces needed for the SPA to function correctly after bootstrap completes.

### Changes

**1. Grant \\Storage Table Data Contributor\\ role (\\deploy/azure-bootstrap/bootstrap.sh\\)**

The deploying user was not granted table-level access, so the SPA could not read/write the programs table. Add the same role-assignment step that \\deploy/web-ui/deploy.sh\\ already performs:
- Resolve the signed-in user principal via \\z ad signed-in-user show\\
- Assign \\Storage Table Data Contributor\\ scoped to the storage account
- Fall back to a warning if the principal or subscription ID cannot be determined
- Check \\z role assignment create\\ exit status and report failure accurately

**2. Add CORS to Function App (\\deploy/bicep/modules/function-placeholder.bicep\\, \\stack.bicep\\)**

The SPA uploads BPF programs by POSTing to the Function App's \\/api/programs/ingest\\ endpoint. Without CORS configured, the browser blocks the preflight OPTIONS request and \\etch()\\ fails with 'Failed to fetch'. Pass the Static Web App origin into the Function App module and configure \\siteConfig.cors.allowedOrigins\\. Also remove unnecessary explicit \\dependsOn\\ entries that the Bicep linter warned about.

**3. Fix program ingest request format (\\deploy/web-ui/app.js\\)**

The handler expects JSON with a base64-encoded \\lf\\ field, but the SPA was sending \\multipart/form-data\\ with the raw file. Read the file as an ArrayBuffer, encode to base64 (using chunked conversion to avoid O(n^2) string concatenation), and POST JSON with \\Content-Type: application/json\\.