### PR TITLE
fix: replace hardcoded `login.microsoftonline.com` with dynamic cloud endpoints

### DIFF
--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -385,6 +385,10 @@ jobs:
             --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
             --query 'properties.apiKey' -o tsv)"
 
+          # Resolve login endpoint from the active cloud for sovereign cloud compatibility
+          LOGIN_ENDPOINT="$(az cloud show --query endpoints.activeDirectory -o tsv)"
+          LOGIN_ENDPOINT="${LOGIN_ENDPOINT%/}"
+
           # Run swa deploy inside the bootstrap image to validate that the
           # image has all required native dependencies (libicu, etc.).
           # Override the ENTRYPOINT (bootstrap.sh, which uses interactive
@@ -397,7 +401,7 @@ jobs:
               cat > /opt/sonde/deploy/web-ui/config.json <<'CFGEOF'
           {
             \"msalClientId\": \"$CLIENT_ID\",
-            \"msalAuthority\": \"https://login.microsoftonline.com/$TENANT_ID\",
+            \"msalAuthority\": \"$LOGIN_ENDPOINT/$TENANT_ID\",
             \"storageAccount\": \"$STORAGE_ACCOUNT\",
             \"functionAppName\": \"$FUNCTION_APP\"
           }

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -468,6 +468,10 @@ if [ "$#" -ge 4 ] && [ "$1" = "functionapp" ] && [ "$2" = "function" ] && [ "$3"
   printf '1\n'
   exit 0
 fi
+if [ "$#" -ge 2 ] && [ "$1" = "cloud" ] && [ "$2" = "show" ]; then
+  printf 'https://login.microsoftonline.us\n'
+  exit 0
+fi
 if [ "$#" -ge 2 ] && [ "$1" = "rest" ]; then
   exit 0
 fi
@@ -590,7 +594,7 @@ esac
     let config_json = fs::read_to_string(web_ui_dir.join("config.json")).unwrap();
     assert!(config_json.contains(r#""msalClientId": "client-456""#));
     assert!(
-        config_json.contains(r#""msalAuthority": "https://login.microsoftonline.com/tenant-123""#)
+        config_json.contains(r#""msalAuthority": "https://login.microsoftonline.us/tenant-123""#)
     );
     assert!(config_json.contains(r#""storageAccount": "stsondetest""#));
     assert!(config_json.contains(r#""functionAppName": "func-sonde""#));

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -185,6 +185,15 @@ az login --use-device-code --output none >&2
 if [ -n "${SONDE_AZURE_SUBSCRIPTION_ID:-}" ]; then
     az account set --subscription "$SONDE_AZURE_SUBSCRIPTION_ID" >&2
 fi
+
+# Resolve login endpoint from the active cloud for sovereign cloud compatibility
+login_endpoint="$(az cloud show --query endpoints.activeDirectory -o tsv)"
+login_endpoint="${login_endpoint%/}"
+if [ -z "$login_endpoint" ]; then
+    echo "could not resolve Azure login endpoint from active cloud" >&2
+    exit 1
+fi
+
 echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2
 deployment_name="sonde-bootstrap-$(date +%Y%m%d%H%M%S)-$$"
 deployment_outputs="$(az deployment sub create \
@@ -237,7 +246,7 @@ fi
 cat > "$web_ui_dir/config.json" <<CONFIGEOF
 {
   "msalClientId": "$companion_client_id",
-  "msalAuthority": "https://login.microsoftonline.com/$companion_tenant_id",
+  "msalAuthority": "$login_endpoint/$companion_tenant_id",
   "storageAccount": "$storage_account_name",
   "functionAppName": "$function_app_name"
 }

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -171,7 +171,7 @@ resource authSettings 'Microsoft.Web/sites/config@2024-04-01' = {
         enabled: true
         registration: {
           clientId: functionAuthClientId
-          openIdIssuer: 'https://login.microsoftonline.com/${functionAuthTenantId}/v2.0'
+          openIdIssuer: '${environment().authentication.loginEndpoint}${functionAuthTenantId}/v2.0'
         }
         validation: {
           allowedAudiences: [

--- a/deploy/web-ui/config.json.example
+++ b/deploy/web-ui/config.json.example
@@ -1,6 +1,6 @@
 {
   "msalClientId": "<your-entra-app-client-id>",
-  "msalAuthority": "https://login.microsoftonline.com/<your-tenant-id>",
+  "msalAuthority": "https://<cloud-login-endpoint>/<your-tenant-id>",
   "storageAccount": "<your-storage-account-name>",
   "functionAppName": "<your-function-app-name>"
 }

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -66,6 +66,14 @@ if [ -z "$APP_OBJECT_ID" ]; then
 fi
 TENANT_ID="$(az account show --query tenantId -o tsv)"
 
+# Resolve login endpoint from the active cloud for sovereign cloud compatibility
+LOGIN_ENDPOINT="$(az cloud show --query endpoints.activeDirectory -o tsv)"
+LOGIN_ENDPOINT="${LOGIN_ENDPOINT%/}"
+if [ -z "$LOGIN_ENDPOINT" ]; then
+  echo "ERROR: Could not resolve Azure login endpoint from active cloud" >&2
+  exit 1
+fi
+
 echo "  Static Web App: $SWA_NAME ($SWA_HOSTNAME)"
 echo "  Function App:   $FUNCTION_APP"
 echo "  Storage Account: $STORAGE_ACCOUNT"
@@ -77,7 +85,7 @@ echo "=== Generating config.json ==="
 cat > "$SCRIPT_DIR/config.json" <<EOF
 {
   "msalClientId": "$CLIENT_ID",
-  "msalAuthority": "https://login.microsoftonline.com/$TENANT_ID",
+  "msalAuthority": "$LOGIN_ENDPOINT/$TENANT_ID",
   "storageAccount": "$STORAGE_ACCOUNT",
   "functionAppName": "$FUNCTION_APP"
 }
@@ -171,7 +179,7 @@ echo "=== Configuring Function App EasyAuth ==="
 # Use az rest with the authSettingsV2 JSON directly for reliable configuration.
 FUNCTION_APP_ID="$(az functionapp show --name "$FUNCTION_APP" \
   --resource-group "$RESOURCE_GROUP" --query 'id' -o tsv)"
-AUTH_BODY="$(jq -n -c --arg clientId "$CLIENT_ID" --arg tenantId "$TENANT_ID" '{
+AUTH_BODY="$(jq -n -c --arg clientId "$CLIENT_ID" --arg tenantId "$TENANT_ID" --arg loginEndpoint "$LOGIN_ENDPOINT" '{
   properties: {
     platform: { enabled: true },
     globalValidation: { unauthenticatedClientAction: "Return401" },
@@ -180,7 +188,7 @@ AUTH_BODY="$(jq -n -c --arg clientId "$CLIENT_ID" --arg tenantId "$TENANT_ID" '{
         enabled: true,
         registration: {
           clientId: $clientId,
-          openIdIssuer: ("https://login.microsoftonline.com/" + $tenantId + "/v2.0")
+          openIdIssuer: ($loginEndpoint + "/" + $tenantId + "/v2.0")
         },
         validation: {
           allowedAudiences: [("api://" + $clientId), $clientId],

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -595,7 +595,7 @@
 
 **Procedure:**
 1. Run bootstrap with device auth stubbed and Bicep deployment stubbed to return known output values including `staticWebAppName`, `staticWebAppHostname`, `companionClientId`, `companionTenantId`, `storageAccountName`, and `functionAppName`.
-2. Assert: bootstrap generates `config.json` containing the correct `msalClientId`, `msalAuthority` (derived from `companionTenantId`), `storageAccount`, and `functionAppName` values from the stubbed outputs.
+2. Assert: bootstrap generates `config.json` containing the correct `msalClientId`, `msalAuthority` (derived dynamically from the active cloud's login endpoint and `companionTenantId`), `storageAccount`, and `functionAppName` values from the stubbed outputs.
 3. Assert: the bootstrap script attempts to deploy SPA content (HTML, JS, CSS, config.json) to the Static Web App named in the outputs.
 4. After bootstrap completes, assert: the Static Web App serves the SPA content at its default hostname without any additional manual deployment step.
 5. Assert: the bootstrap script registers `https://<staticWebAppHostname>` as a SPA redirect URI on the Entra app registration.

--- a/docs/azure-provisioning-design.md
+++ b/docs/azure-provisioning-design.md
@@ -148,8 +148,10 @@ The parameter flow is:
 - `main.bicep` passes these to `stack.bicep` as module parameters.
 - `stack.bicep` passes them to `function-placeholder.bicep` as
   `functionAuthClientId` and `functionAuthTenantId`.
-- `function-placeholder.bicep` uses them to construct the
-  `authSettingsV2` resource with the correct issuer URL and audience.
+- `function-placeholder.bicep` uses them together with the Bicep
+  `environment().authentication.loginEndpoint` function to construct the
+  `authSettingsV2` resource with the correct issuer URL and audience,
+  ensuring compatibility with sovereign clouds.
 
 ---
 

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -245,7 +245,9 @@ added to the Function App with the following configuration:
 - `identityProviders.azureActiveDirectory.registration.clientId` — set to the
   companion Entra app registration's client ID (passed as a Bicep parameter).
 - `identityProviders.azureActiveDirectory.registration.openIdIssuer` — set to
-  `https://login.microsoftonline.com/<tenantId>/v2.0` (passed as a Bicep parameter).
+  `${environment().authentication.loginEndpoint}<tenantId>/v2.0` using the Bicep
+  `environment()` function so the template works in sovereign clouds (Azure
+  Government, Azure China, etc.).
 - `identityProviders.azureActiveDirectory.validation.defaultAuthorizationPolicy.allowedApplications`
   — includes the companion client ID so the SPA's tokens (audience matching the
   client ID) are accepted.


### PR DESCRIPTION
## Summary

Replaces all hardcoded `login.microsoftonline.com` URLs in deployment templates, shell scripts, CI workflow, and documentation with dynamic lookups for sovereign cloud compatibility (Azure Government, Azure China, etc.).

## Changes

| File | Change |
|------|--------|
| `function-placeholder.bicep` | `environment().authentication.loginEndpoint` replaces hardcoded URL |
| `deploy/web-ui/deploy.sh` | `az cloud show` lookup + validation; used in config.json and EasyAuth body |
| `deploy/azure-bootstrap/bootstrap.sh` | `az cloud show` lookup + validation; used in config.json |
| `azure-live-ci.yml` | `az cloud show` lookup on host; used in CI config.json |
| `config.json.example` | Placeholder URL pattern instead of hardcoded |
| `web-ui-design.md` | Updated `openIdIssuer` description |
| `azure-provisioning-design.md` | Noted `environment()` usage for sovereign clouds |
| `azure-companion-validation.md` | T-AZC-0418 updated for dynamic authority |
| `bootstrap_unix.rs` | Fake `az` returns `.us` endpoint to prove dynamic behavior |

## Approach

- **Bicep**: uses the built-in `environment().authentication.loginEndpoint` function which returns the correct login URL for the active cloud
- **Shell scripts**: queries `az cloud show --query endpoints.activeDirectory` at runtime, strips trailing slash, validates non-empty
- **Test**: fake `az` shim returns `https://login.microsoftonline.us` (a sovereign-looking endpoint) so the assertion proves the URL is dynamically derived, not hardcoded

## Out of scope

The hardcoded `login.microsoftonline.com` in the Rust runtime (`sonde-azure-companion/src/main.rs:1394`, OAuth token endpoint) is a separate runtime concern — a follow-up issue will be filed for it.

Other hardcoded environment URLs (`graph.microsoft.com`, `management.azure.com`) exist in the deployment scripts but are not part of this issue's scope.

Closes #905