### PR TITLE
Replace ProgramIngest API key auth with Entra ID EasyAuth

### DIFF
--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -444,6 +444,10 @@ if [ "$#" -ge 4 ] && [ "$1" = "ad" ] && [ "$2" = "app" ] && [ "$3" = "show" ]; t
     printf 'obj-id-789\n'
   elif [ "$query" = "spa.redirectUris" ]; then
     printf '[]\n'
+  elif [ "$query" = "api.oauth2PermissionScopes" ]; then
+    printf '[]\n'
+  elif [ "$query" = "identifierUris" ]; then
+    printf '[]\n'
   fi
   exit 0
 fi
@@ -478,6 +482,10 @@ exit 64
     // 1. jq -e --arg uri <URI> 'index($uri) != null'  → membership test (exit 1 = not found)
     // 2. jq -c --arg uri <URI> '(. // []) + [$uri]'   → merge URIs (output JSON array)
     // 3. jq -n -c --argjson uris <JSON> '{"spa":...}' → build PATCH body
+    // 4. jq -e '[.[] | select(...)] | length > 0'      → scope existence check (exit 1 = none)
+    // 5. jq -c --arg sid <UUID> '. + [{...}]'          → merge scope into array
+    // 6. jq -c --arg uri <URI> 'if index(...) ...'     → merge identifier URIs
+    // 7. jq -n -c --argjson uris <J> --argjson scopes <J> '{"identifierUris":...}' → PATCH body
     write_executable(
         &bin_dir.join("jq"),
         r#"#!/bin/sh
@@ -486,18 +494,32 @@ if [ ! -t 0 ]; then cat >/dev/null 2>&1 || true; fi
 # Find the expression (last argument) and extract --arg/--argjson values
 uri_val=""
 argjson_val=""
+argjson2_val=""
 while [ "$#" -gt 1 ]; do
   case "$1" in
-    --arg)   uri_val="$3"; shift 3 ;;
-    --argjson) argjson_val="$3"; shift 3 ;;
-    *)       shift ;;
+    --arg)     uri_val="$3"; shift 3 ;;
+    --argjson) if [ -z "$argjson_val" ]; then argjson_val="$3"; else argjson2_val="$3"; fi; shift 3 ;;
+    *)         shift ;;
   esac
 done
 expr="$1"
 case "$expr" in
-  *index*)  exit 1 ;;
-  *spa*)    printf '{"spa":{"redirectUris":%s}}\n' "$argjson_val"; exit 0 ;;
-  *)        printf '["%s"]\n' "$uri_val"; exit 0 ;;
+  *select*length*)
+    # Scope existence check — no scopes exist in stub
+    exit 1 ;;
+  *if*index*)
+    # Merge identifier URIs — return array with the new URI
+    printf '["%s"]\n' "$uri_val"; exit 0 ;;
+  *index*)
+    # Membership test — URI not found
+    exit 1 ;;
+  *identifierUris*oauth2*)
+    # Build PATCH body for API scope + identifierUris
+    printf '{"identifierUris":%s,"api":{"oauth2PermissionScopes":%s}}\n' "$argjson_val" "$argjson2_val"; exit 0 ;;
+  *spa*)
+    printf '{"spa":{"redirectUris":%s}}\n' "$argjson_val"; exit 0 ;;
+  *)
+    printf '["%s"]\n' "$uri_val"; exit 0 ;;
 esac
 "#,
     );
@@ -557,6 +579,11 @@ esac
     assert!(stderr.contains("Deploying Web UI to Static Web App sonde-web-test"));
     assert!(stderr.contains("Generated config.json for SPA"));
     assert!(stderr.contains("Configuring Entra app registration for Web UI"));
+    assert!(
+        stderr.contains("Exposed api://client-456/user_impersonation scope")
+            || stderr.contains("API scope user_impersonation already exposed"),
+        "bootstrap did not report API scope exposure: {stderr}"
+    );
     assert!(stderr.contains("Web UI deployment complete"));
 
     // Verify config.json was generated with correct values

--- a/crates/sonde-azure-handler/function-app/ProgramIngest/function.json
+++ b/crates/sonde-azure-handler/function-app/ProgramIngest/function.json
@@ -6,7 +6,7 @@
       "name": "req",
       "methods": ["post"],
       "route": "programs/ingest",
-      "authLevel": "function"
+      "authLevel": "anonymous"
     },
     {
       "type": "http",

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -317,6 +317,43 @@ az ad app permission grant \
     --output none 2>/dev/null || true
 echo "Azure Storage user_impersonation permission granted" >&2
 
+# Expose api://<clientId>/user_impersonation API scope on the Entra app
+# so EasyAuth can validate SPA-acquired tokens for the Function App.
+current_api="$(az ad app show --id "$app_object_id" \
+    --query 'api.oauth2PermissionScopes' --output json 2>/dev/null || echo '[]')"
+if [ -z "$current_api" ] || [ "$current_api" = "null" ]; then
+    current_api="[]"
+fi
+has_scope=0
+echo "$current_api" | jq -e '[.[] | select(.value == "user_impersonation")] | length > 0' >/dev/null 2>&1 && has_scope=1
+current_identifier_uris="$(az ad app show --id "$app_object_id" \
+    --query 'identifierUris' --output json 2>/dev/null || echo '[]')"
+if [ -z "$current_identifier_uris" ] || [ "$current_identifier_uris" = "null" ]; then
+    current_identifier_uris="[]"
+fi
+has_identifier_uri=0
+echo "$current_identifier_uris" | jq -e --arg uri "api://$companion_client_id" 'index($uri) != null' >/dev/null 2>&1 && has_identifier_uri=1
+if [ "$has_scope" -eq 1 ] && [ "$has_identifier_uri" -eq 1 ]; then
+    echo "API scope user_impersonation already exposed" >&2
+else
+    scope_id="$(cat /proc/sys/kernel/random/uuid 2>/dev/null || python3 -c 'import uuid; print(uuid.uuid4())')"
+    if [ "$has_scope" -eq 1 ]; then
+        merged_scopes="$current_api"
+    else
+        merged_scopes="$(echo "$current_api" | jq -c --arg sid "$scope_id" \
+            '. + [{"adminConsentDescription":"Allow the SPA to call the Function App on behalf of the signed-in user","adminConsentDisplayName":"Access Sonde Function App","id":$sid,"isEnabled":true,"type":"User","userConsentDescription":"Allow the app to access the Sonde Function App on your behalf","userConsentDisplayName":"Access Sonde Function App","value":"user_impersonation"}]')"
+    fi
+    merged_identifier_uris="$(echo "$current_identifier_uris" | jq -c --arg uri "api://$companion_client_id" \
+        'if index($uri) != null then . else . + [$uri] end')"
+    patch_body="$(jq -n -c --argjson uris "$merged_identifier_uris" --argjson scopes "$merged_scopes" \
+        '{"identifierUris":$uris,"api":{"oauth2PermissionScopes":$scopes}}')"
+    az rest --method PATCH \
+        --url "https://graph.microsoft.com/v1.0/applications/$app_object_id" \
+        --headers "Content-Type=application/json" \
+        --body "$patch_body"
+    echo "Exposed api://$companion_client_id/user_impersonation scope" >&2
+fi
+
 # Assign Storage Table Data Contributor to the deploying user so they can
 # access the programs table via the SPA immediately after bootstrap.
 deployer_principal="$(az ad signed-in-user show --query id --output tsv 2>/dev/null || true)"

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -123,6 +123,8 @@ module stack './modules/stack.bicep' = {
     functionAppName: effectiveFunctionAppName
     functionPlanName: effectiveFunctionPlanName
     companionServicePrincipalObjectId: companionIdentity.outputs.servicePrincipalObjectId
+    functionAuthClientId: companionIdentity.outputs.clientId
+    functionAuthTenantId: companionIdentity.outputs.tenantId
     staticWebAppName: effectiveStaticWebAppName
     staticWebAppLocation: staticWebAppLocation
   }

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -45,6 +45,14 @@ param appInsightsConnectionString string = ''
 @description('Allowed CORS origins for the Function App (e.g. the SWA hostname). Empty array disables CORS.')
 param corsAllowedOrigins array = []
 
+@description('Entra app (client) ID for EasyAuth token validation on ProgramIngest.')
+@minLength(1)
+param functionAuthClientId string
+
+@description('Entra tenant ID for EasyAuth OpenID issuer URL.')
+@minLength(1)
+param functionAuthTenantId string
+
 resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   name: storageAccountName
 }
@@ -143,6 +151,38 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
       appSettings: concat(baseAppSettings, observabilityAppSettings)
       cors: empty(corsAllowedOrigins) ? null : {
         allowedOrigins: corsAllowedOrigins
+      }
+    }
+  }
+}
+
+resource authSettings 'Microsoft.Web/sites/config@2024-04-01' = {
+  parent: functionApp
+  name: 'authsettingsV2'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      unauthenticatedClientAction: 'Return401'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+        registration: {
+          clientId: functionAuthClientId
+          openIdIssuer: 'https://login.microsoftonline.com/${functionAuthTenantId}/v2.0'
+        }
+        validation: {
+          allowedAudiences: [
+            'api://${functionAuthClientId}'
+          ]
+          defaultAuthorizationPolicy: {
+            allowedApplications: [
+              functionAuthClientId
+            ]
+          }
+        }
       }
     }
   }

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -176,6 +176,7 @@ resource authSettings 'Microsoft.Web/sites/config@2024-04-01' = {
         validation: {
           allowedAudiences: [
             'api://${functionAuthClientId}'
+            functionAuthClientId
           ]
           defaultAuthorizationPolicy: {
             allowedApplications: [

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -45,7 +45,7 @@ param staticWebAppName string
 @description('Azure region for the Static Web App.')
 param staticWebAppLocation string
 
-@description('Entra app (client) ID for Function App EasyAuth. When non-empty, configures authSettingsV2.')
+@description('Entra app (client) ID for Function App EasyAuth token validation.')
 param functionAuthClientId string
 
 @description('Entra tenant ID for Function App EasyAuth OpenID issuer URL.')

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -45,6 +45,12 @@ param staticWebAppName string
 @description('Azure region for the Static Web App.')
 param staticWebAppLocation string
 
+@description('Entra app (client) ID for Function App EasyAuth. When non-empty, configures authSettingsV2.')
+param functionAuthClientId string
+
+@description('Entra tenant ID for Function App EasyAuth OpenID issuer URL.')
+param functionAuthTenantId string
+
 var monitoringWorkspaceName = take('${functionAppName}-logs', 63)
 var monitoringAppInsightsName = take('${functionAppName}-insights', 260)
 
@@ -103,6 +109,8 @@ module functionPlaceholder './function-placeholder.bicep' = {
     programsTableName: storage.outputs.programsTableName
     appInsightsConnectionString: monitoring.outputs.connectionString
     corsAllowedOrigins: ['https://${staticWebApp.outputs.defaultHostname}']
+    functionAuthClientId: functionAuthClientId
+    functionAuthTenantId: functionAuthTenantId
     tags: tags
   }
 }

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -34,6 +34,9 @@ async function loadConfig() {
 }
 
 const STORAGE_SCOPES = ['https://storage.azure.com/.default'];
+function functionScopes() {
+  return [`api://${CONFIG.msalClientId}/user_impersonation`];
+}
 const TAB_IDS = ['dashboard', 'desired-state', 'programs', 'routes'];
 const APP = {
   msalApp: null,
@@ -270,6 +273,33 @@ async function getToken() {
     const result = await APP.msalApp.acquireTokenPopup({
       account: APP.account,
       scopes: STORAGE_SCOPES,
+    });
+    APP.account = result.account || APP.account;
+    APP.msalApp.setActiveAccount?.(APP.account);
+    updateAuthUi();
+    return result.accessToken;
+  }
+}
+
+async function getFunctionToken() {
+  if (!APP.account) {
+    await login();
+  }
+  if (!APP.msalApp || !APP.account) {
+    throw new Error('Sign in is required before calling Azure APIs.');
+  }
+
+  const scopes = functionScopes();
+  try {
+    const result = await APP.msalApp.acquireTokenSilent({
+      account: APP.account,
+      scopes,
+    });
+    return result.accessToken;
+  } catch {
+    const result = await APP.msalApp.acquireTokenPopup({
+      account: APP.account,
+      scopes,
     });
     APP.account = result.account || APP.account;
     APP.msalApp.setActiveAccount?.(APP.account);
@@ -727,7 +757,7 @@ async function renderPrograms() {
 
       try {
         requireConfig('functionAppName', 'Function app name');
-        const token = await getToken();
+        const token = await getFunctionToken();
         const arrayBuf = await file.arrayBuffer();
         const bytes = new Uint8Array(arrayBuf);
         const chunkSize = 8192;

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -183,7 +183,7 @@ AUTH_BODY="$(jq -n -c --arg clientId "$CLIENT_ID" --arg tenantId "$TENANT_ID" '{
           openIdIssuer: ("https://login.microsoftonline.com/" + $tenantId + "/v2.0")
         },
         validation: {
-          allowedAudiences: [("api://" + $clientId)],
+          allowedAudiences: [("api://" + $clientId), $clientId],
           defaultAuthorizationPolicy: {
             allowedApplications: [$clientId]
           }

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -124,6 +124,82 @@ az ad app permission grant \
 echo "  Azure Storage user_impersonation permission granted"
 
 echo ""
+echo "=== Exposing Function App API scope on Entra app ==="
+# Ensure the Entra app exposes api://<clientId>/user_impersonation so that
+# the SPA can acquire tokens scoped to the Function App and EasyAuth can
+# validate them.
+CURRENT_API="$(az ad app show --id "$APP_OBJECT_ID" \
+  --query 'api.oauth2PermissionScopes' -o json 2>/dev/null || echo '[]')"
+if [ -z "$CURRENT_API" ] || [ "$CURRENT_API" = "null" ]; then
+  CURRENT_API="[]"
+fi
+HAS_SCOPE=0
+echo "$CURRENT_API" | jq -e '[.[] | select(.value == "user_impersonation")] | length > 0' >/dev/null 2>&1 && HAS_SCOPE=1
+# Also check identifierUris includes our API URI
+CURRENT_IDENTIFIER_URIS="$(az ad app show --id "$APP_OBJECT_ID" \
+  --query 'identifierUris' -o json 2>/dev/null || echo '[]')"
+if [ -z "$CURRENT_IDENTIFIER_URIS" ] || [ "$CURRENT_IDENTIFIER_URIS" = "null" ]; then
+  CURRENT_IDENTIFIER_URIS="[]"
+fi
+HAS_IDENTIFIER_URI=0
+echo "$CURRENT_IDENTIFIER_URIS" | jq -e --arg uri "api://$CLIENT_ID" 'index($uri) != null' >/dev/null 2>&1 && HAS_IDENTIFIER_URI=1
+if [ "$HAS_SCOPE" -eq 1 ] && [ "$HAS_IDENTIFIER_URI" -eq 1 ]; then
+  echo "  API scope user_impersonation already exposed"
+else
+  SCOPE_ID="$(python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null || uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid)"
+  if [ "$HAS_SCOPE" -eq 1 ]; then
+    MERGED_SCOPES="$CURRENT_API"
+  else
+    MERGED_SCOPES="$(echo "$CURRENT_API" | jq -c --arg sid "$SCOPE_ID" \
+      '. + [{"adminConsentDescription":"Allow the SPA to call the Function App on behalf of the signed-in user","adminConsentDisplayName":"Access Sonde Function App","id":$sid,"isEnabled":true,"type":"User","userConsentDescription":"Allow the app to access the Sonde Function App on your behalf","userConsentDisplayName":"Access Sonde Function App","value":"user_impersonation"}]')"
+  fi
+  MERGED_IDENTIFIER_URIS="$(echo "$CURRENT_IDENTIFIER_URIS" | jq -c --arg uri "api://$CLIENT_ID" \
+    'if index($uri) != null then . else . + [$uri] end')"
+  PATCH_BODY="$(jq -n -c --argjson uris "$MERGED_IDENTIFIER_URIS" --argjson scopes "$MERGED_SCOPES" \
+    '{"identifierUris":$uris,"api":{"oauth2PermissionScopes":$scopes}}')"
+  az rest --method PATCH \
+    --url "https://graph.microsoft.com/v1.0/applications/$APP_OBJECT_ID" \
+    --headers "Content-Type=application/json" \
+    --body "$PATCH_BODY"
+  echo "  Exposed api://$CLIENT_ID/user_impersonation scope"
+fi
+
+echo ""
+echo "=== Configuring Function App EasyAuth ==="
+# Configure Azure App Service Authentication (EasyAuth) on the Function App
+# to validate Entra ID bearer tokens. This replaces function-key auth.
+# Use az rest with the authSettingsV2 JSON directly for reliable configuration.
+FUNCTION_APP_ID="$(az functionapp show --name "$FUNCTION_APP" \
+  --resource-group "$RESOURCE_GROUP" --query 'id' -o tsv)"
+AUTH_BODY="$(jq -n -c --arg clientId "$CLIENT_ID" --arg tenantId "$TENANT_ID" '{
+  properties: {
+    platform: { enabled: true },
+    globalValidation: { unauthenticatedClientAction: "Return401" },
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true,
+        registration: {
+          clientId: $clientId,
+          openIdIssuer: ("https://login.microsoftonline.com/" + $tenantId + "/v2.0")
+        },
+        validation: {
+          allowedAudiences: [("api://" + $clientId)],
+          defaultAuthorizationPolicy: {
+            allowedApplications: [$clientId]
+          }
+        }
+      }
+    }
+  }
+}')"
+az rest --method PUT \
+  --url "https://management.azure.com${FUNCTION_APP_ID}/config/authsettingsV2?api-version=2024-04-01" \
+  --headers "Content-Type=application/json" \
+  --body "$AUTH_BODY" \
+  --output none
+echo "  EasyAuth configured with Entra ID provider"
+
+echo ""
 echo "=== Configuring Function App CORS ==="
 # The web UI calls the Function App ingest endpoint from the browser.
 # Without CORS, the preflight request is rejected and fetch() fails.

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -308,6 +308,9 @@ When bootstrap is required, the Azure companion performs this sequence:
     e. Registers `https://<staticWebAppHostname>` as a SPA redirect URI on the
        Entra app registration, merging with any existing redirect URIs.
     f. Adds Azure Storage `user_impersonation` API permission to the Entra app.
+    g. Exposes `api://<clientId>/user_impersonation` as an API scope on the
+       Entra app registration (required for EasyAuth token validation on the
+       Function App). If the scope already exists, this step is a no-op.
     If any sub-step fails, the bootstrap script exits non-zero and the
     bootstrap container reports failure.
 18. Write `service-principal.json` and `storage-queues.json` to the staging

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -834,6 +834,9 @@ The bootstrap script MUST:
    the Entra app registration, merging with any existing redirect URIs.
 5. Add the Azure Storage `user_impersonation` API permission to the Entra app
    registration if not already present.
+6. Expose `api://<clientId>/user_impersonation` as an API scope on the Entra app
+   registration (required for EasyAuth token validation on the Function App).
+   If the scope already exists, this step is a no-op.
 
 The bootstrap image bundles Node.js and a pinned version of the SWA CLI
 (`@azure/static-web-apps-cli`, installed globally at image build time) to
@@ -848,3 +851,4 @@ deploy SPA content to the Static Web App.
 5. Existing SPA redirect URIs on the Entra app are preserved (not overwritten) when adding the SWA hostname.
 6. Re-running bootstrap updates the SPA content and Entra configuration idempotently.
 7. If SPA deployment fails, bootstrap exits non-zero and does not report success.
+8. The Entra app registration exposes `api://<clientId>/user_impersonation` as an API scope after bootstrap.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -601,6 +601,7 @@
 5. Assert: the bootstrap script registers `https://<staticWebAppHostname>` as a SPA redirect URI on the Entra app registration.
 6. Assert: existing SPA redirect URIs are preserved (not overwritten) during the registration.
 7. Assert: the bootstrap script adds the Azure Storage `user_impersonation` API permission to the Entra app.
-8. Assert: if SPA deployment fails, bootstrap exits non-zero.
-9. Re-run bootstrap with the same stubbed outputs.
-10. Assert: the SPA deployment and Entra configuration succeed idempotently.
+8. Assert: the bootstrap script exposes `api://<clientId>/user_impersonation` as an API scope on the Entra app registration.
+9. Assert: if SPA deployment fails, bootstrap exits non-zero.
+10. Re-run bootstrap with the same stubbed outputs.
+11. Assert: the SPA deployment and Entra configuration succeed idempotently (including the API scope exposure in step 8).

--- a/docs/azure-provisioning-design.md
+++ b/docs/azure-provisioning-design.md
@@ -133,6 +133,24 @@ bootstrap image carries a prebuilt Linux package for the matching Sonde
 release, uploads it into the provisioned deployment target, and waits until
 Azure reports that at least one function is loaded before reporting success.
 
+The function-placeholder module also configures Azure App Service
+Authentication (EasyAuth / `authSettingsV2`) on the Function App. This
+validates Entra ID bearer tokens on HTTP-triggered routes (e.g.,
+`ProgramIngest`) at the platform level, eliminating the need for Azure
+Functions API keys. The EasyAuth configuration requires two parameters:
+the companion Entra app client ID (used as the AAD audience) and the
+tenant ID (used to construct the OpenID issuer URL). Queue-triggered
+invocations are unaffected because they bypass HTTP auth entirely.
+
+The parameter flow is:
+- `main.bicep` accepts `companionClientId` and `companionTenantId` as
+  top-level parameters (populated from the Entra app registration).
+- `main.bicep` passes these to `stack.bicep` as module parameters.
+- `stack.bicep` passes them to `function-placeholder.bicep` as
+  `functionAuthClientId` and `functionAuthTenantId`.
+- `function-placeholder.bicep` uses them to construct the
+  `authSettingsV2` resource with the correct issuer URL and audience.
+
 ---
 
 ## 4  Runtime identity provisioning

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -186,7 +186,7 @@ The script:
 4. Adds Azure Storage API permission (`user_impersonation`) to the Entra app registration
 5. Exposes `api://<clientId>/user_impersonation` API scope on the Entra app
    registration (required for EasyAuth token validation on the Function App)
-6. Configures EasyAuth on the Function App via `az webapp auth` CLI with the
+6. Configures EasyAuth on the Function App via ARM REST API with the
    companion Entra app as the identity provider and `Return401` for
    unauthenticated requests
 7. Deploys the web-ui content to the Static Web App using the SWA CLI
@@ -241,10 +241,10 @@ added to the Function App with the following configuration:
   — includes the companion client ID so the SPA's tokens (audience matching the
   client ID) are accepted.
 - `identityProviders.azureActiveDirectory.validation.allowedAudiences` — includes
-  `api://<clientId>` so that tokens acquired with the
-  `api://<clientId>/user_impersonation` scope are accepted. Without this field,
-  EasyAuth may reject valid SPA tokens whose audience is the Application ID URI
-  rather than the raw client ID.
+  both `api://<clientId>` and the bare `<clientId>`. The Application ID URI form
+  matches v1 access tokens (the default); the bare client ID matches v2 access
+  tokens. Including both makes EasyAuth robust against changes to the Entra app's
+  `requestedAccessTokenVersion` setting.
 
 **Queue-triggered invocations are unaffected.** Azure Functions queue triggers
 are invoked by the runtime, not via HTTP. EasyAuth only applies to HTTP-triggered

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -148,16 +148,16 @@ When the handler publishes a `DESIRED_STATE` message due to program divergence, 
 ## 8. Authentication (WEB-0500)
 
 - MSAL.js 2.x with authorization code flow + PKCE.
-- Scopes: `https://storage.azure.com/.default` (Table/Queue access).
 - Token caching in browser session storage.
 - Silent token renewal; redirect to login on expiry.
-
-> **Note**: The SPA acquires tokens scoped to `https://storage.azure.com/.default`
-> for Azure Table operations. The `ProgramIngest` function endpoint uses
-> `authLevel: "function"` for API key authentication. Browser-based SPA
-> access to this endpoint requires a follow-up to configure Entra/EasyAuth
-> token-based authentication with the function's API scope and appropriate
-> redirect URI configuration.
+- Two token scopes, acquired separately:
+  - `https://storage.azure.com/.default` — for Azure Table/Queue REST API calls
+    (dashboard, desired state, program list).
+  - `api://<companionClientId>/user_impersonation` — for `ProgramIngest` Function
+    App calls. This token is validated by EasyAuth on the Function App (see §9.4).
+- The SPA calls `acquireTokenSilent` (with popup fallback) for the Function App
+  scope before each `ProgramIngest` request and sends the token as a
+  `Bearer` header.
 
 ---
 
@@ -184,7 +184,12 @@ The script:
 2. Generates `config.json` with MSAL client ID, tenant ID, storage account, and function app name
 3. Registers the SWA hostname as a SPA redirect URI on the Entra app registration
 4. Adds Azure Storage API permission (`user_impersonation`) to the Entra app registration
-5. Deploys the web-ui content to the Static Web App using the SWA CLI
+5. Exposes `api://<clientId>/user_impersonation` API scope on the Entra app
+   registration (required for EasyAuth token validation on the Function App)
+6. Configures EasyAuth on the Function App via `az webapp auth` CLI with the
+   companion Entra app as the identity provider and `Return401` for
+   unauthenticated requests
+7. Deploys the web-ui content to the Static Web App using the SWA CLI
 
 > **Note:** Steps 3–4 mutate the Entra app registration associated with the Azure companion.
 
@@ -199,8 +204,9 @@ After deployment, grant users the `Storage Table Data Contributor` role on the s
 
 ### 9.3 Function App Changes
 
-- `ProgramIngest/function.json` defines the HTTP trigger (`authLevel: function`,
-  route `programs/ingest`).
+- `ProgramIngest/function.json` defines the HTTP trigger (`authLevel: anonymous`,
+  route `programs/ingest`). Authentication is handled by EasyAuth (see §9.4),
+  not by the Azure Functions runtime key mechanism.
 - `main.rs` routes `/ProgramIngest` to a dedicated handler that parses the
   Azure Functions HTTP trigger envelope and delegates to
   `AzureHandler::handle_program_ingest()`. The catch-all `/{*path}` route
@@ -211,7 +217,62 @@ After deployment, grant users the `Storage Table Data Contributor` role on the s
 - The HTTP trigger response uses the Azure Functions `res` output binding
   envelope format with `statusCode`, `headers`, and `body` fields.
 
-> **Note**: The `ProgramIngest` endpoint currently uses `authLevel: "function"`
-> for Azure Functions-level API key authentication. Browser-based SPA access
-> requires a follow-up to configure Entra/EasyAuth token-based authentication
-> with the function's API scope.
+### 9.4 EasyAuth Configuration (WEB-0606)
+
+The Function App is configured with Azure App Service Authentication
+(EasyAuth / `authSettingsV2`) to validate Entra ID bearer tokens on HTTP
+routes. This replaces the previous `authLevel: "function"` API key
+mechanism for the `ProgramIngest` endpoint.
+
+**Bicep resource** (`function-placeholder.bicep`):
+
+A `Microsoft.Web/sites/config@2024-04-01` resource named `authsettingsV2` is
+added to the Function App with the following configuration:
+
+- `platform.enabled: true`
+- `globalValidation.unauthenticatedClientAction: 'Return401'` — rejects
+  unauthenticated requests with HTTP 401 instead of redirecting to a login page.
+- `identityProviders.azureActiveDirectory.enabled: true`
+- `identityProviders.azureActiveDirectory.registration.clientId` — set to the
+  companion Entra app registration's client ID (passed as a Bicep parameter).
+- `identityProviders.azureActiveDirectory.registration.openIdIssuer` — set to
+  `https://login.microsoftonline.com/<tenantId>/v2.0` (passed as a Bicep parameter).
+- `identityProviders.azureActiveDirectory.validation.defaultAuthorizationPolicy.allowedApplications`
+  — includes the companion client ID so the SPA's tokens (audience matching the
+  client ID) are accepted.
+- `identityProviders.azureActiveDirectory.validation.allowedAudiences` — includes
+  `api://<clientId>` so that tokens acquired with the
+  `api://<clientId>/user_impersonation` scope are accepted. Without this field,
+  EasyAuth may reject valid SPA tokens whose audience is the Application ID URI
+  rather than the raw client ID.
+
+**Queue-triggered invocations are unaffected.** Azure Functions queue triggers
+are invoked by the runtime, not via HTTP. EasyAuth only applies to HTTP-triggered
+routes.
+
+**Entra app registration prerequisites:**
+
+The Entra app registration (companion client ID) must expose an API scope
+(`api://<clientId>/user_impersonation`). This is configured by:
+- The `deploy/web-ui/deploy.sh` script (standalone deployment), or
+- The bootstrap script inside the `sonde-azure-bootstrap` container (AZC-0410).
+
+Both paths ensure the scope exists and that the SPA redirect URI is registered
+before the SPA attempts to acquire tokens for the Function App audience.
+
+**CORS and preflight:**
+
+EasyAuth applies only to authenticated HTTP methods. Browser preflight
+(`OPTIONS`) requests are unauthenticated by design and are handled by the
+Function App's CORS configuration (already provisioned in Bicep via
+`corsAllowedOrigins`). The existing CORS setup passes through `OPTIONS`
+preflight requests without requiring a bearer token. Only the actual
+`POST` to `/api/programs/ingest` requires authentication.
+
+**SPA scope derivation:**
+
+The SPA derives the Function App API scope as
+`api://${CONFIG.msalClientId}/user_impersonation` — it does not require
+an additional `config.json` field. This works because the companion Entra
+app registration is shared between the SPA and the Function App EasyAuth
+configuration.

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -37,9 +37,15 @@
 | T-WEB-0402 | WEB-0402 | SPA creates/edits `programroute` entries | Manual/E2E | Planned |
 | T-WEB-0501 | WEB-0501 | MSAL.js login flow works | Manual | Planned |
 | T-WEB-0502 | WEB-0502 | Storage API calls use bearer token | Integration | Planned |
-| T-WEB-0503 | WEB-0503 | `ProgramIngest` rejects unauthenticated requests | Unit (Rust) | Planned |
+| T-WEB-0503 | WEB-0503 | `ProgramIngest` rejects unauthenticated requests (EasyAuth returns 401) | Integration | Planned |
+| T-WEB-0504 | WEB-0504 | SPA acquires Function App-scoped token for `ProgramIngest` calls | Manual | Planned |
+| T-WEB-0505 | WEB-0505 | `ProgramIngest` rejects Storage-scoped token (wrong audience) | Integration | Planned |
+| T-WEB-0506 | WEB-0506 | `ProgramIngest` rejects expired bearer token | Integration | Planned |
+| T-WEB-0507 | WEB-0507 | `ProgramIngest` accepts valid `api://<clientId>/user_impersonation` token | Integration | Planned |
 | T-WEB-0601 | WEB-0601 | Bicep provisions Static Web App | Infrastructure | Planned |
 | T-WEB-0602 | WEB-0602 | Bicep provisions `programs` table | Infrastructure | Planned |
 | T-WEB-0603 | WEB-0603 | `ProgramIngest` HTTP trigger deployed alongside `UpstreamConnector` | Infrastructure | Planned |
 | T-WEB-0604 | WEB-0604 | CORS configured for SPA origin | Infrastructure | Planned |
 | T-WEB-0605 | WEB-0605 | Function identity has table contributor on `programs` | Infrastructure | Planned |
+| T-WEB-0606 | WEB-0606 | EasyAuth configured on Function App with Entra ID provider | Infrastructure | Planned |
+| T-WEB-0607 | WEB-0607 | `ProgramIngest` `authLevel` is `anonymous` (auth delegated to EasyAuth) | Infrastructure | Planned |


### PR DESCRIPTION
## Summary

Replaces Azure Functions API key authentication (authLevel: "function") on the ProgramIngest endpoint with Azure App Service Authentication (EasyAuth / authSettingsV2). This eliminates the security risk of embedding function keys in SPA client-side code.

## Problem

The ProgramIngest HTTP endpoint used authLevel: "function", requiring an Azure Functions API key. Since the Web UI is an SPA, this key would need to be embedded in browser-accessible JavaScript, where any user could extract it.

## Solution

EasyAuth validates Entra ID bearer tokens at the platform level before requests reach the custom handler. The SPA acquires tokens scoped to api://<clientId>/user_impersonation via MSAL.js. No Rust code changes required.

### Infrastructure changes
- function.json: authLevel changed to "anonymous" (EasyAuth handles auth)
- function-placeholder.bicep: authSettingsV2 resource with Entra ID provider, Return401, allowedAudiences
- stack.bicep / main.bicep: thread functionAuthClientId and functionAuthTenantId params
- deploy.sh: expose API scope on Entra app + configure EasyAuth via ARM REST API

### SPA changes
- app.js: getFunctionToken() acquires Function App-scoped token; ProgramIngest upload uses it

### Specification changes
- web-ui-design.md: two token scopes, EasyAuth config, CORS/preflight, scope derivation
- web-ui-validation.md: negative auth tests (T-WEB-0503-0507), infra tests (T-WEB-0606-0607)
- azure-companion-requirements.md: AZC-0410 API scope step + acceptance criterion
- azure-companion-design.md / azure-companion-validation.md: bootstrap step 17g, T-AZC-0418
- azure-provisioning-design.md: EasyAuth paragraph + Bicep param flow

## Not affected
- Queue-triggered connector messages (bypass HTTP auth)
- Local gRPC admin ingest path (sonde-admin)
- Existing MSAL.js Storage token flow