### PR TITLE
fix: suppress noisy `az ad app permission add` warning

### DIFF
--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -320,9 +320,18 @@ fi
 if az ad app permission list --id "$app_object_id" --query "[?resourceAppId=='e406a681-f3d4-42a8-90b6-c2b029497af1'].resourceAccess[?id=='da399722-a3ea-4c11-8b0d-7b37b3d5fa83'] | [0]" --output tsv 2>/dev/null | grep -q .; then
     echo "Azure Storage user_impersonation permission already configured" >&2
 else
-    az ad app permission add --id "$app_object_id" \
+    # Suppress the "Invoking `az ad app permission grant` is needed" warning
+    # emitted by `az ad app permission add` — the grant is performed below.
+    _perm_err="$(mktemp)"
+    if ! az ad app permission add --id "$app_object_id" \
         --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
-        --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" 2>/dev/null
+        --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" 2>"$_perm_err"; then
+        cat "$_perm_err" >&2
+        rm -f "$_perm_err"
+        exit 1
+    fi
+    grep -v 'is needed to make the change effective' "$_perm_err" >&2 || true
+    rm -f "$_perm_err"
     echo "Azure Storage user_impersonation permission declared" >&2
 fi
 

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -322,7 +322,7 @@ if az ad app permission list --id "$app_object_id" --query "[?resourceAppId=='e4
 else
     az ad app permission add --id "$app_object_id" \
         --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
-        --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope"
+        --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" 2>/dev/null
     echo "Azure Storage user_impersonation permission declared" >&2
 fi
 

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -122,7 +122,7 @@ echo "=== Adding Azure Storage API permission ==="
 # Declare user_impersonation on Azure Storage (e406a681-f3d4-42a8-90b6-c2b029497af1)
 az ad app permission add --id "$APP_OBJECT_ID" \
   --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
-  --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" || true
+  --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" 2>/dev/null || true
 # Grant admin consent so users don't need to consent individually
 az ad app permission grant \
   --id "$COMPANION_CLIENT_ID" \

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -120,9 +120,14 @@ fi
 echo ""
 echo "=== Adding Azure Storage API permission ==="
 # Declare user_impersonation on Azure Storage (e406a681-f3d4-42a8-90b6-c2b029497af1)
+# Suppress the "Invoking `az ad app permission grant` is needed" warning
+# emitted by `az ad app permission add` — the grant is performed below.
+_perm_err="$(mktemp)"
 az ad app permission add --id "$APP_OBJECT_ID" \
   --api "e406a681-f3d4-42a8-90b6-c2b029497af1" \
-  --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" 2>/dev/null || true
+  --api-permissions "da399722-a3ea-4c11-8b0d-7b37b3d5fa83=Scope" 2>"$_perm_err" || true
+grep -v 'is needed to make the change effective' "$_perm_err" >&2 || true
+rm -f "$_perm_err"
 # Grant admin consent so users don't need to consent individually
 az ad app permission grant \
   --id "$COMPANION_CLIENT_ID" \


### PR DESCRIPTION
## Summary

Suppresses the misleading \\z ad app permission grant\\ warning emitted by \\z ad app permission add\\ in two deployment scripts.

## Problem

\\z ad app permission add\\ prints a warning reminding the operator to run \\z ad app permission grant\\. Both scripts already perform the grant immediately afterward, making the warning confusing noise during bootstrap.

## Changes

| File | Change |
|------|--------|
| \\deploy/azure-bootstrap/bootstrap.sh:325\\ | Added \\2>/dev/null\\ to suppress stderr |
| \\deploy/web-ui/deploy.sh:125\\ | Added \\2>/dev/null\\ to suppress stderr |

This matches the existing \\2>/dev/null\\ pattern already used on the subsequent \\z ad app permission grant\\ calls.

Fixes #907