### PR TITLE
fix(web-ui): remove `If-Match` header from `upsertEntity` to fix route creation

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -446,7 +446,6 @@ async function upsertEntity(tableName, partitionKey, rowKey, entity) {
       Accept: 'application/json;odata=nometadata',
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
-      'If-Match': '*',
       'x-ms-version': '2019-02-02',
     },
     body: JSON.stringify(entity),


### PR DESCRIPTION
## Problem

Adding a route on the Routes page fails with:

```
{
  "odata.error": {
    "code": "ResourceNotFound",
    "message": "The specified resource does not exist."
  }
}
```

## Root Cause

The `upsertEntity()` function in `deploy/web-ui/app.js` included an `If-Match: '*'` header on the PUT request. Per the Azure Table Storage REST API:

- PUT **with** `If-Match` = **Update Entity** (entity must already exist)
- PUT **without** `If-Match` = **Insert or Replace Entity** (true upsert)

When saving a new route, the entity doesn't exist yet, so Azure returned `ResourceNotFound`.

## Fix

Remove the `If-Match: '*'` header from `upsertEntity()`, giving it true insert-or-replace semantics. This is a one-line deletion.

## Traceability

- **Requirement**: Routes page must allow creating new program routes (implicit from UI design)
- **Affected function**: `upsertEntity()` at `deploy/web-ui/app.js:441`
- **Only caller**: Route save handler at line 952

Fixes #910