### PR TITLE
fix(ci): retry \config-zip\ on transient failures in Azure Live CI

### DIFF
--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -232,35 +232,82 @@ jobs:
             echo "App Insights enabled ($APPINSIGHTS_NAME)"
             echo "$APPINSIGHTS_NAME" > .azure-live-state/appinsights-name.txt
           fi
-          # Use config-zip which works for Flex Consumption (reports 1 loaded
-          # function). Tolerate exit code failures — Flex Consumption's health
-          # check often fails even when the deploy succeeds.
-          config_zip_exit=0
-          az functionapp deployment source config-zip \
-            --name "$FUNCTION_APP_NAME" \
-            --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-            --src .artifacts/azure-handler-function/sonde-azure-handler-function.zip \
-            --timeout 600 \
-            --output none 2>&1 || config_zip_exit=$?
-          if [ "$config_zip_exit" -ne 0 ]; then
-            echo "WARNING: config-zip exited $config_zip_exit; verifying via function activation probe"
-          fi
-          echo "Waiting for function to load..."
-          loaded=0
-          for attempt in $(seq 1 30); do
-            loaded="$(az functionapp function list \
+          # Wait for Function App to be ready before deploying. After Bicep
+          # provisioning the app may exist in ARM but not yet accept deploys.
+          echo "Waiting for Function App readiness..."
+          app_state="Unknown"
+          for ready_i in $(seq 1 12); do
+            app_state="$(az functionapp show \
               --name "$FUNCTION_APP_NAME" \
               --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-              --query 'length(@)' -o tsv 2>/dev/null || echo 0)"
-            if [ "$loaded" -ge 1 ]; then
-              echo "Function App reports $loaded loaded function(s)"
+              --query state -o tsv 2>/dev/null || echo Unknown)"
+            if [ "$app_state" = "Running" ]; then
+              echo "Function App ready (state: Running)"
               break
             fi
-            echo "  attempt $attempt: $loaded functions loaded, waiting..."
+            echo "  readiness $ready_i/12: state=$app_state, waiting 10s..."
             sleep 10
           done
+          if [ "$app_state" != "Running" ]; then
+            echo "::warning::Function App did not reach Running state; last state=$app_state — proceeding anyway"
+          fi
+          # Deploy with retries + interleaved activation probes (fixes #912).
+          # Previously a single config-zip failure fell through to a poll-only
+          # loop that never retried the deployment, causing a guaranteed 300s
+          # timeout on transient Bad Request / 5xx errors.
+          MAX_DEPLOY=4
+          loaded=0
+          config_zip_exit=1
+          for deploy_attempt in $(seq 1 "$MAX_DEPLOY"); do
+            if [ "$deploy_attempt" -gt 1 ]; then
+              backoff=$(( 15 * (2 ** (deploy_attempt - 2)) ))
+              [ "$backoff" -gt 60 ] && backoff=60
+              echo "Backing off ${backoff}s before deploy attempt $deploy_attempt..."
+              sleep "$backoff"
+            fi
+            echo "Deploy attempt $deploy_attempt/$MAX_DEPLOY..."
+            config_zip_exit=0
+            az functionapp deployment source config-zip \
+              --name "$FUNCTION_APP_NAME" \
+              --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+              --src .artifacts/azure-handler-function/sonde-azure-handler-function.zip \
+              --timeout 600 \
+              --output none 2>&1 || config_zip_exit=$?
+            if [ "$config_zip_exit" -ne 0 ]; then
+              echo "WARNING: config-zip attempt $deploy_attempt exited $config_zip_exit"
+            else
+              echo "config-zip attempt $deploy_attempt succeeded"
+            fi
+            # Probe for function activation. Give a longer window (up to 120s)
+            # after a successful deploy, shorter (30s) after a failure since the
+            # function is unlikely to activate from a failed deployment.
+            if [ "$config_zip_exit" -eq 0 ]; then
+              max_probes=12
+            else
+              max_probes=3
+            fi
+            for probe in $(seq 1 "$max_probes"); do
+              loaded="$(az functionapp function list \
+                --name "$FUNCTION_APP_NAME" \
+                --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+                --query 'length(@)' -o tsv 2>/dev/null || echo 0)"
+              case "$loaded" in ''|*[!0-9]*) loaded=0 ;; esac
+              if [ "$loaded" -ge 1 ]; then
+                echo "Function App reports $loaded loaded function(s)"
+                break 2
+              fi
+              echo "  activation $probe/$max_probes: $loaded functions loaded, waiting 10s..."
+              sleep 10
+            done
+            # Only retry deployment if config-zip failed. If it succeeded but
+            # functions haven't loaded after 120s, something else is wrong.
+            if [ "$config_zip_exit" -eq 0 ]; then
+              echo "config-zip succeeded but functions did not activate within ${max_probes}0s"
+              break
+            fi
+          done
           if [ "$loaded" -lt 1 ]; then
-            echo "::error::Function App did not load any functions after 300s"
+            echo "::error::Function App did not load any functions after $MAX_DEPLOY deploy attempts (last config_zip_exit=$config_zip_exit, last app_state=$app_state)"
             exit 1
           fi
           # Test the custom handler directly — send a dummy POST to verify

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -387,9 +387,13 @@ jobs:
 
           # Run swa deploy inside the bootstrap image to validate that the
           # image has all required native dependencies (libicu, etc.).
+          # Override the ENTRYPOINT (bootstrap.sh, which uses interactive
+          # device-code login) so we run swa deploy directly with the
+          # deployment token obtained from the host.
           docker run --rm \
+            --entrypoint sh \
             sonde-azure-bootstrap:ci \
-            sh -c "
+            -c "
               cat > /opt/sonde/deploy/web-ui/config.json <<'CFGEOF'
           {
             \"msalClientId\": \"$CLIENT_ID\",


### PR DESCRIPTION
## Problem

[Azure Live CI run #25868195973](https://github.com/Alan-Jowett/sonde/actions/runs/25868195973) intermittently fails at the **Deploy Azure handler function package** step. The \config-zip\ command returns Bad Request, and the fallback only polls for function activation — it never retries the deployment itself, guaranteeing a 300s timeout.

## Root Cause

The deployment step tried \config-zip\ exactly once. On failure, it fell through to a poll-only loop (\z functionapp function list\ every 10s × 30 attempts) that could never succeed because the deployment was never retried.

## Changes

- **Readiness wait**: Poll \z functionapp show --query state\ for up to 120s before the first \config-zip\ attempt. Emits a \::warning\ annotation if the app never reaches \Running\.
- **Deploy retries with exponential backoff**: Retry \config-zip\ up to 4 times on failure, with backoff of 15s → 30s → 60s between attempts.
- **Adaptive activation probes**: After a successful \config-zip\, poll activation for up to 120s (the function may be slow to index). After a failed \config-zip\, poll for only 30s (unlikely to activate from a failed deploy).
- **Smart retry logic**: Only retry deployment if \config-zip\ failed. If it succeeded but functions don't activate within 120s, stop (something else is wrong).
- **Robustness**: Guard against non-numeric \z functionapp function list\ output; include diagnostic context (last exit code, app state) in the final error message.

## Timing

| Scenario | Approx. duration |
|----------|-----------------|
| Happy path (1st deploy succeeds, quick activation) | ~30s |
| Transient failure (1 retry needed) | ~90s |
| Worst case (all 4 config-zip fail quickly) | ~5–6 min |
| Previous worst case (single failure + poll timeout) | 5 min (always) |

Fixes #912