### PR TITLE
feat(gateway): decoder BPF programs for APP_DATA enrichment (GW-1900-GW-1906)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6586,6 +6586,7 @@ dependencies = [
  "serde_yaml_ng",
  "serial2-tokio",
  "sha2 0.10.9",
+ "sonde-bpf",
  "sonde-protocol",
  "tempfile",
  "tokio",

--- a/crates/sonde-admin/tests/integration.rs
+++ b/crates/sonde-admin/tests/integration.rs
@@ -182,6 +182,7 @@ async fn seed_program(
             verification_profile: VerificationProfile::Resident,
             abi_version: None,
             source_filename: source_filename.map(str::to_string),
+            decoder_image: None,
         })
         .await
         .unwrap();

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -43,6 +43,7 @@ fn make_program_from_bytecode(bytecode: &[u8]) -> (ProgramRecord, Vec<u8>) {
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let sha = TestSha256;
@@ -896,6 +897,7 @@ async fn t_e2e_022_run_ephemeral_via_admin() {
         bytecode: nop_bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let eph_cbor = eph_image.encode_deterministic().unwrap();
     let sha = TestSha256;

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -55,6 +55,7 @@ fn make_program_from_bytecode(bytecode: &[u8]) -> (ProgramRecord, Vec<u8>) {
         verification_profile: VerificationProfile::Resident,
         abi_version: None,
         source_filename: None,
+        decoder_image: None,
     };
     (record, hash)
 }
@@ -906,6 +907,7 @@ async fn t_e2e_022_run_ephemeral_via_admin() {
         verification_profile: VerificationProfile::Ephemeral,
         abi_version: None,
         source_filename: None,
+        decoder_image: None,
     };
     env.storage.store_program(&eph_program).await.unwrap();
 

--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -53,6 +53,7 @@ fn make_program_from_bytecode(
         verification_profile: profile,
         abi_version: None,
         source_filename: None,
+        decoder_image: None,
     };
     (record, hash)
 }
@@ -1381,6 +1382,7 @@ async fn t_e2e_081_ephemeral_restrictions() {
         verification_profile: VerificationProfile::Resident,
         abi_version: None,
         source_filename: None,
+        decoder_image: None,
     };
     env.storage.store_program(&resident_record).await.unwrap();
 
@@ -1523,6 +1525,7 @@ async fn t_e2e_080_map_access_through_full_stack() {
         verification_profile: VerificationProfile::Resident,
         abi_version: None,
         source_filename: None,
+        decoder_image: None,
     };
     env.storage.store_program(&program).await.unwrap();
 

--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -41,6 +41,7 @@ fn make_program_from_bytecode(
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let sha = TestSha256;
@@ -1370,6 +1371,7 @@ async fn t_e2e_081_ephemeral_restrictions() {
             max_entries: 1,
         }],
         map_initial_data: vec![vec![]],
+        map_readonly: vec![false; 1],
     };
     let resident_cbor = resident_image.encode_deterministic().unwrap();
     let sha = TestSha256;
@@ -1513,6 +1515,7 @@ async fn t_e2e_080_map_access_through_full_stack() {
             max_entries: 1,
         }],
         map_initial_data: vec![vec![0x42, 0x00, 0x00, 0x00]],
+        map_readonly: vec![false; 1],
     };
     let cbor = image.encode_deterministic().unwrap();
     let sha = TestSha256;

--- a/crates/sonde-e2e/tests/modem_bridge_tests.rs
+++ b/crates/sonde-e2e/tests/modem_bridge_tests.rs
@@ -391,6 +391,7 @@ fn make_program_from_bytecode(bytecode: &[u8]) -> (ProgramRecord, Vec<u8>) {
         verification_profile: VerificationProfile::Resident,
         abi_version: None,
         source_filename: None,
+        decoder_image: None,
     };
     (record, hash)
 }

--- a/crates/sonde-e2e/tests/modem_bridge_tests.rs
+++ b/crates/sonde-e2e/tests/modem_bridge_tests.rs
@@ -377,6 +377,7 @@ fn make_program_from_bytecode(bytecode: &[u8]) -> (ProgramRecord, Vec<u8>) {
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image
         .encode_deterministic()

--- a/crates/sonde-gateway/Cargo.toml
+++ b/crates/sonde-gateway/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 sonde-protocol = { path = "../sonde-protocol" }
+sonde-bpf = { path = "../sonde-bpf" }
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 sha2 = "0.10"

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -2093,6 +2093,7 @@ mod tests {
             verification_profile: sonde_gateway::program::VerificationProfile::Resident,
             abi_version: None,
             source_filename: source_filename.map(str::to_string),
+            decoder_image: None,
         }
     }
 

--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -76,6 +76,8 @@ enum ConnectorOutboundMessage {
         payload: Vec<u8>,
         timestamp_ms: u64,
         payload_origin: ConnectorPayloadOrigin,
+        /// Decoded sensor readings from decoder BPF execution (GW-1903).
+        readings: Option<std::collections::BTreeMap<String, i64>>,
     },
     Health {
         health_state: ConnectorHealthState,
@@ -118,14 +120,28 @@ impl ConnectorOutboundMessage {
                 payload,
                 timestamp_ms,
                 payload_origin,
-            } => Value::Map(vec![
-                map_entry(1, Value::Integer(MSG_TYPE_APP_DATA.into())),
-                map_entry(2, Value::Text(node_id.clone())),
-                map_entry(3, Value::Bytes(program_hash.clone())),
-                map_entry(4, Value::Bytes(payload.clone())),
-                map_entry(5, Value::Integer((*timestamp_ms).into())),
-                map_entry(6, Value::Text(payload_origin.as_str().to_string())),
-            ]),
+                readings,
+            } => {
+                let mut pairs = vec![
+                    map_entry(1, Value::Integer(MSG_TYPE_APP_DATA.into())),
+                    map_entry(2, Value::Text(node_id.clone())),
+                    map_entry(3, Value::Bytes(program_hash.clone())),
+                    map_entry(4, Value::Bytes(payload.clone())),
+                    map_entry(5, Value::Integer((*timestamp_ms).into())),
+                    map_entry(6, Value::Text(payload_origin.as_str().to_string())),
+                ];
+                // GW-1903: append readings at CBOR key 16 when present.
+                if let Some(ref readings_map) = readings {
+                    let readings_cbor = Value::Map(
+                        readings_map
+                            .iter()
+                            .map(|(k, v)| (Value::Text(k.clone()), Value::Integer((*v).into())))
+                            .collect(),
+                    );
+                    pairs.push(map_entry(16, readings_cbor));
+                }
+                Value::Map(pairs)
+            }
             Self::Health {
                 health_state,
                 timestamp_ms,
@@ -217,6 +233,7 @@ impl ConnectorEventHub {
         payload: Vec<u8>,
         timestamp_ms: u64,
         payload_origin: ConnectorPayloadOrigin,
+        readings: Option<std::collections::BTreeMap<String, i64>>,
     ) {
         let _ = self.tx.send(ConnectorOutboundMessage::AppData {
             node_id,
@@ -224,6 +241,7 @@ impl ConnectorEventHub {
             payload,
             timestamp_ms,
             payload_origin,
+            readings,
         });
     }
 

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -45,12 +45,24 @@ impl std::error::Error for DecoderError {}
 
 // ── Thread-local readings collection ────────────────────────────────────
 
+/// Metadata for a single map during decoder execution.
+struct MapInfo {
+    /// The `relocated_ptr` value that identifies this map in BPF registers.
+    relocated_ptr: u64,
+    /// Start address of the map backing storage.
+    data_start: u64,
+    /// Size of each value in bytes.
+    value_size: u32,
+    /// Number of entries (array length).
+    max_entries: u32,
+}
+
 /// State collected during a single decoder execution.
 struct DecoderState {
     readings: BTreeMap<String, i64>,
     count: usize,
-    /// Per-map read-only flag: true if the map is .rodata (writes rejected).
-    map_readonly: Vec<bool>,
+    /// Map metadata for helper implementations.
+    map_infos: Vec<MapInfo>,
 }
 
 thread_local! {
@@ -61,12 +73,12 @@ thread_local! {
 struct DecoderStateGuard;
 
 impl DecoderStateGuard {
-    fn install(map_readonly: Vec<bool>) -> Self {
+    fn install(map_infos: Vec<MapInfo>) -> Self {
         DECODER_STATE.with(|cell| {
             *cell.borrow_mut() = Some(DecoderState {
                 readings: BTreeMap::new(),
                 count: 0,
-                map_readonly,
+                map_infos,
             });
         });
         DecoderStateGuard
@@ -91,6 +103,14 @@ impl Drop for DecoderStateGuard {
 }
 
 // ── BPF helper implementations ─────────────────────────────────────────
+
+/// Find a map by its `relocated_ptr` value.
+fn find_map(state: &DecoderState, relocated_ptr: u64) -> Option<&MapInfo> {
+    state
+        .map_infos
+        .iter()
+        .find(|m| m.relocated_ptr == relocated_ptr)
+}
 
 /// Helper 18: emit_reading(name_ptr, name_len, value_i64, _, _) -> 0 | -1 | -2
 ///
@@ -149,27 +169,81 @@ fn helper_emit_reading(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
 
 /// Helper 10: map_lookup_elem(map_fd, key_ptr) -> value_ptr or null
 ///
-/// Standard BPF map lookup — handled entirely by the interpreter's
-/// built-in map support. This is a pass-through.
-fn helper_map_lookup(_r1: u64, _r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
-    // The interpreter handles map_lookup_elem internally via MapRegion.
-    // This should not be called directly. Return null.
-    0
+/// For array maps: key is a u32 index, returns pointer to the value at
+/// `data_start + index * value_size`. Returns 0 (null) if out of bounds.
+fn helper_map_lookup(r1: u64, r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
+    let map_fd = r1;
+    let key_ptr = r2 as *const u8;
+
+    if key_ptr.is_null() {
+        return 0;
+    }
+
+    DECODER_STATE.with(|cell| {
+        let state = cell.borrow();
+        let state = match state.as_ref() {
+            Some(s) => s,
+            None => return 0,
+        };
+        let map = match find_map(state, map_fd) {
+            Some(m) => m,
+            None => return 0,
+        };
+
+        // Read key as u32 index.
+        // SAFETY: key_ptr was validated by the interpreter (PtrToMapKey).
+        let key_index = unsafe { *(key_ptr as *const u32) };
+
+        if key_index >= map.max_entries {
+            return 0; // out of bounds → null
+        }
+
+        // Return pointer to value at data_start + index * value_size.
+        let offset = key_index as u64 * map.value_size as u64;
+        map.data_start + offset
+    })
 }
 
 /// Helper 11: map_update_elem(map_fd, key_ptr, value_ptr) -> 0 or error
 ///
-/// For .rodata maps, returns error (-1). Otherwise handled by interpreter.
-fn helper_map_update(r1: u64, _r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
-    // Check if the map is read-only (.rodata).
-    let map_idx = r1 as usize;
+/// For array maps: copies `value_size` bytes from `value_ptr` into the map
+/// at the index given by `*key_ptr`.
+fn helper_map_update(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
+    let map_fd = r1;
+    let key_ptr = r2 as *const u8;
+    let value_ptr = r3 as *const u8;
+
+    if key_ptr.is_null() || value_ptr.is_null() {
+        return (-1i64) as u64;
+    }
+
     DECODER_STATE.with(|cell| {
         let state = cell.borrow();
-        if let Some(ref s) = *state {
-            if map_idx < s.map_readonly.len() && s.map_readonly[map_idx] {
-                return (-1i64) as u64; // .rodata — write rejected
-            }
+        let state = match state.as_ref() {
+            Some(s) => s,
+            None => return (-1i64) as u64,
+        };
+        let map = match find_map(state, map_fd) {
+            Some(m) => m,
+            None => return (-1i64) as u64,
+        };
+
+        // SAFETY: pointers validated by the interpreter.
+        let key_index = unsafe { *(key_ptr as *const u32) };
+
+        if key_index >= map.max_entries {
+            return (-1i64) as u64;
         }
+
+        let offset = key_index as u64 * map.value_size as u64;
+        let dst = (map.data_start + offset) as *mut u8;
+
+        // SAFETY: dst is within the map backing storage (heap-allocated Vec<u8>
+        // that outlives this call), and value_ptr is within a valid BPF region.
+        unsafe {
+            std::ptr::copy_nonoverlapping(value_ptr, dst, map.value_size as usize);
+        }
+
         0u64
     })
 }
@@ -230,38 +304,26 @@ pub fn execute_decoder(
     let image = ProgramImage::decode(decoder_image_cbor)
         .map_err(|e| DecoderError::ImageDecodeError(format!("{e}")))?;
 
-    // Determine which maps are read-only (.rodata).
-    // Convention: map_type == 0 maps with non-empty initial_data that exactly
-    // fills the value_size are considered read-only (from .rodata). Maps with
-    // empty initial_data (from .bss) or map_type != 0 are writable.
-    // This is a heuristic — a more precise approach would track provenance
-    // from the ELF section name, but for decoder maps this is sufficient
-    // since .rodata always has initial data and .bss/.data patterns differ.
-    //
-    // NOTE: This heuristic treats .data maps (which also have initial data)
-    // as read-only, which is actually correct for decoder semantics — decoder
-    // maps are ephemeral and reset each execution, so there's no persistence
-    // concern. The spec says .data maps ARE writable though, so we only mark
-    // map_type==0 maps as readonly if they have initial data. This matches
-    // .rodata behavior. For .data (also map_type==0 with initial data), we
-    // cannot distinguish from .rodata using ProgramImage alone.
-    // For safety, we'll treat ALL map_type==0 maps as writable (the program
-    // resets each time anyway), and only enforce read-only at the verifier
-    // level (DecoderPlatform prevents writes to .rodata via Prevail checks).
-    let map_readonly: Vec<bool> = image
-        .maps
-        .iter()
-        .map(|_| false) // All maps writable at runtime; verifier enforces .rodata
-        .collect();
-
     // Allocate and initialize map storage.
     let mut map_backing: Vec<Vec<u8>> = Vec::with_capacity(image.maps.len());
     let mut map_regions: Vec<MapRegion> = Vec::with_capacity(image.maps.len());
+    let mut map_infos: Vec<MapInfo> = Vec::with_capacity(image.maps.len());
 
     for (i, map_def) in image.maps.iter().enumerate() {
         let total_size = (map_def.value_size as usize)
             .checked_mul(map_def.max_entries as usize)
-            .unwrap_or(0);
+            .ok_or_else(|| {
+                DecoderError::ImageDecodeError(format!(
+                    "map {i}: value_size * max_entries overflow ({} * {})",
+                    map_def.value_size, map_def.max_entries
+                ))
+            })?;
+        if total_size == 0 {
+            return Err(DecoderError::ImageDecodeError(format!(
+                "map {i}: zero-size map (value_size={}, max_entries={})",
+                map_def.value_size, map_def.max_entries
+            )));
+        }
         let mut backing = vec![0u8; total_size];
 
         // Initialize from initial_data if present.
@@ -275,16 +337,11 @@ pub fn execute_decoder(
         map_backing.push(backing);
     }
 
-    // Build MapRegion descriptors pointing to the backing storage.
-    // Use a two-pass approach: first allocate all backing, then build regions.
-    // This avoids lifetime issues with Vec reallocation.
+    // Build MapRegion descriptors and MapInfo entries pointing to backing storage.
     for (i, map_def) in image.maps.iter().enumerate() {
         let backing = &map_backing[i];
         let base_ptr = backing.as_ptr() as u64;
         let end_ptr = base_ptr + backing.len() as u64;
-
-        // relocated_ptr: the "fd" value that BPF LDDW instructions resolve to.
-        // In sonde-bpf, map indices start at 1 for the first map.
         let relocated_ptr = (i + 1) as u64;
 
         map_regions.push(MapRegion {
@@ -292,6 +349,13 @@ pub fn execute_decoder(
             value_size: map_def.value_size,
             data_start: base_ptr,
             data_end: end_ptr,
+        });
+
+        map_infos.push(MapInfo {
+            relocated_ptr,
+            data_start: base_ptr,
+            value_size: map_def.value_size,
+            max_entries: map_def.max_entries,
         });
     }
 
@@ -313,7 +377,7 @@ pub fn execute_decoder(
     ctx_buf[8..16].copy_from_slice(&blob_end_addr.to_le_bytes());
 
     // Install thread-local state and execute.
-    let guard = DecoderStateGuard::install(map_readonly);
+    let guard = DecoderStateGuard::install(map_infos);
     let helpers = decoder_helpers();
 
     let result = if map_regions.is_empty() {

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -23,6 +23,12 @@ const MAX_NAME_LEN: usize = 64;
 /// Instruction budget for decoder programs — same as ephemeral.
 const DECODER_INSTRUCTION_BUDGET: u64 = 100_000;
 
+/// Maximum total map backing memory per decoder execution (64 KiB).
+const MAX_DECODER_MAP_MEMORY: usize = 64 * 1024;
+
+/// Maximum number of maps a decoder program may declare.
+const MAX_DECODER_MAPS: usize = 16;
+
 /// Errors from decoder execution.
 #[derive(Debug)]
 pub enum DecoderError {
@@ -248,8 +254,10 @@ fn helper_map_update(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
 
         // SAFETY: dst is within the map backing storage (heap-allocated Vec<u8>
         // that outlives this call), and value_ptr is within a valid BPF region.
+        // Use `copy` (not `copy_nonoverlapping`) because value_ptr may alias
+        // dst when a program updates a map entry from a lookup on the same key.
         unsafe {
-            std::ptr::copy_nonoverlapping(value_ptr, dst, map.value_size as usize);
+            std::ptr::copy(value_ptr, dst, map.value_size as usize);
         }
 
         0u64
@@ -304,6 +312,15 @@ fn decoder_helpers() -> Vec<HelperDescriptor> {
 /// Returns the collected readings on success, or an error if execution fails.
 /// This function is synchronous — call it from `spawn_blocking` in async
 /// contexts to avoid blocking the tokio event loop.
+///
+/// # Safety precondition
+///
+/// `decoder_image_cbor` **must** be a CBOR image that was previously verified
+/// by Prevail via `DecoderPlatform` during ELF ingestion (`extract_decoder`).
+/// Executing unverified bytecode can cause undefined behavior because BPF
+/// helper functions dereference raw register values as host pointers, relying
+/// on the verifier to guarantee that pointer arguments are within valid
+/// memory regions.
 pub fn execute_decoder(
     decoder_image_cbor: &[u8],
     raw_blob: &[u8],
@@ -312,12 +329,28 @@ pub fn execute_decoder(
     let image = ProgramImage::decode(decoder_image_cbor)
         .map_err(|e| DecoderError::ImageDecodeError(format!("{e}")))?;
 
+    // Validate map count.
+    if image.maps.len() > MAX_DECODER_MAPS {
+        return Err(DecoderError::ImageDecodeError(format!(
+            "decoder declares {} maps, max is {MAX_DECODER_MAPS}",
+            image.maps.len()
+        )));
+    }
+
     // Allocate and initialize map storage.
     let mut map_backing: Vec<Vec<u8>> = Vec::with_capacity(image.maps.len());
     let mut map_regions: Vec<MapRegion> = Vec::with_capacity(image.maps.len());
     let mut map_infos: Vec<MapInfo> = Vec::with_capacity(image.maps.len());
+    let mut total_map_memory: usize = 0;
 
     for (i, map_def) in image.maps.iter().enumerate() {
+        // Decoder maps must be array-style with u32 keys.
+        if map_def.key_size != 4 {
+            return Err(DecoderError::ImageDecodeError(format!(
+                "map {i}: unsupported key_size {} (expected 4)",
+                map_def.key_size
+            )));
+        }
         let total_size = (map_def.value_size as usize)
             .checked_mul(map_def.max_entries as usize)
             .ok_or_else(|| {
@@ -330,6 +363,12 @@ pub fn execute_decoder(
             return Err(DecoderError::ImageDecodeError(format!(
                 "map {i}: zero-size map (value_size={}, max_entries={})",
                 map_def.value_size, map_def.max_entries
+            )));
+        }
+        total_map_memory = total_map_memory.saturating_add(total_size);
+        if total_map_memory > MAX_DECODER_MAP_MEMORY {
+            return Err(DecoderError::ImageDecodeError(format!(
+                "decoder map memory ({total_map_memory} bytes) exceeds limit ({MAX_DECODER_MAP_MEMORY})"
             )));
         }
         let mut backing = vec![0u8; total_size];

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Decoder BPF execution engine (GW-1903, GW-1904).
+//!
+//! Executes decoder BPF programs on the gateway to enrich APP_DATA messages
+//! with named sensor readings before forwarding to handlers and connectors.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::fmt;
+
+use sonde_bpf::interpreter::{self, BpfError, HelperDescriptor, HelperReturn, MapRegion};
+use sonde_protocol::ProgramImage;
+use tracing::warn;
+
+/// Maximum number of readings per decoder execution (GW-1904).
+const MAX_READINGS: usize = 32;
+
+/// Maximum name length in bytes for a single reading (GW-1904).
+const MAX_NAME_LEN: usize = 64;
+
+/// Instruction budget for decoder programs — same as ephemeral.
+const DECODER_INSTRUCTION_BUDGET: u64 = 100_000;
+
+/// Errors from decoder execution.
+#[derive(Debug)]
+pub enum DecoderError {
+    /// Failed to decode the decoder image CBOR.
+    ImageDecodeError(String),
+    /// BPF interpreter error.
+    ExecutionError(BpfError),
+}
+
+impl fmt::Display for DecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecoderError::ImageDecodeError(msg) => write!(f, "decoder image decode error: {msg}"),
+            DecoderError::ExecutionError(e) => write!(f, "decoder execution error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for DecoderError {}
+
+// ── Thread-local readings collection ────────────────────────────────────
+
+/// State collected during a single decoder execution.
+struct DecoderState {
+    readings: BTreeMap<String, i64>,
+    count: usize,
+    /// Per-map read-only flag: true if the map is .rodata (writes rejected).
+    map_readonly: Vec<bool>,
+}
+
+thread_local! {
+    static DECODER_STATE: RefCell<Option<DecoderState>> = const { RefCell::new(None) };
+}
+
+/// RAII guard that installs and clears thread-local decoder state.
+struct DecoderStateGuard;
+
+impl DecoderStateGuard {
+    fn install(map_readonly: Vec<bool>) -> Self {
+        DECODER_STATE.with(|cell| {
+            *cell.borrow_mut() = Some(DecoderState {
+                readings: BTreeMap::new(),
+                count: 0,
+                map_readonly,
+            });
+        });
+        DecoderStateGuard
+    }
+
+    fn take_readings(&self) -> BTreeMap<String, i64> {
+        DECODER_STATE.with(|cell| {
+            cell.borrow()
+                .as_ref()
+                .map(|s| s.readings.clone())
+                .unwrap_or_default()
+        })
+    }
+}
+
+impl Drop for DecoderStateGuard {
+    fn drop(&mut self) {
+        DECODER_STATE.with(|cell| {
+            *cell.borrow_mut() = None;
+        });
+    }
+}
+
+// ── BPF helper implementations ─────────────────────────────────────────
+
+/// Helper 18: emit_reading(name_ptr, name_len, value_i64, _, _) -> 0 | -1 | -2
+///
+/// The name_ptr and name_len refer to the BPF program's virtual address space.
+/// We cannot dereference them directly — the interpreter resolves them to
+/// actual memory before calling the helper (via PtrToReadableMem + ConstSize).
+///
+/// However, the sonde-bpf helper calling convention passes raw register values.
+/// The name bytes are in BPF memory at the address pointed to by r1. Since
+/// the interpreter validates the pointer before calling us, we can safely
+/// read from that address.
+fn helper_emit_reading(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
+    let name_ptr = r1 as *const u8;
+    let name_len = r2 as usize;
+    let value = r3 as i64;
+
+    if name_len > MAX_NAME_LEN {
+        return (-1i64) as u64;
+    }
+
+    DECODER_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        let state = match state.as_mut() {
+            Some(s) => s,
+            None => return (-1i64) as u64,
+        };
+
+        // Check if adding a new unique name would exceed the limit.
+        // Last-write-wins: updating an existing name doesn't count as new.
+        let name = if name_len > 0 && !name_ptr.is_null() {
+            // SAFETY: The BPF interpreter validated the pointer and length
+            // before calling this helper. The memory is within a valid BPF
+            // region (context or stack) and remains live during execution.
+            let bytes = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
+            match std::str::from_utf8(bytes) {
+                Ok(s) => s.to_owned(),
+                Err(_) => return (-1i64) as u64,
+            }
+        } else {
+            return (-1i64) as u64;
+        };
+
+        // If this is a new name (not overwrite), check the count limit.
+        if !state.readings.contains_key(&name) {
+            if state.count >= MAX_READINGS {
+                warn!("decoder emit_reading overflow: limit of {MAX_READINGS} readings exceeded");
+                return (-2i64) as u64;
+            }
+            state.count += 1;
+        }
+
+        state.readings.insert(name, value);
+        0u64
+    })
+}
+
+/// Helper 10: map_lookup_elem(map_fd, key_ptr) -> value_ptr or null
+///
+/// Standard BPF map lookup — handled entirely by the interpreter's
+/// built-in map support. This is a pass-through.
+fn helper_map_lookup(_r1: u64, _r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
+    // The interpreter handles map_lookup_elem internally via MapRegion.
+    // This should not be called directly. Return null.
+    0
+}
+
+/// Helper 11: map_update_elem(map_fd, key_ptr, value_ptr) -> 0 or error
+///
+/// For .rodata maps, returns error (-1). Otherwise handled by interpreter.
+fn helper_map_update(r1: u64, _r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
+    // Check if the map is read-only (.rodata).
+    let map_idx = r1 as usize;
+    DECODER_STATE.with(|cell| {
+        let state = cell.borrow();
+        if let Some(ref s) = *state {
+            if map_idx < s.map_readonly.len() && s.map_readonly[map_idx] {
+                return (-1i64) as u64; // .rodata — write rejected
+            }
+        }
+        0u64
+    })
+}
+
+/// Helper 16: bpf_trace_printk(fmt_ptr, fmt_len, ...) -> 0
+fn helper_trace_printk(r1: u64, r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
+    let fmt_ptr = r1 as *const u8;
+    let fmt_len = r2 as usize;
+
+    if !fmt_ptr.is_null() && fmt_len > 0 {
+        // SAFETY: pointer validated by interpreter before call.
+        let bytes = unsafe { std::slice::from_raw_parts(fmt_ptr, fmt_len) };
+        if let Ok(msg) = std::str::from_utf8(bytes) {
+            tracing::debug!(target: "decoder_bpf", "{}", msg.trim_end());
+        }
+    }
+    0
+}
+
+/// Decoder helper descriptors for the BPF interpreter.
+fn decoder_helpers() -> Vec<HelperDescriptor> {
+    vec![
+        HelperDescriptor {
+            id: 10,
+            func: helper_map_lookup,
+            ret: HelperReturn::MapValueOrNull { map_arg: 1 },
+        },
+        HelperDescriptor {
+            id: 11,
+            func: helper_map_update,
+            ret: HelperReturn::Scalar,
+        },
+        HelperDescriptor {
+            id: 16,
+            func: helper_trace_printk,
+            ret: HelperReturn::Scalar,
+        },
+        HelperDescriptor {
+            id: 18,
+            func: helper_emit_reading,
+            ret: HelperReturn::Scalar,
+        },
+    ]
+}
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+/// Execute a decoder BPF program on raw APP_DATA bytes.
+///
+/// Returns the collected readings on success, or an error if execution fails.
+/// This function is synchronous — call it from `spawn_blocking` in async
+/// contexts to avoid blocking the tokio event loop.
+pub fn execute_decoder(
+    decoder_image_cbor: &[u8],
+    raw_blob: &[u8],
+) -> Result<BTreeMap<String, i64>, DecoderError> {
+    // Decode the ProgramImage from CBOR.
+    let image = ProgramImage::decode(decoder_image_cbor)
+        .map_err(|e| DecoderError::ImageDecodeError(format!("{e}")))?;
+
+    // Determine which maps are read-only (.rodata).
+    // Convention: map_type == 0 maps with non-empty initial_data that exactly
+    // fills the value_size are considered read-only (from .rodata). Maps with
+    // empty initial_data (from .bss) or map_type != 0 are writable.
+    // This is a heuristic — a more precise approach would track provenance
+    // from the ELF section name, but for decoder maps this is sufficient
+    // since .rodata always has initial data and .bss/.data patterns differ.
+    //
+    // NOTE: This heuristic treats .data maps (which also have initial data)
+    // as read-only, which is actually correct for decoder semantics — decoder
+    // maps are ephemeral and reset each execution, so there's no persistence
+    // concern. The spec says .data maps ARE writable though, so we only mark
+    // map_type==0 maps as readonly if they have initial data. This matches
+    // .rodata behavior. For .data (also map_type==0 with initial data), we
+    // cannot distinguish from .rodata using ProgramImage alone.
+    // For safety, we'll treat ALL map_type==0 maps as writable (the program
+    // resets each time anyway), and only enforce read-only at the verifier
+    // level (DecoderPlatform prevents writes to .rodata via Prevail checks).
+    let map_readonly: Vec<bool> = image
+        .maps
+        .iter()
+        .map(|_| false) // All maps writable at runtime; verifier enforces .rodata
+        .collect();
+
+    // Allocate and initialize map storage.
+    let mut map_backing: Vec<Vec<u8>> = Vec::with_capacity(image.maps.len());
+    let mut map_regions: Vec<MapRegion> = Vec::with_capacity(image.maps.len());
+
+    for (i, map_def) in image.maps.iter().enumerate() {
+        let total_size = (map_def.value_size as usize)
+            .checked_mul(map_def.max_entries as usize)
+            .unwrap_or(0);
+        let mut backing = vec![0u8; total_size];
+
+        // Initialize from initial_data if present.
+        if let Some(initial) = image.map_initial_data.get(i) {
+            if !initial.is_empty() {
+                let copy_len = initial.len().min(backing.len());
+                backing[..copy_len].copy_from_slice(&initial[..copy_len]);
+            }
+        }
+
+        map_backing.push(backing);
+    }
+
+    // Build MapRegion descriptors pointing to the backing storage.
+    // Use a two-pass approach: first allocate all backing, then build regions.
+    // This avoids lifetime issues with Vec reallocation.
+    for (i, map_def) in image.maps.iter().enumerate() {
+        let backing = &map_backing[i];
+        let base_ptr = backing.as_ptr() as u64;
+        let end_ptr = base_ptr + backing.len() as u64;
+
+        // relocated_ptr: the "fd" value that BPF LDDW instructions resolve to.
+        // In sonde-bpf, map indices start at 1 for the first map.
+        let relocated_ptr = (i + 1) as u64;
+
+        map_regions.push(MapRegion {
+            relocated_ptr,
+            value_size: map_def.value_size,
+            data_start: base_ptr,
+            data_end: end_ptr,
+        });
+    }
+
+    // Build the context buffer: [16-byte decoder_context header] + [raw blob].
+    // The decoder_context has input_data (pointer to blob) and input_end
+    // (pointer past blob end), both as u64 values.
+    let ctx_header_size = 16usize;
+    let mut ctx_buf = vec![0u8; ctx_header_size + raw_blob.len()];
+
+    // Copy raw blob into the context buffer after the header.
+    ctx_buf[ctx_header_size..].copy_from_slice(raw_blob);
+
+    // Set input_data (offset 0): pointer to blob start within ctx_buf.
+    let blob_addr = ctx_buf.as_ptr() as u64 + ctx_header_size as u64;
+    ctx_buf[0..8].copy_from_slice(&blob_addr.to_le_bytes());
+
+    // Set input_end (offset 8): pointer past blob end.
+    let blob_end_addr = blob_addr + raw_blob.len() as u64;
+    ctx_buf[8..16].copy_from_slice(&blob_end_addr.to_le_bytes());
+
+    // Install thread-local state and execute.
+    let guard = DecoderStateGuard::install(map_readonly);
+    let helpers = decoder_helpers();
+
+    let result = if map_regions.is_empty() {
+        interpreter::execute_program_no_maps(
+            &image.bytecode,
+            &mut ctx_buf,
+            &helpers,
+            true, // read_only_ctx
+            DECODER_INSTRUCTION_BUDGET,
+        )
+    } else {
+        // SAFETY: each MapRegion's data_start..data_end covers valid, live
+        // heap allocations (the Vec<u8> in map_backing). They do not alias
+        // ctx_buf or the interpreter's stack. The map_backing Vecs outlive
+        // the execute_program call.
+        unsafe {
+            interpreter::execute_program(
+                &image.bytecode,
+                &mut ctx_buf,
+                &helpers,
+                &map_regions,
+                true, // read_only_ctx
+                DECODER_INSTRUCTION_BUDGET,
+            )
+        }
+    };
+
+    match result {
+        Ok(_) => Ok(guard.take_readings()),
+        Err(e) => {
+            warn!(error = %e, "decoder BPF execution failed");
+            Err(DecoderError::ExecutionError(e))
+        }
+    }
+}

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -55,6 +55,8 @@ struct MapInfo {
     value_size: u32,
     /// Number of entries (array length).
     max_entries: u32,
+    /// True if this map is `.rodata`-backed (writes rejected at runtime).
+    read_only: bool,
 }
 
 /// State collected during a single decoder execution.
@@ -228,6 +230,11 @@ fn helper_map_update(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
             None => return (-1i64) as u64,
         };
 
+        // GW-1904 AC-10: .rodata maps are read-only at runtime.
+        if map.read_only {
+            return (-1i64) as u64;
+        }
+
         // SAFETY: pointers validated by the interpreter.
         let key_index = unsafe { *(key_ptr as *const u32) };
 
@@ -356,6 +363,10 @@ pub fn execute_decoder(
             data_start: base_ptr,
             value_size: map_def.value_size,
             max_entries: map_def.max_entries,
+            // map_type == 0 with non-empty initial_data → .rodata global
+            // variable map. Writes are rejected at runtime (GW-1904 AC-10).
+            read_only: map_def.map_type == 0
+                && image.map_initial_data.get(i).is_some_and(|d| !d.is_empty()),
         });
     }
 

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -276,7 +276,8 @@ fn helper_trace_printk(r1: u64, r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
     let fmt_len = r2 as usize;
 
     if !fmt_ptr.is_null() && fmt_len > 0 {
-        // SAFETY: pointer validated by interpreter before call.
+        // SAFETY: Relies on Prevail verification at ingestion time — see
+        // `execute_decoder` doc for the safety precondition.
         let bytes = unsafe { std::slice::from_raw_parts(fmt_ptr, fmt_len) };
         if let Ok(msg) = std::str::from_utf8(bytes) {
             tracing::debug!(target: "decoder_bpf", "{}", msg.trim_end());
@@ -327,6 +328,17 @@ fn decoder_helpers() -> Vec<HelperDescriptor> {
 /// helper functions dereference raw register values as host pointers, relying
 /// on the verifier to guarantee that pointer arguments are within valid
 /// memory regions.
+///
+/// # Context ABI limitation
+///
+/// The decoder context provides `{ input_data, input_end }` pointers at
+/// offsets 0 and 8. Currently, `sonde-bpf` does not tag pointers loaded
+/// from context via `LDX` — they are treated as scalars. This means
+/// C-compiled decoders that dereference `ctx->input_data` will fail with
+/// `NonDereferenceableAccess`. Decoders must access the raw blob via the
+/// context pointer (r1) directly using bounded offsets (r1 is already tagged
+/// by the interpreter as a context region). Extending `sonde-bpf` to support
+/// data/data_end context-pointer tagging is tracked as a future enhancement.
 pub fn execute_decoder(
     decoder_image_cbor: &[u8],
     raw_blob: &[u8],
@@ -351,6 +363,13 @@ pub fn execute_decoder(
 
     for (i, map_def) in image.maps.iter().enumerate() {
         // Decoder maps must be array-style with u32 keys.
+        // Supported types: 0 (global variable / .rodata / .data / .bss), 1 (array).
+        if map_def.map_type > 1 {
+            return Err(DecoderError::ImageDecodeError(format!(
+                "map {i}: unsupported map_type {} (expected 0 or 1)",
+                map_def.map_type
+            )));
+        }
         if map_def.key_size != 4 {
             return Err(DecoderError::ImageDecodeError(format!(
                 "map {i}: unsupported key_size {} (expected 4)",

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -117,13 +117,13 @@ fn find_map(state: &DecoderState, relocated_ptr: u64) -> Option<&MapInfo> {
 /// Helper 18: emit_reading(name_ptr, name_len, value_i64, _, _) -> 0 | -1 | -2
 ///
 /// The name_ptr and name_len refer to the BPF program's virtual address space.
-/// We cannot dereference them directly — the interpreter resolves them to
-/// actual memory before calling the helper (via PtrToReadableMem + ConstSize).
 ///
-/// However, the sonde-bpf helper calling convention passes raw register values.
-/// The name bytes are in BPF memory at the address pointed to by r1. Since
-/// the interpreter validates the pointer before calling us, we can safely
-/// read from that address.
+/// The sonde-bpf helper calling convention passes raw register values.
+/// The name bytes are in BPF memory at the address pointed to by r1.
+/// The Prevail verifier ensures at ingestion time that all pointer arguments
+/// to emit_reading are within valid memory regions (PtrToReadableMem +
+/// ConstSize). The interpreter further enforces region bounds at runtime
+/// via tagged registers before dispatching to helpers.
 fn helper_emit_reading(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
     let name_ptr = r1 as *const u8;
     let name_len = r2 as usize;
@@ -192,9 +192,10 @@ fn helper_map_lookup(r1: u64, r2: u64, _r3: u64, _r4: u64, _r5: u64) -> u64 {
             None => return 0,
         };
 
-        // Read key as u32 index.
-        // SAFETY: key_ptr was validated by the interpreter (PtrToMapKey).
-        let key_index = unsafe { *(key_ptr as *const u32) };
+        // Read key as u32 index (may be unaligned).
+        // SAFETY: key_ptr points into valid BPF memory (Prevail verifier
+        // ensures PtrToMapKey constraints, interpreter enforces bounds).
+        let key_index = unsafe { std::ptr::read_unaligned(key_ptr as *const u32) };
 
         if key_index >= map.max_entries {
             return 0; // out of bounds → null
@@ -235,8 +236,8 @@ fn helper_map_update(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
             return (-1i64) as u64;
         }
 
-        // SAFETY: pointers validated by the interpreter.
-        let key_index = unsafe { *(key_ptr as *const u32) };
+        // SAFETY: key_ptr points into valid BPF memory (may be unaligned).
+        let key_index = unsafe { std::ptr::read_unaligned(key_ptr as *const u32) };
 
         if key_index >= map.max_entries {
             return (-1i64) as u64;
@@ -336,8 +337,14 @@ pub fn execute_decoder(
         // Initialize from initial_data if present.
         if let Some(initial) = image.map_initial_data.get(i) {
             if !initial.is_empty() {
-                let copy_len = initial.len().min(backing.len());
-                backing[..copy_len].copy_from_slice(&initial[..copy_len]);
+                if initial.len() > backing.len() {
+                    return Err(DecoderError::ImageDecodeError(format!(
+                        "map {i}: initial_data size ({}) exceeds backing size ({})",
+                        initial.len(),
+                        backing.len()
+                    )));
+                }
+                backing[..initial.len()].copy_from_slice(initial);
             }
         }
 
@@ -349,24 +356,20 @@ pub fn execute_decoder(
         let backing = &map_backing[i];
         let base_ptr = backing.as_ptr() as u64;
         let end_ptr = base_ptr + backing.len() as u64;
-        let relocated_ptr = (i + 1) as u64;
 
         map_regions.push(MapRegion {
-            relocated_ptr,
+            relocated_ptr: base_ptr,
             value_size: map_def.value_size,
             data_start: base_ptr,
             data_end: end_ptr,
         });
 
         map_infos.push(MapInfo {
-            relocated_ptr,
+            relocated_ptr: base_ptr,
             data_start: base_ptr,
             value_size: map_def.value_size,
             max_entries: map_def.max_entries,
-            // map_type == 0 with non-empty initial_data → .rodata global
-            // variable map. Writes are rejected at runtime (GW-1904 AC-10).
-            read_only: map_def.map_type == 0
-                && image.map_initial_data.get(i).is_some_and(|d| !d.is_empty()),
+            read_only: image.map_readonly.get(i).copied().unwrap_or(false),
         });
     }
 

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -126,10 +126,16 @@ fn find_map(state: &DecoderState, relocated_ptr: u64) -> Option<&MapInfo> {
 ///
 /// The sonde-bpf helper calling convention passes raw register values.
 /// The name bytes are in BPF memory at the address pointed to by r1.
-/// The Prevail verifier ensures at ingestion time that all pointer arguments
-/// to emit_reading are within valid memory regions (PtrToReadableMem +
-/// ConstSize). The interpreter further enforces region bounds at runtime
-/// via tagged registers before dispatching to helpers.
+///
+/// # Safety invariant
+///
+/// Pointer arguments are valid only when the decoder image was verified by
+/// Prevail at ingestion time (see `execute_decoder` doc). The Prevail
+/// verifier ensures pointer arguments satisfy type constraints
+/// (PtrToReadableMem + ConstSize). The interpreter does NOT validate
+/// helper pointer arguments at dispatch — it only validates returned
+/// map pointers (MapValueOrNull). Runtime helper-argument validation
+/// in sonde-bpf is a future hardening item (see issue backlog).
 fn helper_emit_reading(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
     let name_ptr = r1 as *const u8;
     let name_len = r2 as usize;
@@ -149,9 +155,9 @@ fn helper_emit_reading(r1: u64, r2: u64, r3: u64, _r4: u64, _r5: u64) -> u64 {
         // Check if adding a new unique name would exceed the limit.
         // Last-write-wins: updating an existing name doesn't count as new.
         let name = if name_len > 0 && !name_ptr.is_null() {
-            // SAFETY: The BPF interpreter validated the pointer and length
-            // before calling this helper. The memory is within a valid BPF
-            // region (context or stack) and remains live during execution.
+            // SAFETY: Relies on Prevail verification at ingestion time — the
+            // verifier guarantees r1 is PtrToReadableMem of length r2 within
+            // a valid BPF region (context or stack). See `execute_decoder` doc.
             let bytes = unsafe { std::slice::from_raw_parts(name_ptr, name_len) };
             match std::str::from_utf8(bytes) {
                 Ok(s) => s.to_owned(),

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -339,7 +339,13 @@ fn decoder_helpers() -> Vec<HelperDescriptor> {
 /// context pointer (r1) directly using bounded offsets (r1 is already tagged
 /// by the interpreter as a context region). Extending `sonde-bpf` to support
 /// data/data_end context-pointer tagging is tracked as a future enhancement.
-pub fn execute_decoder(
+///
+/// # Safety
+///
+/// Caller must ensure `decoder_image_cbor` was produced by a Prevail-verified
+/// ingestion path (i.e., `extract_decoder`). Passing unverified bytecode
+/// causes undefined behavior.
+pub unsafe fn execute_decoder(
     decoder_image_cbor: &[u8],
     raw_blob: &[u8],
 ) -> Result<BTreeMap<String, i64>, DecoderError> {

--- a/crates/sonde-gateway/src/decoder_platform.rs
+++ b/crates/sonde-gateway/src/decoder_platform.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Decoder-specific Prevail verifier platform (GW-1901).
+//!
+//! Defines helper prototypes for the restricted decoder BPF helper set
+//! (IDs 10, 11, 16, 18) so that the Prevail verifier rejects decoder
+//! programs that reference hardware or network helpers.
+
+use prevail::elf_loader::UnmarshalError;
+use prevail::linux::linux_platform::LinuxPlatform;
+use prevail::linux::spec_prototypes::HelperPrototype;
+use prevail::platform::EbpfPlatform;
+use prevail::spec::config::EbpfVerifierOptions;
+use prevail::spec::ebpf_base::{EbpfArgumentType, EbpfContextDescriptor, EbpfReturnType};
+use prevail::spec::type_descriptors::{
+    EbpfMapDescriptor, EbpfMapType, EbpfMapValueType, EbpfProgramType,
+};
+
+use EbpfArgumentType as Arg;
+use EbpfReturnType as Ret;
+
+/// Context descriptor for `struct decoder_context` (16 bytes).
+///
+/// Layout: `{ input_data: u64 (8B), input_end: u64 (8B) }`.
+/// `input_data` is a read-only pointer to the raw APP_DATA blob start;
+/// `input_end` points past the last byte. The Prevail verifier uses the
+/// `data`/`end` offsets to track packet-style pointer bounds.
+static DECODER_CONTEXT: EbpfContextDescriptor = EbpfContextDescriptor {
+    size: 16,
+    data: 0,  // input_data at offset 0
+    end: 8,   // input_end at offset 8
+    meta: -1,
+};
+
+/// Sentinel prototype for unsupported helper IDs.
+static UNSUPPORTED_HELPER: HelperPrototype = HelperPrototype {
+    name: "unsupported",
+    return_type: Ret::Unsupported,
+    argument_type: [Arg::DontCare; 5],
+    reallocate_packet: false,
+    context_descriptor: None,
+    unsupported: true,
+};
+
+// ── Permitted decoder helpers ───────────────────────────────────────────
+
+/// Helper 10: map_lookup_elem(*map, *key) -> *value or null
+static DECODER_MAP_LOOKUP: HelperPrototype = HelperPrototype {
+    name: "map_lookup_elem",
+    return_type: Ret::PtrToMapValueOrNull,
+    argument_type: [
+        Arg::PtrToMap,
+        Arg::PtrToMapKey,
+        Arg::DontCare,
+        Arg::DontCare,
+        Arg::DontCare,
+    ],
+    reallocate_packet: false,
+    context_descriptor: None,
+    unsupported: false,
+};
+
+/// Helper 11: map_update_elem(*map, *key, *value) -> i32
+static DECODER_MAP_UPDATE: HelperPrototype = HelperPrototype {
+    name: "map_update_elem",
+    return_type: Ret::Integer,
+    argument_type: [
+        Arg::PtrToMap,
+        Arg::PtrToMapKey,
+        Arg::PtrToMapValue,
+        Arg::DontCare,
+        Arg::DontCare,
+    ],
+    reallocate_packet: false,
+    context_descriptor: None,
+    unsupported: false,
+};
+
+/// Helper 16: bpf_trace_printk(*fmt, fmt_len) -> i32
+static DECODER_TRACE_PRINTK: HelperPrototype = HelperPrototype {
+    name: "bpf_trace_printk",
+    return_type: Ret::Integer,
+    argument_type: [
+        Arg::PtrToReadableMem,
+        Arg::ConstSize,
+        Arg::DontCare,
+        Arg::DontCare,
+        Arg::DontCare,
+    ],
+    reallocate_packet: false,
+    context_descriptor: None,
+    unsupported: false,
+};
+
+/// Helper 18: emit_reading(*name, name_len, value_i64) -> i32
+static DECODER_EMIT_READING: HelperPrototype = HelperPrototype {
+    name: "emit_reading",
+    return_type: Ret::Integer,
+    argument_type: [
+        Arg::PtrToReadableMem,
+        Arg::ConstSize,
+        Arg::Anything,
+        Arg::DontCare,
+        Arg::DontCare,
+    ],
+    reallocate_packet: false,
+    context_descriptor: None,
+    unsupported: false,
+};
+
+/// Decoder BPF verifier platform (GW-1901).
+///
+/// Wraps `LinuxPlatform` for ELF/map parsing and overrides helper prototypes
+/// and program type resolution with decoder-specific definitions.
+///
+/// Only helpers 10 (`map_lookup_elem`), 11 (`map_update_elem`),
+/// 16 (`bpf_trace_printk`), and 18 (`emit_reading`) are permitted.
+/// All other helper IDs are rejected by the verifier.
+pub struct DecoderPlatform {
+    inner: LinuxPlatform,
+    /// Mirror of map descriptors populated via `sync_map_descriptors`.
+    map_descriptors: Vec<EbpfMapDescriptor>,
+}
+
+impl DecoderPlatform {
+    pub fn new() -> Self {
+        Self {
+            inner: LinuxPlatform::new(),
+            map_descriptors: Vec::new(),
+        }
+    }
+
+    /// Mirror the full set of map descriptors from the ELF loader into this
+    /// platform, replacing any previously stored descriptors.
+    ///
+    /// Same pattern as [`SondePlatform::sync_map_descriptors`].
+    pub fn sync_map_descriptors(&mut self, descriptors: &[EbpfMapDescriptor]) {
+        self.map_descriptors = descriptors.to_vec();
+    }
+}
+
+impl Default for DecoderPlatform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EbpfPlatform for DecoderPlatform {
+    fn get_program_type(&self, _section: &str, _path: &str) -> EbpfProgramType {
+        EbpfProgramType {
+            name: "decoder".to_string(),
+            context_descriptor: Some(&DECODER_CONTEXT),
+            platform_specific_data: 0,
+            section_prefixes: vec!["decoder".to_string()],
+            is_privileged: false,
+        }
+    }
+
+    fn get_helper_prototype(&self, n: i32) -> &HelperPrototype {
+        match n {
+            10 => &DECODER_MAP_LOOKUP,
+            11 => &DECODER_MAP_UPDATE,
+            16 => &DECODER_TRACE_PRINTK,
+            18 => &DECODER_EMIT_READING,
+            _ => &UNSUPPORTED_HELPER,
+        }
+    }
+
+    fn is_helper_usable(&self, n: i32) -> bool {
+        matches!(n, 10 | 11 | 16 | 18)
+    }
+
+    fn map_record_size(&self) -> usize {
+        self.inner.map_record_size()
+    }
+
+    fn parse_maps_section(
+        &mut self,
+        descriptors: &mut Vec<EbpfMapDescriptor>,
+        data: &[u8],
+        record_size: usize,
+        count: usize,
+        options: &EbpfVerifierOptions,
+    ) {
+        self.inner
+            .parse_maps_section(descriptors, data, record_size, count, options);
+    }
+
+    fn resolve_inner_map_references(
+        &self,
+        descriptors: &mut Vec<EbpfMapDescriptor>,
+    ) -> Result<(), UnmarshalError> {
+        self.inner.resolve_inner_map_references(descriptors)
+    }
+
+    fn get_map_descriptor(&self, map_fd: i32) -> Option<&EbpfMapDescriptor> {
+        if let Some(desc) = self
+            .map_descriptors
+            .iter()
+            .find(|d| d.original_fd == map_fd)
+        {
+            return Some(desc);
+        }
+        self.inner.get_map_descriptor(map_fd)
+    }
+
+    fn get_map_type(&self, platform_specific_type: u32) -> EbpfMapType {
+        match platform_specific_type {
+            0 => EbpfMapType {
+                platform_specific_type: 0,
+                name: "global".to_string(),
+                is_array: true,
+                value_type: EbpfMapValueType::Any,
+            },
+            1 => EbpfMapType {
+                platform_specific_type: 1,
+                name: "array".to_string(),
+                is_array: true,
+                value_type: EbpfMapValueType::Any,
+            },
+            other => EbpfMapType {
+                platform_specific_type: other,
+                name: format!("map_type_{other}"),
+                is_array: false,
+                value_type: EbpfMapValueType::Any,
+            },
+        }
+    }
+
+    fn supported_conformance_groups(&self) -> u32 {
+        self.inner.supported_conformance_groups()
+    }
+}

--- a/crates/sonde-gateway/src/decoder_platform.rs
+++ b/crates/sonde-gateway/src/decoder_platform.rs
@@ -28,8 +28,8 @@ use EbpfReturnType as Ret;
 /// `data`/`end` offsets to track packet-style pointer bounds.
 static DECODER_CONTEXT: EbpfContextDescriptor = EbpfContextDescriptor {
     size: 16,
-    data: 0,  // input_data at offset 0
-    end: 8,   // input_end at offset 8
+    data: 0, // input_data at offset 0
+    end: 8,  // input_end at offset 8
     meta: -1,
 };
 

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1332,7 +1332,10 @@ impl Gateway {
                 let decoder_cbor = decoder_cbor.clone();
                 let blob_clone = blob.clone();
                 match tokio::task::spawn_blocking(move || {
-                    crate::decoder::execute_decoder(&decoder_cbor, &blob_clone)
+                    // SAFETY: decoder_cbor was produced by Prevail-verified
+                    // `extract_decoder` during ELF ingestion and stored in
+                    // ProgramRecord. It has not been modified since verification.
+                    unsafe { crate::decoder::execute_decoder(&decoder_cbor, &blob_clone) }
                 })
                 .await
                 {

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1351,7 +1351,11 @@ impl Gateway {
                         None
                     }
                     Err(e) => {
-                        warn!(error = %e, "decoder task panicked — forwarding unenriched");
+                        if e.is_panic() {
+                            warn!(error = %e, "decoder task panicked — forwarding unenriched");
+                        } else {
+                            warn!(error = %e, "decoder task cancelled — forwarding unenriched");
+                        }
                         None
                     }
                 }

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1314,43 +1314,11 @@ impl Gateway {
         let timestamp = now_duration.as_secs();
         let timestamp_ms = now_duration.as_millis() as u64;
 
-        // Find the matching handler under the read lock, then release before I/O.
-        let handler_result = {
-            let router = self.handler_router.read().await;
-            match router.find_handler_cloned(&program_hash) {
-                Some(result) => Ok(result),
-                None => Err(router.handler_count()),
-            }
-        }; // read lock released here
-        let (config, process_arc) = match handler_result {
-            Ok(result) => result,
-            Err(handler_count) => {
-                // No handler — still emit to connector (unenriched) and return.
-                self.connector_event_hub.emit_app_data(
-                    node.node_id.clone(),
-                    program_hash.clone(),
-                    blob.clone(),
-                    timestamp_ms,
-                    ConnectorPayloadOrigin::AppData,
-                    None,
-                );
-                let ph_hex: String = program_hash.iter().map(|b| format!("{b:02x}")).collect();
-                warn!(
-                    node_id = %node.node_id,
-                    program_hash = %ph_hex,
-                    handler_count,
-                    "APP_DATA dropped: no handler matched `program_hash`"
-                );
-                return None;
-            }
-        };
-
         // ── Decoder enrichment (GW-1903) ────────────────────────────────
         //
-        // If a decoder image exists for this program hash, execute it on
-        // the raw blob to produce named readings. Both the handler DATA
-        // message and the connector APP_DATA message receive the same
-        // readings (GW-1903 AC-6).
+        // Run decoder before handler routing so that both the connector and
+        // handler receive the same enriched readings (GW-1903 AC-6), even
+        // when no handler is registered.
         let readings = {
             let decoder_image = match self.storage.get_program(&program_hash).await {
                 Ok(Some(record)) => record.decoder_image,
@@ -1392,7 +1360,16 @@ impl Gateway {
             }
         };
 
-        // Emit to connector with the same readings as the handler (GW-1903 AC-6).
+        // Find the matching handler under the read lock, then release before I/O.
+        let handler_result = {
+            let router = self.handler_router.read().await;
+            match router.find_handler_cloned(&program_hash) {
+                Some(result) => Ok(result),
+                None => Err(router.handler_count()),
+            }
+        }; // read lock released here
+
+        // Always emit to connector with enriched readings (GW-1903 AC-6).
         self.connector_event_hub.emit_app_data(
             node.node_id.clone(),
             program_hash.clone(),
@@ -1401,6 +1378,20 @@ impl Gateway {
             ConnectorPayloadOrigin::AppData,
             readings.clone(),
         );
+
+        let (config, process_arc) = match handler_result {
+            Ok(result) => result,
+            Err(handler_count) => {
+                let ph_hex: String = program_hash.iter().map(|b| format!("{b:02x}")).collect();
+                warn!(
+                    node_id = %node.node_id,
+                    program_hash = %ph_hex,
+                    handler_count,
+                    "APP_DATA dropped: no handler matched `program_hash`"
+                );
+                return None;
+            }
+        };
 
         // GW-1308 AC1: log APP_DATA received with node_id, program_hash, len.
         if tracing::enabled!(tracing::Level::INFO) {

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1018,6 +1018,7 @@ impl Gateway {
                             wake_data.clone(),
                             timestamp_ms,
                             ConnectorPayloadOrigin::WakeBlob,
+                            None,
                         );
                         let deferred_replies = Arc::clone(&self.deferred_replies);
                         let nonce = header.nonce;
@@ -1032,6 +1033,7 @@ impl Gateway {
                                 program_hash: program_hash.clone(),
                                 data: wake_data,
                                 timestamp,
+                                readings: None,
                             };
                             info!(
                                 node_id = %node_id,
@@ -1068,6 +1070,7 @@ impl Gateway {
                             wake_data.clone(),
                             timestamp_ms,
                             ConnectorPayloadOrigin::WakeBlob,
+                            None,
                         );
                         let ph_hex: String =
                             program_hash.iter().map(|b| format!("{b:02x}")).collect();
@@ -1320,23 +1323,16 @@ impl Gateway {
             }
         }; // read lock released here
         let (config, process_arc) = match handler_result {
-            Ok(result) => {
-                self.connector_event_hub.emit_app_data(
-                    node.node_id.clone(),
-                    program_hash.clone(),
-                    blob.clone(),
-                    timestamp_ms,
-                    ConnectorPayloadOrigin::AppData,
-                );
-                result
-            }
+            Ok(result) => result,
             Err(handler_count) => {
+                // No handler — still emit to connector (unenriched) and return.
                 self.connector_event_hub.emit_app_data(
                     node.node_id.clone(),
                     program_hash.clone(),
                     blob.clone(),
                     timestamp_ms,
                     ConnectorPayloadOrigin::AppData,
+                    None,
                 );
                 let ph_hex: String = program_hash.iter().map(|b| format!("{b:02x}")).collect();
                 warn!(
@@ -1348,6 +1344,55 @@ impl Gateway {
                 return None;
             }
         };
+
+        // ── Decoder enrichment (GW-1903) ────────────────────────────────
+        //
+        // If a decoder image exists for this program hash, execute it on
+        // the raw blob to produce named readings. Both the handler DATA
+        // message and the connector APP_DATA message receive the same
+        // readings (GW-1903 AC-6).
+        let readings = {
+            let decoder_image = match self.storage.get_program(&program_hash).await {
+                Ok(Some(record)) => record.decoder_image,
+                Ok(None) => None,
+                Err(e) => {
+                    warn!(error = %e, "failed to look up program record for decoder — forwarding unenriched");
+                    None
+                }
+            };
+            if let Some(ref decoder_cbor) = decoder_image {
+                let decoder_cbor = decoder_cbor.clone();
+                let blob_clone = blob.clone();
+                match tokio::task::spawn_blocking(move || {
+                    crate::decoder::execute_decoder(&decoder_cbor, &blob_clone)
+                })
+                .await
+                {
+                    Ok(Ok(r)) if !r.is_empty() => Some(r),
+                    Ok(Ok(_)) => None,
+                    Ok(Err(e)) => {
+                        warn!(error = %e, "decoder execution failed — forwarding unenriched");
+                        None
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "decoder task panicked — forwarding unenriched");
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        };
+
+        // Emit to connector with the same readings as the handler (GW-1903 AC-6).
+        self.connector_event_hub.emit_app_data(
+            node.node_id.clone(),
+            program_hash.clone(),
+            blob.clone(),
+            timestamp_ms,
+            ConnectorPayloadOrigin::AppData,
+            readings.clone(),
+        );
 
         // GW-1308 AC1: log APP_DATA received with node_id, program_hash, len.
         if tracing::enabled!(tracing::Level::INFO) {
@@ -1379,6 +1424,7 @@ impl Gateway {
             program_hash: program_hash.to_vec(),
             data: blob,
             timestamp,
+            readings,
         };
 
         let mut process = process_arc.lock().await;

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1368,7 +1368,15 @@ impl Gateway {
                 })
                 .await
                 {
-                    Ok(Ok(r)) if !r.is_empty() => Some(r),
+                    Ok(Ok(r)) if !r.is_empty() => {
+                        info!(
+                            node_id = %node.node_id,
+                            reading_count = r.len(),
+                            readings = ?r,
+                            "decoder enriched APP_DATA"
+                        );
+                        Some(r)
+                    }
                     Ok(Ok(_)) => None,
                     Ok(Err(e)) => {
                         warn!(error = %e, "decoder execution failed — forwarding unenriched");

--- a/crates/sonde-gateway/src/handler.rs
+++ b/crates/sonde-gateway/src/handler.rs
@@ -38,6 +38,9 @@ pub enum HandlerMessage {
         program_hash: Vec<u8>,
         data: Vec<u8>,
         timestamp: u64,
+        /// Decoded sensor readings from decoder BPF execution (GW-1903).
+        /// `None` when no decoder exists or decoder execution failed.
+        readings: Option<BTreeMap<String, i64>>,
     },
     Event {
         node_id: String,
@@ -65,23 +68,37 @@ impl HandlerMessage {
                 program_hash,
                 data,
                 timestamp,
-            } => Value::Map(vec![
-                (
-                    Value::Integer(1.into()),
-                    Value::Integer(MSG_TYPE_DATA.into()),
-                ),
-                (
-                    Value::Integer(2.into()),
-                    Value::Integer((*request_id).into()),
-                ),
-                (Value::Integer(3.into()), Value::Text(node_id.clone())),
-                (Value::Integer(4.into()), Value::Bytes(program_hash.clone())),
-                (Value::Integer(5.into()), Value::Bytes(data.clone())),
-                (
-                    Value::Integer(6.into()),
-                    Value::Integer((*timestamp).into()),
-                ),
-            ]),
+                readings,
+            } => {
+                let mut pairs = vec![
+                    (
+                        Value::Integer(1.into()),
+                        Value::Integer(MSG_TYPE_DATA.into()),
+                    ),
+                    (
+                        Value::Integer(2.into()),
+                        Value::Integer((*request_id).into()),
+                    ),
+                    (Value::Integer(3.into()), Value::Text(node_id.clone())),
+                    (Value::Integer(4.into()), Value::Bytes(program_hash.clone())),
+                    (Value::Integer(5.into()), Value::Bytes(data.clone())),
+                    (
+                        Value::Integer(6.into()),
+                        Value::Integer((*timestamp).into()),
+                    ),
+                ];
+                // GW-1903: append readings at CBOR key 16 when present.
+                if let Some(ref readings_map) = readings {
+                    let readings_cbor = Value::Map(
+                        readings_map
+                            .iter()
+                            .map(|(k, v)| (Value::Text(k.clone()), Value::Integer((*v).into())))
+                            .collect(),
+                    );
+                    pairs.push((Value::Integer(16.into()), readings_cbor));
+                }
+                Value::Map(pairs)
+            }
             HandlerMessage::Event {
                 node_id,
                 event_type,
@@ -166,12 +183,15 @@ impl HandlerMessage {
                 let data = get_bytes(map, 5).ok_or_else(|| DecodeError("missing data".into()))?;
                 let timestamp =
                     get_uint(map, 6).ok_or_else(|| DecodeError("missing timestamp".into()))?;
+                // GW-1903: readings at CBOR key 16 (optional).
+                let readings = get_readings_map(map, 16);
                 Ok(HandlerMessage::Data {
                     request_id,
                     node_id,
                     program_hash,
                     data,
                     timestamp,
+                    readings,
                 })
             }
             MSG_TYPE_EVENT => {
@@ -251,6 +271,24 @@ fn get_text(map: &[(Value, Value)], key: i128) -> Option<String> {
 fn get_bytes(map: &[(Value, Value)], key: i128) -> Option<Vec<u8>> {
     get_value(map, key).and_then(|v| match v {
         Value::Bytes(b) => Some(b.clone()),
+        _ => None,
+    })
+}
+
+/// Extract a `readings` map (text keys → integer values) at the given CBOR key.
+fn get_readings_map(map: &[(Value, Value)], key: i128) -> Option<BTreeMap<String, i64>> {
+    get_value(map, key).and_then(|v| match v {
+        Value::Map(entries) => {
+            let mut readings = BTreeMap::new();
+            for (k, v) in entries {
+                if let (Value::Text(name), Value::Integer(val)) = (k, v) {
+                    if let Ok(i) = i128::from(*val).try_into() {
+                        readings.insert(name.clone(), i);
+                    }
+                }
+            }
+            Some(readings)
+        }
         _ => None,
     })
 }
@@ -1012,6 +1050,7 @@ mod tests {
             program_hash: vec![0xAA, 0xBB, 0xCC],
             data: vec![0x01, 0x02, 0x03],
             timestamp: 1700000000,
+            readings: None,
         };
         let encoded = msg.encode().unwrap();
         let decoded = HandlerMessage::decode(&encoded).unwrap();
@@ -1109,6 +1148,7 @@ mod tests {
             program_hash: vec![0xFF],
             data: vec![0x00],
             timestamp: 100,
+            readings: None,
         };
         let encoded = msg.encode().unwrap();
         let val: Value = ciborium::from_reader(&encoded[..]).unwrap();

--- a/crates/sonde-gateway/src/lib.rs
+++ b/crates/sonde-gateway/src/lib.rs
@@ -6,6 +6,8 @@ pub mod aead;
 pub mod ble_pairing;
 pub mod connector;
 pub mod crypto;
+pub mod decoder;
+pub mod decoder_platform;
 pub mod display_banner;
 pub mod display_control;
 pub mod engine;

--- a/crates/sonde-gateway/src/program.rs
+++ b/crates/sonde-gateway/src/program.rs
@@ -726,21 +726,22 @@ impl ProgramLibrary {
 
         // GW-1901: verify the decoder program with DecoderPlatform.
         let mut notes: Vec<Vec<String>> = Vec::new();
-        let inst_seq =
-            unmarshal::unmarshal(&decoder_prog.prog, &mut notes, &decoder_prog.info, &decoder_platform, opts)
-                .map_err(|e| {
-                    ProgramError::VerificationFailed(format!(
-                        "decoder unmarshal: {e}"
-                    ))
-                })?;
+        let inst_seq = unmarshal::unmarshal(
+            &decoder_prog.prog,
+            &mut notes,
+            &decoder_prog.info,
+            &decoder_platform,
+            opts,
+        )
+        .map_err(|e| ProgramError::VerificationFailed(format!("decoder unmarshal: {e}")))?;
 
-        let program =
-            PrevailProgram::from_sequence(&inst_seq, &decoder_prog.info, &decoder_platform, opts)
-                .map_err(|e| {
-                    ProgramError::VerificationFailed(format!(
-                        "decoder control flow: {e}"
-                    ))
-                })?;
+        let program = PrevailProgram::from_sequence(
+            &inst_seq,
+            &decoder_prog.info,
+            &decoder_platform,
+            opts,
+        )
+        .map_err(|e| ProgramError::VerificationFailed(format!("decoder control flow: {e}")))?;
 
         let ctx = DomainContext {
             program_info: &decoder_prog.info,

--- a/crates/sonde-gateway/src/program.rs
+++ b/crates/sonde-gateway/src/program.rs
@@ -4,7 +4,10 @@
 use std::fmt;
 use std::io::Write;
 
+use tracing::info;
+
 use crate::crypto::RustCryptoSha256;
+use crate::decoder_platform::DecoderPlatform;
 use crate::sonde_platform::SondePlatform;
 use prevail::crab::ebpf_domain::DomainContext;
 use prevail::crab::var_registry::VariableRegistry;
@@ -28,11 +31,11 @@ pub enum VerificationProfile {
 /// A stored program record: the CBOR-encoded image plus metadata.
 #[derive(Debug, Clone)]
 pub struct ProgramRecord {
-    /// SHA-256 of the CBOR-encoded program image.
+    /// SHA-256 of the CBOR-encoded node program image.
     pub hash: Vec<u8>,
-    /// CBOR-encoded program image (bytecode + map definitions).
+    /// CBOR-encoded node program image (bytecode + map definitions).
     pub image: Vec<u8>,
-    /// Byte length of the CBOR image.
+    /// Byte length of the CBOR node image.
     pub size: u32,
     /// Verification profile used at ingestion time.
     pub verification_profile: VerificationProfile,
@@ -40,6 +43,11 @@ pub struct ProgramRecord {
     pub abi_version: Option<u32>,
     /// Original filename passed at ingestion time (operator-supplied metadata).
     pub source_filename: Option<String>,
+    /// CBOR-encoded decoder `ProgramImage` extracted from `SEC("decoder")` (GW-1902).
+    ///
+    /// `None` for ELFs without a decoder section. Never sent to nodes — used
+    /// only by the gateway for APP_DATA enrichment (GW-1903).
+    pub decoder_image: Option<Vec<u8>>,
 }
 
 /// Errors from program library operations.
@@ -378,6 +386,7 @@ impl ProgramLibrary {
             verification_profile: profile,
             abi_version: None,
             source_filename: None,
+            decoder_image: None,
         })
     }
 
@@ -643,7 +652,179 @@ impl ProgramLibrary {
             .map_err(|e| ProgramError::Internal(format!("CBOR encoding failed: {e}")))?;
 
         // Delegate size-limit and hashing logic to the canonical ingest path.
-        self.ingest_unverified(cbor, profile)
+        let mut record = self.ingest_unverified(cbor, profile)?;
+
+        // ── Decoder extraction (GW-1900, GW-1901, GW-1906) ─────────────
+        //
+        // Check for an optional `SEC("decoder")` section. The decoder image
+        // is stored alongside the node image but does NOT affect the node
+        // program hash.
+        let decoder_image = self.extract_decoder(elf_bytes, tmp_path, &opts)?;
+        if decoder_image.is_some() {
+            info!("decoder section extracted and verified");
+        }
+        record.decoder_image = decoder_image;
+
+        Ok(record)
+    }
+
+    /// Extract and verify an optional decoder section from a BPF ELF (GW-1900).
+    ///
+    /// Returns `Ok(Some(cbor_bytes))` if a valid decoder section is found,
+    /// `Ok(None)` if no decoder section exists (or it is empty), and
+    /// `Err(...)` if the decoder section is invalid (verification failure,
+    /// multiple sections, etc.).
+    fn extract_decoder(
+        &self,
+        elf_bytes: &[u8],
+        tmp_path: &str,
+        opts: &EbpfVerifierOptions,
+    ) -> Result<Option<Vec<u8>>, ProgramError> {
+        // Parse the ELF again with a DecoderPlatform to extract the decoder
+        // section. We re-parse rather than reusing the ElfObject because
+        // get_programs() mutates internal state (map descriptors).
+        let mut elf = ElfObject::new(tmp_path, *opts)
+            .map_err(|e| ProgramError::ElfParseError(e.to_string()))?;
+
+        let mut decoder_platform = DecoderPlatform::new();
+        let decoder_programs = match elf.get_programs("decoder", "", &mut decoder_platform) {
+            Ok(progs) => progs,
+            Err(e) => {
+                let msg = e.to_string();
+                // "Section not found" (or similar) means no decoder section —
+                // this is the common case for ELFs without SEC("decoder").
+                if msg.contains("not found") || msg.contains("Not found") {
+                    return Ok(None);
+                }
+                return Err(ProgramError::ElfParseError(format!(
+                    "decoder section extraction failed: {msg}"
+                )));
+            }
+        };
+
+        if decoder_programs.is_empty() {
+            return Ok(None);
+        }
+
+        // GW-1900 AC-7: reject ELFs with multiple decoder sections.
+        if decoder_programs.len() > 1 {
+            return Err(ProgramError::ElfParseError(format!(
+                "ELF contains {} decoder programs; expected at most one",
+                decoder_programs.len()
+            )));
+        }
+
+        let decoder_prog = &decoder_programs[0];
+
+        // GW-1900 AC-8: empty decoder section (zero bytecode) → no decoder.
+        if decoder_prog.prog.is_empty() {
+            return Ok(None);
+        }
+
+        // Sync map descriptors for the decoder platform.
+        decoder_platform.sync_map_descriptors(&decoder_prog.info.map_descriptors);
+
+        // GW-1901: verify the decoder program with DecoderPlatform.
+        let mut notes: Vec<Vec<String>> = Vec::new();
+        let inst_seq =
+            unmarshal::unmarshal(&decoder_prog.prog, &mut notes, &decoder_prog.info, &decoder_platform, opts)
+                .map_err(|e| {
+                    ProgramError::VerificationFailed(format!(
+                        "decoder unmarshal: {e}"
+                    ))
+                })?;
+
+        let program =
+            PrevailProgram::from_sequence(&inst_seq, &decoder_prog.info, &decoder_platform, opts)
+                .map_err(|e| {
+                    ProgramError::VerificationFailed(format!(
+                        "decoder control flow: {e}"
+                    ))
+                })?;
+
+        let ctx = DomainContext {
+            program_info: &decoder_prog.info,
+            options: opts,
+            platform: &decoder_platform,
+        };
+        let mut registry = VariableRegistry::new();
+        let result = fwd_analyzer::analyze(&program, &ctx, &mut registry);
+
+        if result.failed {
+            let mut diag = String::new();
+            if let Some(first_error) = result.find_first_error() {
+                let mut buf = Vec::new();
+                let _ = printing::print_error(&mut buf, &first_error);
+                if let Ok(s) = String::from_utf8(buf) {
+                    diag.push_str(s.trim_end());
+                }
+            }
+            return Err(ProgramError::VerificationFailed(format!(
+                "decoder program failed verification: {diag}"
+            )));
+        }
+
+        // Build the decoder ProgramImage.
+        let mut bytecode = Vec::with_capacity(decoder_prog.prog.len() * 8);
+        for inst in &decoder_prog.prog {
+            bytecode.push(inst.opcode);
+            bytecode.push(inst.dst_src);
+            bytecode.extend_from_slice(&inst.offset.to_le_bytes());
+            bytecode.extend_from_slice(&inst.imm.to_le_bytes());
+        }
+
+        let maps: Vec<MapDef> = decoder_prog
+            .info
+            .map_descriptors
+            .iter()
+            .map(|md| MapDef {
+                map_type: md.map_type,
+                key_size: md.key_size,
+                value_size: md.value_size,
+                max_entries: md.max_entries,
+            })
+            .collect();
+
+        // Extract initial data for decoder global variable maps.
+        let global_sections = extract_global_section_data(elf_bytes);
+        // Decoder shares ELF global sections with sonde — we need to build
+        // a fresh global section iterator scoped to decoder map descriptors.
+        // Since both sonde and decoder parse the same ELF, the global
+        // sections are the same set. We consume them in map_type==0 order.
+        let mut global_iter = global_sections.into_iter();
+        let map_initial_data: Vec<Vec<u8>> = decoder_prog
+            .info
+            .map_descriptors
+            .iter()
+            .map(|md| {
+                if md.map_type == 0 {
+                    global_iter.next().unwrap_or_default()
+                } else {
+                    Vec::new()
+                }
+            })
+            .collect();
+
+        let decoder_image = ProgramImage {
+            bytecode,
+            maps,
+            map_initial_data,
+        };
+
+        // Enforce size limit: decoder image same as ephemeral (GW-1904).
+        let cbor = decoder_image
+            .encode_deterministic()
+            .map_err(|e| ProgramError::Internal(format!("decoder CBOR encoding failed: {e}")))?;
+
+        let decoder_size = cbor.len() as u32;
+        if decoder_size > MAX_EPHEMERAL_SIZE {
+            return Err(ProgramError::ImageTooLarge {
+                size: decoder_size,
+                limit: MAX_EPHEMERAL_SIZE,
+            });
+        }
+
+        Ok(Some(cbor))
     }
 
     /// Look up a program by its hash in the given storage snapshot.

--- a/crates/sonde-gateway/src/program.rs
+++ b/crates/sonde-gateway/src/program.rs
@@ -217,6 +217,110 @@ fn elf_has_map_sections(data: &[u8]) -> bool {
     false
 }
 
+/// Check whether a BPF ELF contains a section with the given exact name.
+///
+/// Lightweight scan of section headers — does not invoke the full prevail
+/// loader. Returns `false` on any malformed input.
+fn elf_has_section(data: &[u8], target: &str) -> bool {
+    if data.len() < 64 {
+        return false;
+    }
+    if data[0..4] != [0x7f, b'E', b'L', b'F'] || data[4] != 2 || data[5] != 1 {
+        return false;
+    }
+    let e_machine = u16::from_le_bytes([data[18], data[19]]);
+    if e_machine != 0x00F7 {
+        return false;
+    }
+
+    let read_u16 = |off: usize| u16::from_le_bytes([data[off], data[off + 1]]);
+    let read_u64 = |off: usize| {
+        u64::from_le_bytes([
+            data[off],
+            data[off + 1],
+            data[off + 2],
+            data[off + 3],
+            data[off + 4],
+            data[off + 5],
+            data[off + 6],
+            data[off + 7],
+        ])
+    };
+
+    let sh_off = read_u64(40) as usize;
+    let sh_entsize = read_u16(58) as usize;
+    let sh_num = read_u16(60) as usize;
+    let sh_strndx = read_u16(62) as usize;
+
+    if sh_strndx >= sh_num || sh_entsize < 64 {
+        return false;
+    }
+    let str_sh = match sh_strndx
+        .checked_mul(sh_entsize)
+        .and_then(|offset| sh_off.checked_add(offset))
+    {
+        Some(v) => v,
+        None => return false,
+    };
+    if str_sh > data.len().saturating_sub(40) {
+        return false;
+    }
+    let strtab_off = read_u64(str_sh + 24) as usize;
+    let strtab_size = read_u64(str_sh + 32) as usize;
+    let strtab_end = match strtab_off.checked_add(strtab_size) {
+        Some(end) => end,
+        None => return false,
+    };
+    if strtab_end > data.len() {
+        return false;
+    }
+    let strtab = &data[strtab_off..strtab_end];
+
+    for i in 0..sh_num {
+        let hdr = match i
+            .checked_mul(sh_entsize)
+            .and_then(|offset| sh_off.checked_add(offset))
+        {
+            Some(v) => v,
+            None => return false,
+        };
+        if hdr > data.len().saturating_sub(4) {
+            break;
+        }
+        let name_off =
+            u32::from_le_bytes([data[hdr], data[hdr + 1], data[hdr + 2], data[hdr + 3]]) as usize;
+        if name_off >= strtab.len() {
+            continue;
+        }
+        let name_end = strtab[name_off..]
+            .iter()
+            .position(|&b| b == 0)
+            .map_or(strtab.len(), |p| name_off + p);
+        if let Ok(name) = std::str::from_utf8(&strtab[name_off..name_end]) {
+            if name == target {
+                // Also check that the section has non-zero size (GW-1900 AC-8:
+                // empty decoder section is treated as no decoder).
+                if hdr + 40 <= data.len() {
+                    let sec_size = u64::from_le_bytes([
+                        data[hdr + 32],
+                        data[hdr + 33],
+                        data[hdr + 34],
+                        data[hdr + 35],
+                        data[hdr + 36],
+                        data[hdr + 37],
+                        data[hdr + 38],
+                        data[hdr + 39],
+                    ]);
+                    if sec_size > 0 {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
 /// Extract initial data for global variable sections from a BPF ELF.
 ///
 /// Returns section content for `.rodata`, `.data`, and `.bss` sections in
@@ -680,6 +784,12 @@ impl ProgramLibrary {
         tmp_path: &str,
         opts: &EbpfVerifierOptions,
     ) -> Result<Option<Vec<u8>>, ProgramError> {
+        // Lightweight check: scan ELF section headers for a "decoder" section
+        // before invoking Prevail. This avoids relying on error message strings.
+        if !elf_has_section(elf_bytes, "decoder") {
+            return Ok(None);
+        }
+
         // Parse the ELF again with a DecoderPlatform to extract the decoder
         // section. We re-parse rather than reusing the ElfObject because
         // get_programs() mutates internal state (map descriptors).
@@ -687,20 +797,11 @@ impl ProgramLibrary {
             .map_err(|e| ProgramError::ElfParseError(e.to_string()))?;
 
         let mut decoder_platform = DecoderPlatform::new();
-        let decoder_programs = match elf.get_programs("decoder", "", &mut decoder_platform) {
-            Ok(progs) => progs,
-            Err(e) => {
-                let msg = e.to_string();
-                // "Section not found" (or similar) means no decoder section —
-                // this is the common case for ELFs without SEC("decoder").
-                if msg.contains("not found") || msg.contains("Not found") {
-                    return Ok(None);
-                }
-                return Err(ProgramError::ElfParseError(format!(
-                    "decoder section extraction failed: {msg}"
-                )));
-            }
-        };
+        let decoder_programs = elf
+            .get_programs("decoder", "", &mut decoder_platform)
+            .map_err(|e| {
+                ProgramError::ElfParseError(format!("decoder section extraction failed: {e}"))
+            })?;
 
         if decoder_programs.is_empty() {
             return Ok(None);
@@ -788,10 +889,7 @@ impl ProgramLibrary {
 
         // Extract initial data for decoder global variable maps.
         let global_sections = extract_global_section_data(elf_bytes);
-        // Decoder shares ELF global sections with sonde — we need to build
-        // a fresh global section iterator scoped to decoder map descriptors.
-        // Since both sonde and decoder parse the same ELF, the global
-        // sections are the same set. We consume them in map_type==0 order.
+        let global_count = global_sections.len();
         let mut global_iter = global_sections.into_iter();
         let map_initial_data: Vec<Vec<u8>> = decoder_prog
             .info
@@ -805,6 +903,21 @@ impl ProgramLibrary {
                 }
             })
             .collect();
+
+        // Validate 1:1 correspondence between ELF global sections and
+        // map_type==0 descriptors (same check as the node image path).
+        let type0_count = decoder_prog
+            .info
+            .map_descriptors
+            .iter()
+            .filter(|md| md.map_type == 0)
+            .count();
+        if type0_count != global_count {
+            return Err(ProgramError::ElfParseError(format!(
+                "decoder global section count mismatch: ELF has {global_count} sections \
+                 but Prevail reports {type0_count} map_type==0 descriptors"
+            )));
+        }
 
         let decoder_image = ProgramImage {
             bytecode,

--- a/crates/sonde-gateway/src/program.rs
+++ b/crates/sonde-gateway/src/program.rs
@@ -333,7 +333,7 @@ fn elf_has_section(data: &[u8], target: &str) -> bool {
 /// returned for them since map storage is already zero-initialized.
 ///
 /// Returns an empty Vec if the ELF is malformed.
-fn extract_global_section_data(data: &[u8]) -> Vec<Vec<u8>> {
+fn extract_global_section_data(data: &[u8]) -> Vec<(Vec<u8>, bool)> {
     if data.len() < 64 {
         return Vec::new();
     }
@@ -430,16 +430,21 @@ fn extract_global_section_data(data: &[u8]) -> Vec<Vec<u8>> {
         let sec_off = read_u64(hdr + 24) as usize;
         let sec_size = read_u64(hdr + 32) as usize;
 
+        let is_readonly = name == ".rodata"
+            || name
+                .strip_prefix(".rodata")
+                .is_some_and(|rest| rest.starts_with('.'));
+
         if sh_type == SHT_PROGBITS {
             // .rodata / .data — extract file content.
             let sec_end = match sec_off.checked_add(sec_size) {
                 Some(end) if end <= data.len() => end,
                 _ => continue,
             };
-            sections.push(data[sec_off..sec_end].to_vec());
+            sections.push((data[sec_off..sec_end].to_vec(), is_readonly));
         } else {
             // .bss (SHT_NOBITS) — no file data; maps are zero-initialized.
-            sections.push(Vec::new());
+            sections.push((Vec::new(), false));
         }
     }
     sections
@@ -717,19 +722,18 @@ impl ProgramLibrary {
         let global_sections = extract_global_section_data(elf_bytes);
         let global_count = global_sections.len();
         let mut global_iter = global_sections.into_iter();
-        let map_initial_data: Vec<Vec<u8>> = first
-            .info
-            .map_descriptors
-            .iter()
-            .map(|md| {
-                if md.map_type == 0 {
-                    // Global variable map — consume next section data.
-                    global_iter.next().unwrap_or_default()
-                } else {
-                    Vec::new()
-                }
-            })
-            .collect();
+        let mut map_initial_data: Vec<Vec<u8>> = Vec::with_capacity(maps.len());
+        let mut map_readonly: Vec<bool> = Vec::with_capacity(maps.len());
+        for md in &first.info.map_descriptors {
+            if md.map_type == 0 {
+                let (data, readonly) = global_iter.next().unwrap_or_default();
+                map_initial_data.push(data);
+                map_readonly.push(readonly);
+            } else {
+                map_initial_data.push(Vec::new());
+                map_readonly.push(false);
+            }
+        }
 
         // Verify 1:1 correspondence between ELF global sections and
         // Prevail map_type==0 descriptors (GW-0405 criterion 4).
@@ -750,6 +754,7 @@ impl ProgramLibrary {
             bytecode,
             maps,
             map_initial_data,
+            map_readonly,
         };
         let cbor = image
             .encode_deterministic()
@@ -891,18 +896,18 @@ impl ProgramLibrary {
         let global_sections = extract_global_section_data(elf_bytes);
         let global_count = global_sections.len();
         let mut global_iter = global_sections.into_iter();
-        let map_initial_data: Vec<Vec<u8>> = decoder_prog
-            .info
-            .map_descriptors
-            .iter()
-            .map(|md| {
-                if md.map_type == 0 {
-                    global_iter.next().unwrap_or_default()
-                } else {
-                    Vec::new()
-                }
-            })
-            .collect();
+        let mut map_initial_data: Vec<Vec<u8>> = Vec::with_capacity(maps.len());
+        let mut map_readonly: Vec<bool> = Vec::with_capacity(maps.len());
+        for md in &decoder_prog.info.map_descriptors {
+            if md.map_type == 0 {
+                let (data, readonly) = global_iter.next().unwrap_or_default();
+                map_initial_data.push(data);
+                map_readonly.push(readonly);
+            } else {
+                map_initial_data.push(Vec::new());
+                map_readonly.push(false);
+            }
+        }
 
         // Validate 1:1 correspondence between ELF global sections and
         // map_type==0 descriptors (same check as the node image path).
@@ -923,6 +928,7 @@ impl ProgramLibrary {
             bytecode,
             maps,
             map_initial_data,
+            map_readonly,
         };
 
         // Enforce size limit: decoder image same as ephemeral (GW-1904).
@@ -1515,7 +1521,11 @@ mod tests {
             1,
             "expected one global data section (.rodata)"
         );
-        assert_eq!(sections[0], rodata_content);
+        assert_eq!(sections[0].0, rodata_content);
+        assert!(
+            sections[0].1,
+            "expected .rodata section to be marked read-only"
+        );
     }
 
     /// T-0412: ELF .bss section (SHT_NOBITS) produces empty data (GW-0405).
@@ -1588,9 +1598,10 @@ mod tests {
         let sections = extract_global_section_data(&elf);
         assert_eq!(sections.len(), 1, "expected one global data section (.bss)");
         assert!(
-            sections[0].is_empty(),
+            sections[0].0.is_empty(),
             ".bss section should produce empty data"
         );
+        assert!(!sections[0].1, ".bss section should not be read-only");
     }
 
     /// Non-BPF ELF (wrong e_machine) returns no sections.
@@ -1718,9 +1729,10 @@ mod tests {
             "only .rodata should produce initial data; .maps must be excluded"
         );
         assert_eq!(
-            sections[0], rodata_content,
+            sections[0].0, rodata_content,
             "the single initial data entry should match .rodata content"
         );
+        assert!(sections[0].1, ".rodata section should be marked read-only");
     }
 
     /// GW-0405 criterion 6: prefix matching captures `.rodata.str1.1` etc.
@@ -1807,7 +1819,8 @@ mod tests {
             1,
             "prefixed .rodata.str1.1 should be matched"
         );
-        assert_eq!(sections[0], rodata_content);
+        assert_eq!(sections[0].0, rodata_content);
+        assert!(sections[0].1, ".rodata.str1.1 should be marked read-only");
     }
 
     /// Build a minimal BPF ELF whose only non-`.text` section has the given

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -650,6 +650,25 @@ impl SqliteStorage {
                 })?;
             }
         }
+        // Migration: add decoder_image column to programs table (GW-1902).
+        {
+            let prog_cols: Vec<String> = conn
+                .prepare("PRAGMA table_info(programs)")
+                .and_then(|mut stmt| stmt.query_map([], |row| row.get::<_, String>(1))?.collect())
+                .map_err(|e| {
+                    StorageError::Internal(format!(
+                        "migration check failed (table: programs, column: decoder_image): {e}"
+                    ))
+                })?;
+            if !prog_cols.iter().any(|n| n == "decoder_image") {
+                conn.execute_batch("ALTER TABLE programs ADD COLUMN decoder_image BLOB")
+                    .map_err(|e| {
+                        StorageError::Internal(format!(
+                            "migration failed: ALTER TABLE programs ADD COLUMN decoder_image: {e}"
+                        ))
+                    })?;
+            }
+        }
         // Migrate any legacy plaintext 32-byte PSK blobs to AES-256-GCM encrypted
         // form. This must run before `validate_master_key` since validation only
         // checks encrypted blobs.
@@ -1033,17 +1052,17 @@ impl Storage for SqliteStorage {
         let hash = hash.to_vec();
         self.with_conn(move |conn| {
             conn.query_row(
-                "SELECT hash, image, size, verification_profile, abi_version, source_filename FROM programs WHERE hash = ?1",
+                "SELECT hash, image, size, verification_profile, abi_version, source_filename, decoder_image FROM programs WHERE hash = ?1",
                 params![hash],
                 |row| {
                     let profile_str: String = row.get(3)?;
-                    Ok((row.get(0)?, row.get(1)?, row.get(2)?, profile_str, row.get(4)?, row.get(5)?))
+                    Ok((row.get(0)?, row.get(1)?, row.get(2)?, profile_str, row.get(4)?, row.get(5)?, row.get(6)?))
                 },
             )
             .optional()
             .map_err(map_err)?
             .map(
-                |(hash, image, size, profile_str, abi_version, source_filename): (Vec<u8>, Vec<u8>, u32, String, Option<u32>, Option<String>)| {
+                |(hash, image, size, profile_str, abi_version, source_filename, decoder_image): (Vec<u8>, Vec<u8>, u32, String, Option<u32>, Option<String>, Option<Vec<u8>>)| {
                     Ok(ProgramRecord {
                         hash,
                         image,
@@ -1051,6 +1070,7 @@ impl Storage for SqliteStorage {
                         verification_profile: parse_profile(&profile_str)?,
                         abi_version,
                         source_filename,
+                        decoder_image,
                     })
                 },
             )
@@ -1064,13 +1084,14 @@ impl Storage for SqliteStorage {
         record.source_filename = normalize_display_filename(&record.source_filename);
         self.with_conn(move |conn| {
             conn.execute(
-                "INSERT INTO programs (hash, image, size, verification_profile, abi_version, source_filename) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+                "INSERT INTO programs (hash, image, size, verification_profile, abi_version, source_filename, decoder_image) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7) \
                  ON CONFLICT(hash) DO UPDATE SET \
                  image=excluded.image, size=excluded.size, \
                  verification_profile=excluded.verification_profile, \
                  abi_version=excluded.abi_version, \
-                 source_filename=excluded.source_filename",
+                 source_filename=excluded.source_filename, \
+                 decoder_image=excluded.decoder_image",
                 params![
                     record.hash,
                     record.image,
@@ -1078,6 +1099,7 @@ impl Storage for SqliteStorage {
                     profile_to_str(&record.verification_profile),
                     record.abi_version,
                     record.source_filename,
+                    record.decoder_image,
                 ],
             )
             .map_err(map_err)?;
@@ -1100,7 +1122,7 @@ impl Storage for SqliteStorage {
         self.with_conn(|conn| {
             let mut stmt = conn
                 .prepare(
-                    "SELECT hash, image, size, verification_profile, abi_version, source_filename FROM programs",
+                    "SELECT hash, image, size, verification_profile, abi_version, source_filename, decoder_image FROM programs",
                 )
                 .map_err(map_err)?;
             let rows = stmt
@@ -1113,18 +1135,20 @@ impl Storage for SqliteStorage {
                         profile_str,
                         row.get(4)?,
                         row.get(5)?,
+                        row.get(6)?,
                     ))
                 })
                 .map_err(map_err)?;
             let mut programs = Vec::new();
             for row in rows {
-                let (hash, image, size, profile_str, abi_version, source_filename): (
+                let (hash, image, size, profile_str, abi_version, source_filename, decoder_image): (
                     Vec<u8>,
                     Vec<u8>,
                     u32,
                     String,
                     Option<u32>,
                     Option<String>,
+                    Option<Vec<u8>>,
                 ) = row.map_err(map_err)?;
                 programs.push(ProgramRecord {
                     hash,
@@ -1133,6 +1157,7 @@ impl Storage for SqliteStorage {
                     verification_profile: parse_profile(&profile_str)?,
                     abi_version,
                     source_filename,
+                    decoder_image,
                 });
             }
             Ok(programs)
@@ -1804,6 +1829,7 @@ mod tests {
             verification_profile: VerificationProfile::Resident,
             abi_version: None,
             source_filename: None,
+            decoder_image: None,
         }
     }
 

--- a/crates/sonde-gateway/src/state_bundle.rs
+++ b/crates/sonde-gateway/src/state_bundle.rs
@@ -91,6 +91,7 @@ const PROG_KEY_SIZE: i64 = 3;
 const PROG_KEY_PROFILE: i64 = 4;
 const PROG_KEY_ABI: i64 = 5;
 const PROG_KEY_SRC_FILENAME: i64 = 6;
+const PROG_KEY_DECODER_IMAGE: i64 = 7;
 
 // ── CBOR key IDs (gateway identity map) ─────────────────────────────────────
 
@@ -472,6 +473,13 @@ fn program_to_cbor(p: &ProgramRecord) -> ciborium::value::Value {
             Value::Integer(PROG_KEY_SRC_FILENAME.into()),
             match &p.source_filename {
                 Some(s) => Value::Text(s.clone()),
+                None => Value::Null,
+            },
+        ),
+        (
+            Value::Integer(PROG_KEY_DECODER_IMAGE.into()),
+            match &p.decoder_image {
+                Some(b) => Value::Bytes(b.clone()),
                 None => Value::Null,
             },
         ),
@@ -950,6 +958,7 @@ fn program_from_cbor(v: ciborium::value::Value) -> Result<ProgramRecord, BundleE
     let mut profile_int: Option<u32> = None;
     let mut abi_version: Option<Option<u32>> = None;
     let mut source_filename: Option<String> = None;
+    let mut decoder_image: Option<Vec<u8>> = None;
 
     for (k, v) in map {
         if let Value::Integer(key_int) = k {
@@ -995,6 +1004,17 @@ fn program_from_cbor(v: ciborium::value::Value) -> Result<ProgramRecord, BundleE
                         _ => {
                             return Err(BundleError::Decode(
                                 "source_filename must be text or null".into(),
+                            ))
+                        }
+                    };
+                }
+                Some(PROG_KEY_DECODER_IMAGE) => {
+                    decoder_image = match v {
+                        Value::Bytes(b) => Some(b),
+                        Value::Null => None,
+                        _ => {
+                            return Err(BundleError::Decode(
+                                "decoder_image must be bytes or null".into(),
                             ))
                         }
                     };
@@ -1045,6 +1065,7 @@ fn program_from_cbor(v: ciborium::value::Value) -> Result<ProgramRecord, BundleE
         verification_profile,
         abi_version: abi_version.flatten(),
         source_filename,
+        decoder_image,
     })
 }
 
@@ -1406,6 +1427,7 @@ mod tests {
             verification_profile: profile,
             abi_version: None,
             source_filename: None,
+            decoder_image: None,
         }
     }
 
@@ -1557,6 +1579,7 @@ mod tests {
             verification_profile: VerificationProfile::Ephemeral,
             abi_version: Some(2),
             source_filename: None,
+            decoder_image: None,
         };
 
         let bundle = encrypt_state(&[node], &[prog], "abi-pass").unwrap();

--- a/crates/sonde-gateway/tests/behavioral_gaps.rs
+++ b/crates/sonde-gateway/tests/behavioral_gaps.rs
@@ -149,6 +149,7 @@ fn make_cbor_image(bytecode: &[u8]) -> Vec<u8> {
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     image.encode_deterministic().unwrap()
 }
@@ -189,6 +190,7 @@ async fn store_test_program(storage: &InMemoryStorage, bytecode: &[u8]) -> Vec<u
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let record = lib
@@ -209,6 +211,7 @@ async fn store_test_program_with_profile(
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let record = lib.ingest_unverified(cbor, profile).unwrap();
@@ -249,6 +252,7 @@ fn t0402_deterministic_cbor_sorted_keys_and_shortest_form() {
             },
         ],
         map_initial_data: vec![Vec::new(); 2],
+        map_readonly: vec![false; 2],
     };
 
     let cbor = image.encode_deterministic().unwrap();
@@ -559,6 +563,7 @@ fn t0402_deterministic_hash_identity() {
             max_entries: 256,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false; 1],
     };
     let image_b = image_a.clone();
 

--- a/crates/sonde-gateway/tests/connector_api.rs
+++ b/crates/sonde-gateway/tests/connector_api.rs
@@ -159,6 +159,7 @@ async fn store_program_with_profile(
             verification_profile,
             abi_version: None,
             source_filename: None,
+            decoder_image: None,
         })
         .await
         .unwrap();

--- a/crates/sonde-gateway/tests/connector_api.rs
+++ b/crates/sonde-gateway/tests/connector_api.rs
@@ -141,6 +141,7 @@ fn make_cbor_image(bytecode: &[u8]) -> Vec<u8> {
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     image.encode_deterministic().unwrap()
 }

--- a/crates/sonde-gateway/tests/decoder.rs
+++ b/crates/sonde-gateway/tests/decoder.rs
@@ -637,7 +637,7 @@ fn t1904d_map_lookup_reads_rodata() {
     // if r0 == 0 goto +5 (skip to exit)
     bytecode.extend_from_slice(&bpf_insn(0x15, 0x00, 5, 0)); // jeq r0, 0, +5
                                                              // r3 = *(u32*)(r0 + 0)
-    bytecode.extend_from_slice(&bpf_insn(0x61, 0x03 | (0x00 << 4), 0, 0)); // ldxw r3, [r0+0]
+    bytecode.extend_from_slice(&bpf_insn(0x61, 0x03, 0, 0)); // ldxw r3, [r0+0]
                                                                            // *(u8*)(r10-8) = 'v'
     bytecode.extend_from_slice(&st_mem_b(10, -8, b'v' as i32));
     // r1 = r10 - 8

--- a/crates/sonde-gateway/tests/decoder.rs
+++ b/crates/sonde-gateway/tests/decoder.rs
@@ -638,7 +638,7 @@ fn t1904d_map_lookup_reads_rodata() {
     bytecode.extend_from_slice(&bpf_insn(0x15, 0x00, 5, 0)); // jeq r0, 0, +5
                                                              // r3 = *(u32*)(r0 + 0)
     bytecode.extend_from_slice(&bpf_insn(0x61, 0x03, 0, 0)); // ldxw r3, [r0+0]
-                                                                           // *(u8*)(r10-8) = 'v'
+                                                             // *(u8*)(r10-8) = 'v'
     bytecode.extend_from_slice(&st_mem_b(10, -8, b'v' as i32));
     // r1 = r10 - 8
     bytecode.extend_from_slice(&mov_reg(1, 10));

--- a/crates/sonde-gateway/tests/decoder.rs
+++ b/crates/sonde-gateway/tests/decoder.rs
@@ -383,7 +383,7 @@ fn t1904_emit_reading_captures_readings() {
     blob[1] = 0x80;
     blob[2..6].copy_from_slice(&25125i32.to_le_bytes());
 
-    let readings = decoder::execute_decoder(&cbor, &blob).unwrap();
+    let readings = unsafe { decoder::execute_decoder(&cbor, &blob) }.unwrap();
 
     assert_eq!(readings.len(), 1);
     assert_eq!(readings.get("temp_mc"), Some(&25125i64));
@@ -424,7 +424,7 @@ fn t1904b_emit_reading_name_too_long() {
     };
     let cbor = image.encode_deterministic().unwrap();
 
-    let readings = decoder::execute_decoder(&cbor, &[0u8; 10]).unwrap();
+    let readings = unsafe { decoder::execute_decoder(&cbor, &[0u8; 10]) }.unwrap();
 
     // The reading should NOT have been included (name too long).
     assert!(
@@ -463,7 +463,7 @@ fn t1904a_emit_reading_max_name_ok() {
     };
     let cbor = image.encode_deterministic().unwrap();
 
-    let readings = decoder::execute_decoder(&cbor, &[0u8; 10]).unwrap();
+    let readings = unsafe { decoder::execute_decoder(&cbor, &[0u8; 10]) }.unwrap();
 
     assert_eq!(readings.len(), 1, "expected one reading with 64-byte name");
     let name = "A".repeat(64);
@@ -490,7 +490,7 @@ fn t1903b_decoder_failure_returns_error() {
     };
     let cbor = image.encode_deterministic().unwrap();
 
-    let result = decoder::execute_decoder(&cbor, &[0u8; 10]);
+    let result = unsafe { decoder::execute_decoder(&cbor, &[0u8; 10]) };
     assert!(
         result.is_err(),
         "expected decoder to fail with budget exceeded"
@@ -527,7 +527,7 @@ fn t1903c_enriched_preserves_raw_blob() {
     let cbor = image.encode_deterministic().unwrap();
 
     let original_blob: Vec<u8> = vec![0x19, 0x80, 0x45, 0x62, 0x00, 0x00];
-    let readings = decoder::execute_decoder(&cbor, &original_blob).unwrap();
+    let readings = unsafe { decoder::execute_decoder(&cbor, &original_blob) }.unwrap();
 
     // Readings should be non-empty.
     assert!(!readings.is_empty());
@@ -570,7 +570,7 @@ fn t1904c_emit_reading_overflow() {
     };
     let cbor = image.encode_deterministic().unwrap();
 
-    let readings = decoder::execute_decoder(&cbor, &[0u8; 10]).unwrap();
+    let readings = unsafe { decoder::execute_decoder(&cbor, &[0u8; 10]) }.unwrap();
 
     // First 32 readings should be present, 33rd rejected.
     assert_eq!(
@@ -665,7 +665,7 @@ fn t1904d_map_lookup_reads_rodata() {
     };
     let cbor = image.encode_deterministic().unwrap();
 
-    let readings = decoder::execute_decoder(&cbor, &[0u8; 4]).unwrap();
+    let readings = unsafe { decoder::execute_decoder(&cbor, &[0u8; 4]) }.unwrap();
     assert_eq!(
         readings.get("v"),
         Some(&1337i64),
@@ -741,7 +741,7 @@ fn t1904e_map_update_rodata_rejected() {
     };
     let cbor = image.encode_deterministic().unwrap();
 
-    let readings = decoder::execute_decoder(&cbor, &[0u8; 4]).unwrap();
+    let readings = unsafe { decoder::execute_decoder(&cbor, &[0u8; 4]) }.unwrap();
     // map_update returns -1 (0xFFFFFFFFFFFFFFFF as u64, reinterpreted as i64 = -1)
     let ret = readings.get("r").expect("expected return value reading");
     assert_eq!(*ret, -1i64, "map_update on .rodata should return -1");

--- a/crates/sonde-gateway/tests/decoder.rs
+++ b/crates/sonde-gateway/tests/decoder.rs
@@ -201,9 +201,7 @@ fn t1900_dual_section_elf_ingestion() {
     let elf = make_dual_section_elf(&sonde_code, &decoder_code);
 
     let lib = ProgramLibrary::new();
-    let record = lib
-        .ingest_elf(&elf, VerificationProfile::Resident)
-        .unwrap();
+    let record = lib.ingest_elf(&elf, VerificationProfile::Resident).unwrap();
 
     assert!(
         record.decoder_image.is_some(),
@@ -220,9 +218,7 @@ fn t1900a_elf_without_decoder() {
     let elf = make_sonde_elf(&sonde_code);
 
     let lib = ProgramLibrary::new();
-    let record = lib
-        .ingest_elf(&elf, VerificationProfile::Resident)
-        .unwrap();
+    let record = lib.ingest_elf(&elf, VerificationProfile::Resident).unwrap();
 
     assert!(
         record.decoder_image.is_none(),
@@ -249,9 +245,7 @@ fn t1900c_empty_decoder_section() {
     let elf = make_dual_section_elf(&sonde_code, empty);
 
     let lib = ProgramLibrary::new();
-    let record = lib
-        .ingest_elf(&elf, VerificationProfile::Resident)
-        .unwrap();
+    let record = lib.ingest_elf(&elf, VerificationProfile::Resident).unwrap();
 
     assert!(
         record.decoder_image.is_none(),
@@ -392,7 +386,10 @@ fn t1904b_emit_reading_name_too_long() {
     let readings = decoder::execute_decoder(&cbor, &[0u8; 10]).unwrap();
 
     // The reading should NOT have been included (name too long).
-    assert!(readings.is_empty(), "expected no readings for name_len > 64");
+    assert!(
+        readings.is_empty(),
+        "expected no readings for name_len > 64"
+    );
 }
 
 // T-1904a: emit_reading with name_len=64 succeeds
@@ -451,7 +448,10 @@ fn t1903b_decoder_failure_returns_error() {
     let cbor = image.encode_deterministic().unwrap();
 
     let result = decoder::execute_decoder(&cbor, &[0u8; 10]);
-    assert!(result.is_err(), "expected decoder to fail with budget exceeded");
+    assert!(
+        result.is_err(),
+        "expected decoder to fail with budget exceeded"
+    );
 }
 
 // T-1901: Decoder verification passes with permitted helpers
@@ -503,7 +503,7 @@ fn t1904c_emit_reading_overflow() {
     for i in 0u8..33 {
         // Write name byte to stack at r10 - 4
         insns.push(st_mem_b(10, -4, i as i32 + 0x30)); // '0', '1', ..., 'P'
-        // r1 = r10 - 4
+                                                       // r1 = r10 - 4
         insns.push(mov_reg(1, 10));
         insns.push(add_imm(1, -4));
         // r2 = 1 (name length)

--- a/crates/sonde-gateway/tests/decoder.rs
+++ b/crates/sonde-gateway/tests/decoder.rs
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Decoder BPF program tests (GW-1900 through GW-1906).
+//!
+//! Validates decoder section extraction from ELF, DecoderPlatform
+//! verification, decoder image storage, APP_DATA enrichment via
+//! decoder execution, and backward compatibility.
+
+use std::collections::BTreeMap;
+
+use sonde_gateway::decoder;
+use sonde_gateway::program::{ProgramLibrary, VerificationProfile};
+
+// ── BPF instruction helpers ────────────────────────────────────────────
+
+fn bpf_insn(opcode: u8, dst_src: u8, offset: i16, imm: i32) -> [u8; 8] {
+    let mut insn = [0u8; 8];
+    insn[0] = opcode;
+    insn[1] = dst_src;
+    insn[2..4].copy_from_slice(&offset.to_le_bytes());
+    insn[4..8].copy_from_slice(&imm.to_le_bytes());
+    insn
+}
+
+fn mov_imm(dst: u8, imm: i32) -> [u8; 8] {
+    bpf_insn(0xb7, dst, 0, imm)
+}
+
+fn call_helper(id: i32) -> [u8; 8] {
+    bpf_insn(0x85, 0, 0, id)
+}
+
+fn exit_insn() -> [u8; 8] {
+    bpf_insn(0x95, 0, 0, 0)
+}
+
+fn st_mem_w(dst: u8, offset: i16, imm: i32) -> [u8; 8] {
+    bpf_insn(0x62, dst, offset, imm)
+}
+
+fn st_mem_b(dst: u8, offset: i16, imm: i32) -> [u8; 8] {
+    bpf_insn(0x72, dst, offset, imm)
+}
+
+fn mov_reg(dst: u8, src: u8) -> [u8; 8] {
+    bpf_insn(0xbf, dst | (src << 4), 0, 0)
+}
+
+fn add_imm(dst: u8, imm: i32) -> [u8; 8] {
+    bpf_insn(0x07, dst, 0, imm)
+}
+
+fn assemble(insns: &[[u8; 8]]) -> Vec<u8> {
+    insns.iter().flat_map(|i| i.iter().copied()).collect()
+}
+
+// ── ELF builder ────────────────────────────────────────────────────────
+
+/// Build a minimal BPF ELF with a single `sonde` section.
+fn make_sonde_elf(bpf_code: &[u8]) -> Vec<u8> {
+    make_elf_with_sections(&[("sonde", bpf_code)])
+}
+
+/// Build a BPF ELF with both `sonde` and `decoder` sections.
+fn make_dual_section_elf(sonde_code: &[u8], decoder_code: &[u8]) -> Vec<u8> {
+    make_elf_with_sections(&[("sonde", sonde_code), ("decoder", decoder_code)])
+}
+
+/// Build a BPF ELF with arbitrary named sections.
+fn make_elf_with_sections(sections: &[(&str, &[u8])]) -> Vec<u8> {
+    // Build the shstrtab: null byte + each section name + ".shstrtab"
+    let mut shstrtab = vec![0u8]; // null prefix
+    let mut name_offsets: Vec<u32> = Vec::new();
+    for (name, _) in sections {
+        name_offsets.push(shstrtab.len() as u32);
+        shstrtab.extend_from_slice(name.as_bytes());
+        shstrtab.push(0);
+    }
+    let shstrtab_name_offset = shstrtab.len() as u32;
+    shstrtab.extend_from_slice(b".shstrtab\0");
+
+    // Compute offsets.
+    let mut data_offset: u64 = 64; // after ELF header
+    let mut section_offsets: Vec<u64> = Vec::new();
+    for (_, code) in sections {
+        section_offsets.push(data_offset);
+        data_offset += code.len() as u64;
+    }
+    let shstrtab_offset: u64 = data_offset;
+    let shdr_offset: u64 = shstrtab_offset + shstrtab.len() as u64;
+
+    // Number of section headers: null + each section + .shstrtab
+    let num_sections = 1 + sections.len() + 1;
+    let shstrndx = num_sections - 1; // .shstrtab is last
+
+    let mut elf = Vec::new();
+
+    // ELF header (64 bytes)
+    elf.extend_from_slice(&[0x7f, b'E', b'L', b'F']);
+    elf.push(2); // ELFCLASS64
+    elf.push(1); // ELFDATA2LSB
+    elf.push(1); // EI_VERSION
+    elf.extend_from_slice(&[0; 9]);
+    elf.extend_from_slice(&1u16.to_le_bytes()); // ET_REL
+    elf.extend_from_slice(&247u16.to_le_bytes()); // EM_BPF
+    elf.extend_from_slice(&1u32.to_le_bytes()); // e_version
+    elf.extend_from_slice(&0u64.to_le_bytes()); // e_entry
+    elf.extend_from_slice(&0u64.to_le_bytes()); // e_phoff
+    elf.extend_from_slice(&shdr_offset.to_le_bytes()); // e_shoff
+    elf.extend_from_slice(&0u32.to_le_bytes()); // e_flags
+    elf.extend_from_slice(&64u16.to_le_bytes()); // e_ehsize
+    elf.extend_from_slice(&0u16.to_le_bytes()); // e_phentsize
+    elf.extend_from_slice(&0u16.to_le_bytes()); // e_phnum
+    elf.extend_from_slice(&64u16.to_le_bytes()); // e_shentsize
+    elf.extend_from_slice(&(num_sections as u16).to_le_bytes());
+    elf.extend_from_slice(&(shstrndx as u16).to_le_bytes());
+    assert_eq!(elf.len(), 64);
+
+    // Section data
+    for (_, code) in sections {
+        elf.extend_from_slice(code);
+    }
+    elf.extend_from_slice(&shstrtab);
+
+    // Section headers
+
+    // [0] Null
+    elf.extend_from_slice(&[0u8; 64]);
+
+    // Program sections
+    for (i, (_, code)) in sections.iter().enumerate() {
+        let mut sh = [0u8; 64];
+        sh[0..4].copy_from_slice(&name_offsets[i].to_le_bytes());
+        sh[4..8].copy_from_slice(&1u32.to_le_bytes()); // SHT_PROGBITS
+        let flags: u64 = 0x6; // SHF_ALLOC | SHF_EXECINSTR
+        sh[8..16].copy_from_slice(&flags.to_le_bytes());
+        sh[24..32].copy_from_slice(&section_offsets[i].to_le_bytes());
+        sh[32..40].copy_from_slice(&(code.len() as u64).to_le_bytes());
+        sh[48..56].copy_from_slice(&8u64.to_le_bytes()); // alignment
+        elf.extend_from_slice(&sh);
+    }
+
+    // .shstrtab section header
+    let mut sh = [0u8; 64];
+    sh[0..4].copy_from_slice(&shstrtab_name_offset.to_le_bytes());
+    sh[4..8].copy_from_slice(&3u32.to_le_bytes()); // SHT_STRTAB
+    sh[24..32].copy_from_slice(&shstrtab_offset.to_le_bytes());
+    sh[32..40].copy_from_slice(&(shstrtab.len() as u64).to_le_bytes());
+    sh[48..56].copy_from_slice(&1u64.to_le_bytes());
+    elf.extend_from_slice(&sh);
+
+    elf
+}
+
+/// Minimal valid BPF program: `mov r0, 0; exit`
+fn nop_bytecode() -> Vec<u8> {
+    assemble(&[mov_imm(0, 0), exit_insn()])
+}
+
+/// Decoder BPF program that calls emit_reading("temp_mc", 7, 25125).
+///
+/// The program writes the name "temp_mc" to stack memory, then calls
+/// emit_reading with: r1=name_ptr, r2=7, r3=25125.
+fn emit_temp_decoder_bytecode() -> Vec<u8> {
+    // We need to write "temp_mc" (7 bytes) to the stack, then call emit_reading.
+    // Stack starts at r10 - 512. Let's use r10 - 8 for name storage.
+    //
+    // "temp_mc" = 0x74 0x65 0x6d 0x70 0x5f 0x6d 0x63
+    //
+    // Store 4 bytes at r10-8: "temp" = 0x706d6574
+    // Store 3 bytes at r10-4: "_mc\0" = 0x00636d5f (but we only need 3 bytes)
+    let insns: Vec<[u8; 8]> = vec![
+        // Store "temp" at r10 - 8
+        st_mem_w(10, -8, 0x706d6574_u32 as i32), // "temp" (little-endian)
+        // Store "_mc" at r10 - 4 (with trailing null byte — we pass name_len=7)
+        st_mem_w(10, -4, 0x00636d5f_u32 as i32), // "_mc\0"
+        // r1 = r10 - 8 (pointer to name on stack)
+        mov_reg(1, 10),
+        add_imm(1, -8),
+        // r2 = 7 (name length)
+        mov_imm(2, 7),
+        // r3 = 25125 (temperature in milli-degrees)
+        mov_imm(3, 25125),
+        // call emit_reading (helper 18)
+        call_helper(18),
+        // r0 = 0; exit
+        mov_imm(0, 0),
+        exit_insn(),
+    ];
+    assemble(&insns)
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+// T-1900: Dual-section ELF ingestion
+#[test]
+fn t1900_dual_section_elf_ingestion() {
+    let sonde_code = nop_bytecode();
+    let decoder_code = nop_bytecode();
+    let elf = make_dual_section_elf(&sonde_code, &decoder_code);
+
+    let lib = ProgramLibrary::new();
+    let record = lib
+        .ingest_elf(&elf, VerificationProfile::Resident)
+        .unwrap();
+
+    assert!(
+        record.decoder_image.is_some(),
+        "expected decoder_image to be present"
+    );
+    // Node program hash covers only the sonde image.
+    assert_eq!(record.hash.len(), 32);
+}
+
+// T-1900a: ELF without decoder section (backward compat)
+#[test]
+fn t1900a_elf_without_decoder() {
+    let sonde_code = nop_bytecode();
+    let elf = make_sonde_elf(&sonde_code);
+
+    let lib = ProgramLibrary::new();
+    let record = lib
+        .ingest_elf(&elf, VerificationProfile::Resident)
+        .unwrap();
+
+    assert!(
+        record.decoder_image.is_none(),
+        "expected no decoder_image for single-section ELF"
+    );
+}
+
+// T-1900b: ELF with decoder only (no sonde section) rejected
+#[test]
+fn t1900b_decoder_only_elf_rejected() {
+    let decoder_code = nop_bytecode();
+    let elf = make_elf_with_sections(&[("decoder", &decoder_code)]);
+
+    let lib = ProgramLibrary::new();
+    let result = lib.ingest_elf(&elf, VerificationProfile::Resident);
+    assert!(result.is_err(), "expected rejection of decoder-only ELF");
+}
+
+// T-1900c: ELF with empty decoder section treated as no decoder
+#[test]
+fn t1900c_empty_decoder_section() {
+    let sonde_code = nop_bytecode();
+    let empty: &[u8] = &[];
+    let elf = make_dual_section_elf(&sonde_code, empty);
+
+    let lib = ProgramLibrary::new();
+    let record = lib
+        .ingest_elf(&elf, VerificationProfile::Resident)
+        .unwrap();
+
+    assert!(
+        record.decoder_image.is_none(),
+        "expected empty decoder section to produce no decoder_image"
+    );
+}
+
+// T-1906: Program hash unchanged by decoder presence
+#[test]
+fn t1906_hash_unchanged_by_decoder() {
+    let sonde_code = nop_bytecode();
+    let lib = ProgramLibrary::new();
+
+    // Ingest without decoder
+    let elf_no_decoder = make_sonde_elf(&sonde_code);
+    let record_no_decoder = lib
+        .ingest_elf(&elf_no_decoder, VerificationProfile::Resident)
+        .unwrap();
+
+    // Ingest with decoder
+    let decoder_code = nop_bytecode();
+    let elf_with_decoder = make_dual_section_elf(&sonde_code, &decoder_code);
+    let record_with_decoder = lib
+        .ingest_elf(&elf_with_decoder, VerificationProfile::Resident)
+        .unwrap();
+
+    assert_eq!(
+        record_no_decoder.hash, record_with_decoder.hash,
+        "node program hash must be identical with and without decoder"
+    );
+}
+
+// T-1901a: Decoder using hardware helpers rejected
+#[test]
+fn t1901a_decoder_with_hardware_helper_rejected() {
+    let sonde_code = nop_bytecode();
+    // Decoder that calls i2c_read (helper 1) — should fail verification.
+    let decoder_code = assemble(&[
+        mov_imm(1, 0),
+        mov_imm(2, 0),
+        mov_imm(3, 0),
+        call_helper(1), // i2c_read — not allowed in decoder
+        mov_imm(0, 0),
+        exit_insn(),
+    ]);
+    let elf = make_dual_section_elf(&sonde_code, &decoder_code);
+
+    let lib = ProgramLibrary::new();
+    let result = lib.ingest_elf(&elf, VerificationProfile::Resident);
+    assert!(
+        result.is_err(),
+        "expected decoder with hardware helper to be rejected"
+    );
+}
+
+// T-1901b: Decoder using send helper rejected
+#[test]
+fn t1901b_decoder_with_send_helper_rejected() {
+    let sonde_code = nop_bytecode();
+    // Decoder that calls send (helper 8).
+    let decoder_code = assemble(&[
+        mov_imm(1, 0),
+        mov_imm(2, 0),
+        call_helper(8), // send — not allowed in decoder
+        mov_imm(0, 0),
+        exit_insn(),
+    ]);
+    let elf = make_dual_section_elf(&sonde_code, &decoder_code);
+
+    let lib = ProgramLibrary::new();
+    let result = lib.ingest_elf(&elf, VerificationProfile::Resident);
+    assert!(
+        result.is_err(),
+        "expected decoder with send helper to be rejected"
+    );
+}
+
+// T-1904: emit_reading captures readings with last-write-wins
+#[test]
+fn t1904_emit_reading_captures_readings() {
+    // Build a decoder ProgramImage that calls emit_reading with known values.
+    // We can't easily build a full ELF for this, so we test the decoder
+    // execution engine directly.
+    let bytecode = emit_temp_decoder_bytecode();
+    let image = sonde_protocol::ProgramImage {
+        bytecode,
+        maps: vec![],
+        map_initial_data: vec![],
+    };
+    let cbor = image.encode_deterministic().unwrap();
+
+    // Simulate a 6-byte TMP102 payload: raw_hi=0x19, raw_lo=0x80, temp_mC=25125
+    let mut blob = vec![0u8; 6];
+    blob[0] = 0x19;
+    blob[1] = 0x80;
+    blob[2..6].copy_from_slice(&25125i32.to_le_bytes());
+
+    let readings = decoder::execute_decoder(&cbor, &blob).unwrap();
+
+    assert_eq!(readings.len(), 1);
+    assert_eq!(readings.get("temp_mc"), Some(&25125i64));
+}
+
+// T-1904b: emit_reading with name_len=65 returns -1
+#[test]
+fn t1904b_emit_reading_name_too_long() {
+    // Build a decoder that calls emit_reading with a 65-byte name.
+    // We'll write 65 bytes to the stack and call emit_reading.
+    // Since BPF stack is 512 bytes per frame, we can allocate 68 bytes
+    // (round up to 4-byte boundary).
+    let mut insns: Vec<[u8; 8]> = Vec::new();
+
+    // Initialize 68 bytes of stack at r10 - 68 (17 words of 4 bytes)
+    for i in 0..17 {
+        insns.push(st_mem_w(10, -68 + i * 4, 0x41414141)); // 'AAAA'
+    }
+
+    // r1 = r10 - 68 (pointer to name)
+    insns.push(mov_reg(1, 10));
+    insns.push(add_imm(1, -68));
+    // r2 = 65 (name length — exceeds 64 byte limit)
+    insns.push(mov_imm(2, 65));
+    // r3 = 42 (value)
+    insns.push(mov_imm(3, 42));
+    // call emit_reading
+    insns.push(call_helper(18));
+    // exit with r0 (should be -1)
+    insns.push(exit_insn());
+
+    let bytecode = assemble(&insns);
+    let image = sonde_protocol::ProgramImage {
+        bytecode,
+        maps: vec![],
+        map_initial_data: vec![],
+    };
+    let cbor = image.encode_deterministic().unwrap();
+
+    let readings = decoder::execute_decoder(&cbor, &[0u8; 10]).unwrap();
+
+    // The reading should NOT have been included (name too long).
+    assert!(readings.is_empty(), "expected no readings for name_len > 64");
+}
+
+// T-1904a: emit_reading with name_len=64 succeeds
+#[test]
+fn t1904a_emit_reading_max_name_ok() {
+    let mut insns: Vec<[u8; 8]> = Vec::new();
+
+    // Initialize 64 bytes of stack at r10 - 64 (16 words of 4 bytes)
+    for i in 0..16 {
+        insns.push(st_mem_w(10, -64 + i * 4, 0x41414141)); // 'AAAA'
+    }
+
+    // r1 = r10 - 64 (pointer to name)
+    insns.push(mov_reg(1, 10));
+    insns.push(add_imm(1, -64));
+    // r2 = 64 (name length — exactly at limit)
+    insns.push(mov_imm(2, 64));
+    // r3 = 99 (value)
+    insns.push(mov_imm(3, 99));
+    insns.push(call_helper(18));
+    insns.push(mov_imm(0, 0));
+    insns.push(exit_insn());
+
+    let bytecode = assemble(&insns);
+    let image = sonde_protocol::ProgramImage {
+        bytecode,
+        maps: vec![],
+        map_initial_data: vec![],
+    };
+    let cbor = image.encode_deterministic().unwrap();
+
+    let readings = decoder::execute_decoder(&cbor, &[0u8; 10]).unwrap();
+
+    assert_eq!(readings.len(), 1, "expected one reading with 64-byte name");
+    let name = "A".repeat(64);
+    assert_eq!(readings.get(&name), Some(&99i64));
+}
+
+// T-1903a: APP_DATA without decoder forwarded unchanged
+// (tested implicitly: execute_decoder is only called when decoder_image is Some)
+
+// T-1903b: Decoder failure does not block data delivery
+#[test]
+fn t1903b_decoder_failure_returns_error() {
+    // Build a decoder that exceeds instruction budget (infinite loop).
+    // BPF: `label: ja label` (unconditional jump to self)
+    let insns = vec![
+        bpf_insn(0x05, 0, -1, 0), // ja -1 (infinite loop)
+    ];
+    let bytecode = assemble(&insns);
+    let image = sonde_protocol::ProgramImage {
+        bytecode,
+        maps: vec![],
+        map_initial_data: vec![],
+    };
+    let cbor = image.encode_deterministic().unwrap();
+
+    let result = decoder::execute_decoder(&cbor, &[0u8; 10]);
+    assert!(result.is_err(), "expected decoder to fail with budget exceeded");
+}
+
+// T-1901: Decoder verification passes with permitted helpers
+#[test]
+fn t1901_decoder_with_emit_reading_passes() {
+    let sonde_code = nop_bytecode();
+    let decoder_code = emit_temp_decoder_bytecode();
+    let elf = make_dual_section_elf(&sonde_code, &decoder_code);
+
+    let lib = ProgramLibrary::new();
+    let result = lib.ingest_elf(&elf, VerificationProfile::Resident);
+    assert!(
+        result.is_ok(),
+        "decoder with emit_reading should pass verification: {:?}",
+        result.err()
+    );
+    assert!(result.unwrap().decoder_image.is_some());
+}
+
+// T-1903c: Enriched message preserves raw blob unchanged
+#[test]
+fn t1903c_enriched_preserves_raw_blob() {
+    let bytecode = emit_temp_decoder_bytecode();
+    let image = sonde_protocol::ProgramImage {
+        bytecode,
+        maps: vec![],
+        map_initial_data: vec![],
+    };
+    let cbor = image.encode_deterministic().unwrap();
+
+    let original_blob: Vec<u8> = vec![0x19, 0x80, 0x45, 0x62, 0x00, 0x00];
+    let readings = decoder::execute_decoder(&cbor, &original_blob).unwrap();
+
+    // Readings should be non-empty.
+    assert!(!readings.is_empty());
+
+    // The blob should not have been mutated (we verify by checking the
+    // original_blob variable is still intact — it was passed by reference).
+    assert_eq!(original_blob, vec![0x19, 0x80, 0x45, 0x62, 0x00, 0x00]);
+}
+
+// T-1904c: emit_reading overflow (33rd reading returns -2)
+#[test]
+fn t1904c_emit_reading_overflow() {
+    // Build a decoder that calls emit_reading 33 times with different names.
+    // Each name is a single byte (different value) written to stack.
+    let mut insns: Vec<[u8; 8]> = Vec::new();
+
+    for i in 0u8..33 {
+        // Write name byte to stack at r10 - 4
+        insns.push(st_mem_b(10, -4, i as i32 + 0x30)); // '0', '1', ..., 'P'
+        // r1 = r10 - 4
+        insns.push(mov_reg(1, 10));
+        insns.push(add_imm(1, -4));
+        // r2 = 1 (name length)
+        insns.push(mov_imm(2, 1));
+        // r3 = i (value)
+        insns.push(mov_imm(3, i as i32));
+        insns.push(call_helper(18));
+        // Note: we don't check return value here — just keep calling
+    }
+
+    insns.push(mov_imm(0, 0));
+    insns.push(exit_insn());
+
+    let bytecode = assemble(&insns);
+    let image = sonde_protocol::ProgramImage {
+        bytecode,
+        maps: vec![],
+        map_initial_data: vec![],
+    };
+    let cbor = image.encode_deterministic().unwrap();
+
+    let readings = decoder::execute_decoder(&cbor, &[0u8; 10]).unwrap();
+
+    // First 32 readings should be present, 33rd rejected.
+    assert_eq!(
+        readings.len(),
+        32,
+        "expected exactly 32 readings (33rd overflow)"
+    );
+}
+
+// Smoke test: handler DATA message roundtrip with readings
+#[test]
+fn handler_data_message_with_readings_roundtrip() {
+    use sonde_gateway::HandlerMessage;
+
+    let mut readings = BTreeMap::new();
+    readings.insert("temp_mc".to_string(), 25125i64);
+    readings.insert("rh_mpermille".to_string(), 45000i64);
+
+    let msg = HandlerMessage::Data {
+        request_id: 42,
+        node_id: "node-01".to_string(),
+        program_hash: vec![0xAA; 32],
+        data: vec![0x01, 0x02, 0x03],
+        timestamp: 1700000000,
+        readings: Some(readings.clone()),
+    };
+
+    let encoded = msg.encode().unwrap();
+    let decoded = HandlerMessage::decode(&encoded).unwrap();
+    assert_eq!(msg, decoded);
+}

--- a/crates/sonde-gateway/tests/decoder.rs
+++ b/crates/sonde-gateway/tests/decoder.rs
@@ -253,6 +253,44 @@ fn t1900c_empty_decoder_section() {
     );
 }
 
+// T-1900d: ELF with multiple decoder sections rejected (AC-7)
+#[test]
+fn t1900d_multiple_decoder_sections_rejected() {
+    // Build an ELF with sonde + two decoder sections.
+    let sonde_code = nop_bytecode();
+    let decoder_code = nop_bytecode();
+    let elf = make_elf_with_sections(&[
+        ("sonde", &sonde_code),
+        ("decoder", &decoder_code),
+        ("decoder", &decoder_code),
+    ]);
+
+    let lib = ProgramLibrary::new();
+    let result = lib.ingest_elf(&elf, VerificationProfile::Resident);
+    // Should be rejected (either at extraction or by Prevail finding >1 program).
+    assert!(
+        result.is_err() || result.as_ref().is_ok_and(|r| r.decoder_image.is_none()),
+        "expected rejection or no decoder for ELF with multiple decoder sections"
+    );
+}
+
+// GW-1900 AC-6: Section matching is exact — `decoder.text` must be ignored
+#[test]
+fn t1900_ac6_decoder_text_section_ignored() {
+    let sonde_code = nop_bytecode();
+    let other_code = nop_bytecode();
+    // Use "decoder.text" — not "decoder". Should be ignored.
+    let elf = make_elf_with_sections(&[("sonde", &sonde_code), ("decoder.text", &other_code)]);
+
+    let lib = ProgramLibrary::new();
+    let record = lib.ingest_elf(&elf, VerificationProfile::Resident).unwrap();
+
+    assert!(
+        record.decoder_image.is_none(),
+        "expected `decoder.text` section to be ignored (exact match only)"
+    );
+}
+
 // T-1906: Program hash unchanged by decoder presence
 #[test]
 fn t1906_hash_unchanged_by_decoder() {

--- a/crates/sonde-gateway/tests/decoder.rs
+++ b/crates/sonde-gateway/tests/decoder.rs
@@ -602,3 +602,147 @@ fn handler_data_message_with_readings_roundtrip() {
     let decoded = HandlerMessage::decode(&encoded).unwrap();
     assert_eq!(msg, decoded);
 }
+
+// T-1904d: map_lookup_elem reads .rodata initial data
+#[test]
+fn t1904d_map_lookup_reads_rodata() {
+    // Decoder program: lookup map[0], read value, emit as reading.
+    //
+    // Map 0: rodata, value_size=4, max_entries=1, initial_data = [0x39, 0x05, 0x00, 0x00] (1337 LE)
+    //
+    // BPF:
+    //   r1 = map_fd[0]    (LDDW with src=1, imm=0)
+    //   *(u32*)(r10-4) = 0  // key = 0
+    //   r2 = r10 - 4
+    //   call map_lookup_elem (10)
+    //   if r0 == 0 goto exit
+    //   r3 = *(u32*)(r0 + 0)  // read value
+    //   *(u8*)(r10-8) = 'v'
+    //   r1 = r10 - 8
+    //   r2 = 1
+    //   call emit_reading (18)
+    //   r0 = 0
+    //   exit
+    let mut bytecode = Vec::new();
+    // LDDW r1, map_fd=0 (opcode 0x18, src_reg=1, imm=0, next insn imm=0)
+    bytecode.extend_from_slice(&bpf_insn(0x18, 0x11, 0, 0));
+    bytecode.extend_from_slice(&[0u8; 8]); // second half of LDDW
+                                           // *(u32*)(r10-4) = 0  (store key)
+    bytecode.extend_from_slice(&st_mem_w(10, -4, 0));
+    // r2 = r10 - 4
+    bytecode.extend_from_slice(&mov_reg(2, 10));
+    bytecode.extend_from_slice(&add_imm(2, -4));
+    // call map_lookup_elem (10)
+    bytecode.extend_from_slice(&call_helper(10));
+    // if r0 == 0 goto +5 (skip to exit)
+    bytecode.extend_from_slice(&bpf_insn(0x15, 0x00, 5, 0)); // jeq r0, 0, +5
+                                                             // r3 = *(u32*)(r0 + 0)
+    bytecode.extend_from_slice(&bpf_insn(0x61, 0x03 | (0x00 << 4), 0, 0)); // ldxw r3, [r0+0]
+                                                                           // *(u8*)(r10-8) = 'v'
+    bytecode.extend_from_slice(&st_mem_b(10, -8, b'v' as i32));
+    // r1 = r10 - 8
+    bytecode.extend_from_slice(&mov_reg(1, 10));
+    bytecode.extend_from_slice(&add_imm(1, -8));
+    // r2 = 1
+    bytecode.extend_from_slice(&mov_imm(2, 1));
+    // call emit_reading (18)
+    bytecode.extend_from_slice(&call_helper(18));
+    // r0 = 0
+    bytecode.extend_from_slice(&mov_imm(0, 0));
+    // exit
+    bytecode.extend_from_slice(&exit_insn());
+
+    let image = sonde_protocol::ProgramImage {
+        bytecode,
+        maps: vec![sonde_protocol::MapDef {
+            map_type: 0,
+            key_size: 4,
+            value_size: 4,
+            max_entries: 1,
+        }],
+        map_initial_data: vec![vec![0x39, 0x05, 0x00, 0x00]], // 1337 LE
+        map_readonly: vec![true],
+    };
+    let cbor = image.encode_deterministic().unwrap();
+
+    let readings = decoder::execute_decoder(&cbor, &[0u8; 4]).unwrap();
+    assert_eq!(
+        readings.get("v"),
+        Some(&1337i64),
+        "expected .rodata value 1337 to be read via map_lookup"
+    );
+}
+
+// T-1904e: map_update_elem on .rodata returns error
+#[test]
+fn t1904e_map_update_rodata_rejected() {
+    // Decoder program: try to update map[0] (rodata), should return -1.
+    //
+    // BPF:
+    //   r1 = map_fd[0]    (LDDW with src=1, imm=0)
+    //   *(u32*)(r10-4) = 0  // key = 0
+    //   *(u32*)(r10-8) = 42 // value = 42
+    //   r2 = r10 - 4
+    //   r3 = r10 - 8
+    //   r4 = 0 (flags)
+    //   call map_update_elem (11)
+    //   // r0 should be -1 (error), emit as reading to capture the return value
+    //   r3 = r0  // value = return code
+    //   *(u8*)(r10-12) = 'r'
+    //   r1 = r10 - 12
+    //   r2 = 1
+    //   call emit_reading (18)
+    //   r0 = 0
+    //   exit
+    let mut bytecode = Vec::new();
+    // LDDW r1, map_fd=0
+    bytecode.extend_from_slice(&bpf_insn(0x18, 0x11, 0, 0));
+    bytecode.extend_from_slice(&[0u8; 8]);
+    // *(u32*)(r10-4) = 0
+    bytecode.extend_from_slice(&st_mem_w(10, -4, 0));
+    // *(u32*)(r10-8) = 42
+    bytecode.extend_from_slice(&st_mem_w(10, -8, 42));
+    // r2 = r10 - 4
+    bytecode.extend_from_slice(&mov_reg(2, 10));
+    bytecode.extend_from_slice(&add_imm(2, -4));
+    // r3 = r10 - 8
+    bytecode.extend_from_slice(&mov_reg(3, 10));
+    bytecode.extend_from_slice(&add_imm(3, -8));
+    // r4 = 0
+    bytecode.extend_from_slice(&mov_imm(4, 0));
+    // call map_update_elem (11)
+    bytecode.extend_from_slice(&call_helper(11));
+    // r3 = r0 (capture return value)
+    bytecode.extend_from_slice(&mov_reg(3, 0));
+    // *(u8*)(r10-12) = 'r'
+    bytecode.extend_from_slice(&st_mem_b(10, -12, b'r' as i32));
+    // r1 = r10 - 12
+    bytecode.extend_from_slice(&mov_reg(1, 10));
+    bytecode.extend_from_slice(&add_imm(1, -12));
+    // r2 = 1
+    bytecode.extend_from_slice(&mov_imm(2, 1));
+    // call emit_reading (18)
+    bytecode.extend_from_slice(&call_helper(18));
+    // r0 = 0
+    bytecode.extend_from_slice(&mov_imm(0, 0));
+    // exit
+    bytecode.extend_from_slice(&exit_insn());
+
+    let image = sonde_protocol::ProgramImage {
+        bytecode,
+        maps: vec![sonde_protocol::MapDef {
+            map_type: 0,
+            key_size: 4,
+            value_size: 4,
+            max_entries: 1,
+        }],
+        map_initial_data: vec![vec![0xAA, 0xBB, 0xCC, 0xDD]],
+        map_readonly: vec![true],
+    };
+    let cbor = image.encode_deterministic().unwrap();
+
+    let readings = decoder::execute_decoder(&cbor, &[0u8; 4]).unwrap();
+    // map_update returns -1 (0xFFFFFFFFFFFFFFFF as u64, reinterpreted as i64 = -1)
+    let ret = readings.get("r").expect("expected return value reading");
+    assert_eq!(*ret, -1i64, "map_update on .rodata should return -1");
+}

--- a/crates/sonde-gateway/tests/decoder.rs
+++ b/crates/sonde-gateway/tests/decoder.rs
@@ -267,10 +267,11 @@ fn t1900d_multiple_decoder_sections_rejected() {
 
     let lib = ProgramLibrary::new();
     let result = lib.ingest_elf(&elf, VerificationProfile::Resident);
-    // Should be rejected (either at extraction or by Prevail finding >1 program).
+    // Multiple decoder sections must be rejected.
     assert!(
-        result.is_err() || result.as_ref().is_ok_and(|r| r.decoder_image.is_none()),
-        "expected rejection or no decoder for ELF with multiple decoder sections"
+        result.is_err(),
+        "expected error for ELF with multiple decoder sections, got {:?}",
+        result
     );
 }
 
@@ -372,6 +373,7 @@ fn t1904_emit_reading_captures_readings() {
         bytecode,
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
 
@@ -418,6 +420,7 @@ fn t1904b_emit_reading_name_too_long() {
         bytecode,
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
 
@@ -456,6 +459,7 @@ fn t1904a_emit_reading_max_name_ok() {
         bytecode,
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
 
@@ -482,6 +486,7 @@ fn t1903b_decoder_failure_returns_error() {
         bytecode,
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
 
@@ -517,6 +522,7 @@ fn t1903c_enriched_preserves_raw_blob() {
         bytecode,
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
 
@@ -560,6 +566,7 @@ fn t1904c_emit_reading_overflow() {
         bytecode,
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
 

--- a/crates/sonde-gateway/tests/error_observability.rs
+++ b/crates/sonde-gateway/tests/error_observability.rs
@@ -279,6 +279,7 @@ async fn t1307i_queue_ephemeral_wrong_profile_includes_details() {
             bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
             maps: vec![],
             map_initial_data: vec![],
+            map_readonly: vec![],
         };
         img.encode_deterministic().unwrap()
     };

--- a/crates/sonde-gateway/tests/logging.rs
+++ b/crates/sonde-gateway/tests/logging.rs
@@ -64,6 +64,7 @@ async fn store_test_program(storage: &InMemoryStorage, bytecode: &[u8]) -> Vec<u
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let record = lib

--- a/crates/sonde-gateway/tests/phase2b.rs
+++ b/crates/sonde-gateway/tests/phase2b.rs
@@ -139,6 +139,7 @@ async fn store_test_program_with_profile(
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let record = lib.ingest_unverified(cbor, profile).unwrap();
@@ -158,6 +159,7 @@ async fn store_test_program_with_abi(
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let mut record = lib
@@ -1171,6 +1173,7 @@ async fn t0705_abi_incompatibility_skips_run_ephemeral() {
         bytecode: b"eph-abi3".to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let mut eph_record = lib
@@ -1206,6 +1209,7 @@ async fn t0705_abi_incompatibility_skips_run_ephemeral() {
         bytecode: b"eph-abi2".to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     }
     .encode_deterministic()
     .unwrap();

--- a/crates/sonde-gateway/tests/phase2c.rs
+++ b/crates/sonde-gateway/tests/phase2c.rs
@@ -3062,6 +3062,7 @@ async fn t0523_deferred_not_delivered_on_non_nop() {
         ],
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let prog_record = lib

--- a/crates/sonde-gateway/tests/phase2c_admin.rs
+++ b/crates/sonde-gateway/tests/phase2c_admin.rs
@@ -126,6 +126,7 @@ fn make_cbor_image(bytecode: &[u8]) -> Vec<u8> {
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     image.encode_deterministic().unwrap()
 }

--- a/crates/sonde-gateway/tests/phase3.rs
+++ b/crates/sonde-gateway/tests/phase3.rs
@@ -84,6 +84,7 @@ async fn store_test_program(storage: &InMemoryStorage, bytecode: &[u8]) -> Vec<u
         bytecode: bytecode.to_vec(),
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
     let record = lib
@@ -371,6 +372,7 @@ async fn t1001_program_hash_consistency() {
         bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = image.encode_deterministic().unwrap();
 

--- a/crates/sonde-node/src/program_store.rs
+++ b/crates/sonde-node/src/program_store.rs
@@ -281,6 +281,7 @@ mod tests {
             bytecode: bytecode.to_vec(),
             maps: maps.to_vec(),
             map_initial_data: vec![Vec::new(); maps.len()],
+            map_readonly: vec![false; maps.len()],
         };
         let cbor = image.encode_deterministic().unwrap();
         let hash = TestSha256.hash(&cbor).to_vec();

--- a/crates/sonde-node/src/wake_cycle.rs
+++ b/crates/sonde-node/src/wake_cycle.rs
@@ -1502,6 +1502,7 @@ mod tests {
             bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
             maps: vec![],
             map_initial_data: vec![],
+            map_readonly: vec![],
         };
         let image_cbor = image.encode_deterministic().unwrap();
 
@@ -1593,6 +1594,7 @@ mod tests {
                 max_entries: 512,
             }],
             map_initial_data: vec![Vec::new()],
+            map_readonly: vec![false; 1],
         };
         let image_cbor = image.encode_deterministic().unwrap();
 
@@ -2008,6 +2010,7 @@ mod tests {
                 bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
                 maps: vec![],
                 map_initial_data: vec![],
+                map_readonly: vec![],
             };
             let image_cbor = image.encode_deterministic().unwrap();
 
@@ -2143,6 +2146,7 @@ mod tests {
                 bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
                 maps: vec![],
                 map_initial_data: vec![],
+                map_readonly: vec![],
             };
             let image_cbor = image.encode_deterministic().unwrap();
             let chunk_size = image_cbor.len() as u32; // single chunk
@@ -2323,6 +2327,7 @@ mod tests {
                 bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
                 maps: vec![],
                 map_initial_data: vec![],
+                map_readonly: vec![],
             };
             let image_cbor = image.encode_deterministic().unwrap();
             let mut storage = MockStorage::new().with_key(key_hint, psk);
@@ -2400,6 +2405,7 @@ mod tests {
                 bytecode: vec![0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
                 maps: vec![],
                 map_initial_data: vec![],
+                map_readonly: vec![],
             };
             let image_cbor = image.encode_deterministic().unwrap();
             let image_hash = sha.hash(&image_cbor);

--- a/crates/sonde-protocol/src/constants.rs
+++ b/crates/sonde-protocol/src/constants.rs
@@ -88,6 +88,7 @@ pub const MAP_KEY_KEY_SIZE: u64 = 2;
 pub const MAP_KEY_VALUE_SIZE: u64 = 3;
 pub const MAP_KEY_MAX_ENTRIES: u64 = 4;
 pub const MAP_KEY_INITIAL_DATA: u64 = 5;
+pub const MAP_KEY_READONLY: u64 = 6;
 
 // CBOR integer keys (DIAG_REQUEST / DIAG_REPLY -- separate keyspace)
 // Keys are scoped per msg_type — key 1 in DIAG_REQUEST (diagnostic_type)

--- a/crates/sonde-protocol/src/program_image.rs
+++ b/crates/sonde-protocol/src/program_image.rs
@@ -189,7 +189,9 @@ impl ProgramImage {
                                         .to_vec();
                                 }
                                 MAP_KEY_READONLY => {
-                                    readonly = mv.as_bool().unwrap_or(false);
+                                    readonly = mv
+                                        .as_bool()
+                                        .ok_or(DecodeError::InvalidFieldType(MAP_KEY_READONLY))?;
                                 }
                                 _ => {} // ignore unknown keys
                             }

--- a/crates/sonde-protocol/src/program_image.rs
+++ b/crates/sonde-protocol/src/program_image.rs
@@ -31,6 +31,12 @@ pub struct ProgramImage {
     /// ELF section content so the node can pre-populate map memory before
     /// BPF execution.
     pub map_initial_data: Vec<Vec<u8>>,
+    /// Read-only flag for each map, parallel to `maps`.
+    ///
+    /// `map_readonly[i]` is `true` when `maps[i]` corresponds to a `.rodata`
+    /// ELF section and must not be modified at runtime. Defaults to `false`
+    /// for maps without this flag.
+    pub map_readonly: Vec<bool>,
 }
 
 impl ProgramImage {
@@ -43,6 +49,13 @@ impl ProgramImage {
             return Err(EncodeError::CborError(format!(
                 "map_initial_data length ({}) != maps length ({})",
                 self.map_initial_data.len(),
+                self.maps.len()
+            )));
+        }
+        if self.map_readonly.len() != self.maps.len() {
+            return Err(EncodeError::CborError(format!(
+                "map_readonly length ({}) != maps length ({})",
+                self.map_readonly.len(),
                 self.maps.len()
             )));
         }
@@ -79,6 +92,10 @@ impl ProgramImage {
                             Value::Bytes(data.clone()),
                         ));
                     }
+                }
+                // Include readonly flag (key 6) only when true.
+                if self.map_readonly.get(i).copied().unwrap_or(false) {
+                    entries.push((Value::Integer(MAP_KEY_READONLY.into()), Value::Bool(true)));
                 }
                 Value::Map(entries)
             })
@@ -118,6 +135,7 @@ impl ProgramImage {
         let mut bytecode: Option<Vec<u8>> = None;
         let mut maps: Vec<MapDef> = Vec::new();
         let mut map_initial_data: Vec<Vec<u8>> = Vec::new();
+        let mut map_readonly: Vec<bool> = Vec::new();
 
         for (k, v) in fields {
             let key = k
@@ -147,6 +165,7 @@ impl ProgramImage {
                         let mut value_size = None;
                         let mut max_entries = None;
                         let mut initial_data: Vec<u8> = Vec::new();
+                        let mut readonly = false;
 
                         for (mk, mv) in map_fields {
                             let mkey = mk
@@ -169,6 +188,9 @@ impl ProgramImage {
                                         .ok_or(DecodeError::InvalidFieldType(MAP_KEY_INITIAL_DATA))?
                                         .to_vec();
                                 }
+                                MAP_KEY_READONLY => {
+                                    readonly = mv.as_bool().unwrap_or(false);
+                                }
                                 _ => {} // ignore unknown keys
                             }
                         }
@@ -183,6 +205,7 @@ impl ProgramImage {
                                 .ok_or(DecodeError::MissingField(MAP_KEY_MAX_ENTRIES))?,
                         });
                         map_initial_data.push(initial_data);
+                        map_readonly.push(readonly);
                     }
                 }
                 _ => {} // ignore unknown keys
@@ -193,6 +216,7 @@ impl ProgramImage {
             bytecode: bytecode.ok_or(DecodeError::MissingField(IMG_KEY_BYTECODE))?,
             maps,
             map_initial_data,
+            map_readonly,
         })
     }
 }

--- a/crates/sonde-protocol/tests/validation.rs
+++ b/crates/sonde-protocol/tests/validation.rs
@@ -1116,6 +1116,7 @@ fn test_p040() {
             max_entries: 16,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
     let cbor = img.encode_deterministic().unwrap();
     let decoded = ProgramImage::decode(&cbor).unwrap();
@@ -1133,6 +1134,7 @@ fn test_p041() {
         bytecode: vec![0x01],
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor = img.encode_deterministic().unwrap();
     let decoded = ProgramImage::decode(&cbor).unwrap();
@@ -1150,6 +1152,7 @@ fn test_p042() {
             max_entries: 16,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
     let cbor_a = make_img().encode_deterministic().unwrap();
     let cbor_b = make_img().encode_deterministic().unwrap();
@@ -1170,6 +1173,7 @@ fn test_p043() {
             max_entries: 16,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
     let cbor = img.encode_deterministic().unwrap();
     let reference_hash = program_hash(&cbor, &SoftwareSha256);
@@ -1191,6 +1195,7 @@ fn test_p044() {
             max_entries: 16,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
     let img_b = ProgramImage {
         bytecode,
@@ -1201,6 +1206,7 @@ fn test_p044() {
             max_entries: 32,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
     let ha = program_hash(&img_a.encode_deterministic().unwrap(), &SoftwareSha256);
     let hb = program_hash(&img_b.encode_deterministic().unwrap(), &SoftwareSha256);
@@ -1219,10 +1225,12 @@ fn test_p045() {
         bytecode: vec![0x01],
         maps: maps.clone(),
         map_initial_data: vec![Vec::new(); maps.len()],
+        map_readonly: vec![false; maps.len()],
     };
     let img_b = ProgramImage {
         bytecode: vec![0x02],
         map_initial_data: vec![Vec::new(); maps.len()],
+        map_readonly: vec![false; maps.len()],
         maps,
     };
     let ha = program_hash(&img_a.encode_deterministic().unwrap(), &SoftwareSha256);
@@ -1241,6 +1249,7 @@ fn test_p046() {
             max_entries: 16,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
     let cbor = img.encode_deterministic().unwrap();
     // Decode as generic CBOR and verify key ordering.
@@ -1278,6 +1287,7 @@ fn test_p047() {
             max_entries: 16,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
     let cbor = img.encode_deterministic().unwrap();
     let decoded = ProgramImage::decode(&cbor).unwrap();
@@ -1293,6 +1303,7 @@ fn test_p047() {
         bytecode: vec![],
         maps: vec![],
         map_initial_data: vec![],
+        map_readonly: vec![],
     };
     let cbor2 = img2.encode_deterministic().unwrap();
     let decoded2 = ProgramImage::decode(&cbor2).unwrap();
@@ -1352,6 +1363,7 @@ fn test_p053() {
             },
         ],
         map_initial_data: vec![Vec::new(); 2],
+        map_readonly: vec![false, false],
     };
     let cbor = img.encode_deterministic().unwrap();
     let n = chunk_count(cbor.len(), 190).unwrap();
@@ -1433,6 +1445,7 @@ fn test_p062() {
             },
         ],
         map_initial_data: vec![Vec::new(); 3],
+        map_readonly: vec![false, false, false],
     };
     let cbor = img.encode_deterministic().unwrap();
     let hash_orig = program_hash(&cbor, &SoftwareSha256);
@@ -1611,6 +1624,7 @@ fn test_p048() {
             max_entries: 256, // boundary: first 3-byte value
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
 
     let cbor = img.encode_deterministic().unwrap();
@@ -1679,6 +1693,7 @@ fn test_p049a() {
             max_entries: 16,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
     let cbor = img.encode_deterministic().unwrap();
     assert!(cbor.len() > 10, "encoded image must be non-trivial");
@@ -1897,6 +1912,7 @@ fn test_p070() {
             max_entries: 1,
         }],
         map_initial_data: vec![initial.clone()],
+        map_readonly: vec![false],
     };
     let cbor = img.encode_deterministic().unwrap();
     let decoded = ProgramImage::decode(&cbor).unwrap();
@@ -1929,6 +1945,7 @@ fn test_p071() {
             max_entries: 16,
         }],
         map_initial_data: vec![Vec::new()],
+        map_readonly: vec![false],
     };
     let cbor = img.encode_deterministic().unwrap();
 
@@ -1965,6 +1982,7 @@ fn test_p072() {
         }],
         // 2 entries vs 1 map — mismatch
         map_initial_data: vec![vec![0xDE, 0xAD, 0xBE, 0xEF], vec![0x01, 0x02, 0x03, 0x04]],
+        map_readonly: vec![false],
     };
     let result = img.encode_deterministic();
     assert!(result.is_err(), "length mismatch must be rejected");

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -175,7 +175,14 @@ struct decoder_context {
  *   if (data + offset + sizeof(value) <= data_end) { // safe to read }
  * The decoder reads sensor-specific bytes from input_data and calls
  * emit_reading() to produce named values.
- * Input length can be computed as: (uint32_t)(input_end - input_data). */
+ * Input length can be computed as: (uint32_t)(input_end - input_data).
+ *
+ * NOTE: The current sonde-bpf interpreter does not preserve pointer tags
+ * for values loaded from context fields via LDX — they are treated as
+ * scalars. Until data/data_end pointer tagging is added to sonde-bpf,
+ * decoders must access the raw blob via the context pointer (R1) with
+ * bounded offsets rather than loading and dereferencing ctx->input_data.
+ */
 ```
 
 ### Wake reasons

--- a/docs/bpf-environment.md
+++ b/docs/bpf-environment.md
@@ -160,19 +160,22 @@ The `timestamp` is derived from the gateway's `timestamp_ms` field in the COMMAN
 
 Decoder programs (§2.3) run in the gateway and receive a different context
 than node programs. The decoder context provides read-only access to the raw
-APP_DATA payload bytes:
+APP_DATA payload bytes using the standard BPF data/data_end pointer pair
+pattern:
 
 ```c
 struct decoder_context {
-    const uint64_t input_data;  // read-only pointer to raw APP_DATA blob (uint64_t for BPF verifier compatibility)
-    uint32_t input_len;         // length of input_data in bytes
-    uint32_t _padding;          // explicit padding; must be zero
+    const uint64_t input_data;  // read-only pointer to raw APP_DATA blob start (uint64_t for BPF verifier compatibility)
+    const uint64_t input_end;   // pointer past end of raw APP_DATA blob
 };
 /* Total: 16 bytes, 8-byte aligned.
  * input_data is typed as readable memory — writes cause verification failure.
  * Pointer width is uint64_t consistent with sonde_context (see §4).
+ * Use the standard BPF packet access pattern:
+ *   if (data + offset + sizeof(value) <= data_end) { // safe to read }
  * The decoder reads sensor-specific bytes from input_data and calls
- * emit_reading() to produce named values. */
+ * emit_reading() to produce named values.
+ * Input length can be computed as: (uint32_t)(input_end - input_data). */
 ```
 
 ### Wake reasons

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -513,10 +513,11 @@ via composition.
 
 **Module:** `crate::decoder_platform` (`crates/sonde-gateway/src/decoder_platform.rs`)
 
-**Context descriptor:** 16 bytes — `{ input_data: ptr (8B, uint64_t for BPF verifier compatibility), input_len: u32 (4B), _padding: 4B }`.
-The `input_data` pointer is typed as readable memory; writes cause verification
-failure. Pointer width is `uint64_t` consistent with the existing `sonde_context`
-convention (see bpf-environment.md §4).
+**Context descriptor:** 16 bytes — `{ input_data: ptr (8B), input_end: ptr (8B) }`.
+Uses the standard BPF data/data_end pointer pair pattern (Prevail context
+descriptor: `data=0`, `end=8`). The `input_data` pointer is typed as readable
+memory; writes cause verification failure. Pointer width is `uint64_t`
+consistent with the existing `sonde_context` convention (see bpf-environment.md §4).
 
 **Program type:** `"decoder"` with section name `"decoder"` (exact match, not prefix — see GW-1900 AC-6).
 
@@ -603,7 +604,7 @@ On receiving APP_DATA from a node:
 2a. **Decoder enrichment (GW-1903):** If the program record for the node's
    `current_program_hash` has a non-`None` `decoder_image`:
    1. Load the decoder `ProgramImage` and execute it via `sonde-bpf` with:
-      - Context: raw APP_DATA `blob` bytes as `decoder_context { input_data, input_len }`.
+      - Context: raw APP_DATA `blob` bytes as `decoder_context { input_data, input_end }`.
       - Helpers: `emit_reading` (collects name→value pairs), `map_lookup_elem`,
         `map_update_elem`, `bpf_trace_printk`.
       - Maps: allocated and initialized from the decoder image's map definitions

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2588,6 +2588,13 @@ struct decoder_context {
 
 The `input_data` memory is read-only — writes cause verification failure.
 
+> **Limitation:** The current `sonde-bpf` interpreter does not preserve
+> pointer tags for values loaded from context fields via `LDX` — they are
+> treated as scalars. Until data/data\_end pointer tagging is added to
+> `sonde-bpf`, decoders must access the raw blob via the context pointer
+> (R1) with bounded offsets rather than loading and dereferencing
+> `ctx->input_data`. See `execute_decoder` documentation for details.
+
 **Helpers:**
 
 | ID | Name | Signature | Description |

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2508,7 +2508,7 @@ The gateway's ELF ingestion pipeline (GW-0400) MUST be extended to extract an op
 **Description:**
 The gateway MUST define a separate `DecoderPlatform` for Prevail verification of decoder BPF programs. The `DecoderPlatform` defines:
 - A program type named `"decoder"` with section name `"decoder"` (exact match, not prefix — see GW-1900 AC-6).
-- A context descriptor for the decoder input: `struct decoder_context { const uint64_t input_data; uint32_t input_len; uint32_t _padding; }` (16 bytes, 8-byte aligned — see bpf-environment.md §4.2).
+- A context descriptor for the decoder input: `struct decoder_context { const uint64_t input_data; const uint64_t input_end; }` (16 bytes, 8-byte aligned — see bpf-environment.md §4.2). Uses the standard BPF data/data_end pointer pair pattern for verifier compatibility.
 - Helper prototypes for the decoder-permitted helpers only: `emit_reading` (ID 18), `map_lookup_elem` (ID 10), `map_update_elem` (ID 11), `bpf_trace_printk` (ID 16).
 - No hardware helpers (no I2C, SPI, GPIO, ADC, send, recv, delay, etc.).
 
@@ -2516,7 +2516,7 @@ The gateway MUST define a separate `DecoderPlatform` for Prevail verification of
 
 1. Decoder programs that use only permitted helpers pass verification.
 2. Decoder programs that call hardware helpers (e.g., `i2c_read`, `send`) fail verification with a descriptive error.
-3. The decoder context descriptor accurately models the `{ input_data, input_len }` struct.
+3. The decoder context descriptor accurately models the `{ input_data, input_end }` struct using the Prevail verifier's data/end pointer pair mechanism.
 4. The `DecoderPlatform` is distinct from `SondePlatform` — changing one does not affect the other.
 
 ---
@@ -2578,11 +2578,12 @@ The decoder BPF program operates in a restricted environment. Its execution cont
 **Context (passed in R1):**
 ```c
 struct decoder_context {
-    const uint64_t input_data;  // read-only pointer to raw APP_DATA blob (uint64_t for BPF verifier compatibility)
-    uint32_t input_len;         // length of input_data in bytes
-    uint32_t _padding;          // explicit padding; must be zero
+    const uint64_t input_data;  // read-only pointer to raw APP_DATA blob start (uint64_t for BPF verifier compatibility)
+    const uint64_t input_end;   // pointer past end of raw APP_DATA blob
 };
 // Total: 16 bytes, 8-byte aligned. See bpf-environment.md §4.2.
+// Uses the standard BPF data/data_end pointer pair pattern.
+// Input length = (uint32_t)(input_end - input_data).
 ```
 
 The `input_data` memory is read-only — writes cause verification failure.
@@ -2602,7 +2603,7 @@ The `input_data` memory is read-only — writes cause verification failure.
 
 **Acceptance criteria:**
 
-1. The decoder receives a valid `decoder_context` with pointer to raw payload and its length.
+1. The decoder receives a valid `decoder_context` with `input_data`/`input_end` pointers bounding the raw payload.
 2. `emit_reading` captures the name and value for inclusion in the `readings` field.
 3. Multiple calls to `emit_reading` with different names are accumulated.
 4. Duplicate names in `emit_reading` calls: last-write-wins.

--- a/test-programs/include/sonde_helpers.h
+++ b/test-programs/include/sonde_helpers.h
@@ -84,6 +84,23 @@ struct sonde_context {
 /* Total size: 8 + 2 + 2 + 1 + 3 + 8 + 8 = 32 bytes; 8-byte aligned.
  * The BPF interpreter bounds-checks R1 accesses against this size. */
 
+/* -------------------------------------------------------------------------
+ * decoder_context — execution context for decoder BPF programs (GW-1904).
+ *
+ * Decoder programs run in the gateway (not on nodes) and receive the raw
+ * APP_DATA payload bytes for decoding into named readings.
+ *
+ * input_data points to the first byte of the raw blob; input_end points
+ * past the last byte. Use the standard BPF packet access pattern:
+ *   if (data + offset + sizeof(value) <= data_end) { ... }
+ * ---------------------------------------------------------------------- */
+
+struct decoder_context {
+    __u64 input_data;            /**< Read-only pointer to raw APP_DATA blob start */
+    __u64 input_end;             /**< Pointer past end of blob                     */
+};
+/* Total size: 8 + 8 = 16 bytes; 8-byte aligned. */
+
 /** Normal scheduled wake. */
 #define WAKE_SCHEDULED      0x00u
 
@@ -338,6 +355,23 @@ static int (*bpf_trace_printk)(const char *fmt, __u32 fmt_len, ...) = (void *)16
  *          too large or ptr is null
  */
 static int (*send_async)(const void *ptr, __u32 len) = (void *)17;
+
+/**
+ * emit_reading — emit a named sensor reading (decoder programs only).
+ *
+ * The gateway collects all emitted readings into a CBOR map that is added
+ * to the APP_DATA message before forwarding to handlers and connectors.
+ *
+ * @name:     pointer to UTF-8 reading name in BPF memory
+ * @name_len: length of the name in bytes (max 64)
+ * @value:    reading value as a signed 64-bit integer
+ * Returns:   0 on success, -1 if name_len exceeds 64 or name is invalid,
+ *            -2 if the reading-count limit is exceeded (max 32 per execution)
+ *
+ * Duplicate names: last-write-wins — only the final value is included.
+ * Helper ID: 18. Availability: decoder only.
+ */
+static int (*emit_reading)(const char *name, __u32 name_len, __s64 value) = (void *)18;
 
 #pragma GCC diagnostic pop
 

--- a/test-programs/include/sonde_helpers.h
+++ b/test-programs/include/sonde_helpers.h
@@ -93,6 +93,12 @@ struct sonde_context {
  * input_data points to the first byte of the raw blob; input_end points
  * past the last byte. Use the standard BPF packet access pattern:
  *   if (data + offset + sizeof(value) <= data_end) { ... }
+ *
+ * NOTE: The current sonde-bpf interpreter does not preserve pointer tags
+ * for values loaded from context fields (LDX yields a scalar). Until
+ * data/data_end pointer tagging is added to sonde-bpf, decoders must
+ * access the raw blob via the context pointer (R1) with bounded offsets
+ * rather than loading and dereferencing ctx->input_data.
  * ---------------------------------------------------------------------- */
 
 struct decoder_context {

--- a/test-programs/sht40_sensor.c
+++ b/test-programs/sht40_sensor.c
@@ -178,6 +178,12 @@ int program(struct sonde_context *ctx)
  *   [14..17] temp_mC (little-endian i32, millidegrees Celsius)
  *   [18..21] rh_mpermille (little-endian i32, milli-%RH)
  */
+/*
+ * NOTE: The ctx->input_data dereference pattern below requires sonde-bpf
+ * data/data_end pointer tagging (not yet implemented). Until then, decoders
+ * must access the blob via R1 bounded offsets at runtime.  This source file
+ * documents the intended ABI; hand-crafted bytecode is used for gateway tests.
+ */
 SEC("decoder")
 int decode(struct decoder_context *ctx)
 {

--- a/test-programs/sht40_sensor.c
+++ b/test-programs/sht40_sensor.c
@@ -168,3 +168,47 @@ int program(struct sonde_context *ctx)
     }
     return 0;
 }
+
+/**
+ * Decoder: parse the 22-byte SHT40 APP_DATA payload and emit named readings.
+ *
+ * Payload layout (from the sonde program above):
+ *   [0..7]   timestamp (little-endian u64, ms since epoch)
+ *   [8..13]  raw frame (T_msb, T_lsb, CRC_T, RH_msb, RH_lsb, CRC_RH)
+ *   [14..17] temp_mC (little-endian i32, millidegrees Celsius)
+ *   [18..21] rh_mpermille (little-endian i32, milli-%RH)
+ */
+SEC("decoder")
+int decode(struct decoder_context *ctx)
+{
+    const __u8 *data = (const __u8 *)(__u64)ctx->input_data;
+    const __u8 *data_end = (const __u8 *)(__u64)ctx->input_end;
+
+    /* Need at least 22 bytes. */
+    if (data + 22 > data_end)
+        return 0;
+
+    /* Extract temp_mC from bytes [14..17] (little-endian i32). */
+    __s32 temp_mc = (__s32)(
+        (__u32)data[14] |
+        ((__u32)data[15] << 8) |
+        ((__u32)data[16] << 16) |
+        ((__u32)data[17] << 24)
+    );
+
+    /* Extract rh_mpermille from bytes [18..21] (little-endian i32). */
+    __s32 rh_mpermille = (__s32)(
+        (__u32)data[18] |
+        ((__u32)data[19] << 8) |
+        ((__u32)data[20] << 16) |
+        ((__u32)data[21] << 24)
+    );
+
+    char name_temp[] = "temp_mc";
+    emit_reading(name_temp, 7, (__s64)temp_mc);
+
+    char name_rh[] = "rh_mpermille";
+    emit_reading(name_rh, 12, (__s64)rh_mpermille);
+
+    return 0;
+}

--- a/test-programs/tmp102_sensor.c
+++ b/test-programs/tmp102_sensor.c
@@ -88,3 +88,36 @@ int program(struct sonde_context *ctx)
     send(payload, sizeof(payload));
     return 0;
 }
+
+/**
+ * Decoder: parse the 6-byte TMP102 APP_DATA payload and emit named readings.
+ *
+ * Payload layout (from the sonde program above):
+ *   [0]   raw_hi   (MSB of 12-bit temperature register)
+ *   [1]   raw_lo   (LSB, upper 4 bits are D3..D0)
+ *   [2:5] temp_mC  (little-endian i32, millidegrees Celsius)
+ */
+SEC("decoder")
+int decode(struct decoder_context *ctx)
+{
+    const __u8 *data = (const __u8 *)(__u64)ctx->input_data;
+    const __u8 *data_end = (const __u8 *)(__u64)ctx->input_end;
+
+    /* Need at least 6 bytes. */
+    if (data + 6 > data_end)
+        return 0;
+
+    /* Extract temp_mC from bytes [2..5] (little-endian i32). */
+    __s32 temp_mc = (__s32)(
+        (__u32)data[2] |
+        ((__u32)data[3] << 8) |
+        ((__u32)data[4] << 16) |
+        ((__u32)data[5] << 24)
+    );
+
+    /* Emit the temperature reading in millidegrees Celsius. */
+    char name_temp[] = "temp_mc";
+    emit_reading(name_temp, 7, (__s64)temp_mc);
+
+    return 0;
+}

--- a/test-programs/tmp102_sensor.c
+++ b/test-programs/tmp102_sensor.c
@@ -97,6 +97,12 @@ int program(struct sonde_context *ctx)
  *   [1]   raw_lo   (LSB, upper 4 bits are D3..D0)
  *   [2:5] temp_mC  (little-endian i32, millidegrees Celsius)
  */
+/*
+ * NOTE: The ctx->input_data dereference pattern below requires sonde-bpf
+ * data/data_end pointer tagging (not yet implemented). Until then, decoders
+ * must access the blob via R1 bounded offsets at runtime.  This source file
+ * documents the intended ABI; hand-crafted bytecode is used for gateway tests.
+ */
 SEC("decoder")
 int decode(struct decoder_context *ctx)
 {


### PR DESCRIPTION
## Summary

Implements gateway-side decoder BPF program support (GW-1900 through GW-1906). Optional `SEC("decoder")` ELF sections are extracted during ingestion, verified with a restricted `DecoderPlatform`, stored alongside the node image, and executed on APP_DATA messages to produce named sensor readings.

## New modules

- **`decoder_platform.rs`** — Prevail verifier platform with restricted helper set (IDs 10, 11, 16, 18). All hardware/network helpers rejected. Uses data/end pointer pair context descriptor (16 bytes).
- **`decoder.rs`** — BPF execution engine using `sonde-bpf`. Thread-local state for `emit_reading` collection. Max 32 readings, 64-byte names, last-write-wins. 100k instruction budget. Runs via `spawn_blocking`.

## Changes

- `ProgramRecord` gains `decoder_image: Option<Vec<u8>>` field (GW-1902)
- `ingest_elf()` extended with `extract_decoder()` for decoder section extraction, Prevail verification, and CBOR image construction (GW-1900, GW-1901)
- `HandlerMessage::Data` and `ConnectorOutboundMessage::AppData` gain optional `readings` field at CBOR key 16 (GW-1903)
- `handle_app_data_core()` performs decoder enrichment before emitting to both handler and connector (GW-1903 AC-6)
- SQLite migration adds `decoder_image` column; state bundle export/import updated with key 7 (GW-1902)
- Decoder results logged at INFO level with `node_id`, `reading_count`, and full readings map
- `sonde_helpers.h` gains `decoder_context` struct and `emit_reading` helper declaration
- `tmp102_sensor.c` and `sht40_sensor.c` gain `SEC("decoder")` functions

## Spec updates

- `decoder_context` uses `{ input_data, input_end }` (data/end pointer pair) instead of `{ input_data, input_len }` for Prevail verifier compatibility
- Updated `bpf-environment.md`, `gateway-requirements.md`, `gateway-design.md`

## Tests

15 new tests in `tests/decoder.rs`:
- T-1900, T-1900a/b/c — ELF extraction (dual, single, decoder-only, empty)
- T-1901, T-1901a/b — DecoderPlatform verification (permitted + rejected helpers)
- T-1903b/c — decoder failure forwarding, blob preservation
- T-1904, T-1904a/b/c — emit_reading (basic, 64-byte name, 65-byte reject, overflow)
- T-1906 — hash stability (unchanged by decoder presence)
- Handler DATA message roundtrip with readings

All existing tests pass. Clippy clean.
