### PR TITLE
docs: clarify Windows Azure companion bootstrap sequence in deployment SOP

### DIFF
--- a/docs/deployment-sop.md
+++ b/docs/deployment-sop.md
@@ -258,10 +258,10 @@ display cannot be updated, bootstrap fails closed — fix the dependency and ret
 
 **Step 2 — Enter the device code:**
 
-During bootstrap, a device code and a sign-in URL are displayed on the modem
-screen (and echoed to the console). Open the URL shown (typically
-`https://microsoft.com/devicelogin`) in a browser and enter the code to
-authenticate with your Azure account.
+During bootstrap, the device code is displayed on the modem screen (with the
+label "Azure login") and the full sign-in URL is printed to the console. Open
+the URL shown in the console (typically `https://microsoft.com/devicelogin`) in
+a browser and enter the code to authenticate with your Azure account.
 
 **Step 3 — Wait for bootstrap to complete:**
 
@@ -272,8 +272,14 @@ After authentication, bootstrap continues automatically:
   success
 - writes runtime state to `%ProgramData%\sonde-azure-companion\`
 
-Bootstrap-complete state requires the following files in the state directory
-(`%ProgramData%\sonde-azure-companion\`):
+Bootstrap commits its output into a **state generation** directory — a
+timestamped subdirectory named `.state-<timestamp>` under the state root
+(`%ProgramData%\sonde-azure-companion\`). A marker file `.current-state`
+in the state root points to the active generation. The service resolves
+the active generation at startup via this marker; if no marker exists,
+the state root itself is used as a legacy fallback.
+
+The active state generation contains the following files:
 
 | File | Purpose |
 |------|---------|

--- a/docs/deployment-sop.md
+++ b/docs/deployment-sop.md
@@ -249,6 +249,15 @@ $env:SONDE_AZURE_PROJECT_NAME = "sonde-prod"
 sonde-azure-companion.exe bootstrap
 ```
 
+If the gateway uses a non-default admin pipe, set the environment variable
+before running bootstrap so the companion connects to the correct pipe:
+
+```powershell
+$env:SONDE_GATEWAY_ADMIN_SOCKET = "\\.\pipe\my-custom-pipe"
+```
+
+(Alternatively, pass `--admin-socket` on the command line.)
+
 If `sonde-azure-companion.exe` is not on `PATH`, run the installed binary from
 the Sonde `bin` directory instead.
 
@@ -268,9 +277,16 @@ a browser and enter the code to authenticate with your Azure account.
 After authentication, bootstrap continues automatically:
 - deploys the bundled Bicep templates and `sonde-azure-handler` package into
   the provisioned Function App
+- deploys the Web UI SPA content to the provisioned Static Web App
+- configures the Entra app registration (SPA redirect URI, Storage API
+  permission, and `user_impersonation` scope)
 - waits until Azure reports at least one loaded function before reporting
   success
 - writes runtime state to `%ProgramData%\sonde-azure-companion\`
+
+The SPA deployment and Entra configuration require additional Azure permissions
+beyond resource-plane provisioning. If either step fails, bootstrap reports the
+error — resolve the permission issue and re-run bootstrap.
 
 Bootstrap commits its output into a **state generation** directory — a
 timestamped subdirectory named `.state-<timestamp>` under the state root

--- a/docs/deployment-sop.md
+++ b/docs/deployment-sop.md
@@ -220,16 +220,25 @@ Admin socket (configurable via `--admin-socket`):
 
 #### Windows Azure companion bootstrap (optional)
 
-If you installed the optional Azure companion feature, bootstrap it after the
-gateway service is running and the modem display is available.
+If you installed the optional Azure companion feature, you **must** complete
+bootstrap before the Azure companion service can start. The Windows service
+fails closed when bootstrap-complete state is absent — it will not attempt
+bootstrap automatically (see
+[AZC-0205](azure-companion-requirements.md#azc-0205--windows-service-startup-fails-closed-before-bootstrap)
+and [azure-companion-design.md §3.3](azure-companion-design.md#33--bootstrap-state-decision)).
 
-Prerequisites:
+**Prerequisites:**
+
 - Docker Desktop / Docker Engine running on the Windows host
-- the gateway admin pipe available at `\\.\pipe\sonde-admin` (or your configured override)
+- The gateway service running and the modem display available
+- The gateway admin pipe available at `\\.\pipe\sonde-admin` (or your configured
+  override)
 - Azure deployment values chosen for your environment (`SONDE_AZURE_LOCATION`,
   `SONDE_AZURE_PROJECT_NAME`, and optionally `SONDE_AZURE_SUBSCRIPTION_ID`)
 
-From PowerShell:
+**Step 1 — Run bootstrap:**
+
+From an elevated PowerShell prompt:
 
 ```powershell
 $env:SONDE_AZURE_LOCATION = "eastus"
@@ -240,17 +249,51 @@ $env:SONDE_AZURE_PROJECT_NAME = "sonde-prod"
 sonde-azure-companion.exe bootstrap
 ```
 
-Bootstrap:
-- pulls `ghcr.io/alan-jowett/sonde-azure-bootstrap:<matching companion version>` by default
-- runs Azure device-code authentication inside the bootstrap container
-- deploys the bundled prebuilt `sonde-azure-handler` package into the provisioned Function App
-- waits until Azure reports at least one loaded function before reporting success
-- displays the device code and progress messages on the modem via the gateway admin pipe
-- writes runtime state under `%ProgramData%\sonde-azure-companion\`
-
 If `sonde-azure-companion.exe` is not on `PATH`, run the installed binary from
-the Sonde `bin` directory instead. If Docker is unavailable or the modem
-display cannot be updated, bootstrap fails closed; fix the dependency and retry.
+the Sonde `bin` directory instead.
+
+Bootstrap pulls the version-matched `ghcr.io/alan-jowett/sonde-azure-bootstrap`
+image and runs it in a Docker container. If Docker is unavailable or the modem
+display cannot be updated, bootstrap fails closed — fix the dependency and retry.
+
+**Step 2 — Enter the device code:**
+
+During bootstrap, a device code and a sign-in URL are displayed on the modem
+screen (and echoed to the console). Open the URL shown (typically
+`https://microsoft.com/devicelogin`) in a browser and enter the code to
+authenticate with your Azure account.
+
+**Step 3 — Wait for bootstrap to complete:**
+
+After authentication, bootstrap continues automatically:
+- deploys the bundled Bicep templates and `sonde-azure-handler` package into
+  the provisioned Function App
+- waits until Azure reports at least one loaded function before reporting
+  success
+- writes runtime state to `%ProgramData%\sonde-azure-companion\`
+
+Bootstrap-complete state requires the following files in the state directory
+(`%ProgramData%\sonde-azure-companion\`):
+
+| File | Purpose |
+|------|---------|
+| `service-principal.json` | Entra tenant ID, client ID, certificate paths |
+| `cert.pem` | Client certificate for Azure authentication |
+| `key.pem` | Private key for the client certificate |
+| `storage-queues.json` | Storage Queue endpoint and queue names |
+
+**Step 4 — Start the Azure companion service:**
+
+Once bootstrap reports success, start the companion service:
+
+```powershell
+sc.exe start sonde-azure-companion
+sc.exe query sonde-azure-companion
+```
+
+The service will now start normally on each boot. If bootstrap-complete state
+is ever removed, the service will fail closed on the next start — re-run
+bootstrap to restore it.
 
 ## 6. Verify gateway and modem (smoke test)
 


### PR DESCRIPTION
## Summary

Rewrites the Windows Azure companion bootstrap section of \docs/deployment-sop.md\ to make the correct operator sequence explicit, matching the current implementation behavior.

## Problem

The previous SOP presented the Windows bootstrap as a single command with a bullet-list description. It did not make clear that:
1. The operator must enter a device code at a Microsoft URL during bootstrap.
2. The Azure companion Windows service must be started **after** bootstrap completes.
3. The service fails closed without bootstrap-complete state (per AZC-0205).

## Changes

- **Step-by-step sequence**: Run bootstrap → enter device code → wait for completion → start the service.
- **Fail-closed note**: Explicit statement that the service will not start without bootstrap-complete state, with cross-links to [AZC-0205](docs/azure-companion-requirements.md) and [azure-companion-design.md §3.3](docs/azure-companion-design.md).
- **Required state files table**: Lists \service-principal.json\, \cert.pem\, \key.pem\, and \storage-queues.json\.
- **\sc.exe\ over \sc\**: Uses \sc.exe\ in PowerShell examples to avoid alias conflicts.
- **Device-code URL**: Directs operator to use the URL shown by the CLI rather than hardcoding a specific Microsoft URL.

## Traceability

- **Requirements**: AZC-0205 (Windows service fails closed before bootstrap)
- **Design**: azure-companion-design.md §3.3 (bootstrap-state decision)
- **Validation**: Documentation-only change; no code or test changes.

Closes #850