### PR TITLE
fix: replace hardcoded login.microsoftonline.com with configurable login_endpoint

### DIFF
--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -50,6 +50,7 @@ const DEFAULT_CONNECTOR_SOCKET: &str = r"\\.\pipe\sonde-connector";
 const DEFAULT_STATE_DIR: &str = "/var/lib/sonde-azure-companion";
 
 const SERVICE_PRINCIPAL_STATE_FILENAME: &str = "service-principal.json";
+const DEFAULT_LOGIN_ENDPOINT: &str = "https://login.microsoftonline.com";
 const DEFAULT_BOOTSTRAP_IMAGE_REPOSITORY: &str = "ghcr.io/alan-jowett/sonde-azure-bootstrap";
 const CERT_PEM_FILENAME: &str = "cert.pem";
 const KEY_PEM_FILENAME: &str = "key.pem";
@@ -187,6 +188,8 @@ struct RuntimeConfig {
 struct ServicePrincipalStateFile {
     tenant_id: String,
     client_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    login_endpoint: Option<String>,
     certificate_path: String,
     private_key_path: String,
 }
@@ -202,6 +205,7 @@ struct StorageQueuesConfigFile {
 struct RuntimeCredentialState {
     tenant_id: String,
     client_id: String,
+    login_endpoint: String,
     certificate_path: PathBuf,
     private_key_path: PathBuf,
 }
@@ -229,6 +233,11 @@ struct BicepBootstrapValues {
     tenant_id: String,
     #[serde(rename = "clientId", deserialize_with = "deserialize_bicep_string")]
     client_id: String,
+    #[serde(
+        rename = "loginEndpoint",
+        deserialize_with = "deserialize_bicep_string"
+    )]
+    login_endpoint: String,
     #[serde(
         rename = "storageQueueEndpoint",
         deserialize_with = "deserialize_bicep_string"
@@ -1001,6 +1010,33 @@ fn canonicalize_state_file_path(
     Ok(canonical_path)
 }
 
+/// Resolves an optional `login_endpoint` from the service-principal state file.
+///
+/// - `None` (field absent): returns the public-cloud default.
+/// - `Some(value)` with non-empty trimmed content: returns the value with any
+///   trailing slash stripped.
+/// - `Some("")` or whitespace-only: returns a configuration error.
+fn resolve_login_endpoint(value: Option<String>) -> Result<String, CompanionError> {
+    match value {
+        None => Ok(DEFAULT_LOGIN_ENDPOINT.to_string()),
+        Some(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Err(CompanionError::Config(
+                    "service principal login_endpoint must not be empty when present".to_string(),
+                ));
+            }
+            let normalized = trimmed.trim_end_matches('/');
+            if normalized.is_empty() {
+                return Err(CompanionError::Config(
+                    "service principal login_endpoint must not be empty when present".to_string(),
+                ));
+            }
+            Ok(normalized.to_string())
+        }
+    }
+}
+
 fn load_runtime_credential_state(
     state_dir: &Path,
 ) -> Result<RuntimeCredentialState, CompanionError> {
@@ -1019,6 +1055,7 @@ fn load_runtime_credential_state(
     let state: ServicePrincipalStateFile = serde_json::from_slice(&state_bytes)?;
     let tenant_id = require_non_empty(state.tenant_id, "service principal tenant_id")?;
     let client_id = require_non_empty(state.client_id, "service principal client_id")?;
+    let login_endpoint = resolve_login_endpoint(state.login_endpoint)?;
     let certificate_path_value =
         require_non_empty(state.certificate_path, "service principal certificate_path")?;
     let certificate_path =
@@ -1052,6 +1089,7 @@ fn load_runtime_credential_state(
     Ok(RuntimeCredentialState {
         tenant_id,
         client_id,
+        login_endpoint,
         certificate_path,
         private_key_path,
     })
@@ -1284,6 +1322,7 @@ fn parse_bicep_outputs(
     let sp = ServicePrincipalStateFile {
         tenant_id: bootstrap_values.tenant_id,
         client_id: bootstrap_values.client_id,
+        login_endpoint: Some(bootstrap_values.login_endpoint),
         certificate_path: CERT_PEM_FILENAME.to_string(),
         private_key_path: KEY_PEM_FILENAME.to_string(),
     };
@@ -1391,8 +1430,8 @@ fn build_storage_queue_credential(
     let certificate_thumbprint = load_certificate_thumbprint(&runtime_state.certificate_path)?;
     let (signing_algorithm, signing_key) = load_signing_key(&runtime_state.private_key_path)?;
     let token_endpoint = format!(
-        "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
-        runtime_state.tenant_id
+        "{}/{}/oauth2/v2.0/token",
+        runtime_state.login_endpoint, runtime_state.tenant_id
     );
     let http_client = reqwest::Client::builder()
         .connect_timeout(Duration::from_secs(TOKEN_HTTP_CONNECT_TIMEOUT_SECS))
@@ -2748,13 +2787,13 @@ mod tests {
         generate_certificate, load_runtime_config, load_runtime_credential_state, load_signing_key,
         parse_bicep_outputs, parse_queue_message_xml, prepare_staging_dir, pump_downstream_once,
         pump_upstream_once, read_framed, resolve_bootstrap_image, resolve_effective_state_dir,
-        resolve_state_relative_path, run_bootstrap_deployment_with_docker_and_image,
-        trim_buffer_to_max_len, urlencoding_encode, validate_display_lines, write_framed,
-        ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
-        RuntimeCredentialState, ServicePrincipalStateFile, StorageQueuesConfigFile,
-        UpstreamPublisher, ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH,
-        KEY_PEM_FILENAME, SERVICE_PRINCIPAL_STATE_FILENAME, STATE_GENERATION_PREFIX,
-        STORAGE_QUEUES_CONFIG_FILENAME,
+        resolve_login_endpoint, resolve_state_relative_path,
+        run_bootstrap_deployment_with_docker_and_image, trim_buffer_to_max_len, urlencoding_encode,
+        validate_display_lines, write_framed, ClientAssertionCredential, CompanionError,
+        DownstreamConsumer, RuntimeConfig, RuntimeCredentialState, ServicePrincipalStateFile,
+        StorageQueuesConfigFile, UpstreamPublisher, ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME,
+        CONNECTOR_MAX_FRAME_LENGTH, DEFAULT_LOGIN_ENDPOINT, KEY_PEM_FILENAME,
+        SERVICE_PRINCIPAL_STATE_FILENAME, STATE_GENERATION_PREFIX, STORAGE_QUEUES_CONFIG_FILENAME,
     };
     #[cfg(windows)]
     use super::{
@@ -2828,6 +2867,7 @@ mod tests {
         let state = ServicePrincipalStateFile {
             tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
             client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            login_endpoint: None,
             certificate_path: "client-cert.pem".to_string(),
             private_key_path: "client-key.pem".to_string(),
         };
@@ -2841,6 +2881,7 @@ mod tests {
         let state = ServicePrincipalStateFile {
             tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
             client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            login_endpoint: None,
             certificate_path: "client-cert.pem".to_string(),
             private_key_path: "client-key.pem".to_string(),
         };
@@ -3656,6 +3697,7 @@ mod tests {
                 "value": {
                     "tenantId": "11111111-1111-1111-1111-111111111111",
                     "clientId": "22222222-2222-2222-2222-222222222222",
+                    "loginEndpoint": "https://login.microsoftonline.com/",
                     "storageQueueEndpoint": "https://example.queue.core.windows.net",
                     "upstreamQueue": "upstream",
                     "downstreamQueue": "downstream"
@@ -3669,6 +3711,7 @@ mod tests {
             ServicePrincipalStateFile {
                 tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
                 client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                login_endpoint: Some("https://login.microsoftonline.com/".to_string()),
                 certificate_path: CERT_PEM_FILENAME.to_string(),
                 private_key_path: KEY_PEM_FILENAME.to_string(),
             }
@@ -3690,6 +3733,7 @@ mod tests {
                 "value": {
                     "tenantId": { "value": "11111111-1111-1111-1111-111111111111" },
                     "clientId": { "value": "22222222-2222-2222-2222-222222222222" },
+                    "loginEndpoint": { "value": "https://login.microsoftonline.com/" },
                     "storageQueueEndpoint": { "value": "https://example.queue.core.windows.net" },
                     "upstreamQueue": { "value": "upstream" },
                     "downstreamQueue": { "value": "downstream" }
@@ -3700,9 +3744,33 @@ mod tests {
         let (sp, sb) = parse_bicep_outputs(json).unwrap();
         assert_eq!(sp.tenant_id, "11111111-1111-1111-1111-111111111111");
         assert_eq!(sp.client_id, "22222222-2222-2222-2222-222222222222");
+        assert_eq!(
+            sp.login_endpoint.as_deref(),
+            Some("https://login.microsoftonline.com/")
+        );
         assert_eq!(sb.queue_endpoint, "https://example.queue.core.windows.net");
         assert_eq!(sb.upstream_queue, "upstream");
         assert_eq!(sb.downstream_queue, "downstream");
+    }
+
+    #[test]
+    fn test_parse_bicep_outputs_rejects_missing_login_endpoint() {
+        let json = r#"{
+            "companionBootstrapValues": {
+                "value": {
+                    "tenantId": "11111111-1111-1111-1111-111111111111",
+                    "clientId": "22222222-2222-2222-2222-222222222222",
+                    "storageQueueEndpoint": "https://example.queue.core.windows.net",
+                    "upstreamQueue": "upstream",
+                    "downstreamQueue": "downstream"
+                }
+            }
+        }"#;
+
+        let err = parse_bicep_outputs(json).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("failed to parse companionBootstrapValues"));
     }
 
     #[test]
@@ -3716,6 +3784,7 @@ mod tests {
             serde_json::to_vec(&ServicePrincipalStateFile {
                 tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
                 client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                login_endpoint: None,
                 certificate_path: CERT_PEM_FILENAME.to_string(),
                 private_key_path: KEY_PEM_FILENAME.to_string(),
             })
@@ -3781,6 +3850,7 @@ mod tests {
             serde_json::to_vec(&ServicePrincipalStateFile {
                 tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
                 client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                login_endpoint: None,
                 certificate_path: CERT_PEM_FILENAME.to_string(),
                 private_key_path: KEY_PEM_FILENAME.to_string(),
             })
@@ -3934,6 +4004,7 @@ mod tests {
                 RuntimeCredentialState {
                     tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
                     client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                    login_endpoint: DEFAULT_LOGIN_ENDPOINT.to_string(),
                     certificate_path: temp.path().join("client-cert.pem").canonicalize().unwrap(),
                     private_key_path: temp.path().join("client-key.pem").canonicalize().unwrap(),
                 }
@@ -3947,6 +4018,7 @@ mod tests {
         let state = ServicePrincipalStateFile {
             tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
             client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            login_endpoint: None,
             certificate_path: " ".to_string(),
             private_key_path: "client-key.pem".to_string(),
         };
@@ -3961,6 +4033,85 @@ mod tests {
             assert!(err
                 .to_string()
                 .contains("service principal certificate_path must be set and non-empty"));
+        });
+    }
+
+    #[test]
+    fn resolve_login_endpoint_defaults_when_absent() {
+        let result = resolve_login_endpoint(None).unwrap();
+        assert_eq!(result, DEFAULT_LOGIN_ENDPOINT);
+    }
+
+    #[test]
+    fn resolve_login_endpoint_strips_trailing_slash() {
+        let result =
+            resolve_login_endpoint(Some("https://login.microsoftonline.com/".to_string())).unwrap();
+        assert_eq!(result, "https://login.microsoftonline.com");
+    }
+
+    #[test]
+    fn resolve_login_endpoint_preserves_no_trailing_slash() {
+        let result =
+            resolve_login_endpoint(Some("https://login.microsoftonline.com".to_string())).unwrap();
+        assert_eq!(result, "https://login.microsoftonline.com");
+    }
+
+    #[test]
+    fn resolve_login_endpoint_rejects_empty() {
+        let err = resolve_login_endpoint(Some("".to_string())).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("login_endpoint must not be empty when present"));
+    }
+
+    #[test]
+    fn resolve_login_endpoint_rejects_whitespace_only() {
+        let err = resolve_login_endpoint(Some("   ".to_string())).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("login_endpoint must not be empty when present"));
+    }
+
+    #[test]
+    fn resolve_login_endpoint_sovereign_cloud() {
+        let result =
+            resolve_login_endpoint(Some("https://login.microsoftonline.us/".to_string())).unwrap();
+        assert_eq!(result, "https://login.microsoftonline.us");
+    }
+
+    #[test]
+    fn resolve_login_endpoint_rejects_slash_only() {
+        let err = resolve_login_endpoint(Some("/".to_string())).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("login_endpoint must not be empty when present"));
+    }
+
+    #[test]
+    fn runtime_ready_uses_default_login_endpoint_when_absent() {
+        let temp = TempDir::new().unwrap();
+        write_service_principal_state(&temp);
+        with_runtime_env(|| {
+            let state = load_runtime_credential_state(temp.path()).unwrap();
+            assert_eq!(state.login_endpoint, DEFAULT_LOGIN_ENDPOINT);
+        });
+    }
+
+    #[test]
+    fn runtime_ready_rejects_empty_login_endpoint() {
+        let temp = TempDir::new().unwrap();
+        write_service_principal_state(&temp);
+        let state_path = temp.path().join("service-principal.json");
+        std::fs::write(
+            &state_path,
+            br#"{"tenant_id":"11111111-1111-1111-1111-111111111111","client_id":"22222222-2222-2222-2222-222222222222","login_endpoint":"","certificate_path":"client-cert.pem","private_key_path":"client-key.pem"}"#,
+        )
+        .unwrap();
+        with_runtime_env(|| {
+            let err = load_runtime_credential_state(temp.path()).unwrap_err();
+            assert!(err
+                .to_string()
+                .contains("login_endpoint must not be empty when present"));
         });
     }
 
@@ -4476,6 +4627,7 @@ mod tests {
         let state = ServicePrincipalStateFile {
             tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
             client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            login_endpoint: None,
             certificate_path: "client-cert.pem".to_string(),
             private_key_path: "client-key.pem".to_string(),
         };
@@ -4524,6 +4676,7 @@ mod tests {
         let runtime_state = RuntimeCredentialState {
             tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
             client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            login_endpoint: DEFAULT_LOGIN_ENDPOINT.to_string(),
             certificate_path: temp.path().join("client-cert.pem"),
             private_key_path: temp.path().join("client-key.pem"),
         };

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -152,6 +152,7 @@ output companionServicePrincipalObjectId string = companionIdentity.outputs.serv
 output companionBootstrapValues object = {
   tenantId: companionIdentity.outputs.tenantId
   clientId: companionIdentity.outputs.clientId
+  loginEndpoint: environment().authentication.loginEndpoint
   storageQueueEndpoint: stack.outputs.queueServiceUri
   upstreamQueue: stack.outputs.upstreamQueueName
   downstreamQueue: stack.outputs.downstreamQueueName

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -140,9 +140,9 @@ Bootstrap-complete state is defined by the combination of:
    persisted `storage-queues.json` in the state directory).
 
 The current runtime artifact shape is a companion-owned `service-principal.json`
-file containing the Entra tenant ID, client ID, PEM certificate path, and PEM
-private-key path, plus the referenced certificate and key files in the state
-directory. After bootstrap, the state directory also contains
+file containing the Entra tenant ID, client ID, login endpoint, PEM certificate
+path, and PEM private-key path, plus the referenced certificate and key files in
+the state directory. After bootstrap, the state directory also contains
 `storage-queues.json` with the Storage Queue endpoint and queue names. New bootstrap
 commits are written into a generation directory under the state directory and made
 current by atomically updating a `.current-state` marker file. For backward
@@ -434,6 +434,13 @@ from the bootstrap-complete state and authenticate to Azure as an Entra
 application / service principal. Interactive device auth is bootstrap-only and
 is not part of normal runtime operation.
 
+The OAuth token endpoint URL is constructed from the `login_endpoint` field
+persisted in `service-principal.json`, with any trailing slash stripped before
+appending `/{tenant_id}/oauth2/v2.0/token`. When the field is absent (pre-existing
+deployments that predate sovereign-cloud support), the runtime defaults to
+`https://login.microsoftonline.com`. When the field is present but empty or
+whitespace-only, startup fails with a configuration error.
+
 ### 7.4  Transparent message bodies
 
 The Storage Queue message body carries the raw Sonde connector payload bytes
@@ -557,6 +564,7 @@ staging directory:
    {
      "tenant_id": "<from companionBootstrapValues.tenantId>",
      "client_id": "<from companionBootstrapValues.clientId>",
+     "login_endpoint": "<from companionBootstrapValues.loginEndpoint>",
      "certificate_path": "cert.pem",
      "private_key_path": "key.pem"
    }

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -467,6 +467,7 @@ required RBAC roles are assumed to be preconfigured outside this document.
 1. Normal runtime starts use the provisioned certificate and private-key material rather than device-code login.
 2. Runtime startup fails closed if the required certificate or private-key material is absent or unusable.
 3. The runtime design does not require interactive Azure authentication after bootstrap-complete state exists.
+4. The OAuth token endpoint used for client-assertion authentication is derived from the `login_endpoint` field in `service-principal.json`, normalized by stripping any trailing slash before constructing the full URL. When the field is absent (pre-existing deployments), the runtime defaults to `https://login.microsoftonline.com`. When the field is present but empty or whitespace-only, startup fails with a configuration error.
 
 ---
 
@@ -677,8 +678,8 @@ the state volume.
 **Acceptance criteria:**
 
 1. Bootstrap writes `service-principal.json` to the mounted state volume after successful Bicep deployment.
-2. The `service-principal.json` contains `tenant_id`, `client_id`, `certificate_path`, and `private_key_path` fields.
-3. The `tenant_id` and `client_id` values are extracted from the Bicep deployment outputs.
+2. The `service-principal.json` contains `tenant_id`, `client_id`, `certificate_path`, `private_key_path`, and `login_endpoint` fields.
+3. The `tenant_id`, `client_id`, and `login_endpoint` values are extracted from the Bicep deployment outputs. The `login_endpoint` is sourced from `environment().authentication.loginEndpoint` exposed through the `companionBootstrapValues` output.
 4. The `certificate_path` and `private_key_path` values are relative paths within the state volume pointing to the generated PEM files.
 5. The resulting state satisfies the `check-runtime-ready` validation without manual intervention.
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -204,10 +204,47 @@
 **Validates:** AZC-0305
 
 **Procedure:**
-1. Prepare bootstrap-complete state containing the required certificate PEM, private-key PEM, and service-principal metadata.
+1. Prepare bootstrap-complete state containing the required certificate PEM, private-key PEM, and service-principal metadata including a `login_endpoint` value.
 2. Start the runtime with a broker test double that records the credential path used.
 3. Assert: runtime startup uses the provisioned certificate and private-key material rather than entering device-code login.
-4. Remove or corrupt the certificate or private-key material and assert: runtime startup fails closed.
+4. Assert: the constructed OAuth token endpoint uses the persisted `login_endpoint` value, not a hardcoded `login.microsoftonline.com`.
+5. Remove or corrupt the certificate or private-key material and assert: runtime startup fails closed.
+
+---
+
+### T-AZC-0305-2  Absent login_endpoint defaults to public cloud
+
+**Validates:** AZC-0305
+
+**Procedure:**
+1. Prepare a `service-principal.json` that does not contain a `login_endpoint` field (simulating a pre-existing deployment).
+2. Load the runtime credential state from this file.
+3. Assert: the resulting `login_endpoint` is `https://login.microsoftonline.com`.
+4. Assert: the OAuth token endpoint is constructed correctly using the default.
+
+---
+
+### T-AZC-0305-3  Present-but-empty login_endpoint fails closed
+
+**Validates:** AZC-0305
+
+**Procedure:**
+1. Prepare a `service-principal.json` with `login_endpoint` set to an empty string.
+2. Attempt to load the runtime credential state.
+3. Assert: loading fails with a configuration error indicating the `login_endpoint` is invalid.
+4. Repeat with a whitespace-only value and assert the same failure.
+
+---
+
+### T-AZC-0305-4  Trailing-slash normalization in login_endpoint
+
+**Validates:** AZC-0305
+
+**Procedure:**
+1. Prepare a `service-principal.json` with `login_endpoint` set to `https://login.microsoftonline.com/` (trailing slash).
+2. Load the runtime credential state and construct the token endpoint.
+3. Assert: the resulting URL is `https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token` (no double slash).
+4. Repeat with `login_endpoint` set to `https://login.microsoftonline.com` (no trailing slash) and assert the same result.
 
 ---
 
@@ -398,8 +435,8 @@
 **Procedure:**
 1. Run the bootstrap subcommand with device-flow stubbed to succeed and Bicep deployment stubbed to return known output values (tenantId, clientId, namespace, queue names).
 2. Assert: `service-principal.json` exists in the state volume after bootstrap completes.
-3. Parse `service-principal.json` and assert: it contains `tenant_id`, `client_id`, `certificate_path`, and `private_key_path`.
-4. Assert: `tenant_id` and `client_id` match the stubbed Bicep output values.
+3. Parse `service-principal.json` and assert: it contains `tenant_id`, `client_id`, `certificate_path`, `private_key_path`, and `login_endpoint`.
+4. Assert: `tenant_id`, `client_id`, and `login_endpoint` match the stubbed Bicep output values.
 5. Assert: `certificate_path` and `private_key_path` are relative paths that resolve to existing PEM files in the state volume.
 6. Assert: `check-runtime-ready` succeeds after bootstrap completes.
 

--- a/docs/azure-provisioning-design.md
+++ b/docs/azure-provisioning-design.md
@@ -156,6 +156,12 @@ The parameter flow is:
   `authSettingsV2` resource with the correct issuer URL and audience,
   ensuring compatibility with sovereign clouds.
 
+The `companionBootstrapValues` Bicep output also includes a `loginEndpoint`
+field populated from `environment().authentication.loginEndpoint`. The Azure
+companion bootstrap persists this value in `service-principal.json` so the
+runtime can construct the correct OAuth token endpoint for the target cloud
+without hardcoding a public-cloud URL.
+
 ---
 
 ## 4  Runtime identity provisioning

--- a/docs/azure-provisioning-requirements.md
+++ b/docs/azure-provisioning-requirements.md
@@ -250,7 +250,7 @@ and private-key PEM.
 **Acceptance criteria:**
 
 1. The workflow documents which values and artifacts must be handed off to bootstrap for runtime starts.
-2. The handoff contract includes the tenant ID, client ID, certificate reference or material, private-key reference or material, Storage Queue endpoint/queue configuration, and the Function App / deployment-target values needed for package deployment and activation checks.
+2. The handoff contract includes the tenant ID, client ID, login endpoint, certificate reference or material, private-key reference or material, Storage Queue endpoint/queue configuration, and the Function App / deployment-target values needed for package deployment and activation checks.
 3. The handoff contract is compatible with the current Azure companion runtime expectations in `azure-companion-requirements.md`.
 
 ---


### PR DESCRIPTION
## Problem

`build_storage_queue_credential()` hardcodes the OAuth token endpoint to `login.microsoftonline.com`, preventing the Azure companion from working in sovereign clouds (Azure Government, Azure China, etc.).

## Solution

Add a configurable `login_endpoint` field that flows from Bicep deployment outputs through the `service-principal.json` state file to the runtime token endpoint construction.

### Bicep
- Add `loginEndpoint: environment().authentication.loginEndpoint` to `companionBootstrapValues` output

### Rust (`sonde-azure-companion`)
- Add optional `login_endpoint` to `ServicePrincipalStateFile` (`#[serde(default)]` for backward compatibility)
- Add required `login_endpoint` to `BicepBootstrapValues` (new deployments always populate it)
- Add `login_endpoint: String` to `RuntimeCredentialState` (always populated at load time)
- New `resolve_login_endpoint()` helper: absent → default (`https://login.microsoftonline.com`), empty/whitespace → error, trailing slash → stripped
- Use `runtime_state.login_endpoint` in `build_storage_queue_credential()` instead of hardcoded URL

### Specifications
- **AZC-0305**: added criterion 4 (configurable login endpoint with default/validation)
- **AZC-0403**: amended criteria 2–3 (`login_endpoint` in service-principal.json schema)
- **AZP-0203**: amended criterion 2 (login endpoint in handoff contract)
- **Design docs**: updated §3.2, §7.3, §8 in azure-companion-design.md; added `loginEndpoint` in azure-provisioning-design.md
- **Validation**: updated T-AZC-0113, T-AZC-0403; added T-AZC-0305-2, T-AZC-0305-3, T-AZC-0305-4

### Tests
- 10 new/updated tests covering: default when absent, trailing-slash normalization, empty/whitespace rejection, slash-only rejection, sovereign cloud URL, backward compatibility, missing Bicep field rejection
- 62 total tests pass, clippy clean

### Backward compatibility
- Existing `service-principal.json` files without `login_endpoint` continue to work — the runtime silently defaults to `https://login.microsoftonline.com`
- `bootstrap_unix.rs` integration tests deliberately omit the field to validate this path

### Not in scope
- Bootstrap `az cloud set` for first-time sovereign cloud provisioning (separate concern)
- Other sovereign-cloud hardcodings (Graph URLs, table suffixes)

Closes #921
