### PR TITLE
fix: switch Azure handler to Flex Consumption plan

### DIFF
--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -236,8 +236,17 @@ jobs:
           # like Classic Consumption. Wait for RBAC propagation instead (the
           # function app's managed identity needs Storage Blob Data Owner to
           # read its deployment package from the blob container).
-          echo "Waiting 60s for RBAC propagation before deploying..."
-          sleep 60
+          # The function app was created before RBAC was assigned, so its
+          # initial host startup attempt may have failed with 403. After
+          # the RBAC wait, restart it to force re-initialization.
+          echo "Waiting 90s for RBAC propagation before deploying..."
+          sleep 90
+          echo "Restarting function app to pick up RBAC permissions..."
+          az functionapp restart \
+            --name "$FUNCTION_APP_NAME" \
+            --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+            --output none 2>&1 || echo "::warning::restart returned non-zero (may be normal for Flex Consumption)"
+          sleep 30
           # Deploy by uploading the zip directly to the deployment blob
           # container configured in functionAppConfig.deployment.storage.
           # Flex Consumption does not support Kudu/SCM (config-zip returns 415)

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -286,7 +286,19 @@ jobs:
               echo "WARNING: blob upload attempt $deploy_attempt exited $deploy_exit"
             else
               echo "Blob upload attempt $deploy_attempt succeeded"
-              # Sync triggers so the function host discovers the new deployment.
+              # Flex Consumption apps scale to zero — there is no running host
+              # to receive a syncfunctiontriggers request.  Restart the function
+              # app to force a cold start that reads the newly uploaded blob
+              # from the deployment container.
+              echo "Restarting function app to pick up new deployment..."
+              az functionapp restart \
+                --name "$FUNCTION_APP_NAME" \
+                --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+                --output none 2>&1 || echo "::warning::restart returned non-zero (may be normal for Flex Consumption)"
+              sleep 30
+              # Belt-and-suspenders: sync triggers after restart so the host
+              # re-indexes functions even if it started before the blob was
+              # fully visible.
               echo "Syncing function triggers..."
               az rest --method POST \
                 --url "https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/syncfunctiontriggers?api-version=2024-04-01" \
@@ -313,11 +325,18 @@ jobs:
               echo "  activation $probe/$max_probes: $loaded functions loaded, waiting 10s..."
               sleep 10
             done
-            # Only retry if the deploy command failed. If it succeeded but
-            # functions haven't loaded after 120s, something else is wrong.
+            # Activation failed — dump diagnostics before retrying so we can
+            # debug in the CI log without a separate diagnostic step.
             if [ "$deploy_exit" -eq 0 ]; then
-              echo "Deploy succeeded but functions did not activate within ${max_probes}0s"
-              break
+              echo "::warning::Deploy attempt $deploy_attempt succeeded but functions did not activate within ${max_probes}0s"
+              echo "--- deployment diagnostics (attempt $deploy_attempt) ---"
+              az functionapp show --name "$FUNCTION_APP_NAME" \
+                --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+                --query "{state:state,usageState:usageState}" -o json 2>/dev/null || true
+              az rest --method GET \
+                --url "https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/config/web?api-version=2024-04-01" \
+                --query "{functionAppConfig:functionAppConfig}" -o json 2>/dev/null || true
+              echo "--- end diagnostics ---"
             fi
           done
           if [ "$loaded" -lt 1 ]; then

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -232,29 +232,27 @@ jobs:
             echo "App Insights enabled ($APPINSIGHTS_NAME)"
             echo "$APPINSIGHTS_NAME" > .azure-live-state/appinsights-name.txt
           fi
-          # Wait for Function App to be ready before deploying. After Bicep
-          # provisioning the app may exist in ARM but not yet accept deploys.
-          echo "Waiting for Function App readiness..."
-          app_state="Unknown"
-          for ready_i in $(seq 1 12); do
-            app_state="$(az functionapp show \
-              --name "$FUNCTION_APP_NAME" \
-              --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-              --query state -o tsv 2>/dev/null || echo Unknown)"
-            if [ "$app_state" = "Running" ]; then
-              echo "Function App ready (state: Running)"
-              break
-            fi
-            echo "  readiness $ready_i/12: state=$app_state, waiting 10s..."
-            sleep 10
-          done
-          if [ "$app_state" != "Running" ]; then
-            echo "::warning::Function App did not reach Running state; last state=$app_state — proceeding anyway"
-          fi
-          # Deploy with retries + interleaved activation probes (fixes #912).
-          # Flex Consumption does not support the Kudu-based config-zip endpoint.
-          # Use `az functionapp deploy --type zip` (One Deploy) which uploads the
-          # package to the deployment blob container configured in functionAppConfig.
+          # Flex Consumption apps scale to zero — they don't report "Running"
+          # like Classic Consumption. Wait for RBAC propagation instead (the
+          # function app's managed identity needs Storage Blob Data Owner to
+          # read its deployment package from the blob container).
+          echo "Waiting 60s for RBAC propagation before deploying..."
+          sleep 60
+          # Deploy by uploading the zip directly to the deployment blob
+          # container configured in functionAppConfig.deployment.storage.
+          # Flex Consumption does not support Kudu/SCM (config-zip returns 415)
+          # or the `az functionapp deploy` One Deploy endpoint. The native
+          # deployment mechanism is: upload zip to container, then sync triggers.
+          STORAGE_ACCOUNT_NAME="$(python3 -c "
+          import json
+          d = json.load(open('.azure-live-state/deployment.json'))
+          print(d['properties']['outputs']['storageAccountName']['value'])
+          ")"
+          DEPLOYMENT_CONTAINER="$(python3 -c "
+          import json
+          d = json.load(open('.azure-live-state/deployment.json'))
+          print(d['properties']['outputs']['deploymentContainerName']['value'])
+          ")"
           MAX_DEPLOY=4
           loaded=0
           deploy_exit=1
@@ -265,18 +263,25 @@ jobs:
               echo "Backing off ${backoff}s before deploy attempt $deploy_attempt..."
               sleep "$backoff"
             fi
-            echo "Deploy attempt $deploy_attempt/$MAX_DEPLOY..."
+            echo "Deploy attempt $deploy_attempt/$MAX_DEPLOY (blob upload to $STORAGE_ACCOUNT_NAME/$DEPLOYMENT_CONTAINER)..."
             deploy_exit=0
-            az functionapp deploy \
-              --name "$FUNCTION_APP_NAME" \
-              --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-              --src-path .artifacts/azure-handler-function/sonde-azure-handler-function.zip \
-              --type zip \
+            az storage blob upload \
+              --account-name "$STORAGE_ACCOUNT_NAME" \
+              --container-name "$DEPLOYMENT_CONTAINER" \
+              --file .artifacts/azure-handler-function/sonde-azure-handler-function.zip \
+              --name sonde-azure-handler-function.zip \
+              --overwrite \
+              --auth-mode login \
               --output none 2>&1 || deploy_exit=$?
             if [ "$deploy_exit" -ne 0 ]; then
-              echo "WARNING: deploy attempt $deploy_attempt exited $deploy_exit"
+              echo "WARNING: blob upload attempt $deploy_attempt exited $deploy_exit"
             else
-              echo "Deploy attempt $deploy_attempt succeeded"
+              echo "Blob upload attempt $deploy_attempt succeeded"
+              # Sync triggers so the function host discovers the new deployment.
+              echo "Syncing function triggers..."
+              az rest --method POST \
+                --url "https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/syncfunctiontriggers?api-version=2024-04-01" \
+                --output none 2>&1 || echo "::warning::trigger sync returned non-zero (may be transient)"
             fi
             # Probe for function activation. Give a longer window (up to 120s)
             # after a successful deploy, shorter (30s) after a failure since the
@@ -307,7 +312,7 @@ jobs:
             fi
           done
           if [ "$loaded" -lt 1 ]; then
-            echo "::error::Function App did not load any functions after $MAX_DEPLOY deploy attempts (last deploy_exit=$deploy_exit, last app_state=$app_state)"
+            echo "::error::Function App did not load any functions after $MAX_DEPLOY deploy attempts (last deploy_exit=$deploy_exit)"
             exit 1
           fi
           # Test the custom handler directly — send a dummy POST to verify

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -247,21 +247,13 @@ jobs:
             --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
             --output none 2>&1 || echo "::warning::restart returned non-zero (may be normal for Flex Consumption)"
           sleep 30
-          # Deploy by uploading the zip directly to the deployment blob
-          # container configured in functionAppConfig.deployment.storage.
-          # Flex Consumption does not support Kudu/SCM (config-zip returns 415)
-          # or the `az functionapp deploy` One Deploy endpoint. The native
-          # deployment mechanism is: upload zip to container, then sync triggers.
-          STORAGE_ACCOUNT_NAME="$(python3 -c "
-          import json
-          d = json.load(open('.azure-live-state/deployment.json'))
-          print(d['properties']['outputs']['storageAccountName']['value'])
-          ")"
-          DEPLOYMENT_CONTAINER="$(python3 -c "
-          import json
-          d = json.load(open('.azure-live-state/deployment.json'))
-          print(d['properties']['outputs']['deploymentContainerName']['value'])
-          ")"
+          # Deploy using One Deploy (`az functionapp deploy`), which is the
+          # only deployment technology supported by Flex Consumption.  Manual
+          # blob upload to the deployment container does NOT register a
+          # deployment — the platform never discovers the package.
+          #
+          # Previous attempts used raw blob upload + syncfunctiontriggers,
+          # which failed consistently (ServiceUnavailable: no host runtime).
           MAX_DEPLOY=4
           loaded=0
           deploy_exit=1
@@ -272,37 +264,20 @@ jobs:
               echo "Backing off ${backoff}s before deploy attempt $deploy_attempt..."
               sleep "$backoff"
             fi
-            echo "Deploy attempt $deploy_attempt/$MAX_DEPLOY (blob upload to $STORAGE_ACCOUNT_NAME/$DEPLOYMENT_CONTAINER)..."
+            echo "Deploy attempt $deploy_attempt/$MAX_DEPLOY (One Deploy zip)..."
             deploy_exit=0
-            az storage blob upload \
-              --account-name "$STORAGE_ACCOUNT_NAME" \
-              --container-name "$DEPLOYMENT_CONTAINER" \
-              --file .artifacts/azure-handler-function/sonde-azure-handler-function.zip \
-              --name sonde-azure-handler-function.zip \
-              --overwrite \
-              --auth-mode login \
+            az functionapp deploy \
+              --name "$FUNCTION_APP_NAME" \
+              --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+              --src-path .artifacts/azure-handler-function/sonde-azure-handler-function.zip \
+              --type zip \
+              --clean true \
+              --restart true \
               --output none 2>&1 || deploy_exit=$?
             if [ "$deploy_exit" -ne 0 ]; then
-              echo "WARNING: blob upload attempt $deploy_attempt exited $deploy_exit"
+              echo "WARNING: deploy attempt $deploy_attempt exited $deploy_exit"
             else
-              echo "Blob upload attempt $deploy_attempt succeeded"
-              # Flex Consumption apps scale to zero — there is no running host
-              # to receive a syncfunctiontriggers request.  Restart the function
-              # app to force a cold start that reads the newly uploaded blob
-              # from the deployment container.
-              echo "Restarting function app to pick up new deployment..."
-              az functionapp restart \
-                --name "$FUNCTION_APP_NAME" \
-                --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-                --output none 2>&1 || echo "::warning::restart returned non-zero (may be normal for Flex Consumption)"
-              sleep 30
-              # Belt-and-suspenders: sync triggers after restart so the host
-              # re-indexes functions even if it started before the blob was
-              # fully visible.
-              echo "Syncing function triggers..."
-              az rest --method POST \
-                --url "https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/syncfunctiontriggers?api-version=2024-04-01" \
-                --output none 2>&1 || echo "::warning::trigger sync returned non-zero (may be transient)"
+              echo "Deploy attempt $deploy_attempt succeeded"
             fi
             # Probe for function activation. Give a longer window (up to 120s)
             # after a successful deploy, shorter (30s) after a failure since the
@@ -325,19 +300,18 @@ jobs:
               echo "  activation $probe/$max_probes: $loaded functions loaded, waiting 10s..."
               sleep 10
             done
-            # Activation failed — dump diagnostics before retrying so we can
-            # debug in the CI log without a separate diagnostic step.
+            # Activation failed — dump diagnostics before retrying.
             if [ "$deploy_exit" -eq 0 ]; then
               echo "::warning::Deploy attempt $deploy_attempt succeeded but functions did not activate within ${max_probes}0s"
-              echo "--- deployment diagnostics (attempt $deploy_attempt) ---"
-              az functionapp show --name "$FUNCTION_APP_NAME" \
-                --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-                --query "{state:state,usageState:usageState}" -o json 2>/dev/null || true
-              az rest --method GET \
-                --url "https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}/config/web?api-version=2024-04-01" \
-                --query "{functionAppConfig:functionAppConfig}" -o json 2>/dev/null || true
-              echo "--- end diagnostics ---"
             fi
+            echo "--- deployment diagnostics (attempt $deploy_attempt) ---"
+            az functionapp show --name "$FUNCTION_APP_NAME" \
+              --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+              --query "{state:state,usageState:usageState,kind:kind}" -o json 2>/dev/null || true
+            az rest --method GET \
+              --url "https://management.azure.com/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/sites/${FUNCTION_APP_NAME}?api-version=2024-04-01" \
+              --query "{functionAppConfig:properties.functionAppConfig,siteConfig_customHandler:properties.siteConfig.customHandler}" -o json 2>/dev/null || true
+            echo "--- end diagnostics ---"
           done
           if [ "$loaded" -lt 1 ]; then
             echo "::error::Function App did not load any functions after $MAX_DEPLOY deploy attempts (last deploy_exit=$deploy_exit)"

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -252,12 +252,12 @@ jobs:
             echo "::warning::Function App did not reach Running state; last state=$app_state — proceeding anyway"
           fi
           # Deploy with retries + interleaved activation probes (fixes #912).
-          # Previously a single config-zip failure fell through to a poll-only
-          # loop that never retried the deployment, causing a guaranteed 300s
-          # timeout on transient Bad Request / 5xx errors.
+          # Flex Consumption does not support the Kudu-based config-zip endpoint.
+          # Use `az functionapp deploy --type zip` (One Deploy) which uploads the
+          # package to the deployment blob container configured in functionAppConfig.
           MAX_DEPLOY=4
           loaded=0
-          config_zip_exit=1
+          deploy_exit=1
           for deploy_attempt in $(seq 1 "$MAX_DEPLOY"); do
             if [ "$deploy_attempt" -gt 1 ]; then
               backoff=$(( 15 * (2 ** (deploy_attempt - 2)) ))
@@ -266,22 +266,22 @@ jobs:
               sleep "$backoff"
             fi
             echo "Deploy attempt $deploy_attempt/$MAX_DEPLOY..."
-            config_zip_exit=0
-            az functionapp deployment source config-zip \
+            deploy_exit=0
+            az functionapp deploy \
               --name "$FUNCTION_APP_NAME" \
               --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-              --src .artifacts/azure-handler-function/sonde-azure-handler-function.zip \
-              --timeout 600 \
-              --output none 2>&1 || config_zip_exit=$?
-            if [ "$config_zip_exit" -ne 0 ]; then
-              echo "WARNING: config-zip attempt $deploy_attempt exited $config_zip_exit"
+              --src-path .artifacts/azure-handler-function/sonde-azure-handler-function.zip \
+              --type zip \
+              --output none 2>&1 || deploy_exit=$?
+            if [ "$deploy_exit" -ne 0 ]; then
+              echo "WARNING: deploy attempt $deploy_attempt exited $deploy_exit"
             else
-              echo "config-zip attempt $deploy_attempt succeeded"
+              echo "Deploy attempt $deploy_attempt succeeded"
             fi
             # Probe for function activation. Give a longer window (up to 120s)
             # after a successful deploy, shorter (30s) after a failure since the
             # function is unlikely to activate from a failed deployment.
-            if [ "$config_zip_exit" -eq 0 ]; then
+            if [ "$deploy_exit" -eq 0 ]; then
               max_probes=12
             else
               max_probes=3
@@ -299,15 +299,15 @@ jobs:
               echo "  activation $probe/$max_probes: $loaded functions loaded, waiting 10s..."
               sleep 10
             done
-            # Only retry deployment if config-zip failed. If it succeeded but
+            # Only retry if the deploy command failed. If it succeeded but
             # functions haven't loaded after 120s, something else is wrong.
-            if [ "$config_zip_exit" -eq 0 ]; then
-              echo "config-zip succeeded but functions did not activate within ${max_probes}0s"
+            if [ "$deploy_exit" -eq 0 ]; then
+              echo "Deploy succeeded but functions did not activate within ${max_probes}0s"
               break
             fi
           done
           if [ "$loaded" -lt 1 ]; then
-            echo "::error::Function App did not load any functions after $MAX_DEPLOY deploy attempts (last config_zip_exit=$config_zip_exit, last app_state=$app_state)"
+            echo "::error::Function App did not load any functions after $MAX_DEPLOY deploy attempts (last deploy_exit=$deploy_exit, last app_state=$app_state)"
             exit 1
           fi
           # Test the custom handler directly — send a dummy POST to verify

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -45,6 +45,10 @@ param appInsightsConnectionString string = ''
 @description('Allowed CORS origins for the Function App (e.g. the SWA hostname). Empty array disables CORS.')
 param corsAllowedOrigins array = []
 
+@description('Full URL of the deployment blob container (e.g. https://<account>.blob.core.windows.net/<container>). Used by Flex Consumption to fetch the function app package.')
+@minLength(1)
+param deploymentContainerUrl string
+
 @description('Entra app (client) ID for EasyAuth token validation on ProgramIngest.')
 @minLength(1)
 param functionAuthClientId string
@@ -53,20 +57,14 @@ param functionAuthClientId string
 @minLength(1)
 param functionAuthTenantId string
 
-resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
-  name: storageAccountName
-}
-
-var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${existingStorageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${existingStorageAccount.listKeys().keys[0].value}'
-
 resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: functionPlanName
   location: location
-  kind: 'functionapp'
+  kind: 'functionapp,linux'
   tags: tags
   sku: {
-    name: 'Y1'
-    tier: 'Dynamic'
+    name: 'FC1'
+    tier: 'FlexConsumption'
   }
   properties: {
     reserved: true
@@ -75,20 +73,8 @@ resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
 
 var baseAppSettings = [
         {
-          name: 'AzureWebJobsStorage'
-          value: storageConnectionString
-        }
-        {
-          name: 'FUNCTIONS_WORKER_RUNTIME'
-          value: 'custom'
-        }
-        {
-          name: 'FUNCTIONS_EXTENSION_VERSION'
-          value: '~4'
-        }
-        {
-          name: 'WEBSITE_RUN_FROM_PACKAGE'
-          value: '1'
+          name: 'AzureWebJobsStorage__accountName'
+          value: storageAccountName
         }
         {
           name: 'SONDE_AZURE_HANDLER_STORAGE_QUEUE_ENDPOINT'
@@ -146,6 +132,25 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
   properties: {
     httpsOnly: true
     serverFarmId: hostingPlan.id
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: deploymentContainerUrl
+          authentication: {
+            type: 'SystemAssignedIdentity'
+          }
+        }
+      }
+      scaleAndConcurrency: {
+        instanceMemoryMB: 512
+        maximumInstanceCount: 1
+      }
+      runtime: {
+        name: 'custom'
+        version: ''
+      }
+    }
     siteConfig: {
       minTlsVersion: '1.2'
       appSettings: concat(baseAppSettings, observabilityAppSettings)

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -148,7 +148,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
       }
       runtime: {
         name: 'custom'
-        version: ''
+        version: '1.0'
       }
     }
     siteConfig: {

--- a/deploy/bicep/modules/function-rbac.bicep
+++ b/deploy/bicep/modules/function-rbac.bicep
@@ -23,6 +23,7 @@ param programsTableName string
 
 var storageQueueDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
 var storageTableDataContributorRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3')
+var storageBlobDataOwnerRoleId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b')
 
 resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   name: storageAccountName
@@ -100,5 +101,15 @@ resource functionProgramsTableContributor 'Microsoft.Authorization/roleAssignmen
     principalId: functionPrincipalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: storageTableDataContributorRoleId
+  }
+}
+
+resource functionBlobDataOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid('function-blob-data-owner', functionPrincipalId, storageBlobDataOwnerRoleId, storageAccountName)
+  scope: existingStorageAccount
+  properties: {
+    principalId: functionPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: storageBlobDataOwnerRoleId
   }
 }

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -108,6 +108,7 @@ module functionPlaceholder './function-placeholder.bicep' = {
     programRouteTableName: storage.outputs.programRouteTableName
     programsTableName: storage.outputs.programsTableName
     appInsightsConnectionString: monitoring.outputs.connectionString
+    deploymentContainerUrl: '${storage.outputs.blobEndpoint}${storage.outputs.deploymentContainerName}'
     corsAllowedOrigins: ['https://${staticWebApp.outputs.defaultHostname}']
     functionAuthClientId: functionAuthClientId
     functionAuthTenantId: functionAuthTenantId


### PR DESCRIPTION
## Summary

Migrates the Azure handler Function App from Classic Consumption (\Y1\/\Dynamic\) to Flex Consumption (\FC1\/\FlexConsumption\) to resolve the custom handler startup failure reported in #870.

## Changes

### Bicep — \unction-placeholder.bicep\
- Hosting plan: SKU \Y1\/\Dynamic\ → \FC1\/\FlexConsumption\ with 512 MB / 1 instance
- Runtime config: \unctionAppConfig.runtime.name = 'custom'\ replaces \FUNCTIONS_WORKER_RUNTIME\ app setting
- Storage auth: identity-based \AzureWebJobsStorage__accountName\ replaces connection-string \AzureWebJobsStorage\
- Deployment: \unctionAppConfig.deployment.storage\ points at blob container with \SystemAssignedIdentity\ auth
- Removed Classic-only settings: \FUNCTIONS_EXTENSION_VERSION\, \WEBSITE_RUN_FROM_PACKAGE\

### Bicep — \unction-rbac.bicep\
- Added \Storage Blob Data Owner\ role for function identity (required for identity-based \AzureWebJobsStorage\)

### Bicep — \stack.bicep\
- Threads \deploymentContainerUrl\ to the function-placeholder module

### CI — \zure-live-ci.yml\
- Replaced \z functionapp deployment source config-zip\ (Kudu, not available on Flex Consumption) with \z functionapp deploy --type zip\ (One Deploy)
- Kept retry logic and activation probes

## Testing

Run the \Azure Live CI\ workflow to validate end-to-end: Bicep provisioning → handler deployment → queue message processing.

Closes #870