### PR TITLE
feat(web-ui): populate Node ID from actual nodes on Desired State page

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -638,16 +638,16 @@ async function renderDesiredState() {
       const actualNode = latestActual.find((node) => node.node_id === selectedNodeId);
       const desiredNode = desiredByPartition.get(actualNode?.PartitionKey);
 
-      // Desired-over-actual priority: if a desired-state row exists for
-      // this node, use its values exclusively (an absent program hash
-      // means "no program target" — don't fall back to actual state).
-      const scheduleValue = desiredNode
-        ? (desiredNode.desired_schedule_interval_s ?? '')
-        : (actualNode?.observed_schedule_interval_s ?? '');
-      const hashValue = (desiredNode
-        ? (desiredNode.desired_assigned_program_hash ?? '')
-        : (actualNode?.observed_assigned_program_hash ?? '')
-      ).toLowerCase();
+      // Per-field desired-over-actual fallback: use the desired value for
+      // each field when present, otherwise fall back to the latest actual
+      // value.  We use ?? (not ||) so that a zero schedule or an explicit
+      // empty-string hash from a future schema change won't be skipped.
+      const scheduleValue = desiredNode?.desired_schedule_interval_s
+        ?? actualNode?.observed_schedule_interval_s
+        ?? '';
+      const hashValue = (desiredNode?.desired_assigned_program_hash
+        ?? actualNode?.observed_assigned_program_hash
+        ?? '').toLowerCase();
 
       const scheduleInput = form.querySelector('[name="scheduleInterval"]');
       if (scheduleInput) scheduleInput.value = scheduleValue;

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -580,10 +580,24 @@ async function renderDesiredState() {
   APP.viewMessage = savedMessage;
 
   try {
-    const [programs, desiredRows] = await Promise.all([
+    const [programs, desiredRows, actualRows] = await Promise.all([
       listPrograms(),
       queryTable(CONFIG.desiredStateTable, ''),
+      queryTable(CONFIG.actualStateTable, ''),
     ]);
+
+    const latestActual = latestByPartition(actualRows)
+      .filter((node) => node.node_id)
+      .sort((left, right) =>
+        String(left.node_id || '').localeCompare(String(right.node_id || '')));
+    const desiredByPartition = new Map(
+      latestByPartition(desiredRows).map((row) => [row.PartitionKey, row]));
+
+    const nodeOptions = [
+      '<option value="" disabled selected>Select a node…</option>',
+      ...latestActual.map((node) =>
+        `<option value="${escapeHtml(node.node_id || '')}">${escapeHtml(node.node_id || '—')}</option>`),
+    ].join('');
 
     const programOptions = [
       '<option value="">No program target</option>',
@@ -594,7 +608,7 @@ async function renderDesiredState() {
       <div class="panel stack">
         <form id="desired-state-form" class="form-grid">
           <label>Node ID
-            <input name="nodeId" type="text" required>
+            <select name="nodeId" required>${nodeOptions}</select>
           </label>
           <label>Schedule Interval (s)
             <input name="scheduleInterval" type="number" min="1" step="1" placeholder="60">
@@ -614,6 +628,34 @@ async function renderDesiredState() {
     `);
 
     const form = document.getElementById('desired-state-form');
+
+    // Auto-populate fields when a node is selected (WEB-0206, WEB-0207)
+    const nodeSelect = form?.querySelector('[name="nodeId"]');
+    nodeSelect?.addEventListener('change', () => {
+      const selectedNodeId = nodeSelect.value;
+      if (!selectedNodeId) return;
+
+      const actualNode = latestActual.find((node) => node.node_id === selectedNodeId);
+      const desiredNode = desiredByPartition.get(actualNode?.PartitionKey);
+
+      const scheduleValue = desiredNode?.desired_schedule_interval_s
+        ?? actualNode?.observed_schedule_interval_s
+        ?? '';
+      const hashValue = (desiredNode?.desired_assigned_program_hash
+        || actualNode?.observed_assigned_program_hash
+        || '').toLowerCase();
+
+      const scheduleInput = form.querySelector('[name="scheduleInterval"]');
+      if (scheduleInput) scheduleInput.value = scheduleValue;
+
+      const programSelect = form.querySelector('[name="programHash"]');
+      if (programSelect) {
+        const matchingOption = [...programSelect.options].find(
+          (opt) => opt.value.toLowerCase() === hashValue);
+        programSelect.value = matchingOption ? matchingOption.value : '';
+      }
+    });
+
     form?.addEventListener('submit', async (event) => {
       event.preventDefault();
       const formData = new FormData(form);

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -638,12 +638,16 @@ async function renderDesiredState() {
       const actualNode = latestActual.find((node) => node.node_id === selectedNodeId);
       const desiredNode = desiredByPartition.get(actualNode?.PartitionKey);
 
-      const scheduleValue = desiredNode?.desired_schedule_interval_s
-        ?? actualNode?.observed_schedule_interval_s
-        ?? '';
-      const hashValue = (desiredNode?.desired_assigned_program_hash
-        || actualNode?.observed_assigned_program_hash
-        || '').toLowerCase();
+      // Desired-over-actual priority: if a desired-state row exists for
+      // this node, use its values exclusively (an absent program hash
+      // means "no program target" — don't fall back to actual state).
+      const scheduleValue = desiredNode
+        ? (desiredNode.desired_schedule_interval_s ?? '')
+        : (actualNode?.observed_schedule_interval_s ?? '');
+      const hashValue = (desiredNode
+        ? (desiredNode.desired_assigned_program_hash ?? '')
+        : (actualNode?.observed_assigned_program_hash ?? '')
+      ).toLowerCase();
 
       const scheduleInput = form.querySelector('[name="scheduleInterval"]');
       if (scheduleInput) scheduleInput.value = scheduleValue;

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -55,7 +55,13 @@ deploy/web-ui/
 
 ## 5. Desired State Management (WEB-0200)
 
-- Form: Node ID (text), Schedule Interval (number, seconds), Program Hash (dropdown from `programs` table).
+- Form: Node ID (dropdown), Schedule Interval (number, seconds), Program Hash (dropdown from `programs` table).
+- **Node ID dropdown (WEB-0206):** The Node ID field is a `<select>` populated from nodes that have reported actual state (i.e., rows in the `actualstate` table, deduplicated via `latestByPartition`). A placeholder `<option>` prompts the operator to select a node. Free-text entry is not supported — only nodes known to the gateway appear; arbitrary node IDs cannot be entered or submitted.
+- **Auto-populate on selection (WEB-0206, WEB-0207):** When the operator selects a node, the Schedule Interval and Program Hash fields are pre-populated. The latest row per node is used (same `latestByPartition` dedup as the dashboard). Priority order:
+  1. **Existing desired state** for the selected node (latest row from `desiredstate` table) — `desired_schedule_interval_s` and `desired_assigned_program_hash`.
+  2. **Last reported actual state** — `observed_schedule_interval_s` and `observed_assigned_program_hash`.
+  3. **Empty** — if neither source has a value for a given field.
+- If the pre-populated program hash is not present in the Program Hash dropdown (i.e., the program was deleted from the `programs` table), the Program Hash field is left at the default "No program target" option.
 - On submit:
   - `PartitionKey`: `"n:" + SHA-256(node_id).hex()` using `SubtleCrypto`
   - `RowKey`: reverse-timestamp format `{(u64::MAX - timestamp_ms):016x}:{(u64::MAX - sequence):016x}:{random_nonce:016x}`

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -22,6 +22,8 @@
 | T-WEB-0203 | WEB-0203 | RowKey uses reverse-timestamp format | Unit (JS) | Planned |
 | T-WEB-0204 | WEB-0204 | PartitionKey = `n:{SHA-256(node_id)}` | Unit (JS) | Planned |
 | T-WEB-0205 | WEB-0205 | `timestamp_ms` stored as `Edm.Int64` | Integration | Planned |
+| T-WEB-0206 | WEB-0206 | Node ID field is a dropdown-only control populated from latest `actualstate` nodes; arbitrary node IDs cannot be entered or submitted | Manual/E2E | Planned |
+| T-WEB-0207 | WEB-0207 | Selecting a node pre-populates Schedule and Program Hash (desired state preferred over actual state) | Manual/E2E | Planned |
 | T-WEB-0301 | WEB-0301 | `ProgramIngest` accepts ELF + metadata via JSON POST | Unit (Rust) | Pass |
 | T-WEB-0302 | WEB-0302 | Prevail verification runs; invalid ELF rejected | Unit (Rust) | Pass |
 | T-WEB-0303 | WEB-0303 | Program hash matches gateway computation | Unit (Rust) | Pass |


### PR DESCRIPTION
## Summary

Replaces the free-text Node ID input on the Desired State page with a dropdown populated from nodes that have reported actual state (WEB-0206). When a node is selected, the Schedule Interval and Program Hash fields are auto-populated (WEB-0207).

## Changes

### deploy/web-ui/app.js
- renderDesiredState() now fetches actualstate table in parallel with programs and desiredstate
- Node ID field changed from text input to select dropdown populated from latestByPartition(actualRows)
- Added change event listener that pre-populates Schedule Interval and Program Hash on node selection
- Pre-population priority: existing desired state then last actual state then empty
- Uses desired_assigned_program_hash / observed_assigned_program_hash (assigned, not current)
- Filters out actual-state rows with missing node_id
- Falls back to No program target if program hash is not in the programs dropdown

### docs/web-ui-design.md
- Updated section 5 (WEB-0200): Node ID text to dropdown, added WEB-0206/WEB-0207 specifications

### docs/web-ui-validation.md
- Added T-WEB-0206: dropdown-only control, no arbitrary node IDs
- Added T-WEB-0207: selection-driven pre-population with desired-over-actual priority

Closes #911
