### PR TITLE
spec: BPF decoder programs and sensor data pipeline

### DIFF
--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -244,10 +244,12 @@ never seeds or updates desired-state rows while processing `GW-0812`.
 For each `GW-0813` invocation:
 
 1. decode the top-level connector payload enough to extract `program_hash`,
-2. look up the `ProgramRoute` row for that hash,
-3. if the row exists, send the original raw connector payload bytes unchanged to
+   `node_id`, `timestamp_ms`, raw `blob`, and optional `readings` (key 16),
+2. append a `SensorData` row (§6.1) using the extracted fields,
+3. look up the `ProgramRoute` row for that hash,
+4. if the row exists, send the original raw connector payload bytes unchanged to
    the queue named by `handler_queue`, and
-4. if the row is missing, log the missing mapping and fail the invocation so the
+5. if the row is missing, log the missing mapping and fail the invocation so the
    upstream message is not reported as successfully handled.
 
 The design does not route unmapped application-data messages to a default queue.

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -254,6 +254,35 @@ The design does not route unmapped application-data messages to a default queue.
 It also does not attempt to create the mapped queue if it does not already
 exist.
 
+### 6.1  SensorData table storage (AZH-0500)
+
+In addition to routing `GW-0813` to the handler queue, the Azure handler MUST
+append a row to the `SensorData` table for every `GW-0813` message. This
+provides a queryable time-series store of sensor readings for the SPA.
+
+**Table schema:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `PartitionKey` | `String` | `"n:" + SHA-256(node_id).hex()` |
+| `RowKey` | `String` | Reverse-tick key + `":"` + uniqueness suffix |
+| `node_id` | `String` | Originating node identifier |
+| `timestamp_ms` | `Edm.Int64` | Message timestamp in milliseconds |
+| `program_hash` | `String` | BPF program hash (hex) |
+| `raw_payload` | `String` | Base64-encoded raw APP_DATA blob |
+| `decoded_readings` | `String` | JSON string of `readings` map, or `""` |
+
+If the upstream CBOR message contains a `readings` key (CBOR key 16, added by
+gateway decoder enrichment per GW-1903), the handler extracts it and serializes
+as JSON into `decoded_readings`. Otherwise `decoded_readings` is `""`.
+
+The `PartitionKey` and `RowKey` follow the same patterns as `ActualNodeState`
+(§4.1) — hashed partition key for safe table keys, reverse-tick plus uniqueness
+suffix for chronological ordering and append uniqueness.
+
+`SensorData` writes are independent of `ProgramRoute` routing — the table is
+populated even if no handler queue is configured for the program hash.
+
 ---
 
 ## 7  Failure handling

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -264,7 +264,7 @@ provides a queryable time-series store of sensor readings for the SPA.
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `PartitionKey` | `String` | `"n:" + SHA-256(node_id).hex()` |
+| `PartitionKey` | `String` | `"n:" + lowercase-hex-encoded SHA-256(node_id UTF-8 bytes)` |
 | `RowKey` | `String` | Reverse-tick key + `":"` + uniqueness suffix |
 | `node_id` | `String` | Originating node identifier |
 | `timestamp_ms` | `Edm.Int64` | Message timestamp in milliseconds |

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -245,7 +245,13 @@ For each `GW-0813` invocation:
 
 1. decode the top-level connector payload enough to extract `program_hash`,
    `node_id`, `timestamp_ms`, raw `blob`, and optional `readings` (key 16),
-2. append a `SensorData` row (§6.1) using the extracted fields,
+2. append a `SensorData` row (§6.1) using the extracted fields. To avoid
+   duplicate rows on at-least-once retries, derive the `RowKey` uniqueness
+   suffix deterministically from the upstream message (e.g., a hash of the
+   raw payload bytes or the upstream queue message ID). This makes the
+   `SensorData` write idempotent — a retry with the same message produces
+   the same `RowKey` and overwrites the existing row rather than appending
+   a duplicate,
 3. look up the `ProgramRoute` row for that hash,
 4. if the row exists, send the original raw connector payload bytes unchanged to
    the queue named by `handler_queue`, and

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -95,11 +95,14 @@ this document and are therefore logged and ignored by the reconciliation path.
 
 For `APP_DATA`, the handler decodes:
 
-1. `program_hash` for route lookup, and
-2. the raw connector payload bytes for transparent delivery.
+1. `program_hash` for route lookup,
+2. `node_id`, `timestamp_ms`, raw `blob`, and optional `readings` (key 16)
+   for `SensorData` table storage (§6.1), and
+3. the raw connector payload bytes for transparent delivery to the handler
+   queue.
 
-The handler does not reinterpret or normalize the opaque application payload
-inside the `GW-0813` message body.
+Fields beyond `program_hash` were previously opaque to the handler; the
+`SensorData` feature (AZH-0500) extends the handler's parsing scope.
 
 ---
 
@@ -247,11 +250,12 @@ For each `GW-0813` invocation:
    `node_id`, `timestamp_ms`, raw `blob`, and optional `readings` (key 16),
 2. append a `SensorData` row (§6.1) using the extracted fields. To avoid
    duplicate rows on at-least-once retries, derive the `RowKey` uniqueness
-   suffix deterministically from the upstream message (e.g., a hash of the
-   raw payload bytes or the upstream queue message ID). This makes the
-   `SensorData` write idempotent — a retry with the same message produces
-   the same `RowKey` and overwrites the existing row rather than appending
-   a duplicate,
+   suffix from the upstream queue message ID (or connector envelope
+   sequence number). This makes the `SensorData` write idempotent — a
+   retry with the same message produces the same `RowKey` and overwrites
+   the existing row rather than appending a duplicate. Do NOT use a hash
+   of the raw payload alone, as distinct messages with identical payloads
+   would collide,
 3. look up the `ProgramRoute` row for that hash,
 4. if the row exists, send the original raw connector payload bytes unchanged to
    the queue named by `handler_queue`, and

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -286,7 +286,10 @@ provides a queryable time-series store of sensor readings for the SPA.
 
 If the upstream CBOR message contains a `readings` key (CBOR key 16, added by
 gateway decoder enrichment per GW-1903), the handler extracts it and serializes
-as JSON into `decoded_readings`. Otherwise `decoded_readings` is `""`.
+as JSON into `decoded_readings`. Int64 values within JavaScript's
+`Number.MAX_SAFE_INTEGER` (2^53 - 1) are encoded as JSON numbers; values
+exceeding that threshold are encoded as JSON strings to preserve precision
+(AZH-0501 AC-5). Otherwise `decoded_readings` is `""`.
 
 The `PartitionKey` and `RowKey` follow the same patterns as `ActualNodeState`
 (§4.1) — hashed partition key for safe table keys, reverse-tick plus uniqueness

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -441,5 +441,5 @@ No additional API endpoint is required — the SPA queries Azure Tables directly
 **Acceptance criteria:**
 
 1. The SPA can query `SensorData` rows for a specific node within a time range.
-2. The SPA can query all `SensorData` rows across nodes for a specific program hash.
+2. The SPA can query `SensorData` rows for a specific program hash within a single node's partition. Cross-node program-hash queries are performed as parallel per-node requests by the SPA.
 3. Query performance is acceptable for time-series visualization (< 2 seconds for 1000 rows).

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -383,7 +383,7 @@ keys and uniqueness-suffixed row keys.
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `PartitionKey` | `String` | `"n:" + SHA-256(node_id).hex()` |
+| `PartitionKey` | `String` | `"n:" + lowercase-hex-encoded SHA-256(node_id UTF-8 bytes)` |
 | `RowKey` | `String` | Reverse-tick key + `":"` + uniqueness suffix |
 | `node_id` | `String` | Originating node identifier (display) |
 | `timestamp_ms` | `Edm.Int64` | Message timestamp in milliseconds |

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -419,6 +419,7 @@ failure), `decoded_readings` is an empty string.
 2. Multiple readings produce a single JSON object with all key-value pairs.
 3. The column is an `Edm.String` Azure Table property.
 4. Empty readings (no decoder) result in `""` (empty string), not `null`.
+5. Int64 values within JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 - 1) are encoded as JSON numbers. Values exceeding this threshold are encoded as JSON strings (e.g., `"9007199254740993"`) to preserve precision for SPA consumers that use `JSON.parse`.
 
 ---
 

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -363,3 +363,82 @@ and fail closed for the affected message.
 4. Downstream `GW-0811` publish failures are surfaced through logging, function failure, or both.
 5. Mapped handler-queue publish failures are surfaced through logging, function failure, or both.
 6. The Azure handler does not silently claim success after a detected storage or broker failure.
+
+---
+
+## 7  Sensor data storage
+
+### AZH-0500  SensorData table storage
+
+**Priority:** Must
+**Source:** User request (GW-1903 enrichment)
+
+**Description:**
+The Azure handler MUST store enriched APP_DATA messages in an Azure Storage
+Table named `SensorData`. Each `GW-0813` app-data message results in one row.
+The table uses the same safety patterns as existing tables: hashed partition
+keys and uniqueness-suffixed row keys.
+
+**Table schema:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `PartitionKey` | `String` | `"n:" + SHA-256(node_id).hex()` |
+| `RowKey` | `String` | Reverse-tick key + `":"` + uniqueness suffix |
+| `node_id` | `String` | Originating node identifier (display) |
+| `timestamp_ms` | `Edm.Int64` | Message timestamp in milliseconds |
+| `program_hash` | `String` | BPF program hash (hex) |
+| `raw_payload` | `String` | Base64-encoded raw APP_DATA blob |
+| `decoded_readings` | `String` | JSON string of `readings` map, or `""` |
+
+**Acceptance criteria:**
+
+1. Every `GW-0813` app-data message results in a row in the `SensorData` table.
+2. Rows are queryable by node ID (partition key) and time range (row key).
+3. Multiple messages within the same millisecond produce distinct rows (uniqueness suffix).
+4. The `SensorData` table is pre-provisioned (added to Bicep/provisioning).
+
+---
+
+### AZH-0501  SensorData decoded readings column
+
+**Priority:** Must
+**Source:** User request (GW-1903 enrichment)
+
+**Description:**
+The `decoded_readings` column in the `SensorData` table MUST store the
+`readings` map from enriched CBOR as a JSON string. The JSON format is
+`{ "reading_name": value, ... }` where values are integers. If no `readings`
+key is present in the upstream message (no decoder configured or decoder
+failure), `decoded_readings` is an empty string.
+
+**Acceptance criteria:**
+
+1. A reading emitted as `emit_reading("temperature_mc", 25125)` produces
+   `decoded_readings` containing `{"temperature_mc":25125}`.
+2. Multiple readings produce a single JSON object with all key-value pairs.
+3. The column is an `Edm.String` Azure Table property.
+4. Empty readings (no decoder) result in `""` (empty string), not `null`.
+
+---
+
+### AZH-0502  SensorData query support
+
+**Priority:** Must
+**Source:** User request (WEB-0700 visualization)
+
+**Description:**
+The `SensorData` table MUST be queryable by the SPA via Azure Table Storage
+REST API using the logged-in user's bearer token. The table MUST support
+queries by:
+- Node ID (partition key filter)
+- Time range (row key range, using reverse-timestamp convention)
+- Program hash (property filter)
+
+No additional API endpoint is required — the SPA queries Azure Tables directly.
+
+**Acceptance criteria:**
+
+1. The SPA can query `SensorData` rows for a specific node within a time range.
+2. The SPA can query all `SensorData` rows across nodes for a specific program hash.
+3. Query performance is acceptable for time-series visualization (< 2 seconds for 1000 rows).

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -408,7 +408,9 @@ keys and uniqueness-suffixed row keys.
 **Description:**
 The `decoded_readings` column in the `SensorData` table MUST store the
 `readings` map from enriched CBOR as a JSON string. The JSON format is
-`{ "reading_name": value, ... }` where values are integers. If no `readings`
+`{ "reading_name": value, ... }` where values are JSON numbers for int64
+values within JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 - 1), or JSON
+strings for values exceeding that threshold (see AC-5). If no `readings`
 key is present in the upstream message (no decoder configured or decoder
 failure), `decoded_readings` is an empty string.
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -273,3 +273,63 @@ published when both desired fields diverge simultaneously.
 For downstream `GW-0811` publication failures, repeat delivery of the same
 `GW-0812` with the same `timestamp_ms` and assert that the handler retries the
 divergence publication instead of treating that redelivery as permanently stale.
+
+---
+
+### T-AZH-0500  SensorData table row creation
+
+**Validates:** AZH-0500
+
+**Procedure:**
+1. Deliver a `GW-0813` app-data message through the handler with a known
+   `node_id` and `program_hash`.
+2. Assert: a row is created in the `SensorData` table with correct
+   `PartitionKey` (`"n:" + SHA-256(node_id).hex()`), `node_id`,
+   `program_hash`, and `raw_payload` (base64 of original blob).
+3. Assert: `RowKey` is a reverse-tick key with uniqueness suffix.
+
+---
+
+### T-AZH-0500a  Duplicate-timestamp writes use unique RowKey suffixes
+
+**Validates:** AZH-0500
+
+**Procedure:**
+1. Deliver two `GW-0813` messages for the same node with identical
+   `timestamp_ms`.
+2. Assert: both messages produce distinct rows (different `RowKey` suffixes).
+3. Assert: no overwrite or conflict.
+
+---
+
+### T-AZH-0501  Decoded readings stored as JSON
+
+**Validates:** AZH-0501
+
+**Procedure:**
+1. Deliver a `GW-0813` message whose CBOR contains a `readings` map
+   (key 16) with `{ "temperature_mc": 25125, "humidity_pct": 4500 }`.
+2. Assert: the `decoded_readings` column contains
+   `{"temperature_mc":25125,"humidity_pct":4500}`.
+
+---
+
+### T-AZH-0501a  Missing readings stored as empty string
+
+**Validates:** AZH-0501
+
+**Procedure:**
+1. Deliver a `GW-0813` message without a `readings` key.
+2. Assert: `decoded_readings` is `""` (empty string).
+
+---
+
+### T-AZH-0502  SensorData queryable by node and time range
+
+**Validates:** AZH-0502
+
+**Procedure:**
+1. Insert 10 `SensorData` rows for the same node at 1-second intervals.
+2. Query with `PartitionKey` filter and `RowKey` range covering the middle
+   5 rows.
+3. Assert: exactly 5 rows returned in reverse-chronological order.

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -284,7 +284,7 @@ divergence publication instead of treating that redelivery as permanently stale.
 1. Deliver a `GW-0813` app-data message through the handler with a known
    `node_id` and `program_hash`.
 2. Assert: a row is created in the `SensorData` table with correct
-   `PartitionKey` (`"n:" + SHA-256(node_id).hex()`), `node_id`,
+   `PartitionKey` (`"n:" + lowercase-hex-encoded SHA-256(node_id)`), `node_id`,
    `program_hash`, and `raw_payload` (base64 of original blob).
 3. Assert: `RowKey` is a reverse-tick key with uniqueness suffix.
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -284,8 +284,8 @@ divergence publication instead of treating that redelivery as permanently stale.
 1. Deliver a `GW-0813` app-data message through the handler with a known
    `node_id` and `program_hash`.
 2. Assert: a row is created in the `SensorData` table with correct
-   `PartitionKey` (`"n:" + lowercase-hex-encoded SHA-256(node_id)`), `node_id`,
-   `program_hash`, and `raw_payload` (base64 of original blob).
+   `PartitionKey` (`"n:" + lowercase-hex-encoded SHA-256(node_id UTF-8 bytes)`),
+   `node_id`, `program_hash`, and `raw_payload` (base64 of original blob).
 3. Assert: `RowKey` is a reverse-tick key with uniqueness suffix.
 
 ---

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -325,6 +325,20 @@ divergence publication instead of treating that redelivery as permanently stale.
 
 ---
 
+### T-AZH-0501b  Large int64 values encoded as JSON strings
+
+**Validates:** AZH-0501 (AC-5)
+
+**Procedure:**
+1. Deliver a `GW-0813` message whose CBOR `readings` map contains
+   `{ "big_value": 9007199254740993 }` (one above `Number.MAX_SAFE_INTEGER`).
+2. Assert: parsing the `decoded_readings` column as JSON yields
+   `big_value` encoded as a JSON string `"9007199254740993"`, not a number.
+3. Deliver a second message with `{ "small_value": 42 }`.
+4. Assert: `small_value` is encoded as a JSON number `42`.
+
+---
+
 ### T-AZH-0502  SensorData queryable by node and time range
 
 **Validates:** AZH-0502

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -309,8 +309,9 @@ divergence publication instead of treating that redelivery as permanently stale.
 **Procedure:**
 1. Deliver a `GW-0813` message whose CBOR contains a `readings` map
    (key 16) with `{ "temperature_mc": 25125, "humidity_pct": 4500 }`.
-2. Assert: the `decoded_readings` column contains
-   `{"temperature_mc":25125,"humidity_pct":4500}`.
+2. Assert: parsing the `decoded_readings` column as JSON yields an object
+   containing `temperature_mc` = `25125` and `humidity_pct` = `4500`
+   (comparison is on parsed values, not exact string representation).
 
 ---
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -302,6 +302,19 @@ divergence publication instead of treating that redelivery as permanently stale.
 
 ---
 
+### T-AZH-0500b  Same upstream message retried produces single row
+
+**Validates:** AZH-0500
+
+**Procedure:**
+1. Deliver the same `GW-0813` message twice (same upstream message ID /
+   envelope sequence number).
+2. Assert: only one `SensorData` row exists (the retry overwrites, not
+   appends).
+3. Assert: row content matches the message payload.
+
+---
+
 ### T-AZH-0501  Decoded readings stored as JSON
 
 **Validates:** AZH-0501

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -622,7 +622,7 @@ All programs are verified by [Prevail](https://github.com/vbpf/ebpf-verifier) on
 | **Loops** | Bounded | None or tightly bounded | Bounded |
 | **Map access** | Read/write | None (ephemeral programs must not declare maps) | Read/write (per-execution, not persistent) |
 | **Instruction budget** | Larger | Small | Same as ephemeral |
-| **Helper set** | Full (all 17 helpers) | Limited — see table below | Restricted (4 helpers) — see table below |
+| **Helper set** | Full node set (IDs 1–17) | Limited — see table below | Restricted (4 helpers, including decoder-only ID 18) — see table below |
 | **Side effects** | Allowed | No persistent node state changes under program control; `send_async` may enqueue outbound data for transmission on the next wake cycle | None (no hardware, no network I/O) |
 
 #### Ephemeral helper availability

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -51,6 +51,36 @@ Ephemeral programs are one-shot diagnostics pushed by the gateway.
 
 Ephemeral programs are used for remote introspection: dump map contents, read sensor values, or report node state — without disturbing the resident program.
 
+### 2.3  Decoder programs
+
+Decoder programs run in the gateway (not on nodes) to decode raw sensor bytes into named readings (GW-1900, GW-1903).
+
+| Property | Value |
+|---|---|
+| **Execution location** | Gateway (server-side) |
+| **Storage** | Gateway program library, alongside node image |
+| **Lifetime** | Executed per APP_DATA message |
+| **ELF section** | `SEC("decoder")` |
+| **Map access** | Read/write (per-execution, not persistent) |
+| **Helper set** | Restricted — `emit_reading`, `map_lookup_elem`, `map_update_elem`, `bpf_trace_printk` only |
+| **Side effects** | None (no hardware access, no network I/O) |
+| **Context** | `decoder_context` — pointer to raw APP_DATA bytes + length |
+| **Max size** | Same as ephemeral (2 KB) |
+
+Decoder programs receive the raw `blob` bytes from an APP_DATA message and call `emit_reading()` to produce named sensor values. The gateway collects these readings and enriches the APP_DATA message with a `readings` map (CBOR key 16) before forwarding to handlers and the connector.
+
+**Decoder map lifecycle:** Decoder maps are ephemeral — allocated and initialized from the decoder `ProgramImage` map definitions (including `map_initial_data`) on every APP_DATA execution. No state persists across executions. `.rodata`-backed maps are read-only at runtime. `.data` and `.bss` maps are writable but reset on each execution.
+
+```c
+SEC("decoder")
+int decode(struct decoder_context *ctx) {
+    // Read raw bytes from ctx->input_data (read-only)
+    // Parse sensor-specific encoding
+    // Call emit_reading() for each decoded value
+    return 0;
+}
+```
+
 ---
 
 ## 3  Execution lifecycle
@@ -125,6 +155,23 @@ struct sonde_context {
 ```
 
 The `timestamp` is derived from the gateway's `timestamp_ms` field in the COMMAND response (see [protocol.md §5.2](protocol.md)). The node has no independent clock source across deep sleep — the gateway is the authoritative time reference. Within a wake cycle, the firmware adds local elapsed time to the gateway-supplied value.
+
+### 4.2  Decoder context
+
+Decoder programs (§2.3) run in the gateway and receive a different context
+than node programs. The decoder context provides read-only access to the raw
+APP_DATA payload bytes:
+
+```c
+struct decoder_context {
+    const uint8_t *input_data;  // read-only pointer to raw APP_DATA blob
+    uint32_t input_len;         // length of input_data in bytes
+};
+/* Total: 8 bytes (BPF pointer width + u32).
+ * input_data is typed as readable memory — writes cause verification failure.
+ * The decoder reads sensor-specific bytes from input_data and calls
+ * emit_reading() to produce named values. */
+```
 
 ### Wake reasons
 
@@ -534,21 +581,47 @@ int bpf_trace_printk(const char *fmt, uint32_t fmt_len, ...);
 
 Emit a debug trace message. Output is platform-dependent (serial console, log buffer, etc.). Not intended for production use.
 
-**Availability:** Resident and ephemeral.
+**Availability:** Resident, ephemeral, and decoder.
+
+---
+
+### 6.6  Decoder
+
+#### `emit_reading`
+
+```c
+int emit_reading(const char *name, uint32_t name_len, int64_t value);
+```
+
+Emit a named sensor reading. The gateway collects all emitted readings into a `readings` map (CBOR key 16) that is added to the APP_DATA message before forwarding to handlers and the connector.
+
+| Parameter | Description |
+|---|---|
+| `name` | Pointer to UTF-8 reading name in BPF memory (e.g., `"temperature_mc"`). |
+| `name_len` | Length of the name in bytes. Maximum 64 bytes. |
+| `value` | Reading value as a signed 64-bit integer. |
+
+**Returns:** `0` on success, `-1` if `name_len` exceeds 64, `-2` if the reading limit is exceeded (max 32 readings per execution, max 2048 bytes total reading-name bytes).
+
+**Duplicate names:** Last-write-wins — if the decoder emits the same name multiple times, only the final value is included.
+
+**Helper ID:** 18
+
+**Availability:** Decoder only. Not available in resident or ephemeral programs.
 
 ---
 
 ## 7  Verification profiles
 
-All programs are verified by [Prevail](https://github.com/vbpf/ebpf-verifier) on the gateway before distribution. Two profiles enforce different safety guarantees:
+All programs are verified by [Prevail](https://github.com/vbpf/ebpf-verifier) on the gateway before distribution. Three profiles enforce different safety guarantees:
 
-| Property | Resident | Ephemeral |
-|---|---|---|
-| **Loops** | Bounded | None or tightly bounded |
-| **Map access** | Read/write | None (ephemeral programs must not declare maps) |
-| **Instruction budget** | Larger | Small |
-| **Helper set** | Full (all 17 helpers) | Limited — see table below |
-| **Side effects** | Allowed | No persistent node state changes under program control; `send_async` may enqueue outbound data for transmission on the next wake cycle |
+| Property | Resident | Ephemeral | Decoder |
+|---|---|---|---|
+| **Loops** | Bounded | None or tightly bounded | Bounded |
+| **Map access** | Read/write | None (ephemeral programs must not declare maps) | Read/write (per-execution, not persistent) |
+| **Instruction budget** | Larger | Small | Same as ephemeral |
+| **Helper set** | Full (all 17 helpers) | Limited — see table below | Restricted (4 helpers) — see table below |
+| **Side effects** | Allowed | No persistent node state changes under program control; `send_async` may enqueue outbound data for transmission on the next wake cycle | None (no hardware, no network I/O) |
 
 #### Ephemeral helper availability
 
@@ -571,6 +644,29 @@ All programs are verified by [Prevail](https://github.com/vbpf/ebpf-verifier) on
 | `set_next_wake` | ❌ | Blocked — ephemeral programs cannot modify the schedule (ND-0604 AC5) |
 | `bpf_trace_printk` | ✅ | |
 | `send_async` | ✅ | Enqueues data for next wake cycle (ND-0602 AC6) |
+
+#### Decoder helper availability
+
+| Helper | Available | Notes |
+|---|---|---|
+| `i2c_read` | ❌ | No hardware access |
+| `i2c_write` | ❌ | No hardware access |
+| `i2c_write_read` | ❌ | No hardware access |
+| `spi_transfer` | ❌ | No hardware access |
+| `gpio_read` | ❌ | No hardware access |
+| `gpio_write` | ❌ | No hardware access |
+| `adc_read` | ❌ | No hardware access |
+| `send` | ❌ | No network I/O |
+| `send_recv` | ❌ | No network I/O |
+| `map_lookup_elem` | ✅ | Decoder maps (per-execution) |
+| `map_update_elem` | ✅ | Decoder maps (per-execution); `.rodata` maps are read-only |
+| `get_time` | ❌ | Not needed |
+| `get_battery_mv` | ❌ | Not needed |
+| `delay_us` | ❌ | No blocking |
+| `set_next_wake` | ❌ | No schedule control |
+| `bpf_trace_printk` | ✅ | Debug tracing |
+| `send_async` | ❌ | No network I/O |
+| `emit_reading` | ✅ | **Decoder only** (ID 18) |
 
 A program that fails verification is rejected with a diagnostic explaining why. It never reaches the node.
 

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -495,7 +495,7 @@ Look up a value in a BPF map.
 
 **Returns:** Pointer to the value on success, `NULL` if the key is not found.
 
-**Availability:** Resident only. Ephemeral programs cannot declare maps and therefore cannot use map helpers (see §2.2 and §7).
+**Availability:** Resident and decoder. Ephemeral programs cannot declare maps and therefore cannot use map helpers (see §2.2 and §7). Decoder maps are per-execution and not persistent (see §2.3).
 
 #### `map_update_elem`
 
@@ -513,7 +513,7 @@ Insert or update a key-value pair in a BPF map.
 
 **Returns:** `0` on success, negative on failure (key/index out of range for array type).
 
-**Availability:** Resident only. Ephemeral programs cannot modify maps.
+**Availability:** Resident and decoder. Ephemeral programs cannot modify maps.
 
 ---
 

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -603,7 +603,7 @@ Emit a named sensor reading. The gateway collects all emitted readings into a `r
 | `name_len` | Length of the name in bytes. Maximum 64 bytes. |
 | `value` | Reading value as a signed 64-bit integer. |
 
-**Returns:** `0` on success, `-1` if `name_len` exceeds 64, `-2` if the reading limit is exceeded (max 32 readings per execution, max 2048 bytes total reading-name bytes).
+**Returns:** `0` on success, `-1` if `name_len` exceeds 64, `-2` if the reading-count limit is exceeded (max 32 readings per execution).
 
 **Duplicate names:** Last-write-wins — if the decoder emits the same name multiple times, only the final value is included.
 

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -164,11 +164,13 @@ APP_DATA payload bytes:
 
 ```c
 struct decoder_context {
-    const uint8_t *input_data;  // read-only pointer to raw APP_DATA blob
+    const uint64_t input_data;  // read-only pointer to raw APP_DATA blob (uint64_t for BPF verifier compatibility)
     uint32_t input_len;         // length of input_data in bytes
+    uint32_t _padding;          // explicit padding; must be zero
 };
-/* Total: 8 bytes (BPF pointer width + u32).
+/* Total: 16 bytes, 8-byte aligned.
  * input_data is typed as readable memory — writes cause verification failure.
+ * Pointer width is uint64_t consistent with sonde_context (see §4).
  * The decoder reads sensor-specific bytes from input_data and calls
  * emit_reading() to produce named values. */
 ```

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -518,7 +518,7 @@ The `input_data` pointer is typed as readable memory; writes cause verification
 failure. Pointer width is `uint64_t` consistent with the existing `sonde_context`
 convention (see bpf-environment.md §4).
 
-**Program type:** `"decoder"` with section prefix `"decoder"`.
+**Program type:** `"decoder"` with section name `"decoder"` (exact match, not prefix — see GW-1900 AC-6).
 
 **Helper prototypes:**
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -415,12 +415,13 @@ The program library stores verified BPF programs and serves chunks.
 
 ```rust
 pub struct ProgramRecord {
-    pub hash: Vec<u8>,         // SHA-256 of CBOR-encoded program image
-    pub image: Vec<u8>,        // CBOR-encoded program image (bytecode + map definitions)
-    pub size: u32,             // byte length of the CBOR image
+    pub hash: Vec<u8>,         // SHA-256 of CBOR-encoded node program image
+    pub image: Vec<u8>,        // CBOR-encoded node program image (bytecode + map definitions)
+    pub size: u32,             // byte length of the CBOR node image
     pub verification_profile: VerificationProfile,
     pub abi_version: Option<u32>,        // ABI version (None = any ABI)
     pub source_filename: Option<String>, // original filename passed at ingestion time
+    pub decoder_image: Option<Vec<u8>>,  // CBOR-encoded decoder ProgramImage (GW-1902)
 }
 
 pub enum VerificationProfile {
@@ -438,6 +439,15 @@ basename as the default program identifier, falling back to the hash when the
 metadata is absent. It does NOT affect the program hash — the hash covers only
 the CBOR image.
 
+The `decoder_image` field (GW-1902) stores the CBOR-encoded decoder
+`ProgramImage` extracted from the `SEC("decoder")` ELF section. It is `None`
+for ELFs without a decoder section. The decoder image is never sent to nodes —
+it is used only by the gateway for APP_DATA enrichment (§9.2a). The decoder
+image does NOT affect `hash` — the hash covers only the node image. Ingesting
+an ELF with the same node program hash but a different decoder replaces the
+existing decoder image (upsert). Ingesting without a decoder for a hash that
+previously had one removes the decoder image.
+
 ### 8.2  Program ingestion
 
 1. Accept pre-compiled BPF ELF (GW-0400).
@@ -450,6 +460,9 @@ the CBOR image.
 8. Enforce size limits on the CBOR image: 4 KB resident, 2 KB ephemeral (GW-0403).
 9. Compute `program_hash` using `sonde_protocol::program_hash()` with the gateway's SHA-256 provider (GW-0402).
 10. Store in library. Verification and encoding complete at ingestion time — chunk serving is immediate (GW-0400).
+11. **Decoder extraction (GW-1900):** Check for an optional `decoder` ELF section — `elf.get_programs("decoder", "", &mut decoder_platform)`. If no programs are found, `decoder_image` = `None`. If exactly one program is found, proceed to step 12. If more than one is found, reject the ELF. An empty decoder section (zero bytecode) is treated as no decoder. Section matching is exact: only `SEC("decoder")` is recognized.
+12. **Decoder verification (GW-1901):** Verify the decoder program with `DecoderPlatform` (§8.2.2) — uses a restricted helper set and decoder-specific context descriptor. If verification fails, reject the entire ELF (even if the `sonde` section is valid).
+13. **Decoder image construction:** Extract decoder bytecode and map definitions. Build a separate `ProgramImage` for the decoder. Encode with `encode_deterministic()`. Store as `decoder_image` alongside the node image. The decoder image is NOT included in the node program hash computation (GW-1906).
 
 ### 8.2.1  Sonde verifier platform (`SondePlatform`)
 
@@ -491,6 +504,39 @@ The gateway uses a custom Prevail platform (`SondePlatform`) instead of `LinuxPl
 **Workaround:** after calling `get_programs`, the gateway copies the full set of map descriptors from `RawProgram.info.map_descriptors` into `SondePlatform` via `sync_map_descriptors(&[EbpfMapDescriptor])`. `SondePlatform` maintains a mirror `Vec<EbpfMapDescriptor>` that is checked first in `get_map_descriptor()`, falling back to the inner `LinuxPlatform` for maps parsed via `parse_maps_section`.
 
 **Section name prefix matching:** the initial data extraction (step 5 above) uses prefix matching rather than exact equality for global data section names. Prevail promotes sections such as `.rodata.str1.1` and `.data.rel.ro` — not just `.rodata` and `.data` — so the scanner matches any section whose name equals or starts with a known global data prefix followed by `.`.
+
+### 8.2.2  Decoder verifier platform (`DecoderPlatform`)
+
+The gateway defines a separate `DecoderPlatform` for Prevail verification of
+decoder BPF programs (GW-1901). Like `SondePlatform`, it wraps `LinuxPlatform`
+via composition.
+
+**Module:** `crate::decoder_platform` (`crates/sonde-gateway/src/decoder_platform.rs`)
+
+**Context descriptor:** 8 bytes — `{ input_data: ptr (4B), input_len: u32 (4B) }`.
+The `input_data` pointer is typed as readable memory; writes cause verification
+failure.
+
+**Program type:** `"decoder"` with section prefix `"decoder"`.
+
+**Helper prototypes:**
+
+| ID | Name | Return | Args |
+|----|------|--------|------|
+| 10 | `map_lookup_elem` | `PtrToMapValueOrNull` | `(*map, *key)` |
+| 11 | `map_update_elem` | `Integer` | `(*map, *key, *value)` |
+| 16 | `bpf_trace_printk` | `Integer` | `(*readable, size)` |
+| 18 | `emit_reading` | `Integer` | `(*readable, size, value_i64)` |
+
+All other helper IDs (1–9, 12–15, 17) return `None` from
+`get_helper_prototype()`, causing Prevail to reject programs that reference
+them.
+
+**Map type mapping:** Same as `SondePlatform` (§8.2.1) — reuses the existing
+array/global-variable map semantics.
+
+**Global variable map sync:** Same `sync_map_descriptors` pattern as
+`SondePlatform` (§8.2.1.1).
 
 ### 8.3  Chunk serving
 
@@ -552,7 +598,25 @@ On receiving APP_DATA from a node:
 
 1. Look up the node's current `program_hash` in the handler config.
 2. If no match and no catch-all → do not send APP_DATA_REPLY to the node (GW-0504).
-3. If match → forward to handler as a DATA message (GW-0505).
+2a. **Decoder enrichment (GW-1903):** If the program record for the node's
+   `current_program_hash` has a non-`None` `decoder_image`:
+   1. Load the decoder `ProgramImage` and execute it via `sonde-bpf` with:
+      - Context: raw APP_DATA `blob` bytes as `decoder_context { input_data, input_len }`.
+      - Helpers: `emit_reading` (collects name→value pairs), `map_lookup_elem`,
+        `map_update_elem`, `bpf_trace_printk`.
+      - Maps: allocated and initialized from the decoder image's map definitions
+        on every execution. No state persists across executions. `.rodata` maps
+        are read-only; `.data`/`.bss` maps are writable but reset each time.
+      - Instruction budget: same as ephemeral programs.
+   2. If execution succeeds, add a `readings` field (CBOR key 16) to the DATA
+      message and the connector GW-0813 message. The value is a CBOR map of
+      `{ text_name: int64_value, ... }` from `emit_reading` calls. The raw
+      `blob` / `data` field is preserved byte-for-byte.
+   3. If execution fails (budget exceeded, invalid memory access), log the
+      error at WARN level and forward the original unenriched message.
+   4. Limits: max 32 readings, max 2048 bytes total reading-name bytes, max 64
+      bytes per name. Overflow → stop accepting, log, include partial readings.
+3. If match → forward (enriched or original) to handler as a DATA message (GW-0505).
 
 ### 9.3  Handler process lifecycle
 
@@ -575,6 +639,11 @@ The `DATA_REPLY` message supports an optional `delivery` field (CBOR key 4). Whe
 APP_DATA from node
   │
   ├── route by program_hash
+  │
+  ├── decoder enrichment (if decoder_image exists, GW-1903):
+  │     ├── execute decoder BPF with raw blob as input
+  │     ├── collect emit_reading() outputs (max 32 readings)
+  │     └── add readings map (key 16) as sibling of data field
   │
   ├── construct DATA message:
   │     msg_type: 0x01

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -531,7 +531,8 @@ convention (see bpf-environment.md §4).
 
 All other helper IDs (1–9, 12–15, 17) return `None` from
 `get_helper_prototype()`, causing Prevail to reject programs that reference
-them.
+them. Note: ID 17 (`send_async`) is a valid node helper defined in
+`SondePlatform` (§8.2.1) but is explicitly excluded from the decoder set.
 
 **Map type mapping:** Same as `SondePlatform` (§8.2.1) — reuses the existing
 array/global-variable map semantics.

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -442,7 +442,7 @@ the CBOR image.
 The `decoder_image` field (GW-1902) stores the CBOR-encoded decoder
 `ProgramImage` extracted from the `SEC("decoder")` ELF section. It is `None`
 for ELFs without a decoder section. The decoder image is never sent to nodes —
-it is used only by the gateway for APP_DATA enrichment (§9.2a). The decoder
+it is used only by the gateway for APP_DATA enrichment (§9.2). The decoder
 image does NOT affect `hash` — the hash covers only the node image. Ingesting
 an ELF with the same node program hash but a different decoder replaces the
 existing decoder image (upsert). Ingesting without a decoder for a hash that
@@ -513,9 +513,10 @@ via composition.
 
 **Module:** `crate::decoder_platform` (`crates/sonde-gateway/src/decoder_platform.rs`)
 
-**Context descriptor:** 8 bytes — `{ input_data: ptr (4B), input_len: u32 (4B) }`.
+**Context descriptor:** 16 bytes — `{ input_data: ptr (8B, uint64_t for BPF verifier compatibility), input_len: u32 (4B), _padding: 4B }`.
 The `input_data` pointer is typed as readable memory; writes cause verification
-failure.
+failure. Pointer width is `uint64_t` consistent with the existing `sonde_context`
+convention (see bpf-environment.md §4).
 
 **Program type:** `"decoder"` with section prefix `"decoder"`.
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -616,8 +616,8 @@ On receiving APP_DATA from a node:
       `blob` / `data` field is preserved byte-for-byte.
    3. If execution fails (budget exceeded, invalid memory access), log the
       error at WARN level and forward the original unenriched message.
-   4. Limits: max 32 readings, max 2048 bytes total reading-name bytes, max 64
-      bytes per name. Overflow → stop accepting, log, include partial readings.
+   4. Limits: max 32 readings, max 64 bytes per name. Overflow → stop
+      accepting, log, include partial readings.
 3. If match → forward (enriched or original) to handler as a DATA message (GW-0505).
 
 ### 9.3  Handler process lifecycle

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2477,6 +2477,184 @@ The nightly/release orchestrator workflow MUST build and publish standalone sens
 
 ---
 
+## 19  Decoder BPF programs
+
+### GW-1900  Decoder BPF section extraction from ELF
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+The gateway's ELF ingestion pipeline (GW-0400) MUST be extended to extract an optional `SEC("decoder")` section from the ELF file in addition to the required `SEC("sonde")` section. If the `decoder` section is present, the gateway extracts its bytecode and map definitions into a separate `ProgramImage` (the "decoder image"). If the `decoder` section is absent, ingestion proceeds as today with no decoder image.
+
+**Acceptance criteria:**
+
+1. An ELF with both `SEC("sonde")` and `SEC("decoder")` sections is ingested successfully, producing both a node image and a decoder image.
+2. An ELF with only `SEC("sonde")` is ingested successfully with no decoder image (backward compatible).
+3. An ELF with only `SEC("decoder")` and no `SEC("sonde")` is rejected.
+4. An ELF with an invalid `decoder` section (fails Prevail verification) is rejected even if the `sonde` section is valid.
+5. Global data sections (`.rodata`, `.data`) shared between both programs are handled correctly — each image receives the map definitions and initial data relevant to its section.
+6. Section matching is exact: only `SEC("decoder")` is recognized. Sections with similar names (e.g., `decoder.text`) are ignored.
+7. An ELF with multiple `SEC("decoder")` sections is rejected.
+8. An ELF with an empty `SEC("decoder")` section (zero bytecode) is treated as having no decoder.
+
+---
+
+### GW-1901  DecoderPlatform for Prevail verification
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+The gateway MUST define a separate `DecoderPlatform` for Prevail verification of decoder BPF programs. The `DecoderPlatform` defines:
+- A program type named `"decoder"` with section prefix `"decoder"`.
+- A context descriptor for the decoder input: `struct decoder_context { const uint8_t *input_data; uint32_t input_len; }`.
+- Helper prototypes for the decoder-permitted helpers only: `emit_reading` (ID 18), `map_lookup_elem` (ID 10), `map_update_elem` (ID 11), `bpf_trace_printk` (ID 16).
+- No hardware helpers (no I2C, SPI, GPIO, ADC, send, recv, delay, etc.).
+
+**Acceptance criteria:**
+
+1. Decoder programs that use only permitted helpers pass verification.
+2. Decoder programs that call hardware helpers (e.g., `i2c_read`, `send`) fail verification with a descriptive error.
+3. The decoder context descriptor accurately models the `{ input_data, input_len }` struct.
+4. The `DecoderPlatform` is distinct from `SondePlatform` — changing one does not affect the other.
+
+---
+
+### GW-1902  Decoder program storage
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+The gateway MUST store the decoder `ProgramImage` alongside the node `ProgramImage`, indexed by the same node program hash. The decoder image MUST be retrievable by node program hash. The decoder image is never sent to nodes — it is used only by the gateway for APP_DATA enrichment (GW-1903).
+
+**Acceptance criteria:**
+
+1. When a program with a decoder section is ingested, both the node image and decoder image are stored.
+2. The decoder image can be retrieved by the node program hash.
+3. Re-ingesting the same ELF is idempotent — the decoder image is updated in place.
+4. When a program is removed (GW-0802 `RemoveProgram`), the decoder image is also removed.
+5. State export/import (GW-0805) includes decoder images.
+6. The decoder image does NOT affect the node program hash — the hash covers only the node image.
+7. Ingesting an ELF with the same node program hash but a different decoder replaces the existing decoder image (upsert). The gateway logs the decoder change at INFO level.
+8. Ingesting an ELF without a decoder section for a hash that previously had a decoder removes the decoder image.
+
+---
+
+### GW-1903  APP_DATA enrichment via decoder execution
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+When the gateway receives an `APP_DATA` message (GW-0500) and a decoder image exists for the sending node's current program hash, the gateway MUST execute the decoder BPF program with the raw APP_DATA payload as input. The decoder program calls the `emit_reading` helper to produce named readings. The gateway adds a `readings` field to the handler DATA message (GW-0505) and the connector GW-0813 upstream message as a sibling field alongside the existing `data` / `payload` field. The raw `blob` from the node's APP_DATA is always preserved unchanged in the `data` field. The `readings` field is purely additive — it never mutates the raw payload.
+
+If no decoder image exists for the program hash, the message is forwarded unchanged (backward compatible).
+
+If the decoder program fails (runtime error, budget exceeded), the gateway MUST log the failure and forward the original unenriched message. Decoder failures MUST NOT prevent data delivery.
+
+**Acceptance criteria:**
+
+1. APP_DATA from a program with a decoder is enriched with a `readings` field before forwarding.
+2. APP_DATA from a program without a decoder is forwarded unchanged.
+3. The `readings` field contains the name-value pairs emitted by `emit_reading` during decoder execution.
+4. Reading names are UTF-8 strings; values are signed 64-bit integers.
+5. Decoder runtime failures (e.g., budget exceeded, invalid memory access) are logged and the unenriched message is forwarded.
+6. Both the handler and the connector receive the same enriched message.
+7. Decoder execution does not block or delay other node wake cycles.
+8. The raw `blob` / `data` field is preserved byte-for-byte — enrichment never mutates the raw payload.
+
+---
+
+### GW-1904  Decoder BPF context and helper API
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+The decoder BPF program operates in a restricted environment. Its execution context and helpers are:
+
+**Context (passed in R1):**
+```c
+struct decoder_context {
+    const uint8_t *input_data;  // read-only pointer to raw APP_DATA blob
+    uint32_t input_len;         // length of input_data in bytes
+};
+```
+
+The `input_data` memory is read-only — writes cause verification failure.
+
+**Helpers:**
+
+| ID | Name | Signature | Description |
+|----|------|-----------|-------------|
+| 18 | `emit_reading` | `(name_ptr, name_len, value_i64) → 0` | Emit a named reading. Name is UTF-8 bytes in BPF memory (max 64 bytes). Value is a signed 64-bit integer. |
+| 10 | `map_lookup_elem` | `(map_fd, key_ptr) → value_ptr_or_null` | Existing BPF map lookup. |
+| 11 | `map_update_elem` | `(map_fd, key_ptr, value_ptr, flags) → 0_or_error` | Existing BPF map update. |
+| 16 | `bpf_trace_printk` | `(fmt_ptr, fmt_len, arg1, arg2, arg3) → 0` | Debug tracing. |
+
+**Limits:** Maximum 32 readings per decoder execution. Maximum total reading-name bytes: 2048. If either limit is exceeded, subsequent `emit_reading` calls return `-2` (overflow), the gateway logs a warning, and readings collected so far are still included in the enriched message.
+
+**Decoder map lifecycle:** Decoder maps are ephemeral — allocated and initialized from the decoder `ProgramImage` map definitions (including `map_initial_data`) on every APP_DATA execution. No state persists across executions. `.rodata`-backed maps are read-only at runtime — `map_update_elem` on a `.rodata` map returns error. `.data` and `.bss` maps are writable but reset on each execution.
+
+**Acceptance criteria:**
+
+1. The decoder receives a valid `decoder_context` with pointer to raw payload and its length.
+2. `emit_reading` captures the name and value for inclusion in the `readings` field.
+3. Multiple calls to `emit_reading` with different names are accumulated.
+4. Duplicate names in `emit_reading` calls: last-write-wins.
+5. `map_lookup_elem` and `map_update_elem` work with decoder-image maps.
+6. `bpf_trace_printk` output is logged by the gateway.
+7. Hardware helpers (I2C, SPI, GPIO, ADC, send, recv) are NOT available — calling them fails verification (GW-1901).
+8. `emit_reading` with `name_len` > 64 returns `-1`.
+9. The 33rd `emit_reading` call returns `-2` (overflow).
+10. `map_update_elem` on a `.rodata`-backed map returns error.
+
+---
+
+### GW-1905  Decoder backward compatibility
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+The decoder feature MUST be fully backward compatible:
+- ELFs without a `SEC("decoder")` section are ingested and used exactly as today.
+- Programs already stored in the gateway (without decoder images) continue to function.
+- The handler protocol DATA message format is unchanged — the `readings` field is additive.
+- Connectors that do not understand the `readings` field ignore it (CBOR maps are extensible).
+- Nodes are completely unaware of decoders.
+
+**Acceptance criteria:**
+
+1. Existing ELFs without decoder sections ingest successfully.
+2. Existing programs in the database are unaffected by the schema migration.
+3. Handlers that do not parse the `readings` field continue to function.
+4. Connectors that do not parse the `readings` field continue to function.
+5. No changes to the node firmware or wire protocol are required.
+
+---
+
+### GW-1906  Node program hash stability
+
+**Priority:** Must
+**Source:** User request
+
+**Description:**
+The node-facing `program_hash` MUST remain the SHA-256 of the CBOR-encoded node `ProgramImage` only (bytecode from `SEC("sonde")` + maps). The decoder bytecode MUST NOT be included in the node program hash computation. This ensures:
+- Updating only the decoder does not trigger a program re-download on nodes.
+- Existing node assignments are unaffected when a decoder is added to a program.
+- The wire protocol `program_hash` fields (WAKE, UPDATE_PROGRAM, PROGRAM_ACK) remain consistent.
+
+**Acceptance criteria:**
+
+1. Ingesting an ELF with a decoder section produces the same node program hash as ingesting the same ELF without the decoder section (assuming identical `sonde` bytecode and maps).
+2. Adding a decoder to a previously ingested program does not change the program hash stored in node assignments.
+3. The hash is computed exactly as specified in `protocol.md` §5 (SHA-256 of CBOR node image).
+
+---
+
 ## Appendix A  Requirement index
 
 | ID | Title | Priority |
@@ -2611,3 +2789,10 @@ The nightly/release orchestrator workflow MUST build and publish standalone sens
 | GW-1804 | Bundled modem flashing assets | Must |
 | GW-1805 | Bundled BPF test-program assets | Must |
 | GW-1806 | Nightly release sensor assets | Must |
+| GW-1900 | Decoder BPF section extraction from ELF | Must |
+| GW-1901 | DecoderPlatform for Prevail verification | Must |
+| GW-1902 | Decoder program storage | Must |
+| GW-1903 | APP_DATA enrichment via decoder execution | Must |
+| GW-1904 | Decoder BPF context and helper API | Must |
+| GW-1905 | Decoder backward compatibility | Must |
+| GW-1906 | Node program hash stability | Must |

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2591,12 +2591,12 @@ The `input_data` memory is read-only — writes cause verification failure.
 
 | ID | Name | Signature | Description |
 |----|------|-----------|-------------|
-| 18 | `emit_reading` | `(name_ptr, name_len, value_i64) → 0 or -1 or -2` | Emit a named reading. Name is UTF-8 bytes in BPF memory (max 64 bytes). Value is a signed 64-bit integer. Returns `-1` if `name_len` exceeds 64, `-2` if the reading-count limit (32) or total-name-bytes limit (2048) is exceeded. |
+| 18 | `emit_reading` | `(name_ptr, name_len, value_i64) → 0 or -1 or -2` | Emit a named reading. Name is UTF-8 bytes in BPF memory (max 64 bytes). Value is a signed 64-bit integer. Returns `-1` if `name_len` exceeds 64, `-2` if the reading-count limit (32) is exceeded. |
 | 10 | `map_lookup_elem` | `(map_fd, key_ptr) → value_ptr_or_null` | Existing BPF map lookup. |
 | 11 | `map_update_elem` | `(map_fd, key_ptr, value_ptr) → 0_or_error` | Existing BPF map update (no flags argument — sonde convention). |
 | 16 | `bpf_trace_printk` | `(fmt_ptr, fmt_len, arg1, arg2, arg3) → 0` | Debug tracing. |
 
-**Limits:** Maximum 32 readings per decoder execution. Maximum total reading-name bytes: 2048. If either limit is exceeded, subsequent `emit_reading` calls return `-2` (overflow), the gateway logs a warning, and readings collected so far are still included in the enriched message.
+**Limits:** Maximum 32 readings per decoder execution. If the limit is exceeded, subsequent `emit_reading` calls return `-2` (overflow), the gateway logs a warning, and readings collected so far are still included in the enriched message.
 
 **Decoder map lifecycle:** Decoder maps are ephemeral — allocated and initialized from the decoder `ProgramImage` map definitions (including `map_initial_data`) on every APP_DATA execution. No state persists across executions. `.rodata`-backed maps are read-only at runtime — `map_update_elem` on a `.rodata` map returns error. `.data` and `.bss` maps are writable but reset on each execution.
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2591,7 +2591,7 @@ The `input_data` memory is read-only — writes cause verification failure.
 
 | ID | Name | Signature | Description |
 |----|------|-----------|-------------|
-| 18 | `emit_reading` | `(name_ptr, name_len, value_i64) → 0 or -1 or -2` | Emit a named reading. Name is UTF-8 bytes in BPF memory (max 64 bytes). Value is a signed 64-bit integer. Returns `-1` if `name_len` exceeds 64, `-2` on reading-count overflow. |
+| 18 | `emit_reading` | `(name_ptr, name_len, value_i64) → 0 or -1 or -2` | Emit a named reading. Name is UTF-8 bytes in BPF memory (max 64 bytes). Value is a signed 64-bit integer. Returns `-1` if `name_len` exceeds 64, `-2` if the reading-count limit (32) or total-name-bytes limit (2048) is exceeded. |
 | 10 | `map_lookup_elem` | `(map_fd, key_ptr) → value_ptr_or_null` | Existing BPF map lookup. |
 | 11 | `map_update_elem` | `(map_fd, key_ptr, value_ptr) → 0_or_error` | Existing BPF map update (no flags argument — sonde convention). |
 | 16 | `bpf_trace_printk` | `(fmt_ptr, fmt_len, arg1, arg2, arg3) → 0` | Debug tracing. |

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2589,9 +2589,9 @@ The `input_data` memory is read-only — writes cause verification failure.
 
 | ID | Name | Signature | Description |
 |----|------|-----------|-------------|
-| 18 | `emit_reading` | `(name_ptr, name_len, value_i64) → 0` | Emit a named reading. Name is UTF-8 bytes in BPF memory (max 64 bytes). Value is a signed 64-bit integer. |
+| 18 | `emit_reading` | `(name_ptr, name_len, value_i64) → 0 or -1 or -2` | Emit a named reading. Name is UTF-8 bytes in BPF memory (max 64 bytes). Value is a signed 64-bit integer. Returns `-1` if `name_len` exceeds 64, `-2` on reading-count overflow. |
 | 10 | `map_lookup_elem` | `(map_fd, key_ptr) → value_ptr_or_null` | Existing BPF map lookup. |
-| 11 | `map_update_elem` | `(map_fd, key_ptr, value_ptr, flags) → 0_or_error` | Existing BPF map update. |
+| 11 | `map_update_elem` | `(map_fd, key_ptr, value_ptr) → 0_or_error` | Existing BPF map update (no flags argument — sonde convention). |
 | 16 | `bpf_trace_printk` | `(fmt_ptr, fmt_len, arg1, arg2, arg3) → 0` | Debug tracing. |
 
 **Limits:** Maximum 32 readings per decoder execution. Maximum total reading-name bytes: 2048. If either limit is exceeded, subsequent `emit_reading` calls return `-2` (overflow), the gateway logs a warning, and readings collected so far are still included in the enriched message.

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2507,8 +2507,8 @@ The gateway's ELF ingestion pipeline (GW-0400) MUST be extended to extract an op
 
 **Description:**
 The gateway MUST define a separate `DecoderPlatform` for Prevail verification of decoder BPF programs. The `DecoderPlatform` defines:
-- A program type named `"decoder"` with section prefix `"decoder"`.
-- A context descriptor for the decoder input: `struct decoder_context { const uint8_t *input_data; uint32_t input_len; }`.
+- A program type named `"decoder"` with section name `"decoder"` (exact match, not prefix — see GW-1900 AC-6).
+- A context descriptor for the decoder input: `struct decoder_context { const uint64_t input_data; uint32_t input_len; uint32_t _padding; }` (16 bytes, 8-byte aligned — see bpf-environment.md §4.2).
 - Helper prototypes for the decoder-permitted helpers only: `emit_reading` (ID 18), `map_lookup_elem` (ID 10), `map_update_elem` (ID 11), `bpf_trace_printk` (ID 16).
 - No hardware helpers (no I2C, SPI, GPIO, ADC, send, recv, delay, etc.).
 
@@ -2578,9 +2578,11 @@ The decoder BPF program operates in a restricted environment. Its execution cont
 **Context (passed in R1):**
 ```c
 struct decoder_context {
-    const uint8_t *input_data;  // read-only pointer to raw APP_DATA blob
+    const uint64_t input_data;  // read-only pointer to raw APP_DATA blob (uint64_t for BPF verifier compatibility)
     uint32_t input_len;         // length of input_data in bytes
+    uint32_t _padding;          // explicit padding; must be zero
 };
+// Total: 16 bytes, 8-byte aligned. See bpf-environment.md §4.2.
 ```
 
 The `input_data` memory is read-only — writes cause verification failure.

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4152,22 +4152,6 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
-### T-1904f  emit_reading total-name-bytes overflow returns -2
-
-**Traces to:** GW-1904 (AC-9)
-
-**Steps:**
-1. Call `emit_reading` with 32 distinct 64-byte names (total = 2048 bytes, at limit).
-2. Assert all 32 return `0`.
-3. Call `emit_reading` one more time with a 1-byte name (total would exceed 2048).
-
-**Expected:**
-1. The 33rd call returns `-2` (total-name-bytes overflow).
-2. First 32 readings are included in the readings map.
-3. Warning logged.
-
----
-
 ### T-1904d  Decoder with rodata map reads initial data correctly
 
 **Traces to:** GW-1904 (AC-5)
@@ -4243,6 +4227,6 @@ A configurable stub handler process (or in-process mock) that:
 | GW-1901 | T-1901, T-1901a, T-1901b |
 | GW-1902 | T-1902 |
 | GW-1903 | T-1903, T-1903a, T-1903b, T-1903c, T-1903d |
-| GW-1904 | T-1904, T-1904a, T-1904b, T-1904c, T-1904d, T-1904e, T-1904f |
+| GW-1904 | T-1904, T-1904a, T-1904b, T-1904c, T-1904d, T-1904e |
 | GW-1905 | T-1900a, T-1903a |
 | GW-1906 | T-1906 |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4243,6 +4243,6 @@ A configurable stub handler process (or in-process mock) that:
 | GW-1901 | T-1901, T-1901a, T-1901b |
 | GW-1902 | T-1902 |
 | GW-1903 | T-1903, T-1903a, T-1903b, T-1903c, T-1903d |
-| GW-1904 | T-1904, T-1904a, T-1904b, T-1904c, T-1904d, T-1904e |
+| GW-1904 | T-1904, T-1904a, T-1904b, T-1904c, T-1904d, T-1904e, T-1904f |
 | GW-1905 | T-1900a, T-1903a |
 | GW-1906 | T-1906 |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -3898,6 +3898,298 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1900  Decoder section extraction from ELF
+
+**Traces to:** GW-1900 (AC-1)
+
+**Preconditions:** A test ELF with both `SEC("sonde")` and `SEC("decoder")` sections.
+
+**Steps:**
+1. Ingest the dual-section ELF via `IngestProgram`.
+2. Query the stored program record.
+
+**Expected:**
+1. Program stored with both node image and decoder image.
+2. Node program hash matches hash of node image only (decoder excluded).
+
+---
+
+### T-1900a  ELF without decoder section (backward compat)
+
+**Traces to:** GW-1900 (AC-2), GW-1905 (AC-1)
+
+**Preconditions:** An existing single-section ELF (e.g., `tmp102_sensor.o`).
+
+**Steps:**
+1. Ingest a standard single-section ELF.
+
+**Expected:**
+1. Program stored with no decoder image.
+2. Behavior identical to pre-feature gateway.
+
+---
+
+### T-1900b  ELF with decoder only (no sonde section) rejected
+
+**Traces to:** GW-1900 (AC-3)
+
+**Steps:**
+1. Build an ELF with only `SEC("decoder")`, no `SEC("sonde")`.
+2. Ingest via `IngestProgram`.
+
+**Expected:**
+1. Rejected with error indicating missing sonde section.
+
+---
+
+### T-1900c  ELF with empty decoder section treated as no decoder
+
+**Traces to:** GW-1900 (AC-8)
+
+**Steps:**
+1. Build an ELF with `SEC("sonde")` and an empty `SEC("decoder")` (zero bytecode).
+2. Ingest via `IngestProgram`.
+
+**Expected:**
+1. Program stored with no decoder image (empty section ignored).
+
+---
+
+### T-1900d  ELF with multiple decoder sections rejected
+
+**Traces to:** GW-1900 (AC-7)
+
+**Steps:**
+1. Build an ELF with `SEC("sonde")` and two `SEC("decoder")` sections.
+2. Ingest via `IngestProgram`.
+
+**Expected:**
+1. Rejected with error indicating multiple decoder sections.
+
+---
+
+### T-1901  Decoder verification with DecoderPlatform
+
+**Traces to:** GW-1901 (AC-1)
+
+**Preconditions:** A decoder program that calls only permitted helpers (`emit_reading`, `map_lookup_elem`, `bpf_trace_printk`).
+
+**Steps:**
+1. Ingest the ELF with valid sonde and decoder sections.
+
+**Expected:**
+1. Verification passes, decoder image stored.
+
+---
+
+### T-1901a  Decoder using hardware helpers rejected
+
+**Traces to:** GW-1901 (AC-2)
+
+**Steps:**
+1. Build a decoder program that calls `i2c_read`.
+2. Ingest the ELF.
+
+**Expected:**
+1. Verification fails with error about invalid/unknown helper.
+
+---
+
+### T-1901b  Decoder using send helper rejected
+
+**Traces to:** GW-1901 (AC-2)
+
+**Steps:**
+1. Build a decoder program that calls `send`.
+2. Ingest the ELF.
+
+**Expected:**
+1. Verification fails with error about invalid/unknown helper.
+
+---
+
+### T-1902  Decoder image storage and retrieval
+
+**Traces to:** GW-1902 (AC-1, AC-2, AC-4)
+
+**Steps:**
+1. Ingest an ELF with decoder section.
+2. Retrieve the program record by hash.
+3. Assert decoder image is present and decodable as valid `ProgramImage`.
+4. Remove the program via `RemoveProgram`.
+
+**Expected:**
+1. Decoder image present after ingest.
+2. Decoder image removed after `RemoveProgram`.
+
+---
+
+### T-1903  APP_DATA enrichment with decoder
+
+**Traces to:** GW-1903 (AC-1, AC-3, AC-6)
+
+**Preconditions:** Ingested program with a decoder that calls `emit_reading("temp_mc", 25125)`.
+
+**Steps:**
+1. Assign program to a test node. Simulate an APP_DATA from that node.
+2. Inspect the DATA message forwarded to the handler.
+3. Inspect the GW-0813 message forwarded to the connector.
+
+**Expected:**
+1. Both messages contain a `readings` field with `{ "temp_mc": 25125 }`.
+2. Raw `data`/`blob` field is preserved byte-for-byte.
+
+---
+
+### T-1903a  APP_DATA without decoder forwarded unchanged
+
+**Traces to:** GW-1903 (AC-2), GW-1905 (AC-3, AC-4)
+
+**Preconditions:** Ingested program without a decoder section.
+
+**Steps:**
+1. Simulate an APP_DATA from a node running the program.
+
+**Expected:**
+1. DATA message has no `readings` field.
+
+---
+
+### T-1903b  Decoder failure does not block data delivery
+
+**Traces to:** GW-1903 (AC-5)
+
+**Preconditions:** Ingested program with a decoder that exceeds the instruction budget.
+
+**Steps:**
+1. Simulate an APP_DATA from a node.
+
+**Expected:**
+1. Warning logged.
+2. Original unenriched message forwarded to handler and connector.
+
+---
+
+### T-1903c  Enriched message preserves raw blob unchanged
+
+**Traces to:** GW-1903 (AC-8)
+
+**Steps:**
+1. Ingest a program with a decoder.
+2. Simulate APP_DATA with known blob bytes.
+3. Inspect forwarded DATA message.
+
+**Expected:**
+1. `data` field matches original blob bytes exactly.
+2. `readings` field present as a separate sibling field.
+
+---
+
+### T-1903d  Both handler and connector receive identical enriched message
+
+**Traces to:** GW-1903 (AC-6)
+
+**Steps:**
+1. Capture the DATA message sent to the handler and the GW-0813 message
+   sent to the connector for the same APP_DATA.
+
+**Expected:**
+1. Both contain the same `readings` content.
+
+---
+
+### T-1904  emit_reading helper captures readings
+
+**Traces to:** GW-1904 (AC-2, AC-3, AC-4)
+
+**Steps:**
+1. Execute a decoder BPF program that calls `emit_reading("a", 1)`,
+   `emit_reading("b", 2)`, `emit_reading("a", 3)`.
+2. Inspect the resulting readings.
+
+**Expected:**
+1. Readings map is `{ "a": 3, "b": 2 }` (last-write-wins for "a").
+
+---
+
+### T-1904a  emit_reading with name_len=64 succeeds
+
+**Traces to:** GW-1904 (AC-8)
+
+**Steps:**
+1. Call `emit_reading` with a 64-byte name.
+
+**Expected:**
+1. Returns `0` (success).
+2. Reading is included.
+
+---
+
+### T-1904b  emit_reading with name_len=65 returns -1
+
+**Traces to:** GW-1904 (AC-8)
+
+**Steps:**
+1. Call `emit_reading` with a 65-byte name.
+
+**Expected:**
+1. Returns `-1`.
+2. Reading is NOT included.
+
+---
+
+### T-1904c  emit_reading overflow (33rd reading) returns -2
+
+**Traces to:** GW-1904 (AC-9)
+
+**Steps:**
+1. Call `emit_reading` 33 times with distinct names.
+
+**Expected:**
+1. First 32 calls return `0`.
+2. 33rd call returns `-2`.
+3. First 32 readings are included in the readings map.
+
+---
+
+### T-1904d  Decoder with rodata map reads initial data correctly
+
+**Traces to:** GW-1904 (AC-5)
+
+**Steps:**
+1. Build a decoder with a `.rodata` global variable containing a lookup table.
+2. Execute the decoder. It uses `map_lookup_elem` to read from the table.
+
+**Expected:**
+1. `map_lookup_elem` returns the expected initial data values.
+
+---
+
+### T-1904e  map_update_elem on rodata map returns error
+
+**Traces to:** GW-1904 (AC-10)
+
+**Steps:**
+1. Build a decoder that calls `map_update_elem` on a `.rodata`-backed map.
+
+**Expected:**
+1. `map_update_elem` returns error (non-zero).
+
+---
+
+### T-1906  Program hash unchanged by decoder presence
+
+**Traces to:** GW-1906 (AC-1)
+
+**Steps:**
+1. Build two ELFs from identical `sonde` source: one without decoder, one with.
+2. Ingest both.
+
+**Expected:**
+1. Both produce the same node program hash.
+
+---
+
 | GW-1306 | T-1306a, T-1306b, T-1306c, T-1306d |
 | GW-1307 | T-1307a, T-1307b, T-1307c, T-1307d, T-1307e, T-1307f, T-1307g, T-1307h, T-1307i |
 | GW-1308 | T-1308 |
@@ -3931,3 +4223,10 @@ A configurable stub handler process (or in-process mock) that:
 | GW-1804 | T-1800, T-1802a, T-1806 |
 | GW-1805 | T-1800, T-1802b, T-1806a |
 | GW-1806 | T-1806a, T-1807 |
+| GW-1900 | T-1900, T-1900a, T-1900b, T-1900c, T-1900d |
+| GW-1901 | T-1901, T-1901a, T-1901b |
+| GW-1902 | T-1902 |
+| GW-1903 | T-1903, T-1903a, T-1903b, T-1903c, T-1903d |
+| GW-1904 | T-1904, T-1904a, T-1904b, T-1904c, T-1904d, T-1904e |
+| GW-1905 | T-1900a, T-1903a |
+| GW-1906 | T-1906 |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4152,6 +4152,22 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1904f  emit_reading total-name-bytes overflow returns -2
+
+**Traces to:** GW-1904 (AC-9)
+
+**Steps:**
+1. Call `emit_reading` with 32 distinct 64-byte names (total = 2048 bytes, at limit).
+2. Assert all 32 return `0`.
+3. Call `emit_reading` one more time with a 1-byte name (total would exceed 2048).
+
+**Expected:**
+1. The 33rd call returns `-2` (total-name-bytes overflow).
+2. First 32 readings are included in the readings map.
+3. Warning logged.
+
+---
+
 ### T-1904d  Decoder with rodata map reads initial data correctly
 
 **Traces to:** GW-1904 (AC-5)

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4024,6 +4024,43 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1902a  Decoder image replacement on re-ingest
+
+**Traces to:** GW-1902 (AC-7)
+
+**Preconditions:** Ingested ELF with decoder producing `emit_reading("v1", 1)`.
+
+**Steps:**
+1. Build a second ELF with identical `sonde` section but different `decoder`
+   section (producing `emit_reading("v2", 2)`).
+2. Re-ingest the second ELF.
+3. Simulate APP_DATA and inspect enriched readings.
+
+**Expected:**
+1. Program hash is unchanged (same `sonde` bytecode).
+2. Decoder image is replaced — readings contain `v2`, not `v1`.
+3. Gateway logs decoder change at INFO level.
+
+---
+
+### T-1902b  Decoder removal on re-ingest without decoder
+
+**Traces to:** GW-1902 (AC-8)
+
+**Preconditions:** Ingested ELF with decoder section.
+
+**Steps:**
+1. Build a new ELF with identical `sonde` section but no `decoder` section.
+2. Re-ingest.
+3. Simulate APP_DATA and inspect forwarded message.
+
+**Expected:**
+1. Program hash is unchanged.
+2. Decoder image is removed.
+3. APP_DATA forwarded without `readings` field.
+
+---
+
 ### T-1903  APP_DATA enrichment with decoder
 
 **Traces to:** GW-1903 (AC-1, AC-3, AC-6)
@@ -4225,7 +4262,7 @@ A configurable stub handler process (or in-process mock) that:
 | GW-1806 | T-1806a, T-1807 |
 | GW-1900 | T-1900, T-1900a, T-1900b, T-1900c, T-1900d |
 | GW-1901 | T-1901, T-1901a, T-1901b |
-| GW-1902 | T-1902 |
+| GW-1902 | T-1902, T-1902a, T-1902b |
 | GW-1903 | T-1903, T-1903a, T-1903b, T-1903c, T-1903d |
 | GW-1904 | T-1904, T-1904a, T-1904b, T-1904c, T-1904d, T-1904e |
 | GW-1905 | T-1900a, T-1903a |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -166,6 +166,7 @@ All payload fields below are CBOR-encoded maps with **integer keys** for compact
 | 13 | `starting_seq` | COMMAND |
 | 14 | `timestamp_ms` | COMMAND |
 | 15 | `firmware_version` | WAKE |
+| 16 | `readings` | APP_DATA (enriched by gateway decoder, GW-1903) |
 
 #### Diagnostic message keyspace
 
@@ -250,6 +251,24 @@ BPF ELF file (developer artifact)
 ```
 
 The ELF is never transmitted to the node. The node receives only the CBOR program image.
+
+#### Decoder program image
+
+An ELF file may contain an optional `SEC("decoder")` section in addition to
+the required `SEC("sonde")` section (GW-1900). The gateway extracts both
+sections into separate `ProgramImage` CBOR structures:
+
+- **Node image:** From `SEC("sonde")`. Hashed, stored, and sent to nodes as
+  today.
+- **Decoder image:** From `SEC("decoder")`. Stored alongside the node image,
+  keyed by the same program hash. Never sent to nodes. Used by the gateway for
+  APP_DATA enrichment (GW-1903).
+
+The decoder image uses the same CBOR structure as the node image
+(`{ 1: bytecode, 2: [map_defs...] }`). The decoder image is NOT included in
+the `program_hash` computation — the hash covers only the node image
+(GW-1906). This ensures that adding or modifying a decoder does not trigger
+program re-downloads on nodes.
 
 ### 5.1  WAKE (Node → Gateway)
 
@@ -360,8 +379,15 @@ Sent by the firmware when the BPF program calls `send()` or `send_recv()`.
 | Field | CBOR type | Required | Description |
 |---|---|---|---|
 | `blob` | bstr | Yes | Opaque application data. Content defined by the BPF program. |
+| `readings` | map | No | Decoded sensor readings, added by the gateway when a decoder BPF program exists for the sending program (GW-1903). Keys are UTF-8 text strings (reading names); values are signed 64-bit integers. Absent when no decoder is configured or decoder execution fails. Consumers MUST tolerate absence. |
 
 A node may send **multiple `APP_DATA` messages per wake cycle** (one per `send()` or `send_recv()` call in the BPF program). Each `APP_DATA` frame carries an **incrementing sequence number** in the `nonce` header field, consistent with the session-scoped replay protection scheme (see §7.4). The gateway accepts them as independent authenticated messages.
+
+**Decoder enrichment:** When the gateway has a decoder program image for the
+APP_DATA's program hash, it executes the decoder on the raw `blob` bytes and
+adds the `readings` map to the CBOR message before forwarding to handlers and
+the connector. The `blob` field is always present and unchanged — `readings`
+is purely additive. See [gateway-design.md §9.2a](gateway-design.md).
 
 The BPF program and its corresponding gateway-side handler agree a priori on whether a reply is expected for each message. The protocol carries no explicit flag — the gateway sends `APP_DATA_REPLY` only when the handler provides a non-zero-length response.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -389,7 +389,11 @@ A node may send **multiple `APP_DATA` messages per wake cycle** (one per `send()
 APP_DATA's program hash, it executes the decoder on the raw `blob` bytes and
 adds the `readings` map to the CBOR message before forwarding to handlers and
 the connector. The `blob` field is always present and unchanged — `readings`
-is purely additive. See [gateway-design.md §9.2](gateway-design.md).
+is purely additive. If the node's APP_DATA CBOR already contains a key 16,
+the gateway MUST discard the node-supplied value and replace it with the
+decoder-produced readings (or omit it if no decoder exists). Nodes cannot
+inject `readings` — only the gateway's decoder produces them.
+See [gateway-design.md §9.2](gateway-design.md).
 
 The BPF program and its corresponding gateway-side handler agree a priori on whether a reply is expected for each message. The protocol carries no explicit flag — the gateway sends `APP_DATA_REPLY` only when the handler provides a non-zero-length response.
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -266,10 +266,11 @@ sections into separate `ProgramImage` CBOR structures:
   APP_DATA enrichment (GW-1903).
 
 The decoder image uses the same CBOR structure as the node image
-(`{ 1: bytecode, 2: [map_defs...] }`). The decoder image is NOT included in
-the `program_hash` computation — the hash covers only the node image
-(GW-1906). This ensures that adding or modifying a decoder does not trigger
-program re-downloads on nodes.
+(`{ 1: bytecode, 2: [map_defs...] }`), including optional per-map key 5
+(`initial_data`) for `.rodata`/`.data` global variable maps. The decoder
+image is NOT included in the `program_hash` computation — the hash covers
+only the node image (GW-1906). This ensures that adding or modifying a
+decoder does not trigger program re-downloads on nodes.
 
 ### 5.1  WAKE (Node → Gateway)
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -145,7 +145,7 @@ This makes direction unambiguous from `msg_type` alone, simplifying routing, log
 
 ## 5  Message definitions
 
-All payload fields below are CBOR-encoded maps with **integer keys** for compactness (saves ~3–5 bytes per field vs. string keys). The string names in the tables below are for documentation only — on the wire, only the integer key is used.
+All payload fields below are CBOR-encoded maps with **integer keys** for compactness (saves ~3–5 bytes per field vs. string keys). The string names in the tables below are for documentation only — on the wire, only the integer key is used. **Exception:** the `readings` map (key 16, added by gateway decoder enrichment) uses UTF-8 text keys internally — its keys are sensor reading names, not integer protocol keys.
 
 ### CBOR key mapping
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -213,11 +213,12 @@ Key 5 (`initial_data`) carries the ELF section content for global variable maps 
 
 #### Program hash
 
-The `program_hash` used throughout the protocol is the SHA-256 hash of the **complete CBOR-encoded program image**:
+The `program_hash` used throughout the protocol is the SHA-256 hash of the **complete CBOR-encoded node program image** (the image built from the `SEC("sonde")` ELF section):
 
-- The hash covers bytecode, map definitions, **and** initial map data.
+- The hash covers node bytecode, map definitions, **and** initial map data.
+- The hash does NOT cover the decoder program image — see "Decoder program image" below.
 - Two programs with identical bytecode but different map layouts have different hashes.
-- The gateway computes the hash after encoding the image; the node computes it after reassembling all chunks.
+- The gateway computes the hash after encoding the node image; the node computes it after reassembling all chunks.
 - This CBOR-encoded program image is the canonical byte sequence for all size- and chunk-related fields in this specification (i.e., `program_size` and `chunk_count` in UPDATE_PROGRAM / RUN_EPHEMERAL refer to the byte length and chunking of the CBOR-encoded program image, not the ELF file or raw bytecode).
 
 **Deterministic encoding:** The program image MUST be encoded using CBOR deterministic encoding (RFC 8949 §4.2) to ensure that all gateways produce identical bytes (and therefore identical hashes) for the same program.
@@ -387,7 +388,7 @@ A node may send **multiple `APP_DATA` messages per wake cycle** (one per `send()
 APP_DATA's program hash, it executes the decoder on the raw `blob` bytes and
 adds the `readings` map to the CBOR message before forwarding to handlers and
 the connector. The `blob` field is always present and unchanged — `readings`
-is purely additive. See [gateway-design.md §9.2a](gateway-design.md).
+is purely additive. See [gateway-design.md §9.2](gateway-design.md).
 
 The BPF program and its corresponding gateway-side handler agree a priori on whether a reply is expected for each message. The protocol carries no explicit flag — the gateway sends `APP_DATA_REPLY` only when the handler provides a non-zero-length response.
 

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -23,7 +23,7 @@ Browser (SPA)
 ├── Desired State (read/write desiredstate table)
 ├── Program Upload (POST ELF to ProgramIngest function)
 ├── Program List (read programs + programroute tables)
-└── Sensor Data (read sensordata table, time-series graph)
+└── Sensor Data (read SensorData table, time-series graph)
      │
      │ MSAL.js Bearer Token
      ▼
@@ -315,7 +315,10 @@ reverse-tick `RowKey`); the Y-axis is the reading value.
 - Maximum 1000 rows per query (`$top=1000`). For longer time ranges,
   the SPA downsamples by querying with wider `RowKey` strides.
 - Int64 values exceeding `Number.MAX_SAFE_INTEGER` (2^53 - 1) are displayed
-  as strings.
+  as strings. The Azure handler MUST encode such values as JSON strings
+  (e.g., `"temperature_raw": "9007199254740993"`) in the `decoded_readings`
+  column so that `JSON.parse` preserves them. Values within safe integer
+  range are encoded as JSON numbers.
 
 The chart library is vanilla JS (Canvas-based) or a lightweight dependency
 (e.g., Chart.js loaded from CDN) — no build step required, consistent with

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -291,7 +291,10 @@ The Sensor Data tab reads from the `SensorData` Azure Table (AZH-0500). Each
 row contains `node_id`, `timestamp_ms`, `program_hash`, `raw_payload`, and
 `decoded_readings` (JSON string), plus `PartitionKey` and `RowKey` for
 querying. The tab parses `decoded_readings` JSON to extract reading names
-and values for plotting. Timestamps for the X-axis are derived from
+and values for plotting. When `decoded_readings` is the empty string
+(`""`), the row has no decoded readings — the SPA skips it for plotting
+and shows "—" in table view. The SPA MUST check for empty string before
+calling `JSON.parse`. Timestamps for the X-axis are derived from
 `timestamp_ms`.
 
 Data is queried using the same MSAL.js bearer token as other tabs — no

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -292,17 +292,19 @@ row contains `node_id`, `timestamp_ms`, `program_hash`, `raw_payload`, and
 `decoded_readings` (JSON string), plus `PartitionKey` and `RowKey` for
 querying. The tab parses `decoded_readings` JSON to extract reading names
 and values for plotting. Timestamps for the X-axis are derived from
-`timestamp_ms` (not from `RowKey`).
+`timestamp_ms`.
 
 Data is queried using the same MSAL.js bearer token as other tabs — no
 additional authentication is required. Queries use `PartitionKey` filters
-(per node or all nodes) and `RowKey` range (time window) with `$top=1000`.
+(per node) and `RowKey` range (time window) with `$top=1000`. Cross-node
+queries issue parallel per-node requests for each selected node's partition,
+since Azure Tables do not efficiently support cross-partition range scans.
 
 ### 10.2  Time-series graph (WEB-0701)
 
 Each unique `(NodeId, ProgramHash, ReadingName)` tuple is rendered as a
-separate line on a time-series chart. The X-axis is time (derived from the
-reverse-tick `RowKey`); the Y-axis is the reading value.
+separate line on a time-series chart. The X-axis is time (derived from
+`timestamp_ms`); the Y-axis is the reading value.
 
 **Controls:**
 - Time range selector: Last 1h, 24h, 7d, custom.

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -315,10 +315,9 @@ reverse-tick `RowKey`); the Y-axis is the reading value.
 - Maximum 1000 rows per query (`$top=1000`). For longer time ranges,
   the SPA downsamples by querying with wider `RowKey` strides.
 - Int64 values exceeding `Number.MAX_SAFE_INTEGER` (2^53 - 1) are displayed
-  as strings. The Azure handler MUST encode such values as JSON strings
-  (e.g., `"temperature_raw": "9007199254740993"`) in the `decoded_readings`
-  column so that `JSON.parse` preserves them. Values within safe integer
-  range are encoded as JSON numbers.
+  as strings. The Azure handler encodes such values as JSON strings in the
+  `decoded_readings` column (see AZH-0501 AC-5). The SPA MUST handle both
+  numeric and string-encoded int64 values in `decoded_readings` JSON.
 
 The chart library is vanilla JS (Canvas-based) or a lightweight dependency
 (e.g., Chart.js loaded from CDN) — no build step required, consistent with

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -22,7 +22,8 @@ Browser (SPA)
 ├── Dashboard (read actualstate table)
 ├── Desired State (read/write desiredstate table)
 ├── Program Upload (POST ELF to ProgramIngest function)
-└── Program List (read programs + programroute tables)
+├── Program List (read programs + programroute tables)
+└── Sensor Data (read sensordata table, time-series graph)
      │
      │ MSAL.js Bearer Token
      ▼
@@ -277,3 +278,53 @@ The SPA derives the Function App API scope as
 an additional `config.json` field. This works because the companion Entra
 app registration is shared between the SPA and the Function App EasyAuth
 configuration.
+
+---
+
+## 10. Sensor Data (WEB-0700)
+
+> **Requirements:** WEB-0700, WEB-0701, WEB-0702
+
+### 10.1  Data source
+
+The Sensor Data tab reads from the `SensorData` Azure Table (AZH-0500). Each
+row contains `node_id`, `program_hash`, `raw_payload`, and `decoded_readings`
+(JSON string). The tab parses `decoded_readings` JSON to extract reading names
+and values for plotting.
+
+Data is queried using the same MSAL.js bearer token as other tabs — no
+additional authentication is required. Queries use `PartitionKey` filters
+(per node or all nodes) and `RowKey` range (time window) with `$top=1000`.
+
+### 10.2  Time-series graph (WEB-0701)
+
+Each unique `(NodeId, ProgramHash, ReadingName)` tuple is rendered as a
+separate line on a time-series chart. The X-axis is time (derived from the
+reverse-tick `RowKey`); the Y-axis is the reading value.
+
+**Controls:**
+- Time range selector: Last 1h, 24h, 7d, custom.
+- Auto-refresh toggle with configurable interval (default 30s).
+- Hover tooltip: timestamp, node ID, reading name, value.
+- Series selector: checkboxes to choose which (node, program, reading)
+  combinations to display.
+
+**Scale constraints:**
+- Maximum 20 concurrent lines on the graph. If more combinations exist,
+  the admin selects which to display via the series selector.
+- Maximum 1000 rows per query (`$top=1000`). For longer time ranges,
+  the SPA downsamples by querying with wider `RowKey` strides.
+- Int64 values exceeding `Number.MAX_SAFE_INTEGER` (2^53 - 1) are displayed
+  as strings.
+
+The chart library is vanilla JS (Canvas-based) or a lightweight dependency
+(e.g., Chart.js loaded from CDN) — no build step required, consistent with
+the existing zero-build SPA architecture.
+
+### 10.3  Table view (WEB-0702)
+
+A toggle switches between graph and table views. The table displays all
+`SensorData` columns: Timestamp, Node ID, Program Hash, Decoded Readings,
+Raw Payload (truncated). Sorted by timestamp descending (newest first).
+Rows with empty `decoded_readings` display "—" in the Decoded Readings
+column.

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -288,9 +288,11 @@ configuration.
 ### 10.1  Data source
 
 The Sensor Data tab reads from the `SensorData` Azure Table (AZH-0500). Each
-row contains `node_id`, `program_hash`, `raw_payload`, and `decoded_readings`
-(JSON string). The tab parses `decoded_readings` JSON to extract reading names
-and values for plotting.
+row contains `node_id`, `timestamp_ms`, `program_hash`, `raw_payload`, and
+`decoded_readings` (JSON string), plus `PartitionKey` and `RowKey` for
+querying. The tab parses `decoded_readings` JSON to extract reading names
+and values for plotting. Timestamps for the X-axis are derived from
+`timestamp_ms` (not from `RowKey`).
 
 Data is queried using the same MSAL.js bearer token as other tabs — no
 additional authentication is required. Queries use `PartitionKey` filters

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -313,7 +313,9 @@ reverse-tick `RowKey`); the Y-axis is the reading value.
 - Maximum 20 concurrent lines on the graph. If more combinations exist,
   the admin selects which to display via the series selector.
 - Maximum 1000 rows per query (`$top=1000`). For longer time ranges,
-  the SPA downsamples by querying with wider `RowKey` strides.
+  the SPA downsamples client-side: fetch up to 1000 rows for the
+  requested window, then thin the data points to a displayable density
+  (e.g., pick one point per pixel or per time bucket).
 - Int64 values exceeding `Number.MAX_SAFE_INTEGER` (2^53 - 1) are displayed
   as strings. The Azure handler encodes such values as JSON strings in the
   `decoded_readings` column (see AZH-0501 AC-5). The SPA MUST handle both

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -53,5 +53,5 @@
 | T-WEB-0702 | WEB-0701 | Time-series graph renders lines per (node, program, reading) | Manual/E2E | Planned |
 | T-WEB-0703 | WEB-0701 | Time range selector filters data correctly | Manual/E2E | Planned |
 | T-WEB-0704 | WEB-0702 | Table view shows all SensorData columns | Manual/E2E | Planned |
-| T-WEB-0705 | WEB-0700 | SPA handles empty `decoded_readings` gracefully (shows "—") | Manual/E2E | Planned |
+| T-WEB-0705 | WEB-0702 | SPA handles empty `decoded_readings` gracefully (shows "—") | Manual/E2E | Planned |
 | T-WEB-0706 | WEB-0701 | SPA handles int64 values near `Number.MAX_SAFE_INTEGER` | Manual | Planned |

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -49,3 +49,9 @@
 | T-WEB-0605 | WEB-0605 | Function identity has table contributor on `programs` | Infrastructure | Planned |
 | T-WEB-0606 | WEB-0606 | EasyAuth configured on Function App with Entra ID provider | Infrastructure | Planned |
 | T-WEB-0607 | WEB-0607 | `ProgramIngest` `authLevel` is `anonymous` (auth delegated to EasyAuth) | Infrastructure | Planned |
+| T-WEB-0701 | WEB-0700 | Sensor Data tab appears in tab bar and loads data from `SensorData` table | Manual/E2E | Planned |
+| T-WEB-0702 | WEB-0701 | Time-series graph renders lines per (node, program, reading) | Manual/E2E | Planned |
+| T-WEB-0703 | WEB-0701 | Time range selector filters data correctly | Manual/E2E | Planned |
+| T-WEB-0704 | WEB-0702 | Table view shows all SensorData columns | Manual/E2E | Planned |
+| T-WEB-0705 | WEB-0700 | SPA handles empty `decoded_readings` gracefully (shows "—") | Manual/E2E | Planned |
+| T-WEB-0706 | WEB-0701 | SPA handles int64 values near `Number.MAX_SAFE_INTEGER` | Manual | Planned |

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -54,4 +54,4 @@
 | T-WEB-0703 | WEB-0701 | Time range selector filters data correctly | Manual/E2E | Planned |
 | T-WEB-0704 | WEB-0702 | Table view shows all SensorData columns | Manual/E2E | Planned |
 | T-WEB-0705 | WEB-0702 | SPA handles empty `decoded_readings` gracefully (shows "—") | Manual/E2E | Planned |
-| T-WEB-0706 | WEB-0701 | SPA handles int64 values near `Number.MAX_SAFE_INTEGER` | Manual | Planned |
+| T-WEB-0706 | WEB-0701 | SPA displays string-encoded int64 values (above `Number.MAX_SAFE_INTEGER`) correctly and renders in-range values as numbers | Manual | Planned |


### PR DESCRIPTION
## Summary

Specification for **BPF decoder programs** — a single ELF file containing two BPF sections:
- `SEC("sonde")` — node program (runs on ESP32, collects sensor data)
- `SEC("decoder")` — decoder program (runs in gateway, decodes raw bytes into named readings)

The gateway executes the decoder on incoming `APP_DATA`, enriches the CBOR message with a `readings` map (key 16), and forwards enriched data to handlers and the connector. The Azure handler stores enriched data in a `SensorData` table. The SPA gains a Sensor Data tab with time-series visualization.

## Motivation

Today, adding a new sensor type requires:
1. Writing a BPF program for the node
2. Writing a separate handler process or Azure Function
3. Configuring routes, queues, and storage tables manually
4. Building custom visualization

With decoder programs, the admin uploads a **single ELF file** and everything works automatically — the gateway decodes sensor data, the Azure handler stores it, and the SPA visualizes it.

## Requirements (13 new)

| ID Range | Component | Description |
|----------|-----------|-------------|
| GW-1900–1906 | Gateway | Decoder extraction, `DecoderPlatform` verification, storage, APP_DATA enrichment, `emit_reading` helper (ID 18), backward compat, hash stability |
| AZH-0500–0502 | Azure Handler | `SensorData` table with decoded readings JSON |
| WEB-0700–0702 | Web UI | Sensor Data tab with time-series graph |

## Design Highlights

- **Single artifact**: One ELF → two `ProgramImage`s (node + decoder), separate Prevail verification
- **Node hash unchanged**: Decoder bytecode excluded from `program_hash` — no unnecessary re-downloads
- **Safe extensibility**: BPF sandbox ensures decoder programs can't escape (same verifier as node programs)
- **Restricted helpers**: Decoder gets only `emit_reading` (ID 18), `map_lookup_elem`, `map_update_elem`, `bpf_trace_printk`
- **Enrichment as sibling field**: Raw `blob` preserved byte-for-byte; `readings` (key 16) added alongside
- **Failure-safe**: Decoder failures log + forward unenriched message
- **Limits**: Max 32 readings, 64B per name, 2048B total names per execution

## Docs Changed (10 files, +914 lines)

- `docs/gateway-requirements.md` — GW-1900–1906
- `docs/gateway-design.md` — `ProgramRecord.decoder_image`, ingestion steps 11–13, `DecoderPlatform` (§8.2.2), enrichment (§9.2)
- `docs/gateway-validation.md` — 18 new test cases (T-1900 series)
- `docs/protocol.md` — CBOR key 16, decoder image docs
- `docs/bpf-environment.md` — decoder class (§2.3), `decoder_context` (§4.2), `emit_reading` (§6.6), verification profile
- `docs/azure-handler-requirements.md` — AZH-0500–0502
- `docs/azure-handler-design.md` — `SensorData` table schema (§6.1)
- `docs/azure-handler-validation.md` — 5 new test cases
- `docs/web-ui-design.md` — Sensor Data tab (§10)
- `docs/web-ui-validation.md` — 6 new test cases

## No Code Changes

This is a **spec-only PR**. Implementation will follow in a separate PR.