### PR TITLE
Fix CI: update azure-cli digest and add --version flag

### DIFF
--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -11,7 +11,7 @@
 #   # Requires:
 #   #   .artifacts/azure-handler-function/sonde-azure-handler-function.zip
 
-FROM mcr.microsoft.com/azure-cli@sha256:7f9ca8e6bf1c72e5fafefb6925546272776d635fb428538455c5c79bb77e2aa7
+FROM mcr.microsoft.com/azure-cli@sha256:2b798554ac05f878c7d328cbe9d215cd1c560b6bb6060d9ac7ba5257614a86f2
 
 RUN tdnf install -y jq icu nodejs24 nodejs24-npm && tdnf clean all \
     && npm install -g @azure/static-web-apps-cli@2.0.9

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -113,7 +113,7 @@ trait AsyncIo: AsyncRead + AsyncWrite + Unpin + Send {}
 impl<T> AsyncIo for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
 
 #[derive(Debug, Clone, Parser)]
-#[command(name = "sonde-azure-companion")]
+#[command(name = "sonde-azure-companion", version)]
 struct Cli {
     /// Gateway admin socket path (UDS on Unix, named pipe on Windows).
     #[arg(long, global = true, env = "SONDE_GATEWAY_ADMIN_SOCKET", default_value = DEFAULT_ADMIN_SOCKET)]


### PR DESCRIPTION
## Summary

Fixes two pre-existing CI failures in the Azure companion container workflow:

1. **Docker 403**: The pinned azure-cli image digest in Dockerfile.azure-bootstrap was removed from MCR. Updated to the current 2.86.0 digest.
2. **--version flag**: The CI smoke test runs `sonde-azure-companion --version` but the binary didn't implement that flag. Added `version` to the clap `#[command]` attribute.

Both issues are pre-existing on main and unrelated to the EasyAuth changes in #901.