### PR TITLE
fix(web-ui): default ABI version to 2 on program ingestion

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -759,7 +759,7 @@ async function renderPrograms() {
             <input name="sourceFilename" type="text" required>
           </label>
           <label>ABI Version
-            <input name="abiVersion" type="number" min="1" step="1" value="1" required>
+            <input name="abiVersion" type="number" min="1" step="1" value="2" required>
           </label>
           <label>Verification Profile
             <select name="verificationProfile">
@@ -816,7 +816,7 @@ async function renderPrograms() {
         const payload = {
           elf: elfBase64,
           source_filename: String(formData.get('sourceFilename') || file.name),
-          abi_version: Number(formData.get('abiVersion') || 1),
+          abi_version: Number(formData.get('abiVersion') || 2),
           verification_profile: String(formData.get('verificationProfile') || 'resident'),
         };
 


### PR DESCRIPTION
## Summary

The program ingestion form defaulted `abi_version` to 1, causing operators to accidentally ingest programs with the wrong ABI version. This PR changes the HTML input default and JS fallback from 1 to 2, matching the current ABI version.

## Changes

- `deploy/web-ui/app.js`: Changed input default value from 1 to 2 (line 762)
- `deploy/web-ui/app.js`: Changed JS fallback from 1 to 2 in the form submission handler (line 819)

## Traceability

- **Issue**: #908
- **Scope**: UI-only; no backend, protocol, or spec changes required

Fixes #908
