### PR TITLE
feat: ingest inline ELF from DESIRED_STATE with full Prevail verification

### DIFF
--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -11,7 +11,7 @@
 #   # Requires:
 #   #   .artifacts/azure-handler-function/sonde-azure-handler-function.zip
 
-FROM mcr.microsoft.com/azure-cli@sha256:2b798554ac05f878c7d328cbe9d215cd1c560b6bb6060d9ac7ba5257614a86f2
+FROM mcr.microsoft.com/azure-cli@sha256:925b5871029fe16b82650c8298201e5dd91ac8122c7af1d150b57edc8c9f316a
 
 RUN tdnf install -y jq icu nodejs24 nodejs24-npm && tdnf clean all \
     && npm install -g @azure/static-web-apps-cli@2.0.9

--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -11,7 +11,7 @@
 #   # Requires:
 #   #   .artifacts/azure-handler-function/sonde-azure-handler-function.zip
 
-FROM mcr.microsoft.com/azure-cli@sha256:925b5871029fe16b82650c8298201e5dd91ac8122c7af1d150b57edc8c9f316a
+FROM mcr.microsoft.com/azure-cli@sha256:2b798554ac05f878c7d328cbe9d215cd1c560b6bb6060d9ac7ba5257614a86f2
 
 RUN tdnf install -y jq icu nodejs24 nodejs24-npm && tdnf clean all \
     && npm install -g @azure/static-web-apps-cli@2.0.9

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -14,6 +14,7 @@ use azure_data_tables::prelude::TableServiceClient;
 use azure_identity::ManagedIdentityCredential;
 use azure_identity_legacy::{AppServiceManagedIdentityCredential, TokenCredentialOptions};
 use base64::Engine as _;
+use ciborium::value::Integer;
 use ciborium::Value;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -132,6 +133,7 @@ pub struct ProgramRouteRow {
 pub struct ProgramImageRow {
     pub program_hash: Vec<u8>,
     pub cbor_image: Vec<u8>,
+    pub elf_image: Vec<u8>,
     pub source_filename: Option<String>,
     pub abi_version: Option<u32>,
     pub size_bytes: u32,
@@ -185,7 +187,7 @@ pub trait HandlerStore: Send + Sync {
     async fn load_program_image(
         &self,
         program_hash: &[u8],
-    ) -> Result<Option<Vec<u8>>, HandlerError>;
+    ) -> Result<Option<ProgramImageRow>, HandlerError>;
     async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), HandlerError>;
 }
 
@@ -295,26 +297,36 @@ where
             return Ok(());
         }
 
-        let program_image = if program_diverged {
+        let program_row = if program_diverged {
             match desired_row.desired_assigned_program_hash.as_deref() {
                 Some(desired_hash) => {
-                    let image = self.store.load_program_image(desired_hash).await?;
-                    if image.is_none() {
+                    let row = self.store.load_program_image(desired_hash).await?;
+                    if let Some(ref r) = row {
+                        if r.elf_image.is_empty() {
+                            warn!(
+                                program_hash = hex::encode(desired_hash),
+                                node_id = %actual_state.entity_id,
+                                "program row has no elf_image (legacy row); \
+                                 DESIRED_STATE will omit inline ELF — \
+                                 re-ingest the program to populate elf_image"
+                            );
+                        }
+                    } else {
                         warn!(
                             program_hash = hex::encode(desired_hash),
                             node_id = %actual_state.entity_id,
-                            "program image not found in programs table; \
-                             DESIRED_STATE will omit inline image"
+                            "program not found in programs table; \
+                             DESIRED_STATE will omit inline ELF"
                         );
                     }
-                    image
+                    row
                 }
                 None => None,
             }
         } else {
             None
         };
-        let desired = encode_desired_state(&desired_row, program_image)?;
+        let desired = encode_desired_state(&desired_row, program_row.as_ref())?;
         self.publisher
             .publish(&self.downstream_queue, desired)
             .await
@@ -455,6 +467,7 @@ where
         let row = ProgramImageRow {
             program_hash: record.hash.clone(),
             cbor_image: record.image,
+            elf_image: elf_bytes.to_vec(),
             source_filename: record.source_filename.clone(),
             abi_version: record.abi_version,
             size_bytes: record.size,
@@ -742,7 +755,7 @@ impl HandlerStore for AzureTablesStore {
     async fn load_program_image(
         &self,
         program_hash: &[u8],
-    ) -> Result<Option<Vec<u8>>, HandlerError> {
+    ) -> Result<Option<ProgramImageRow>, HandlerError> {
         let row_key = hex::encode(program_hash);
         let entity_client = self
             .programs_table
@@ -750,7 +763,25 @@ impl HandlerStore for AzureTablesStore {
             .entity_client(row_key);
         match entity_client.get::<ProgramImageEntity>().await {
             Ok(response) => {
-                decode_base64_field(response.entity.cbor_image, "programs.cbor_image").map(Some)
+                let e = response.entity;
+                let cbor_image = decode_base64_field(e.cbor_image, "programs.cbor_image")?;
+                let elf_image = match e.elf_image {
+                    Some(b64) => decode_base64_field(b64, "programs.elf_image")?,
+                    None => Vec::new(),
+                };
+                Ok(Some(ProgramImageRow {
+                    program_hash: program_hash.to_vec(),
+                    cbor_image: cbor_image.clone(),
+                    elf_image,
+                    source_filename: e.source_filename,
+                    abi_version: e.abi_version,
+                    size_bytes: e.size_bytes.unwrap_or(cbor_image.len() as u32),
+                    verification_profile: e
+                        .verification_profile
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or_else(|| "resident".to_string()),
+                    created_at: e.created_at.unwrap_or_default(),
+                }))
             }
             Err(e) if is_legacy_not_found(&e) => Ok(None),
             Err(e) => Err(HandlerError::Store(format!(
@@ -765,6 +796,7 @@ impl HandlerStore for AzureTablesStore {
             partition_key: "program".to_string(),
             row_key: row_key.clone(),
             cbor_image: base64::engine::general_purpose::STANDARD.encode(&row.cbor_image),
+            elf_image: Some(base64::engine::general_purpose::STANDARD.encode(&row.elf_image)),
             source_filename: row.source_filename.clone(),
             abi_version: row.abi_version,
             size_bytes: Some(row.size_bytes),
@@ -935,6 +967,8 @@ struct ProgramImageEntity {
     #[serde(rename = "RowKey")]
     row_key: String,
     cbor_image: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    elf_image: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     source_filename: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -1126,7 +1160,7 @@ fn decode_connector_message(bytes: &[u8]) -> Result<ConnectorMessage, HandlerErr
 
 pub(crate) fn encode_desired_state(
     row: &DesiredStateRow,
-    program_image: Option<Vec<u8>>,
+    program_row: Option<&ProgramImageRow>,
 ) -> Result<Vec<u8>, HandlerError> {
     let mut desired_state_entries = vec![
         map_entry(
@@ -1135,8 +1169,18 @@ pub(crate) fn encode_desired_state(
         ),
         map_entry(2, opt_u32_value(row.desired_schedule_interval_s)),
     ];
-    if let Some(image) = program_image {
-        desired_state_entries.push(map_entry(5, Value::Bytes(image)));
+    if let Some(prog) = program_row {
+        if !prog.elf_image.is_empty() {
+            desired_state_entries.push(map_entry(5, Value::Bytes(prog.elf_image.clone())));
+            desired_state_entries
+                .push(map_entry(6, Value::Text(prog.verification_profile.clone())));
+            if let Some(ref filename) = prog.source_filename {
+                desired_state_entries.push(map_entry(7, Value::Text(filename.clone())));
+            }
+            if let Some(abi) = prog.abi_version {
+                desired_state_entries.push(map_entry(8, Value::Integer(Integer::from(abi))));
+            }
+        }
     }
     let desired_state = Value::Map(desired_state_entries);
     let value = Value::Map(vec![
@@ -1385,7 +1429,7 @@ mod tests {
         actual_rows: Mutex<HashMap<String, Vec<ActualStateRow>>>,
         desired_rows: Mutex<HashMap<String, Vec<DesiredStateRow>>>,
         routes: Mutex<HashMap<String, ProgramRouteRow>>,
-        program_images: Mutex<HashMap<String, Vec<u8>>>,
+        program_images: Mutex<HashMap<String, ProgramImageRow>>,
         stored_program_rows: Mutex<Vec<ProgramImageRow>>,
     }
 
@@ -1418,10 +1462,20 @@ mod tests {
         }
 
         async fn append_program_image(&self, program_hash: &[u8], program_image: &[u8]) {
+            let row = ProgramImageRow {
+                program_hash: program_hash.to_vec(),
+                cbor_image: program_image.to_vec(),
+                elf_image: program_image.to_vec(),
+                source_filename: None,
+                abi_version: None,
+                size_bytes: program_image.len() as u32,
+                verification_profile: "resident".to_string(),
+                created_at: String::new(),
+            };
             self.program_images
                 .lock()
                 .await
-                .insert(hex::encode(program_hash), program_image.to_vec());
+                .insert(hex::encode(program_hash), row);
         }
     }
 
@@ -1479,7 +1533,7 @@ mod tests {
         async fn load_program_image(
             &self,
             program_hash: &[u8],
-        ) -> Result<Option<Vec<u8>>, HandlerError> {
+        ) -> Result<Option<ProgramImageRow>, HandlerError> {
             Ok(self
                 .program_images
                 .lock()
@@ -1492,7 +1546,7 @@ mod tests {
             self.program_images
                 .lock()
                 .await
-                .insert(hex::encode(&row.program_hash), row.cbor_image.clone());
+                .insert(hex::encode(&row.program_hash), row.clone());
             self.stored_program_rows.lock().await.push(row.clone());
             Ok(())
         }
@@ -1587,7 +1641,7 @@ mod tests {
         async fn load_program_image(
             &self,
             _program_hash: &[u8],
-        ) -> Result<Option<Vec<u8>>, HandlerError> {
+        ) -> Result<Option<ProgramImageRow>, HandlerError> {
             match &self.load_program_image_error {
                 Some(error) => Err(HandlerError::Store(error.clone())),
                 None => Ok(None),
@@ -1636,7 +1690,7 @@ mod tests {
         async fn load_program_image(
             &self,
             _program_hash: &[u8],
-        ) -> Result<Option<Vec<u8>>, HandlerError> {
+        ) -> Result<Option<ProgramImageRow>, HandlerError> {
             Ok(None)
         }
 
@@ -1683,7 +1737,7 @@ mod tests {
         async fn load_program_image(
             &self,
             _program_hash: &[u8],
-        ) -> Result<Option<Vec<u8>>, HandlerError> {
+        ) -> Result<Option<ProgramImageRow>, HandlerError> {
             Ok(None)
         }
 
@@ -1842,8 +1896,12 @@ mod tests {
             Some(120)
         );
         assert_eq!(
-            required_bytes(desired_state, 5, "program_image").unwrap(),
+            required_bytes(desired_state, 5, "assigned_program_elf").unwrap(),
             b"program-image"
+        );
+        assert_eq!(
+            optional_text_field(desired_state, 6, "assigned_program_verification_profile").unwrap(),
+            Some("resident".to_string())
         );
         assert!(map_get(desired_state, 3).is_none());
     }
@@ -2866,7 +2924,10 @@ mod tests {
             ) -> Result<Option<ProgramRouteRow>, HandlerError> {
                 Ok(None)
             }
-            async fn load_program_image(&self, _: &[u8]) -> Result<Option<Vec<u8>>, HandlerError> {
+            async fn load_program_image(
+                &self,
+                _: &[u8],
+            ) -> Result<Option<ProgramImageRow>, HandlerError> {
                 Ok(None)
             }
             async fn store_program_image(&self, _: &ProgramImageRow) -> Result<(), HandlerError> {

--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -15,7 +15,7 @@ use tracing::{error, info, warn};
 
 use crate::admin::{system_time_to_millis, validate_program_hash_bytes};
 use crate::engine::PendingCommand;
-use crate::program::VerificationProfile;
+use crate::program::{ProgramLibrary, VerificationProfile};
 use crate::storage::Storage;
 
 pub const MSG_TYPE_DESIRED_STATE: u64 = 0x01;
@@ -248,6 +248,7 @@ impl ConnectorEventHub {
 #[derive(Clone)]
 pub struct ConnectorService {
     storage: Arc<dyn Storage>,
+    program_library: ProgramLibrary,
     pending_commands: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>>,
     event_hub: Arc<ConnectorEventHub>,
     max_message_size: usize,
@@ -262,6 +263,7 @@ impl ConnectorService {
     ) -> Self {
         Self {
             storage,
+            program_library: ProgramLibrary::new(),
             pending_commands,
             event_hub,
             max_message_size: max_message_size.max(1),
@@ -368,6 +370,64 @@ impl ConnectorService {
         let schedule_interval_s = optional_u32_field(desired_state, 2, "schedule_interval_s")?;
         let ephemeral_program_hash =
             optional_bytes_field(desired_state, 3, "ephemeral_program_hash")?;
+
+        // Ingest inline ELF (key 5) only when assigned_program_hash (key 1) is present.
+        if assigned_program_hash.is_some() {
+            let inline_elf = optional_bytes_field(desired_state, 5, "assigned_program_elf")?;
+            if let Some(elf_bytes) = inline_elf.as_deref() {
+                // Validate declared hash format before expensive Prevail verification.
+                let declared_hash = assigned_program_hash.as_deref().unwrap();
+                if declared_hash.len() != 32 {
+                    return Err(format!(
+                        "inline ELF declared hash must be exactly 32 bytes, got {}",
+                        declared_hash.len()
+                    ));
+                }
+
+                let profile_str =
+                    optional_text_field(desired_state, 6, "assigned_program_verification_profile")?;
+                let profile = match profile_str.as_deref() {
+                    Some("resident") | None => VerificationProfile::Resident,
+                    Some("ephemeral") => VerificationProfile::Ephemeral,
+                    Some(other) => {
+                        return Err(format!(
+                            "`assigned_program_verification_profile` must be \
+                             \"resident\" or \"ephemeral\", got \"{other}\""
+                        ));
+                    }
+                };
+                let source_filename =
+                    optional_text_field(desired_state, 7, "assigned_program_source_filename")?;
+                let abi_version =
+                    optional_u32_field(desired_state, 8, "assigned_program_abi_version")?;
+
+                let mut record = self
+                    .program_library
+                    .ingest_elf(elf_bytes, profile)
+                    .map_err(|e| format!("inline ELF verification failed: {e}"))?;
+                record.source_filename = source_filename;
+                record.abi_version = abi_version;
+
+                if record.hash != declared_hash {
+                    return Err(format!(
+                        "inline ELF hash mismatch: ingested `{}` but declared `{}`",
+                        hex::encode(&record.hash),
+                        hex::encode(declared_hash),
+                    ));
+                }
+
+                self.storage
+                    .store_program(&record)
+                    .await
+                    .map_err(|e| format!("store inline program failed: {e}"))?;
+                info!(
+                    program_hash = hex::encode(&record.hash),
+                    size = record.size,
+                    node_id = node_id,
+                    "ingested inline ELF from DESIRED_STATE"
+                );
+            }
+        }
 
         if let Some(program_hash) = assigned_program_hash.as_deref() {
             validate_program_exists(
@@ -709,6 +769,18 @@ fn optional_u32_field(
             .and_then(|v| u32::try_from(v).ok())
             .map(Some)
             .ok_or_else(|| format!("`{field}` must be uint or null")),
+    }
+}
+
+fn optional_text_field(
+    map: &[(Value, Value)],
+    key: u64,
+    field: &str,
+) -> Result<Option<String>, String> {
+    match map_get(map, key) {
+        Some(Value::Text(s)) => Ok(Some(s.clone())),
+        Some(Value::Null) | None => Ok(None),
+        Some(_) => Err(format!("`{field}` must be text or null")),
     }
 }
 

--- a/crates/sonde-gateway/src/crypto.rs
+++ b/crates/sonde-gateway/src/crypto.rs
@@ -5,6 +5,7 @@ use sha2::{Digest, Sha256};
 use sonde_protocol::Sha256Provider;
 
 /// SHA-256 provider using the `sha2` RustCrypto crate.
+#[derive(Clone)]
 pub struct RustCryptoSha256;
 
 impl Sha256Provider for RustCryptoSha256 {

--- a/crates/sonde-gateway/src/program.rs
+++ b/crates/sonde-gateway/src/program.rs
@@ -334,6 +334,7 @@ fn extract_global_section_data(data: &[u8]) -> Vec<Vec<u8>> {
 }
 
 /// Program library: stores verified programs and serves chunks.
+#[derive(Clone)]
 pub struct ProgramLibrary {
     sha256: RustCryptoSha256,
 }

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -213,8 +213,16 @@ For each node-scoped `GW-0812`, the handler performs the following sequence:
    `DESIRED_STATE` payload using:
    1. `entity_kind = "node"`,
    2. `entity_id = node_id`,
-   3. `assigned_program_hash = desired_assigned_program_hash` from the latest desired row, and
-   4. `schedule_interval_s = desired_schedule_interval_s` from the latest desired row.
+   3. `assigned_program_hash = desired_assigned_program_hash` from the latest desired row,
+   4. `schedule_interval_s = desired_schedule_interval_s` from the latest desired row,
+   5. if `assigned_program_hash` diverges and a program row exists for that hash,
+      fetch the program row and embed `elf_image` at key 5
+      (`assigned_program_elf`), `verification_profile` at key 6, `source_filename`
+      at key 7, and `abi_version` at key 8. If the program row exists but
+      `elf_image` is absent (legacy row ingested before ELF storage was added),
+      omit key 5 and log a warning; the gateway will reject the message if it
+      does not already have the program locally. Programs must be re-ingested
+      through `ProgramIngest` to populate the `elf_image` column.
 12. Publish that payload to the downstream queue.
 
 `ephemeral_program_hash` is intentionally omitted in v1. The gateway connector

--- a/docs/gateway-companion-api.md
+++ b/docs/gateway-companion-api.md
@@ -184,7 +184,10 @@ unchanged".
 | `assigned_program_hash` | 1 | bstr/null | Desired resident program hash. `null` means no resident program assignment is desired. |
 | `schedule_interval_s` | 2 | uint/null | Desired node wake interval in seconds. `null` means no scheduled interval target is desired in this draft. |
 | `ephemeral_program_hash` | 3 | bstr/null | Desired ephemeral program hash to queue when reconciliation determines one is needed. `null` means no ephemeral run is requested. |
-| `assigned_program_image` | 5 | bstr/null | CBOR program image bytes for the assigned program. Present when the control plane embeds the program image inline so the gateway can ingest it into its local `ProgramLibrary` without a separate fetch. Absent or `null` means no inline image is provided; the gateway must already have the program locally. |
+| `assigned_program_elf` | 5 | bstr/null | Raw ELF binary for the assigned program. Present when the control plane embeds the program so the gateway can verify and ingest it into its local `ProgramLibrary` without a separate fetch. The gateway MUST run full Prevail verification (`ProgramLibrary::ingest_elf`) on the ELF before accepting it. Absent or `null` means no inline program is provided; the gateway must already have the program locally. |
+| `assigned_program_verification_profile` | 6 | text/null | Verification profile for the inline ELF: `"resident"` (default if absent) or `"ephemeral"`. Only meaningful when key 5 is present. |
+| `assigned_program_source_filename` | 7 | text/null | Display filename for the inline program. Optional metadata stored alongside the ingested program. |
+| `assigned_program_abi_version` | 8 | uint/null | ABI version the inline program targets. Optional metadata stored alongside the ingested program. |
 
 Fields not yet defined by this draft remain reserved for future desired-state
 extension. Receivers MUST ignore unknown integer keys.

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1078,6 +1078,36 @@ operations such as `QueueReboot` or `AssignProgram`. Those remain internal
 effects that fall out of gateway reconciliation when desired state differs from
 actual state.
 
+#### 13A.2.1  Inline program ingestion from DESIRED_STATE
+
+When a node-scoped `DESIRED_STATE` message includes an inline ELF binary at
+CBOR key 5 (`assigned_program_elf`), the connector service ingests the program
+before validating program existence:
+
+1. Extract the raw ELF bytes from key 5.
+2. Determine the verification profile from key 6 (`assigned_program_verification_profile`);
+   default to `Resident` if absent or `null`.
+3. Call `ProgramLibrary::ingest_elf(elf_bytes, profile)` to run full Prevail
+   verification and produce a `ProgramRecord`.
+4. If key 1 (`assigned_program_hash`) is present, verify that the ingested
+   record's hash matches exactly. If they differ, reject the entire
+   `DESIRED_STATE` message — do not persist the program or update node state.
+5. Set optional metadata from key 7 (`assigned_program_source_filename`) and
+   key 8 (`assigned_program_abi_version`) on the record.
+6. Persist the record via `Storage::store_program()`.
+7. If any step fails (verification failure, size limit, invalid ELF, hash
+   mismatch), reject the entire `DESIRED_STATE` message with a descriptive error
+   and do not update the node's desired state.
+
+The `ConnectorService` holds a `ProgramLibrary` instance for this purpose. The
+inline ELF is always fully re-verified locally regardless of any verification the
+control plane may have performed.
+
+The inline ELF plus CBOR envelope overhead must fit within the connector's
+`max_frame_length` (default 1 MB). In practice, BPF ELFs are small (verified
+CBOR images are limited to 4 KB resident / 2 KB ephemeral), so framing limits
+are not a concern for well-formed programs.
+
 ### 13A.3  Upstream actual-state, status, and application-data path
 
 When the gateway accepts a node `WAKE`, it updates the node's latest-known

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1681,6 +1681,40 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-0819a  Inline ELF ingestion from DESIRED_STATE
+
+**Validates:** GW-0811
+
+**Procedure:**
+1. Start the gateway and register a node. Do not pre-ingest any programs.
+2. Build a valid minimal BPF ELF binary via the test-program helpers.
+3. Send a `DESIRED_STATE` message targeting the node with `assigned_program_hash` (key 1) set to the expected program hash, `assigned_program_elf` (key 5) set to the raw ELF bytes, and `assigned_program_verification_profile` (key 6) set to `"resident"`.
+4. Assert: the gateway accepts the message without error.
+5. Assert: the program is now present in `Storage::get_program()` with the expected hash, `Resident` profile, and correct image bytes.
+6. Assert: the node's `assigned_program_hash` is updated to the new hash.
+
+### T-0819b  Inline ELF with invalid bytes is rejected
+
+**Validates:** GW-0811
+
+**Procedure:**
+1. Start the gateway and register a node.
+2. Send a `DESIRED_STATE` message with `assigned_program_hash` (key 1) set to an arbitrary 32-byte hash, `assigned_program_elf` (key 5) set to `[0xDE, 0xAD, 0xBE, 0xEF]` (invalid ELF).
+3. Assert: the gateway rejects the message with a verification error.
+4. Assert: the node's desired state is NOT updated.
+
+### T-0819c  Inline ELF hash mismatch is rejected
+
+**Validates:** GW-0811
+
+**Procedure:**
+1. Start the gateway and register a node.
+2. Build a valid BPF ELF. Compute its correct program hash.
+3. Send a `DESIRED_STATE` message with `assigned_program_hash` (key 1) set to a **different** 32-byte hash, and `assigned_program_elf` (key 5) set to the valid ELF.
+4. Assert: the gateway rejects the message because the ingested program's hash does not match the declared `assigned_program_hash`.
+
+---
+
 ### T-0820  Upstream actual-state/status update after `WAKE`
 
 **Validates:** GW-0812

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -84,8 +84,8 @@ deploy/web-ui/
   7. Store in `programs` Azure Table via `HandlerStore::store_program_image()`
   8. Return JSON: `{"program_hash": "hex", "size": N, "abi_version": N, "source_filename": "name"}`
   9. On failure: return JSON error with diagnostics
-- The uploaded ELF is verified and transformed; the persisted and delivered artifact is the deterministic CBOR program image, not the raw ELF
-- `programs` table schema: `PartitionKey="program"`, `RowKey=hex(program_hash)`, `source_filename`, `abi_version` (`Edm.Int32`), `cbor_image` (base64-encoded CBOR program image), `size_bytes` (`Edm.Int32`, CBOR image byte length), `verification_profile`, `created_at` (ISO 8601 UTC string)
+- The uploaded ELF is verified and transformed; the cloud stores both the deterministic CBOR program image (for hash computation and node delivery) and the original ELF binary (for embedding in `DESIRED_STATE` messages so gateways can re-verify locally)
+- `programs` table schema: `PartitionKey="program"`, `RowKey=hex(program_hash)`, `source_filename`, `abi_version` (`Edm.Int32`), `cbor_image` (base64-encoded CBOR program image), `elf_image` (base64-encoded original ELF binary), `size_bytes` (`Edm.Int32`, CBOR image byte length), `verification_profile`, `created_at` (ISO 8601 UTC string)
 - Idempotent: re-ingesting the same ELF produces the same program hash; all metadata fields (`source_filename`, `abi_version`, `verification_profile`, `created_at`) are overwritten on re-ingest (last-writer-wins)
 - Error responses use HTTP status codes: 400 (malformed JSON, missing `elf` field, invalid base64), 413 (ELF exceeds size limit), 422 (Prevail verification failure, invalid ELF), 500 (storage/internal error)
 
@@ -121,20 +121,21 @@ async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), Handler
 ```
 
 `ProgramImageRow` contains: `program_hash` (`Vec<u8>`), `cbor_image` (`Vec<u8>`),
-`source_filename` (`Option<String>`), `abi_version` (`Option<u32>`), `size_bytes` (`u32`),
+`elf_image` (`Vec<u8>`), `source_filename` (`Option<String>`), `abi_version` (`Option<u32>`), `size_bytes` (`u32`),
 `verification_profile` (`String`), `created_at` (`String`, ISO 8601 UTC).
 
 `AzureTablesStore` implements this as an upsert to the `programs` table, encoding
-`cbor_image` as base64 and `program_hash` as hex for the `RowKey`.
+`cbor_image` and `elf_image` as base64 and `program_hash` as hex for the `RowKey`.
 
-### 6.2 Inline Program Image in DESIRED_STATE (WEB-0309, WEB-0310)
+### 6.2 Inline Program ELF in DESIRED_STATE (WEB-0309, WEB-0310)
 
-When the handler publishes a `DESIRED_STATE` message due to program divergence, it fetches the CBOR program image from the `programs` table and embeds it at CBOR key 5 (`assigned_program_image`, `bstr`). The companion forwards this opaque payload to the gateway, which ingests the inline image into its local `ProgramLibrary`.
-
-> **Note**: The gateway's `DESIRED_STATE` handler (`connector.rs`) does not yet
-> read key 5. Key 5 (`assigned_program_image`) is now documented in
-> `gateway-companion-api.md` §3.2.2. A follow-up change to `connector.rs` is
-> required to parse and ingest the inline program image.
+When the handler publishes a `DESIRED_STATE` message due to program divergence,
+it fetches the original ELF binary from the `programs` table and embeds it at
+CBOR key 5 (`assigned_program_elf`, `bstr`). Keys 6–8 carry the verification
+profile, source filename, and ABI version metadata. The companion forwards this
+opaque payload to the gateway, which runs full Prevail verification via
+`ProgramLibrary::ingest_elf()` and stores the resulting verified program in its
+local `ProgramLibrary`.
 
 ---
 

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -31,8 +31,8 @@
 | T-WEB-0307a | WEB-0307 | Empty ELF rejected | Unit (Rust) | Pass |
 | T-WEB-0307b | WEB-0307 | Multi-program ELF rejected | Unit (Rust) | Planned |
 | T-WEB-0308 | WEB-0308 | `source_filename` normalized to basename | Unit (Rust) | Pass |
-| T-WEB-0309 | WEB-0309 | `DESIRED_STATE` includes inline CBOR image on program divergence | Unit (Rust) | Planned |
-| T-WEB-0310 | WEB-0310 | `DESIRED_STATE` CBOR carries key 5 with program image bytes | Unit (Rust) | Planned |
+| T-WEB-0309 | WEB-0309 | `DESIRED_STATE` includes inline ELF on program divergence | Unit (Rust) | Planned |
+| T-WEB-0310 | WEB-0310 | `DESIRED_STATE` carries key 5 with ELF bytes and keys 6-8 with metadata | Unit (Rust) | Planned |
 | T-WEB-0401 | WEB-0401 | SPA lists programs from `programs` table | Manual/E2E | Planned |
 | T-WEB-0402 | WEB-0402 | SPA creates/edits `programroute` entries | Manual/E2E | Planned |
 | T-WEB-0501 | WEB-0501 | MSAL.js login flow works | Manual | Planned |


### PR DESCRIPTION
## Summary

Fixes the gateway rejecting DESIRED_STATE messages with "program not found" when the control plane assigns a program the gateway doesn't have locally. The Azure handler now embeds the original ELF binary in the DESIRED_STATE message, and the gateway runs full Prevail verification before storing it.

## Problem

The Azure handler's DESIRED_STATE message included an `assigned_program_hash` but the gateway had no way to obtain the program if it wasn't already in local storage. The message was rejected with:

`rejecting connector message error=assign connector desired program failed: program ... not found`

## Solution

### Azure handler
- Stores the original ELF binary alongside the CBOR image during `ProgramIngest`
- When building a DESIRED_STATE message with program divergence, embeds the ELF at CBOR key 5 (`assigned_program_elf`) with metadata at keys 6-8 (profile, filename, ABI version)
- Legacy program rows without `elf_image` emit a warning and omit key 5

### Gateway connector
- Extracts keys 5-8 from DESIRED_STATE; if key 5 is present, runs `ProgramLibrary::ingest_elf()` with full Prevail verification
- Validates the ingested program hash matches the declared `assigned_program_hash` (rejects on mismatch)
- Stores the verified program before the existing existence check

### Specification updates
- `gateway-companion-api.md`: key 5 renamed to `assigned_program_elf`; keys 6-8 added
- `gateway-design.md`: new section 13A.2.1 (inline ELF ingestion with hash validation)
- `gateway-validation.md`: T-0819a (valid ELF accepted), T-0819b (invalid rejected), T-0819c (hash mismatch rejected)
- `azure-handler-design.md`: reconciliation step 11.5
- `web-ui-design.md`: section 6.2 updated; programs table gains `elf_image`

## Security
- Gateway **always** re-verifies the ELF locally with Prevail -- no trust of cloud-side verification
- Hash mismatch between declared hash and ingested result is rejected
- Invalid/malformed ELF is rejected with a descriptive error