### PR TITLE
Design: PSK key escrow for gateway replaceability (#887)

### DIFF
--- a/docs/evolve-887-requirements.md
+++ b/docs/evolve-887-requirements.md
@@ -1,0 +1,803 @@
+<!-- SPDX-License-Identifier: MIT
+     Copyright (c) 2026 sonde contributors -->
+# Requirements Patch: PSK Key Escrow for Gateway Replaceability
+
+> **Issue:** #887
+> **Status:** Draft — Phase 1 requirements discovery
+> **Scope:** New requirements for PSK key escrow across gateway, Azure handler,
+> Azure companion, modem, admin CLI, and security model.
+> **User intent:** Enable gateway replacement without re-pairing nodes by
+> escrowing encrypted PSKs to Azure. Azure never holds plaintext secrets.
+
+---
+
+## Change Manifest
+
+| Action | Component | REQ-IDs | Summary |
+|--------|-----------|---------|---------|
+| **New** | Gateway | GW-2000–GW-2013 | Asymmetric keypair, escrow lifecycle, key rotation, recovery, bootstrap |
+| **New** | Azure Handler | AZH-0600–AZH-0605 | Escrow blob storage, recovery serving, salt/pubkey tables |
+| **New** | Admin CLI | ADMIN-0900–ADMIN-0903 | Passphrase entry, KDF, fingerprint verification, key rotation |
+| **New** | Connector API | — | New message types for escrow operations |
+| **Modify** | Gateway | GW-0601a | Note: master key may now be passphrase-derived (admin-side) |
+| **Modify** | Gateway | GW-1002 | Unknown nodes may now trigger recovery instead of silent discard |
+| **Modify** | Security model | security.md §2 | Updated key hierarchy, escrow threat model |
+
+---
+
+## New Requirements — Gateway (GW-2000 series)
+
+### GW-2000  Recovery keypair generation
+
+**Priority:** Must
+**Source:** Issue #887
+
+**Description:**
+The gateway MUST generate an asymmetric keypair at first startup for use in
+secure master-key delivery. The keypair MUST be persisted locally (encrypted
+at rest with the current master key) so that it survives restarts without
+requiring the admin to re-verify the fingerprint. The private key MUST be
+wrapped in `Zeroizing` and zeroed on drop.
+
+The recommended construction is X25519 (Curve25519 Diffie-Hellman) combined
+with HKDF-SHA-256 and AES-256-GCM for the key-encapsulation step (ECIES /
+HPKE-style). The specific algorithm choice is deferred to the design phase.
+
+**Acceptance criteria:**
+
+1. On first startup, a keypair is generated using `getrandom::fill()` for
+   randomness.
+2. The public key is available for publication via the connector API.
+3. The private key is persisted in the gateway's local storage, encrypted
+   with the current master key.
+4. On subsequent startups, the persisted keypair is loaded (not regenerated).
+5. If the private key cannot be decrypted (master key mismatch), the gateway
+   generates a new keypair and logs a warning.
+
+---
+
+### GW-2001  Recovery public key publication
+
+**Priority:** Must
+**Source:** Issue #887, GW-2000
+
+**Description:**
+The gateway MUST publish its recovery public key to the control plane via a
+new `KEY_ESCROW_PUBKEY` connector message on startup and whenever the keypair
+changes. The message includes the raw public key bytes, a monotonic key epoch
+(incremented on each keypair generation), and a creation timestamp.
+
+**Acceptance criteria:**
+
+1. The gateway emits `KEY_ESCROW_PUBKEY` on every startup after keypair load.
+2. The message contains: public key bytes, key epoch (uint), creation
+   timestamp (uint, Unix milliseconds).
+3. If the keypair is regenerated (new epoch), a new `KEY_ESCROW_PUBKEY` is
+   emitted.
+4. The key epoch is monotonically increasing and persisted across restarts.
+
+---
+
+### GW-2002  Escrow blob format and authenticated binding
+
+**Priority:** Must
+**Source:** Issue #887
+
+**Description:**
+The gateway MUST define a canonical escrow blob format for encrypted PSKs.
+Each blob MUST be AES-256-GCM encrypted with the current master key, with
+the following identity fields authenticated as AAD (Additional Authenticated
+Data):
+
+- `escrow_version` (uint) — schema version for forward compatibility
+- `key_version` (uint) — which master key version encrypted this blob
+- `subject_kind` (text) — `"node"` or `"phone"`
+- `subject_id` (text) — node ID or phone ID
+- `key_hint` (uint16) — the PSK's key_hint value
+
+The blob body (encrypted) contains the raw 32-byte PSK. The nonce MUST be
+unique per encryption (generated via `getrandom::fill()`).
+
+The wire format is CBOR-encoded:
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `escrow_version` | 1 | uint | Schema version (initially `1`) |
+| `key_version` | 2 | uint | Master key version that encrypted this blob |
+| `subject_kind` | 3 | tstr | `"node"` or `"phone"` |
+| `subject_id` | 4 | tstr | Node ID or phone ID |
+| `key_hint` | 5 | uint | PSK key_hint value |
+| `nonce` | 6 | bstr (12 bytes) | AES-256-GCM nonce |
+| `ciphertext` | 7 | bstr (32 bytes) | Encrypted PSK |
+| `tag` | 8 | bstr (16 bytes) | AES-256-GCM authentication tag |
+
+**Acceptance criteria:**
+
+1. Escrow blobs can be produced and consumed by the gateway.
+2. Decryption with the wrong master key fails with an authentication error.
+3. Tampering with any AAD field (subject_kind, subject_id, key_hint,
+   key_version, escrow_version) causes decryption failure.
+4. Swapping two escrow blobs between different nodes causes decryption
+   failure (because AAD differs).
+5. The blob is ≤ 150 bytes CBOR-encoded.
+
+---
+
+### GW-2003  Escrow blob emission in ACTUAL_STATE
+
+**Priority:** Must
+**Source:** Issue #887, GW-2002
+
+**Description:**
+The gateway MUST include the encrypted escrow blob for each node and phone
+PSK in `ACTUAL_STATE` connector messages. A new CBOR key is added to the
+node-scoped `ACTUAL_STATE` payload:
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `encrypted_psk_escrow` | 12 | bstr/null | CBOR-encoded escrow blob (GW-2002 format). `null` when escrow is disabled or not yet bootstrapped. |
+
+For phone PSKs, the gateway MUST emit phone-scoped `ACTUAL_STATE` messages
+(new `entity_kind = "phone"`) with the same `encrypted_psk_escrow` field.
+
+**Acceptance criteria:**
+
+1. Every `ACTUAL_STATE` for a registered node includes `encrypted_psk_escrow`
+   when escrow is enabled.
+2. Phone PSKs are emitted as `entity_kind = "phone"` with escrow blobs.
+3. When escrow is disabled (no passphrase-derived key rotation has occurred),
+   the field is `null`.
+4. After key rotation, all escrow blobs are re-emitted with the new
+   `key_version`.
+
+---
+
+### GW-2004  Escrow lifecycle state machine
+
+**Priority:** Must
+**Source:** Issue #887
+
+**Description:**
+The gateway MUST track and expose its escrow readiness via an explicit
+lifecycle state:
+
+| State | Description |
+|-------|-------------|
+| `disabled` | Gateway is using a random master key. No passphrase-derived key rotation has occurred. Escrow blobs are not emitted. |
+| `bootstrapping` | Key rotation is in progress. Some PSKs may still be encrypted with the old key version. |
+| `ready` | All node and phone PSKs are encrypted with the current passphrase-derived master key and have been emitted to the connector. |
+| `rotation_in_progress` | A new key rotation is underway. |
+| `degraded` | A rotation was interrupted (crash/restart). Some PSKs are encrypted with a different key version than the current master key. The gateway MUST resume rotation on startup. |
+
+The escrow state MUST be persisted and reported in gateway-scoped
+`ACTUAL_STATE` messages.
+
+**Acceptance criteria:**
+
+1. A fresh gateway starts in `disabled` state.
+2. After a successful key rotation, the state transitions to `ready`.
+3. During rotation, the state is `bootstrapping` or `rotation_in_progress`.
+4. If the gateway restarts during rotation, it detects `degraded` state and
+   resumes rotation automatically.
+5. The escrow state is visible to operators via admin API and connector.
+
+---
+
+### GW-2005  Master key version tracking
+
+**Priority:** Must
+**Source:** Issue #887
+
+**Description:**
+The gateway MUST maintain a monotonically increasing `key_version` counter.
+Each encrypted PSK record in local storage MUST be tagged with the
+`key_version` of the master key used to encrypt it. The current
+`key_version` MUST be persisted in the gateway's database.
+
+**Acceptance criteria:**
+
+1. Each encrypted PSK record in SQLite includes a `key_version` column.
+2. The current `key_version` is stored in a gateway metadata table.
+3. `key_version` is monotonically increasing (never decremented).
+4. After key rotation, all PSK records are tagged with the new `key_version`.
+
+---
+
+### GW-2006  Key rotation via connector
+
+**Priority:** Must
+**Source:** Issue #887, GW-2000
+
+**Description:**
+The gateway MUST accept a `MASTER_KEY_INSTALL` connector message containing
+a new master key encrypted with the gateway's recovery public key. On
+receipt, the gateway:
+
+1. Decrypts the payload with its private key to obtain the new master key.
+2. Validates the message includes the correct `target_key_epoch` matching
+   the gateway's current public key epoch.
+3. Increments `key_version`.
+4. Re-encrypts all local PSK records (node + phone) from the old master key
+   to the new master key, transactionally.
+5. Re-encrypts the recovery private key (`escrow_keypair.secret_enc`) under
+   the new master key.
+6. Updates the master key in the `KeyProvider` storage.
+7. Emits updated escrow blobs via `ACTUAL_STATE` for all PSKs.
+8. Transitions escrow state to `ready` (or `rotation_in_progress` → `ready`).
+9. Zeroes the old master key from memory.
+
+The `MASTER_KEY_INSTALL` message format:
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `msg_type` | 1 | uint | New message type TBD |
+| `target_key_epoch` | 2 | uint | Must match gateway's current public key epoch |
+| `encrypted_master_key` | 3 | bstr | Master key encrypted with gateway's public key |
+| `operation_id` | 4 | bstr | Unique operation ID for idempotency |
+| `rotation_counter` | 5 | uint | Monotonic rotation counter for replay protection |
+| `expiry_ms` | 6 | uint | Message expiry timestamp (Unix ms). Gateway rejects expired messages. |
+
+**Acceptance criteria:**
+
+1. Gateway successfully receives and processes a `MASTER_KEY_INSTALL` message.
+2. All local PSKs are re-encrypted with the new master key.
+3. The operation is atomic — a crash during re-encryption is recoverable
+   (see GW-2008).
+4. Messages with wrong `target_key_epoch` are rejected.
+5. Duplicate `operation_id` values are rejected (idempotency).
+6. Expired messages are rejected.
+7. After successful rotation, all escrow blobs are re-emitted.
+
+---
+
+### GW-2007  Crash-safe key rotation
+
+**Priority:** Must
+**Source:** Issue #887, GW-2006
+
+**Description:**
+Key rotation MUST be crash-safe. The gateway MUST use the following
+transactional approach:
+
+1. **Prepare**: Write the new master key (encrypted with the old master key)
+   and new `key_version` to a `pending_rotation` metadata record.
+2. **Migrate**: For each PSK record, decrypt with old key, re-encrypt with
+   new key, write with new `key_version`. Each record update is individually
+   committed (the `key_version` tag on each record tracks progress).
+3. **Commit**: Update the active master key, remove the `pending_rotation`
+   record, update escrow state.
+
+On startup, if a `pending_rotation` record exists, the gateway MUST resume
+migration from where it left off (records with old `key_version` still need
+migration).
+
+During the migration window, the gateway MUST be able to decrypt PSKs
+encrypted with either the old or new `key_version` (two-key window).
+
+**Acceptance criteria:**
+
+1. A crash at any point during rotation leaves the database in a consistent
+   state.
+2. On restart after a crash, the gateway detects the incomplete rotation and
+   resumes automatically.
+3. During migration, nodes can still authenticate (both old and new key
+   versions are supported for decryption).
+4. After migration completes, only the new key version is active.
+
+---
+
+### GW-2008  Salt management
+
+**Priority:** Must
+**Source:** Issue #887
+
+**Description:**
+The gateway MUST manage a KDF salt record containing:
+
+- `salt` (16 bytes, random)
+- `argon2id_m_cost` (uint, memory cost in KiB — default 65536 = 64 MiB)
+- `argon2id_t_cost` (uint, time cost / passes — default 3)
+- `argon2id_p_cost` (uint, parallelism — default 1)
+- `kdf_version` (uint, schema version — initially 1)
+- `created_at` (uint, Unix milliseconds)
+
+The salt record is stored locally in the gateway database and published
+to Azure via the connector. The strategy is **first-writer-wins**:
+
+- If no salt exists locally or in Azure, the gateway generates one and
+  publishes it.
+- If Azure has a salt but the gateway does not, the gateway adopts Azure's
+  salt.
+- If both exist and differ, the gateway logs a warning and uses the local
+  salt (local is authoritative for the running instance).
+
+**Acceptance criteria:**
+
+1. Salt is generated using `getrandom::fill()`.
+2. Salt record is persisted in the gateway database.
+3. Salt record is published via connector on startup and after generation.
+4. Salt is adopted from Azure when local salt is absent.
+5. Conflict detection logs a warning when local and Azure salts differ.
+
+---
+
+### GW-2009  Unknown node recovery request
+
+**Priority:** Must
+**Source:** Issue #887
+
+**Description:**
+When the gateway receives a frame from a `key_hint` for which no local PSK
+exists, and escrow is in `ready` state, the gateway MUST emit a
+`KEY_ESCROW_REQUEST` connector message requesting the escrowed PSK(s) for
+that `key_hint`. The gateway MUST NOT emit recovery requests when escrow is
+`disabled`.
+
+Because `key_hint` is only 16 bits and collisions are possible, the recovery
+response may contain multiple candidate PSKs. The gateway trial-decrypts the
+original frame against each candidate.
+
+**Rate limiting:** The gateway MUST rate-limit recovery requests per
+`key_hint` to prevent radio-triggered amplification attacks. A reasonable
+default is at most 1 request per `key_hint` per 60 seconds.
+
+`KEY_ESCROW_REQUEST` message format:
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `msg_type` | 1 | uint | New message type TBD |
+| `key_hint` | 2 | uint | The key_hint from the undecryptable frame |
+| `request_id` | 3 | bstr | Unique request ID for correlation |
+
+**Acceptance criteria:**
+
+1. An unknown `key_hint` in `ready` state triggers a `KEY_ESCROW_REQUEST`.
+2. The same `key_hint` does not trigger more than 1 request per 60 seconds.
+3. In `disabled` state, unknown `key_hint` values are silently discarded
+   (existing GW-1002 behavior).
+4. The request includes a unique `request_id` for response correlation.
+
+---
+
+### GW-2010  PSK recovery from escrowed blob
+
+**Priority:** Must
+**Source:** Issue #887, GW-2009
+
+**Description:**
+On receiving a `KEY_ESCROW_RESPONSE` connector message, the gateway MUST:
+
+1. Match the `request_id` to a pending recovery request.
+2. For each candidate escrow blob in the response, attempt to decrypt
+   using the current master key.
+3. For each successfully decrypted PSK, attempt trial-decryption of the
+   buffered original frame.
+4. If a PSK successfully decrypts the frame, register the node (or phone)
+   locally and process the frame normally.
+5. If no candidate succeeds, log a warning and discard the frame.
+
+The gateway MUST buffer the original undecryptable frame for a bounded
+time (default: 30 seconds) while awaiting the recovery response.
+
+`KEY_ESCROW_RESPONSE` message format:
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `msg_type` | 1 | uint | New message type TBD |
+| `request_id` | 2 | bstr | Correlates to the `KEY_ESCROW_REQUEST` |
+| `candidates` | 3 | array of bstr | Array of escrow blobs (GW-2002 format) |
+| `key_hint` | 4 | uint | The requested key_hint |
+
+**Acceptance criteria:**
+
+1. A valid recovery response with a matching PSK results in node
+   registration and frame processing.
+2. Multiple candidates are tried in order; first successful match wins.
+3. A maximum candidate count is enforced (e.g., 16) to bound trial
+   decryption cost.
+4. If no candidate matches, the frame is discarded with a warning log.
+5. If the recovery response arrives after the frame buffer expires, it is
+   discarded with a warning log.
+6. Successfully recovered nodes emit `ACTUAL_STATE` with escrow blobs.
+
+---
+
+### GW-2011  Fingerprint display on modem
+
+**Priority:** Must
+**Source:** Issue #887
+
+**Description:**
+The gateway MUST display its recovery public key fingerprint on the modem's
+OLED display as a navigable display page (consistent with GW-1101b
+short-press page navigation). The fingerprint is computed as:
+
+1. `hash = SHA-256(public_key_bytes)`
+2. Take the first 66 bits of `hash` (bits 0–65).
+3. Split into six 11-bit unsigned integers.
+4. Map each to a word from the BIP-39 English wordlist (2048 entries).
+
+The display shows the 6 words clearly on the 128×64 OLED (e.g., three rows
+of two words each). The fingerprint page is always available when a recovery
+keypair exists.
+
+**Acceptance criteria:**
+
+1. The fingerprint is deterministically computed from the public key.
+2. The same public key always produces the same 6 words.
+3. Both the gateway (modem display) and admin tool / SPA compute identical
+   fingerprints for the same public key.
+4. The fingerprint page is accessible via short-press navigation.
+5. The fingerprint is clearly readable on the 128×64 display.
+6. The security target (66-bit anti-MITM work factor) is documented.
+
+---
+
+### GW-2012  Replacement gateway bootstrap sequence
+
+**Priority:** Must
+**Source:** Issue #887
+
+**Description:**
+A replacement gateway (empty database, no local PSKs) MUST follow a defined
+bootstrap sequence before it can recover escrowed PSKs:
+
+1. Start with a fresh random master key (via `KeyProvider`).
+2. Generate a new recovery keypair (GW-2000).
+3. Publish the recovery public key via connector (GW-2001).
+4. Display the fingerprint on the modem (GW-2011).
+5. Fetch the KDF salt from Azure (first-writer-wins, GW-2008). If Azure has
+   a salt, adopt it locally.
+6. Wait for `MASTER_KEY_INSTALL` from the admin (GW-2006).
+7. On successful master key installation, transition escrow state from
+   `disabled` to `bootstrapping` → `ready`.
+8. Begin answering `KEY_ESCROW_REQUEST` responses for unknown nodes
+   (GW-2009, GW-2010).
+
+The gateway MUST NOT attempt node recovery (GW-2009) while escrow state is
+`disabled` — it MUST silently discard unknown frames per GW-1002 until the
+admin completes key installation.
+
+**Acceptance criteria:**
+
+1. A replacement gateway with empty DB starts in `disabled` escrow state.
+2. Fingerprint is displayed before admin performs key rotation.
+3. After `MASTER_KEY_INSTALL`, the gateway can recover escrowed nodes.
+4. Before `MASTER_KEY_INSTALL`, unknown frames are silently discarded.
+5. The full replacement flow (bootstrap → key install → first node recovery)
+   succeeds end-to-end.
+
+---
+
+### GW-2013  Connector key-management message security
+
+**Priority:** Must
+**Source:** Issue #887, security.md
+
+**Description:**
+Connector key-management messages (`MASTER_KEY_INSTALL`, `KEY_ESCROW_REQUEST`,
+`KEY_ESCROW_RESPONSE`) cross a trust boundary between the gateway and the
+control plane. The gateway MUST enforce the following security properties:
+
+1. **`MASTER_KEY_INSTALL` authentication**: The message is cryptographically
+   bound to the gateway's recovery public key via X25519 key agreement. Only
+   a sender who knows the master key AND the gateway's public key can produce
+   a valid message. The `target_key_epoch` prevents replaying messages to a
+   different keypair generation. The `operation_id` prevents replay. The
+   `expiry_ms` prevents delayed delivery.
+
+2. **`KEY_ESCROW_RESPONSE` integrity**: Escrow blobs are individually
+   authenticated via AES-256-GCM with AAD (GW-2002). The gateway
+   trial-decrypts each candidate — invalid or tampered blobs fail
+   authentication and are discarded. The response itself does not require
+   additional authentication because each blob is self-authenticating.
+
+3. **`KEY_ESCROW_REQUEST` is gateway-originated**: Only the gateway emits
+   recovery requests. The control plane cannot trigger requests.
+
+4. **Rate limiting**: Per-key_hint rate limiting (GW-2009) bounds
+   amplification from radio-triggered requests.
+
+**Acceptance criteria:**
+
+1. A `MASTER_KEY_INSTALL` with a valid structure but encrypted with a
+   different gateway's public key fails decryption.
+2. A replayed `MASTER_KEY_INSTALL` (same `operation_id`) is rejected.
+3. A tampered escrow blob in `KEY_ESCROW_RESPONSE` is discarded without
+   affecting other candidates.
+4. An unsolicited `KEY_ESCROW_RESPONSE` (no matching pending request) is
+   discarded.
+
+---
+
+## New Requirements — Azure Handler (AZH-0600 series)
+
+### AZH-0600  Encrypted PSK escrow blob storage
+
+**Priority:** Must
+**Source:** Issue #887, GW-2003
+
+**Description:**
+The Azure handler MUST store `encrypted_psk_escrow` blobs received in
+`ACTUAL_STATE` messages in per-subject Azure Table rows. The table schema
+extends the existing node state table:
+
+- Node PSKs: stored in the existing node state row (new column).
+- Phone PSKs: stored in phone-scoped rows (new `entity_kind = "phone"`).
+
+The handler MUST NOT decrypt or inspect the escrow blob contents. The blob
+is opaque ciphertext from the handler's perspective.
+
+**Acceptance criteria:**
+
+1. Escrow blobs from `ACTUAL_STATE` are persisted in Azure Table Storage.
+2. Blobs are stored verbatim (no transformation or decryption).
+3. Node and phone escrow blobs are stored in separate logical rows.
+4. Blob updates (re-encryption after key rotation) overwrite the previous
+   blob for the same subject.
+
+---
+
+### AZH-0601  Encrypted PSK recovery serving
+
+**Priority:** Must
+**Source:** Issue #887, GW-2009, GW-2010
+
+**Description:**
+On receiving a `KEY_ESCROW_REQUEST` from the gateway (via upstream queue),
+the Azure handler MUST:
+
+1. Look up all escrow blobs matching the requested `key_hint`.
+2. Return them as a `KEY_ESCROW_RESPONSE` via the downstream desired-state
+   queue.
+3. Cap the candidate set at 16 blobs (fail-closed if more exist — log
+   warning and return the first 16).
+
+**Acceptance criteria:**
+
+1. A `KEY_ESCROW_REQUEST` for a known `key_hint` returns matching blobs.
+2. A `KEY_ESCROW_REQUEST` for an unknown `key_hint` returns an empty
+   candidate list.
+3. The candidate set is bounded at 16.
+4. Responses are correlated via `request_id`.
+
+---
+
+### AZH-0602  Gateway recovery public key storage
+
+**Priority:** Must
+**Source:** Issue #887, GW-2001
+
+**Description:**
+The Azure handler MUST store the gateway's recovery public key received via
+`KEY_ESCROW_PUBKEY` messages. The stored record includes public key bytes,
+key epoch, and creation timestamp. This record is readable by the admin
+SPA / CLI for fingerprint verification and master-key encryption.
+
+**Acceptance criteria:**
+
+1. Public key records are stored in Azure Table Storage.
+2. Only the latest (highest epoch) public key is authoritative.
+3. The record is queryable by the admin SPA / CLI.
+
+---
+
+### AZH-0603  KDF salt storage
+
+**Priority:** Must
+**Source:** Issue #887, GW-2008
+
+**Description:**
+The Azure handler MUST store the KDF salt record received from the gateway
+via the connector. The record includes salt bytes, Argon2id parameters, KDF
+version, and creation timestamp. The strategy is first-writer-wins:
+
+- If no salt record exists in Azure, the handler stores the first one received.
+- If a salt record already exists, the handler ignores subsequent writes
+  (does not overwrite) and returns the existing salt in the next
+  gateway-scoped `DESIRED_STATE` (or via a dedicated response).
+
+**Acceptance criteria:**
+
+1. The first salt record received is stored persistently.
+2. Subsequent salt writes from the gateway do not overwrite existing salt.
+3. The existing salt is returned to the gateway on request.
+
+---
+
+### AZH-0604  Master key install relay
+
+**Priority:** Must
+**Source:** Issue #887, GW-2006
+
+**Description:**
+The Azure handler MUST relay `MASTER_KEY_INSTALL` messages from the admin
+SPA / CLI to the gateway via the downstream connector queue. The handler
+MUST NOT decrypt or inspect the encrypted master key payload.
+
+**Acceptance criteria:**
+
+1. `MASTER_KEY_INSTALL` messages from the admin SPA are relayed verbatim.
+2. The handler does not decrypt or modify the encrypted payload.
+3. The message is delivered via the existing downstream queue mechanism.
+
+---
+
+### AZH-0605  Escrow state observability
+
+**Priority:** Should
+**Source:** Issue #887, GW-2004
+
+**Description:**
+The Azure handler SHOULD expose the gateway's escrow lifecycle state
+(from gateway-scoped `ACTUAL_STATE`) to the admin SPA / CLI. This enables
+operators to verify that escrow is `ready` before relying on it for
+recovery.
+
+**Acceptance criteria:**
+
+1. The gateway's escrow state is stored in Azure and queryable.
+2. The admin SPA / CLI can display the current escrow state.
+3. A warning is surfaced when escrow is not `ready`.
+
+---
+
+## New Requirements — Admin CLI (ADMIN-0900 series)
+
+### ADMIN-0900  Key rotation command
+
+**Priority:** Must
+**Source:** Issue #887
+
+**Description:**
+`sonde-admin key rotate` MUST prompt the admin for a passphrase, derive a
+master key using Argon2id with the stored salt and parameters, encrypt the
+master key with the gateway's verified recovery public key, and send a
+`MASTER_KEY_INSTALL` message via the Azure handler (or directly via the
+admin gRPC API if local).
+
+For the first rotation (escrow bootstrap), the admin provides only the new
+passphrase. For subsequent rotations, the admin provides only the new
+passphrase (the gateway handles the old-to-new transition internally since
+it already has the old key).
+
+The command MUST:
+
+1. Fetch the salt record from Azure (or generate if none exists).
+2. Fetch the gateway's recovery public key from Azure.
+3. Display the 6-word fingerprint and prompt the admin to verify it matches
+   the modem display.
+4. On confirmation, derive the master key and encrypt it.
+5. Send `MASTER_KEY_INSTALL` to the gateway.
+6. Wait for and display the rotation result.
+
+**Acceptance criteria:**
+
+1. The command prompts for a passphrase (masked input).
+2. The passphrase is validated for minimum entropy (6 diceware words / 20+
+   random characters).
+3. The 6-word fingerprint is displayed for admin verification.
+4. The command fails if the admin does not confirm the fingerprint.
+5. The rotation result is displayed (success / failure with reason).
+6. The passphrase and derived master key are zeroed from memory after use.
+
+---
+
+### ADMIN-0901  Fingerprint verification
+
+**Priority:** Must
+**Source:** Issue #887, GW-2011
+
+**Description:**
+`sonde-admin key fingerprint` MUST fetch the gateway's recovery public key
+from Azure and display its 6-word BIP-39-wordlist fingerprint. This allows
+the admin to verify the fingerprint independently of the rotation flow.
+
+**Acceptance criteria:**
+
+1. The command fetches the public key from Azure.
+2. The 6-word fingerprint is computed identically to GW-2011.
+3. The fingerprint is displayed in a clear, human-readable format.
+
+---
+
+### ADMIN-0902  Escrow status command
+
+**Priority:** Should
+**Source:** Issue #887, GW-2004
+
+**Description:**
+`sonde-admin key status` SHOULD display the current escrow lifecycle state,
+key version, number of escrowed PSKs (node + phone), and KDF parameters.
+
+**Acceptance criteria:**
+
+1. Escrow state is displayed (disabled / bootstrapping / ready / rotation_in_progress / degraded).
+2. Current key version is displayed.
+3. Count of escrowed node and phone PSKs is displayed.
+
+---
+
+## Connector API Changes
+
+### New message types
+
+The following new connector message types are added:
+
+| `msg_type` | Name | Direction | Description |
+|------------|------|-----------|-------------|
+| `0x10` | `KEY_ESCROW_PUBKEY` | Gateway → control plane | Gateway's recovery public key |
+| `0x11` | `KEY_ESCROW_REQUEST` | Gateway → control plane | Request escrowed PSK(s) for a key_hint |
+| `0x12` | `KEY_ESCROW_RESPONSE` | Control plane → gateway | Escrowed PSK candidate(s) |
+| `0x13` | `MASTER_KEY_INSTALL` | Control plane → gateway | Encrypted new master key for rotation |
+
+These are separate from `DESIRED_STATE`/`ACTUAL_STATE` because they have
+imperative/transactional semantics (operation IDs, expiry, idempotency)
+rather than replacement semantics.
+
+The existing `ACTUAL_STATE` is extended with one new field
+(`encrypted_psk_escrow`, CBOR key 12) using the existing declarative
+replacement semantics.
+
+---
+
+## Modified Requirements
+
+### GW-0601a (addendum)
+
+The master key MAY be derived from a passphrase via Argon2id. This
+derivation happens in the admin tool / SPA — the gateway only receives the
+raw 32-byte master key. The `KeyProvider` trait and existing backends are
+unchanged.
+
+### GW-1002 (addendum)
+
+When escrow is in `ready` state, unknown `key_hint` values MAY trigger a
+recovery request (GW-2009) instead of immediate silent discard. The frame
+is buffered for up to 30 seconds pending recovery. If recovery fails or
+times out, the frame is silently discarded per the original requirement.
+
+### security.md §2.3 (addendum)
+
+New subsection: **2.3.2 PSK key escrow**
+
+Describes the escrow key hierarchy, asymmetric key transport, recovery
+flow, and escrow-specific threats:
+
+- Azure compromise: cannot decrypt PSKs (encrypted with master key that
+  Azure never holds).
+- Public key substitution: mitigated by modem-displayed 6-word fingerprint
+  verification (66-bit anti-MITM work factor).
+- Offline passphrase brute-force: mitigated by Argon2id (64 MiB memory-hard)
+  + minimum 77-bit entropy requirement.
+- Key_hint amplification: mitigated by per-key_hint rate limiting and
+  bounded candidate sets.
+
+---
+
+## Invariant Impact Assessment
+
+| Invariant | Impact |
+|-----------|--------|
+| PSKs never leave gateway in plaintext | **Preserved** — escrow blobs are always AES-256-GCM encrypted with the master key |
+| Azure never holds plaintext secrets | **Preserved** — master key derived from passphrase, never stored in Azure; PSKs encrypted |
+| Silent-discard error model | **Modified** — unknown key_hints may now trigger recovery requests when escrow is enabled, but failed recovery still results in silent discard |
+| Connector API backward compatibility | **Preserved** — new message types use previously unused `msg_type` values; new ACTUAL_STATE field is optional |
+| KeyProvider trait contract | **Preserved** — passphrase derivation is admin-side; gateway still uses raw master keys |
+| State export/import (GW-1001) | **Unaffected** — escrow is complementary to, not a replacement for, state export |
+| Radio protocol | **Unaffected** — no changes to on-air frame format |
+
+---
+
+## Traceability
+
+All new requirements trace to `USER-REQUEST: "Azure should be the long-term
+store for PSKs for the gateway, so replacing the gateway doesn't break
+pairing, but without disclosing the keys."`
+
+The requirements were informed by adversarial analysis that identified:
+- Key_hint collision risks → bounded candidate sets + rate limiting (GW-2009, GW-2010)
+- Escrow blob swap attacks → authenticated context binding via AAD (GW-2002)
+- DESIRED_STATE semantic conflict → new connector message types
+- Crash-safety risks → explicit rotation state machine (GW-2004, GW-2007)
+- Escrow readiness ambiguity → lifecycle state machine (GW-2004)

--- a/docs/evolve-887-requirements.md
+++ b/docs/evolve-887-requirements.md
@@ -230,7 +230,7 @@ The `MASTER_KEY_INSTALL` message format:
 
 | Field | CBOR key | Type | Description |
 |-------|----------|------|-------------|
-| `msg_type` | 1 | uint | New message type TBD |
+| `msg_type` | 1 | uint | `0x13` (`MASTER_KEY_INSTALL`) |
 | `target_key_epoch` | 2 | uint | Must match gateway's current public key epoch |
 | `encrypted_master_key` | 3 | bstr | Master key encrypted with gateway's public key |
 | `operation_id` | 4 | bstr | Unique operation ID for idempotency |
@@ -345,7 +345,7 @@ default is at most 1 request per `key_hint` per 60 seconds.
 
 | Field | CBOR key | Type | Description |
 |-------|----------|------|-------------|
-| `msg_type` | 1 | uint | New message type TBD |
+| `msg_type` | 1 | uint | `0x11` (`KEY_ESCROW_REQUEST`) |
 | `key_hint` | 2 | uint | The key_hint from the undecryptable frame |
 | `request_id` | 3 | bstr | Unique request ID for correlation |
 
@@ -383,7 +383,7 @@ time (default: 30 seconds) while awaiting the recovery response.
 
 | Field | CBOR key | Type | Description |
 |-------|----------|------|-------------|
-| `msg_type` | 1 | uint | New message type TBD |
+| `msg_type` | 1 | uint | `0x12` (`KEY_ESCROW_RESPONSE`) |
 | `request_id` | 2 | bstr | Correlates to the `KEY_ESCROW_REQUEST` |
 | `candidates` | 3 | array of bstr | Array of escrow blobs (GW-2002 format) |
 | `key_hint` | 4 | uint | The requested key_hint |
@@ -525,8 +525,10 @@ extends the existing node state table:
 - Node PSKs: stored in the existing node state row (new column).
 - Phone PSKs: stored in phone-scoped rows (new `entity_kind = "phone"`).
 
-The handler MUST NOT decrypt or inspect the escrow blob contents. The blob
-is opaque ciphertext from the handler's perspective.
+The handler MUST NOT decrypt the escrow blob ciphertext. The blob body is
+opaque from the handler's perspective. However, the handler MAY read the
+unencrypted `escrow_key_hint` field (CBOR key 13) sent alongside the blob
+in ACTUAL_STATE for indexing purposes (see AZH-0601).
 
 **Acceptance criteria:**
 

--- a/docs/evolve-887-requirements.md
+++ b/docs/evolve-887-requirements.md
@@ -17,7 +17,7 @@
 |--------|-----------|---------|---------|
 | **New** | Gateway | GW-2000–GW-2013 | Asymmetric keypair, escrow lifecycle, key rotation, recovery, bootstrap |
 | **New** | Azure Handler | AZH-0600–AZH-0605 | Escrow blob storage, recovery serving, salt/pubkey tables |
-| **New** | Admin CLI | ADMIN-0900–ADMIN-0903 | Passphrase entry, KDF, fingerprint verification, key rotation |
+| **New** | Admin CLI | ADMIN-0900–ADMIN-0902 | Passphrase entry, KDF, fingerprint verification, key rotation |
 | **New** | Connector API | — | New message types for escrow operations |
 | **Modify** | Gateway | GW-0601a | Note: master key may now be passphrase-derived (admin-side) |
 | **Modify** | Gateway | GW-1002 | Unknown nodes may now trigger recovery instead of silent discard |
@@ -242,7 +242,7 @@ The `MASTER_KEY_INSTALL` message format:
 1. Gateway successfully receives and processes a `MASTER_KEY_INSTALL` message.
 2. All local PSKs are re-encrypted with the new master key.
 3. The operation is atomic — a crash during re-encryption is recoverable
-   (see GW-2008).
+   (see GW-2007).
 4. Messages with wrong `target_key_epoch` are rejected.
 5. Duplicate `operation_id` values are rejected (idempotency).
 6. Expired messages are rejected.

--- a/docs/evolve-887-requirements.md
+++ b/docs/evolve-887-requirements.md
@@ -541,8 +541,8 @@ in ACTUAL_STATE for indexing purposes (see AZH-0601).
 1. Escrow blobs from `ACTUAL_STATE` are persisted in Azure Table Storage.
 2. Blobs are stored verbatim (no transformation or decryption).
 3. Node and phone escrow blobs are stored in separate logical rows.
-4. Blob updates (re-encryption after key rotation) overwrite the previous
-   blob for the same subject.
+4. Blob updates (re-encryption after key rotation) are appended as new
+   rows; `Top(1)` per partition returns the latest blob for a subject.
 
 ---
 

--- a/docs/evolve-887-requirements.md
+++ b/docs/evolve-887-requirements.md
@@ -136,9 +136,11 @@ node-scoped `ACTUAL_STATE` payload:
 | Field | CBOR key | Type | Description |
 |-------|----------|------|-------------|
 | `encrypted_psk_escrow` | 12 | bstr/null | CBOR-encoded escrow blob (GW-2002 format). `null` when escrow is disabled or not yet bootstrapped. |
+| `escrow_key_hint` | 13 | uint/null | `key_hint` (u16) from the escrow blob metadata. Sent alongside the blob so that the Azure handler can index by `key_hint` without inspecting blob ciphertext. `null` when escrow is disabled. |
 
 For phone PSKs, the gateway MUST emit phone-scoped `ACTUAL_STATE` messages
-(new `entity_kind = "phone"`) with the same `encrypted_psk_escrow` field.
+(new `entity_kind = "phone"`) with the same `encrypted_psk_escrow` and
+`escrow_key_hint` fields.
 
 **Acceptance criteria:**
 
@@ -218,7 +220,8 @@ receipt, the gateway:
    the gateway's current public key epoch.
 3. Increments `key_version`.
 4. Re-encrypts all local PSK records (node + phone) from the old master key
-   to the new master key, transactionally.
+   to the new master key, incrementally with per-record crash safety
+   (see GW-2007 for the crash-safe migration approach).
 5. Re-encrypts the recovery private key (`escrow_keypair.secret_enc`) under
    the new master key.
 6. Updates the master key in the `KeyProvider` storage.
@@ -226,16 +229,19 @@ receipt, the gateway:
 8. Transitions escrow state to `ready` (or `rotation_in_progress` → `ready`).
 9. Zeroes the old master key from memory.
 
-The `MASTER_KEY_INSTALL` message format:
+The `MASTER_KEY_INSTALL` message format (matches specification §3.9):
 
 | Field | CBOR key | Type | Description |
 |-------|----------|------|-------------|
 | `msg_type` | 1 | uint | `0x13` (`MASTER_KEY_INSTALL`) |
 | `target_key_epoch` | 2 | uint | Must match gateway's current public key epoch |
-| `encrypted_master_key` | 3 | bstr | Master key encrypted with gateway's public key |
-| `operation_id` | 4 | bstr | Unique operation ID for idempotency |
-| `rotation_counter` | 5 | uint | Monotonic rotation counter for replay protection |
-| `expiry_ms` | 6 | uint | Message expiry timestamp (Unix ms). Gateway rejects expired messages. |
+| `sender_public_key` | 3 | bstr (32 bytes) | Admin's ephemeral X25519 public key |
+| `encrypted_master_key` | 4 | bstr | AES-256-GCM ciphertext of the new master key |
+| `nonce` | 5 | bstr (12 bytes) | AES-256-GCM nonce |
+| `tag` | 6 | bstr (16 bytes) | AES-256-GCM authentication tag |
+| `operation_id` | 7 | bstr (16 bytes) | Unique operation ID for idempotency |
+| `rotation_counter` | 8 | uint | Monotonic rotation counter for replay protection |
+| `expiry_ms` | 9 | uint | Message expiry timestamp (Unix ms). Gateway rejects expired messages. |
 
 **Acceptance criteria:**
 

--- a/docs/evolve-887-specification.md
+++ b/docs/evolve-887-specification.md
@@ -113,9 +113,12 @@ pub enum SubjectKind {
 (matching GW-2002 field 3).
 
 CBOR encoding uses integer keys (1–8) as defined in GW-2002. The AAD for
-AES-256-GCM encryption is the CBOR-encoded map of fields 1–5 (escrow_version,
-key_version, subject_kind, subject_id, key_hint). This binds the ciphertext
-to the subject identity, preventing blob swap attacks.
+AES-256-GCM encryption is the deterministically CBOR-encoded map of fields
+1–5 (escrow_version, key_version, subject_kind, subject_id, key_hint),
+following RFC 8949 §4.2 (sorted integer keys, definite-length encoding).
+This binds the ciphertext to the subject identity, preventing blob swap
+attacks. Both encoder and decoder MUST use identical deterministic encoding
+to ensure AAD bytes match exactly.
 
 Total CBOR-encoded size: ≤ 120 bytes typical.
 
@@ -517,24 +520,32 @@ migration resumes.
 | KdfParams | string | JSON: `{"m_cost":65536,"t_cost":3,"p_cost":1,"version":1}` |
 | CreatedAt | int64 | Unix milliseconds |
 
-**ActualNodeState table extension** (existing table):
+**`ActualNodeState` table extension** (existing append-only table, §4.1):
+
+Escrow fields are appended as additional columns on each `ActualNodeState`
+row. Recovery queries use `Top(1)` per node partition to retrieve the
+latest escrow blob.
 
 | Column | Type | Description |
 |--------|------|-------------|
-| EncryptedPskEscrow | binary/null | Opaque escrow blob from gateway |
-| EscrowKeyVersion | int64/null | Key version of the escrow blob |
-| KeyHint | int64/null | `key_hint` (u16) from escrow blob metadata, indexed for recovery queries |
+| `encrypted_psk_escrow` | binary/null | Opaque escrow blob from gateway |
+| `escrow_key_version` | int64/null | Key version of the escrow blob |
+| `key_hint` | int64/null | `key_hint` (u16) from escrow blob metadata, indexed for recovery queries |
 
-**ActualPhoneState table** (new):
+**`ActualPhoneState` table** (new, append-only with same key structure as
+`ActualNodeState`):
+
+Each row uses:
+- `PartitionKey = "p:" + lowercase hex-encoded SHA-256(phone_id UTF-8 bytes)`
+- `RowKey = <reverse_tick_ms> + ":" + <uniqueness suffix>`
 
 | Column | Type | Description |
 |--------|------|-------------|
-| PartitionKey | string | Gateway identifier |
-| RowKey | string | Phone ID |
-| EncryptedPskEscrow | binary | Opaque escrow blob |
-| EscrowKeyVersion | int64 | Key version |
-| KeyHint | int64 | `key_hint` (u16) from escrow blob metadata, indexed for recovery queries |
-| TimestampMs | int64 | Last update timestamp |
+| `phone_id` | string | Original phone identifier |
+| `encrypted_psk_escrow` | binary | Opaque escrow blob |
+| `escrow_key_version` | int64 | Key version |
+| `key_hint` | int64 | `key_hint` (u16) from escrow blob metadata, indexed for recovery queries |
+| `timestamp_ms` | int64 | Last update timestamp |
 
 #### 8.2  Message handling
 

--- a/docs/evolve-887-specification.md
+++ b/docs/evolve-887-specification.md
@@ -5,7 +5,7 @@
 > **Issue:** #887
 > **Status:** Draft — Phase 2 specification changes
 > **Scope:** Design and validation changes propagated from the requirements
-> patch (GW-2000–GW-2011, AZH-0600–AZH-0605, ADMIN-0900–ADMIN-0902).
+> patch (GW-2000–GW-2013, AZH-0600–AZH-0605, ADMIN-0900–ADMIN-0902).
 > **Traceability:** Every section traces to one or more requirement IDs.
 
 ---
@@ -122,10 +122,15 @@ A new CBOR key `12` (`encrypted_psk_escrow`) is added to node-scoped
 ACTUAL_STATE payloads. The value is a bstr containing the CBOR-encoded
 `EscrowBlob`.
 
+A new CBOR key `13` (`escrow_key_hint`) is added to node- and phone-scoped
+ACTUAL_STATE payloads. The value is a uint containing the `key_hint` (u16)
+from the escrow blob metadata. This allows the Azure handler to index
+escrow blobs by `key_hint` without inspecting the encrypted blob.
+
 For phone PSKs, the gateway emits ACTUAL_STATE messages with
 `entity_kind = "phone"` and `entity_id = phone_id`. The phone ACTUAL_STATE
-payload contains only `encrypted_psk_escrow` (key 12) and `timestamp_ms`
-(key 9).
+payload contains only `encrypted_psk_escrow` (key 12), `escrow_key_hint`
+(key 13), and `timestamp_ms` (key 9).
 
 Escrow blobs are emitted:
 - On node/phone registration (initial escrow).
@@ -208,6 +213,15 @@ On receiving a `MASTER_KEY_INSTALL` (msg_type `0x13`), the gateway:
 
 3. **Prepare**: Write `pending_rotation` record to database:
    ```sql
+   CREATE TABLE IF NOT EXISTS pending_rotation (
+       id              INTEGER PRIMARY KEY CHECK (id = 1),
+       new_master_key_enc BLOB    NOT NULL,
+       new_key_version    INTEGER NOT NULL,
+       operation_id       BLOB    NOT NULL,
+       privkey_rewrapped  BOOLEAN NOT NULL DEFAULT FALSE,
+       started_at         INTEGER NOT NULL
+   );
+
    INSERT OR REPLACE INTO pending_rotation (id, new_master_key_enc, new_key_version, operation_id, started_at)
    VALUES (1, ?, ?, ?, ?);
    ```
@@ -301,7 +315,7 @@ The BIP-39 wordlist fingerprint is computed as:
 fn compute_fingerprint(public_key: &[u8; 32]) -> [&'static str; 6] {
     let hash = sha256(public_key);
     let mut words = [""; 6];
-    // Extract 66 bits (6 × 11-bit indices) from hash bytes 0..9
+    // Extract 66 bits (6 × 11-bit indices) from hash bytes 0..8
     let bits = u128::from_be_bytes([
         hash[0], hash[1], hash[2], hash[3],
         hash[4], hash[5], hash[6], hash[7],
@@ -503,6 +517,7 @@ migration resumes.
 |--------|------|-------------|
 | EncryptedPskEscrow | binary/null | Opaque escrow blob from gateway |
 | EscrowKeyVersion | int64/null | Key version of the escrow blob |
+| KeyHint | int64/null | `key_hint` (u16) from escrow blob metadata, indexed for recovery queries |
 
 **ActualPhoneState table** (new):
 
@@ -512,6 +527,7 @@ migration resumes.
 | RowKey | string | Phone ID |
 | EncryptedPskEscrow | binary | Opaque escrow blob |
 | EscrowKeyVersion | int64 | Key version |
+| KeyHint | int64 | `key_hint` (u16) from escrow blob metadata, indexed for recovery queries |
 | TimestampMs | int64 | Last update timestamp |
 
 #### 8.2  Message handling
@@ -523,7 +539,9 @@ migration resumes.
 **`ACTUAL_STATE` with `encrypted_psk_escrow` (upstream):**
 - For `entity_kind = "node"`: store blob in `ActualNodeState` row.
 - For `entity_kind = "phone"`: store blob in `ActualPhoneState` row.
-- The handler MUST NOT decrypt or inspect blob contents.
+- The handler MUST NOT decrypt the blob ciphertext, but MAY read the
+  unencrypted `key_hint` field from the top-level ACTUAL_STATE message
+  (CBOR key 13) for indexing purposes.
 
 **`KEY_ESCROW_REQUEST` (upstream, msg_type `0x11`):**
 - Query `ActualNodeState` and `ActualPhoneState` for rows matching
@@ -550,10 +568,9 @@ On receiving a gateway ACTUAL_STATE with `escrow_salt`:
 
 To efficiently serve `KEY_ESCROW_REQUEST`, the handler stores `key_hint`
 as an indexed column in both `ActualNodeState` and `ActualPhoneState`.
-The column is populated from the `key_hint` field within the escrow blob
-metadata (CBOR key 5 of the EscrowBlob). Since the handler must not
-decrypt the blob, the `key_hint` is also sent as a top-level field in
-the ACTUAL_STATE message alongside `encrypted_psk_escrow`.
+The column is populated from the `key_hint` field sent as a top-level
+ACTUAL_STATE field (CBOR key 13) alongside `encrypted_psk_escrow`
+(CBOR key 12). The handler never inspects blob ciphertext.
 
 ---
 

--- a/docs/evolve-887-specification.md
+++ b/docs/evolve-887-specification.md
@@ -242,16 +242,23 @@ On receiving a `MASTER_KEY_INSTALL` (msg_type `0x13`), the gateway:
    - Update record with new ciphertext and new `key_version`.
    - Commit each record individually.
 
-5. **Commit**: Update master key in KeyProvider storage. Remove
+5. **Rewrap private key**: Re-encrypt `escrow_keypair.secret_enc` under the
+   new master key. Set `privkey_rewrapped = TRUE` in the `pending_rotation`
+   record. This is committed as a single update so crash recovery knows
+   whether rewrapping completed.
+
+6. **Commit**: Update master key in KeyProvider storage. Remove
    `pending_rotation` record. Set `escrow_key_version` in `gateway_config`.
    Update escrow state to `ready`.
 
-6. **Emit**: Re-emit ACTUAL_STATE with new escrow blobs for all subjects.
+7. **Emit**: Re-emit ACTUAL_STATE with new escrow blobs for all subjects.
 
-7. **Cleanup**: Zero old master key from memory.
+8. **Cleanup**: Zero old master key from memory.
 
 **Crash recovery (GW-2007):** On startup, if `pending_rotation` exists:
 - Decrypt the pending new master key using the current (old) master key.
+- If `privkey_rewrapped = FALSE`, re-encrypt the recovery private key
+  under the new master key and set `privkey_rewrapped = TRUE`.
 - Resume migration from step 4, processing only records where
   `key_version < new_key_version`.
 - The two-key window ensures both old and new PSKs can be decrypted
@@ -432,6 +439,7 @@ New field in node-scoped ACTUAL_STATE:
 |-------|----------|------|-------------|
 | `encrypted_psk_escrow` | 12 | bstr/null | CBOR-encoded EscrowBlob |
 | `escrow_key_hint` | 13 | uint/null | `key_hint` (u16) from escrow blob metadata, for Azure indexing without inspecting the encrypted blob |
+| `escrow_key_version` | 14 | uint/null | Master key version used to encrypt this escrow blob, for Azure indexing without inspecting the encrypted blob |
 
 New `entity_kind = "phone"` for phone PSK escrow.
 
@@ -443,6 +451,20 @@ New fields in gateway-scoped ACTUAL_STATE `status_details`:
 | `escrow_key_version` | 2 | uint/null | Current key version |
 | `escrow_salt` | 3 | bstr/null | KDF salt (16 bytes) |
 | `escrow_kdf_params` | 4 | map/null | `{1: m_cost, 2: t_cost, 3: p_cost, 4: kdf_version}` |
+
+**DESIRED_STATE extension (§3.3):**
+
+New fields in gateway-scoped DESIRED_STATE for salt adoption (see §8.3):
+
+| Field | CBOR key (in `desired_state`) | Type | Description |
+|-------|-------------------------------|------|-------------|
+| `escrow_salt` | 1 | bstr/null | KDF salt (16 bytes) from Azure, or null if none stored |
+| `escrow_kdf_params` | 2 | map/null | `{1: m_cost, 2: t_cost, 3: p_cost, 4: kdf_version}` |
+
+The gateway inspects these fields on each DESIRED_STATE receipt. If the
+gateway has no local salt and the DESIRED_STATE provides one, it adopts
+the values. If both exist and differ, the gateway logs a warning and
+keeps its local salt (local is authoritative).
 
 ### 2.4  Startup sequence extension (gateway-design.md §15)
 
@@ -492,11 +514,10 @@ Key-management messages on the connector are secured as follows:
 | `KEY_ESCROW_PUBKEY` | Informational. Admin verifies via out-of-band fingerprint on modem. |
 
 **Rotation step fix:** Step 5 of §20.7 re-encrypts the recovery private
-key (`escrow_keypair.secret_enc`) under the new master key. The
-`pending_rotation` record tracks whether private-key rewrapping has
-completed (`privkey_rewrapped BOOLEAN DEFAULT FALSE`). On crash recovery,
-if `privkey_rewrapped = FALSE`, the private key is re-encrypted before
-migration resumes.
+key (`escrow_keypair.secret_enc`) under the new master key and sets
+`privkey_rewrapped = TRUE` in the `pending_rotation` record. On crash
+recovery, if `privkey_rewrapped = FALSE`, the private key is re-encrypted
+before PSK migration resumes.
 
 ---
 
@@ -529,8 +550,8 @@ latest escrow blob.
 | Column | Type | Description |
 |--------|------|-------------|
 | `encrypted_psk_escrow` | binary/null | Opaque escrow blob from gateway |
-| `escrow_key_version` | int64/null | Key version of the escrow blob |
-| `key_hint` | int64/null | `key_hint` (u16) from escrow blob metadata, indexed for recovery queries |
+| `escrow_key_version` | int64/null | Key version from ACTUAL_STATE CBOR key 14 |
+| `key_hint` | int64/null | `key_hint` (u16) from ACTUAL_STATE CBOR key 13, indexed for recovery queries |
 
 **`ActualPhoneState` table** (new, append-only with same key structure as
 `ActualNodeState`):
@@ -543,8 +564,8 @@ Each row uses:
 |--------|------|-------------|
 | `phone_id` | string | Original phone identifier |
 | `encrypted_psk_escrow` | binary | Opaque escrow blob |
-| `escrow_key_version` | int64 | Key version |
-| `key_hint` | int64 | `key_hint` (u16) from escrow blob metadata, indexed for recovery queries |
+| `escrow_key_version` | int64 | Key version from ACTUAL_STATE CBOR key 14 |
+| `key_hint` | int64 | `key_hint` (u16) from ACTUAL_STATE CBOR key 13, indexed for recovery queries |
 | `timestamp_ms` | int64 | Last update timestamp |
 
 #### 8.2  Message handling
@@ -557,7 +578,9 @@ Each row uses:
 - For `entity_kind = "node"`: store blob in `ActualNodeState` row.
 - For `entity_kind = "phone"`: store blob in `ActualPhoneState` row.
 - The handler MUST NOT decrypt the blob ciphertext, but MAY read the
-  unencrypted `key_hint` field from the top-level ACTUAL_STATE message
+  unencrypted `key_hint` and `escrow_key_version` fields from the
+  top-level ACTUAL_STATE message (CBOR keys 13 and 14) for indexing
+  purposes.
   (CBOR key 13) for indexing purposes.
 
 **`KEY_ESCROW_REQUEST` (upstream, msg_type `0x11`):**
@@ -579,27 +602,17 @@ On receiving a gateway ACTUAL_STATE with `escrow_salt`:
 - If no `GatewayEscrow` row with RowKey `"salt"` exists, create it.
 - If a row exists, ignore the incoming salt (first-writer-wins).
 - On subsequent gateway-scoped DESIRED_STATE emissions (e.g., after
-  reconnect), include the stored salt so the gateway can adopt it.
+  reconnect), include the stored salt so the gateway can adopt it
+  (see §2.3 DESIRED_STATE extension for CBOR schema).
 
-**Gateway-scoped DESIRED_STATE fields for salt adoption:**
-
-| Field | CBOR key (in `desired_state`) | Type | Description |
-|-------|-------------------------------|------|-------------|
-| `escrow_salt` | 1 | bstr/null | KDF salt (16 bytes) from Azure, or null if none stored |
-| `escrow_kdf_params` | 2 | map/null | `{1: m_cost, 2: t_cost, 3: p_cost, 4: kdf_version}` |
-
-The gateway inspects these fields on each DESIRED_STATE receipt. If the
-gateway has no local salt and the DESIRED_STATE provides one, it adopts
-the values. If both exist and differ, the gateway logs a warning and
-keeps its local salt (local is authoritative).
-
-#### 8.4  Key hint index
+#### 8.4  Key hint and key version indexing
 
 To efficiently serve `KEY_ESCROW_REQUEST`, the handler stores `key_hint`
-as an indexed column in both `ActualNodeState` and `ActualPhoneState`.
-The column is populated from the `key_hint` field sent as a top-level
-ACTUAL_STATE field (CBOR key 13) alongside `encrypted_psk_escrow`
-(CBOR key 12). The handler never inspects blob ciphertext.
+and `escrow_key_version` as indexed columns in both `ActualNodeState` and
+`ActualPhoneState`. Both columns are populated from top-level ACTUAL_STATE
+fields (CBOR keys 13 and 14 respectively) alongside
+`encrypted_psk_escrow` (CBOR key 12). The handler never inspects blob
+ciphertext.
 
 ---
 
@@ -1035,9 +1048,9 @@ Admin ──► Argon2id(passphrase, salt) ──► master_key
 1. Send ACTUAL_STATE with `encrypted_psk_escrow` for a node.
 2. Verify blob stored in ActualNodeState table.
 3. Send ACTUAL_STATE for a phone — verify stored in ActualPhoneState table.
-4. Send updated blob (new key_version) — verify previous blob overwritten.
+4. Send updated blob (new key_version) — verify new row appended and `Top(1)` returns the latest blob.
 
-**Pass criteria:** Blobs stored and updated correctly.
+**Pass criteria:** Blobs stored as append-only rows; `Top(1)` returns latest escrow data.
 
 ---
 

--- a/docs/evolve-887-specification.md
+++ b/docs/evolve-887-specification.md
@@ -1,0 +1,1197 @@
+<!-- SPDX-License-Identifier: MIT
+     Copyright (c) 2026 sonde contributors -->
+# Specification Patch: PSK Key Escrow for Gateway Replaceability
+
+> **Issue:** #887
+> **Status:** Draft — Phase 2 specification changes
+> **Scope:** Design and validation changes propagated from the requirements
+> patch (GW-2000–GW-2011, AZH-0600–AZH-0605, ADMIN-0900–ADMIN-0902).
+> **Traceability:** Every section traces to one or more requirement IDs.
+
+---
+
+## 1  Impact Analysis
+
+### 1.1  Affected design documents
+
+| Document | Affected sections | Change type |
+|----------|-------------------|-------------|
+| `gateway-design.md` | §10 Storage trait, §10a Master key provider, §13A Connector API, §15 Startup sequence, NEW §20 | Extend + new section |
+| `gateway-companion-api.md` | §3.1 Message types, §3.3 ACTUAL_STATE, NEW §3.6–3.9 | Extend + new sections |
+| `azure-handler-design.md` | §4 Table schemas, §5 Reconciliation, NEW §8 | Extend + new section |
+| `admin-design.md` | NEW §11 | New section |
+| `modem-design.md` | §9a Display output | Extend |
+| `security.md` | §2.3 Key storage | Extend |
+
+### 1.2  Affected validation documents
+
+| Document | Change type |
+|----------|-------------|
+| `gateway-validation.md` | New test series T-2000–T-2011 |
+| `azure-handler-validation.md` | New test series T-AZH-0600–T-AZH-0605 |
+| `admin-validation.md` | New test series T-0900–T-0902 |
+
+---
+
+## 2  Design Changes — Gateway
+
+### 2.1  New section: §20 PSK Key Escrow (gateway-design.md)
+
+> **Requirements:** GW-2000–GW-2011
+
+#### 20.1  Overview
+
+The escrow subsystem enables gateway replaceability by securely escrowing
+encrypted PSKs to Azure via the connector API. The design introduces four
+new capabilities:
+
+1. **Recovery keypair** — X25519 keypair for secure master-key delivery.
+2. **Escrow blob emission** — encrypted PSKs sent upstream in ACTUAL_STATE.
+3. **Key rotation** — admin-initiated master key replacement with crash-safe
+   record migration.
+4. **Auto-heal recovery** — on-demand PSK retrieval for unknown nodes.
+
+#### 20.2  Recovery keypair (GW-2000, GW-2001)
+
+On first startup, the gateway generates an X25519 keypair:
+
+```rust
+pub struct RecoveryKeypair {
+    /// X25519 secret key (32 bytes), zeroized on drop.
+    secret: Zeroizing<[u8; 32]>,
+    /// X25519 public key (32 bytes).
+    public: [u8; 32],
+    /// Monotonic epoch, incremented on each regeneration.
+    epoch: u64,
+}
+```
+
+The keypair is persisted in the gateway database:
+
+```sql
+CREATE TABLE IF NOT EXISTS escrow_keypair (
+    id          INTEGER PRIMARY KEY CHECK (id = 1),
+    secret_enc  BLOB NOT NULL,     -- private key, AES-256-GCM encrypted with master key
+    public_key  BLOB NOT NULL,     -- raw 32-byte X25519 public key
+    epoch       INTEGER NOT NULL,  -- monotonic key epoch
+    created_at  INTEGER NOT NULL   -- Unix milliseconds
+);
+```
+
+The private key is encrypted at rest with the current master key
+(same `encrypt_psk` pattern used for node PSKs). On startup, if the
+`escrow_keypair` table is empty, a new keypair is generated. If decryption
+fails (master key mismatch after recovery), a new keypair is generated
+and the epoch is incremented.
+
+The public key is published to the connector via `KEY_ESCROW_PUBKEY`
+(msg_type `0x10`) on every startup and whenever the keypair changes.
+
+#### 20.3  Escrow blob format (GW-2002)
+
+Each encrypted PSK is wrapped in a canonical escrow envelope:
+
+```rust
+pub struct EscrowBlob {
+    pub escrow_version: u8,         // schema version (1)
+    pub key_version: u64,           // master key version
+    pub subject_kind: SubjectKind,  // Node or Phone
+    pub subject_id: String,         // node_id or phone_id
+    pub key_hint: u16,              // PSK key_hint
+    pub nonce: [u8; 12],            // AES-256-GCM nonce
+    pub ciphertext: [u8; 32],       // encrypted PSK
+    pub tag: [u8; 16],              // GCM authentication tag
+}
+
+pub enum SubjectKind {
+    Node,
+    Phone,
+}
+```
+
+CBOR encoding uses integer keys (1–8) as defined in GW-2002. The AAD for
+AES-256-GCM encryption is the CBOR-encoded map of fields 1–5 (escrow_version,
+key_version, subject_kind, subject_id, key_hint). This binds the ciphertext
+to the subject identity, preventing blob swap attacks.
+
+Total CBOR-encoded size: ≤ 120 bytes typical.
+
+#### 20.4  Escrow emission in ACTUAL_STATE (GW-2003)
+
+A new CBOR key `12` (`encrypted_psk_escrow`) is added to node-scoped
+ACTUAL_STATE payloads. The value is a bstr containing the CBOR-encoded
+`EscrowBlob`.
+
+For phone PSKs, the gateway emits ACTUAL_STATE messages with
+`entity_kind = "phone"` and `entity_id = phone_id`. The phone ACTUAL_STATE
+payload contains only `encrypted_psk_escrow` (key 12) and `timestamp_ms`
+(key 9).
+
+Escrow blobs are emitted:
+- On node/phone registration (initial escrow).
+- After key rotation (re-encrypted blobs for all subjects).
+- On connector reconnection (full state replay).
+
+When escrow state is `disabled`, the field is `null`.
+
+#### 20.5  Escrow lifecycle state machine (GW-2004)
+
+```
+                 ┌──────────┐
+     startup ──► │ disabled │
+                 └────┬─────┘
+                      │ first MASTER_KEY_INSTALL
+                      ▼
+                 ┌──────────────┐
+                 │ bootstrapping│
+                 └────┬─────────┘
+                      │ all PSKs re-encrypted + emitted
+                      ▼
+                 ┌──────────┐
+           ┌───► │  ready   │ ◄───┐
+           │     └────┬─────┘     │
+           │          │ new MASTER_KEY_INSTALL
+           │          ▼           │
+           │     ┌────────────────┴──┐
+           │     │ rotation_in_progress │
+           │     └────┬──────────────┘
+           │          │ all PSKs migrated
+           │          │
+           │     ┌────▼─────┐
+           └─────┤  ready   │
+                 └──────────┘
+
+  On crash during bootstrapping or rotation:
+                 ┌──────────┐
+     restart ──► │ degraded │ ──► auto-resume ──► ready
+                 └──────────┘
+```
+
+Persisted in `gateway_config` as key `escrow_state`.
+
+The escrow state is reported in gateway-scoped ACTUAL_STATE via a new
+`status_details` sub-key (CBOR key 1 within the `status_details` map):
+
+| Field | CBOR key (in `status_details`) | Type | Description |
+|-------|-------------------------------|------|-------------|
+| `escrow_state` | 1 | tstr | One of: `"disabled"`, `"bootstrapping"`, `"ready"`, `"rotation_in_progress"`, `"degraded"` |
+| `escrow_key_version` | 2 | uint/null | Current master key version, or null if disabled |
+
+#### 20.6  Key version tracking (GW-2005)
+
+A new column `key_version INTEGER NOT NULL DEFAULT 0` is added to the
+`nodes` and `phone_psks` tables via migration:
+
+```sql
+-- Migration: add key_version to nodes
+ALTER TABLE nodes ADD COLUMN key_version INTEGER NOT NULL DEFAULT 0;
+-- Migration: add key_version to phone_psks
+ALTER TABLE phone_psks ADD COLUMN key_version INTEGER NOT NULL DEFAULT 0;
+```
+
+The current key version is stored in `gateway_config` as key
+`escrow_key_version`. Initial value is `0` (pre-escrow state).
+
+#### 20.7  Master key rotation (GW-2006, GW-2007)
+
+On receiving a `MASTER_KEY_INSTALL` (msg_type `0x13`), the gateway:
+
+1. **Validate**: Check `target_key_epoch` matches current keypair epoch.
+   Check `operation_id` has not been seen before (dedup table). Check
+   `expiry_ms` has not passed. Reject and log if any check fails.
+
+2. **Decrypt**: Use X25519 + HKDF-SHA-256 + AES-256-GCM to decrypt the
+   master key payload:
+   - Perform X25519 DH: `shared_secret = X25519(private_key, sender_public_key)`
+   - Derive encryption key: `key = HKDF-SHA-256(shared_secret, salt="sonde-escrow-v1", info=target_key_epoch || operation_id)`
+   - Decrypt: `new_master_key = AES-256-GCM-Open(key, nonce, ciphertext, aad=operation_id || target_key_epoch)`
+
+3. **Prepare**: Write `pending_rotation` record to database:
+   ```sql
+   INSERT OR REPLACE INTO pending_rotation (id, new_master_key_enc, new_key_version, operation_id, started_at)
+   VALUES (1, ?, ?, ?, ?);
+   ```
+   The new master key is encrypted with the OLD master key for crash safety.
+
+4. **Migrate**: For each PSK record (nodes + phone_psks) where
+   `key_version < new_key_version`:
+   - Decrypt PSK with old master key.
+   - Re-encrypt PSK with new master key.
+   - Update record with new ciphertext and new `key_version`.
+   - Commit each record individually.
+
+5. **Commit**: Update master key in KeyProvider storage. Remove
+   `pending_rotation` record. Set `escrow_key_version` in `gateway_config`.
+   Update escrow state to `ready`.
+
+6. **Emit**: Re-emit ACTUAL_STATE with new escrow blobs for all subjects.
+
+7. **Cleanup**: Zero old master key from memory.
+
+**Crash recovery (GW-2007):** On startup, if `pending_rotation` exists:
+- Decrypt the pending new master key using the current (old) master key.
+- Resume migration from step 4, processing only records where
+  `key_version < new_key_version`.
+- The two-key window ensures both old and new PSKs can be decrypted
+  during migration.
+
+**Deduplication table:**
+```sql
+CREATE TABLE IF NOT EXISTS escrow_operations (
+    operation_id BLOB PRIMARY KEY,
+    processed_at INTEGER NOT NULL
+);
+```
+
+#### 20.8  Salt management (GW-2008)
+
+The KDF salt record is stored in `gateway_config`:
+
+| Config key | Value | Description |
+|------------|-------|-------------|
+| `escrow_salt` | hex-encoded 16 bytes | Argon2id salt |
+| `escrow_argon2_m_cost` | uint string | Memory cost in KiB (default: 65536) |
+| `escrow_argon2_t_cost` | uint string | Time cost / passes (default: 3) |
+| `escrow_argon2_p_cost` | uint string | Parallelism (default: 1) |
+| `escrow_kdf_version` | uint string | Schema version (default: 1) |
+| `escrow_salt_created_at` | uint string | Unix milliseconds |
+
+Published via gateway-scoped ACTUAL_STATE in `status_details`.
+Adopted from Azure (first-writer-wins) during connector session setup.
+
+#### 20.9  Unknown node recovery (GW-2009, GW-2010)
+
+When a frame arrives with an unknown `key_hint` and escrow state is `ready`:
+
+1. Check rate limiter: at most 1 request per `key_hint` per 60 seconds.
+2. Buffer the raw frame bytes in a bounded recovery queue (max 64 entries,
+   30-second TTL per entry).
+3. Emit `KEY_ESCROW_REQUEST` (msg_type `0x11`) to the connector.
+4. On receiving `KEY_ESCROW_RESPONSE` (msg_type `0x12`):
+   a. Look up buffered frame by `request_id`.
+   b. For each candidate blob (max 16):
+      - Decrypt escrow blob with master key → PSK.
+      - Attempt trial-decryption of buffered frame with candidate PSK.
+   c. On first successful decryption:
+      - Register the node/phone locally (upsert).
+      - Process the frame normally.
+      - Emit ACTUAL_STATE with escrow blob.
+   d. If no candidate succeeds, discard frame with warning log.
+5. If response arrives after TTL expiry, discard with warning log.
+
+```rust
+struct RecoveryQueue {
+    entries: HashMap<[u8; 16], RecoveryEntry>, // request_id → entry
+    hint_rate: HashMap<u16, Instant>,           // key_hint → last request time
+}
+
+struct RecoveryEntry {
+    key_hint: u16,
+    raw_frame: Vec<u8>,
+    peer_address: [u8; 6],
+    created_at: Instant,
+}
+```
+
+#### 20.10  Fingerprint computation (GW-2011)
+
+The BIP-39 wordlist fingerprint is computed as:
+
+```rust
+fn compute_fingerprint(public_key: &[u8; 32]) -> [&'static str; 6] {
+    let hash = sha256(public_key);
+    let mut words = [""; 6];
+    // Extract 66 bits (6 × 11-bit indices) from hash bytes 0..9
+    let bits = u128::from_be_bytes([
+        hash[0], hash[1], hash[2], hash[3],
+        hash[4], hash[5], hash[6], hash[7],
+        hash[8], 0, 0, 0, 0, 0, 0, 0,
+    ]);
+    for i in 0..6 {
+        let index = ((bits >> (128 - 11 - 11 * i)) & 0x7FF) as usize;
+        words[i] = BIP39_ENGLISH[index];
+    }
+    words
+}
+```
+
+The BIP-39 English wordlist (2048 entries) is embedded as a compile-time
+constant in `sonde-protocol` so both gateway and admin/SPA share the same
+list. The wordlist is the standard list from
+[BIP-0039](https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt).
+
+The gateway renders the fingerprint as a display page using the existing
+reliable display-transfer subprotocol (GW-1101b page navigation). Layout:
+three rows of two words each, centered on the 128×64 OLED.
+
+### 2.2  Storage trait extension (gateway-design.md §10)
+
+The `Storage` trait gains escrow-related methods:
+
+```rust
+// Escrow keypair (GW-2000)
+async fn get_escrow_keypair(&self) -> Result<Option<EscrowKeypairRecord>>;
+async fn store_escrow_keypair(&self, record: &EscrowKeypairRecord) -> Result<()>;
+
+// Escrow operations dedup (GW-2006)
+async fn is_operation_processed(&self, operation_id: &[u8]) -> Result<bool>;
+async fn record_operation(&self, operation_id: &[u8]) -> Result<()>;
+
+// Pending rotation (GW-2007)
+async fn get_pending_rotation(&self) -> Result<Option<PendingRotationRecord>>;
+async fn store_pending_rotation(&self, record: &PendingRotationRecord) -> Result<()>;
+async fn delete_pending_rotation(&self) -> Result<()>;
+```
+
+The existing `upsert_node` and `upsert_phone_psk` methods are unchanged;
+they already handle `key_version` via the column added by migration.
+
+### 2.3  Connector API extension (gateway-companion-api.md §3)
+
+Four new message types are added to the connector API:
+
+| `msg_type` | Name | Direction | Description |
+|------------|------|-----------|-------------|
+| `0x10` | `KEY_ESCROW_PUBKEY` | Gateway → control plane | Recovery public key publication |
+| `0x11` | `KEY_ESCROW_REQUEST` | Gateway → control plane | Request escrowed PSK(s) for a key_hint |
+| `0x12` | `KEY_ESCROW_RESPONSE` | Control plane → gateway | Escrowed PSK candidate(s) |
+| `0x13` | `MASTER_KEY_INSTALL` | Control plane → gateway | Encrypted new master key |
+
+These use imperative/transactional semantics (operation IDs, expiry,
+idempotency) rather than the replacement semantics of DESIRED_STATE/
+ACTUAL_STATE.
+
+**§3.6  `KEY_ESCROW_PUBKEY` (gateway → control plane)**
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `msg_type` | 1 | uint | `0x10` |
+| `public_key` | 2 | bstr (32 bytes) | X25519 public key |
+| `key_epoch` | 3 | uint | Monotonic key epoch |
+| `created_at` | 4 | uint | Creation timestamp (Unix ms) |
+| `fingerprint_words` | 5 | array of tstr | 6-word BIP-39 fingerprint (informational) |
+
+**§3.7  `KEY_ESCROW_REQUEST` (gateway → control plane)**
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `msg_type` | 1 | uint | `0x11` |
+| `key_hint` | 2 | uint | Key hint from undecryptable frame |
+| `request_id` | 3 | bstr (16 bytes) | Unique request ID |
+
+**§3.8  `KEY_ESCROW_RESPONSE` (control plane → gateway)**
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `msg_type` | 1 | uint | `0x12` |
+| `request_id` | 2 | bstr (16 bytes) | Correlates to request |
+| `candidates` | 3 | array of bstr | Array of CBOR-encoded EscrowBlob (max 16) |
+| `key_hint` | 4 | uint | Echo of requested key_hint |
+
+**§3.9  `MASTER_KEY_INSTALL` (control plane → gateway)**
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `msg_type` | 1 | uint | `0x13` |
+| `target_key_epoch` | 2 | uint | Must match gateway's current public key epoch |
+| `sender_public_key` | 3 | bstr (32 bytes) | Admin's ephemeral X25519 public key |
+| `encrypted_master_key` | 4 | bstr | AES-256-GCM ciphertext of the new master key |
+| `nonce` | 5 | bstr (12 bytes) | AES-256-GCM nonce |
+| `tag` | 6 | bstr (16 bytes) | AES-256-GCM authentication tag |
+| `operation_id` | 7 | bstr (16 bytes) | Unique operation ID for idempotency |
+| `rotation_counter` | 8 | uint | Monotonic rotation counter |
+| `expiry_ms` | 9 | uint | Message expiry (Unix ms) |
+
+**ACTUAL_STATE extension (§3.3):**
+
+New field in node-scoped ACTUAL_STATE:
+
+| Field | CBOR key | Type | Description |
+|-------|----------|------|-------------|
+| `encrypted_psk_escrow` | 12 | bstr/null | CBOR-encoded EscrowBlob |
+
+New `entity_kind = "phone"` for phone PSK escrow.
+
+New fields in gateway-scoped ACTUAL_STATE `status_details`:
+
+| Field | CBOR key (in `status_details`) | Type | Description |
+|-------|-------------------------------|------|-------------|
+| `escrow_state` | 1 | tstr | Lifecycle state |
+| `escrow_key_version` | 2 | uint/null | Current key version |
+| `escrow_salt` | 3 | bstr/null | KDF salt (16 bytes) |
+| `escrow_kdf_params` | 4 | map/null | `{1: m_cost, 2: t_cost, 3: p_cost, 4: kdf_version}` |
+
+### 2.4  Startup sequence extension (gateway-design.md §15)
+
+Insert after step 2 (Initialize storage backend):
+
+> 2a. Load or generate escrow keypair (GW-2000). If `pending_rotation`
+>     exists, resume key rotation (GW-2007).
+
+Insert after step 9 (Start connector API server):
+
+> 9a. Emit `KEY_ESCROW_PUBKEY` on connector (GW-2001).
+> 9b. Emit gateway-scoped ACTUAL_STATE with escrow state and salt (GW-2004, GW-2008).
+
+Add fingerprint page to modem display page list (after GW-1101a banner):
+
+> 5a. If escrow keypair exists, register fingerprint as a navigable display
+>     page (GW-2011).
+
+#### 20.11  Replacement gateway bootstrap (GW-2012)
+
+A replacement gateway with an empty database follows this sequence:
+
+1. Normal startup (§15 steps 1–5): generate random master key, initialize
+   storage, generate escrow keypair.
+2. Escrow state = `disabled`.
+3. Publish `KEY_ESCROW_PUBKEY` to connector.
+4. Display fingerprint on modem.
+5. Fetch salt from Azure via connector (adopt if available).
+6. **Wait for admin**: The gateway operates normally (answering registered
+   nodes) but silently discards unknown `key_hint` frames per GW-1002.
+   It does NOT emit `KEY_ESCROW_REQUEST`.
+7. Admin performs `sonde-admin key rotate` → `MASTER_KEY_INSTALL` arrives.
+8. Gateway processes rotation (GW-2006) — re-encrypts any local PSKs (none
+   for a fresh gateway), installs the passphrase-derived master key.
+9. Escrow state transitions to `ready`.
+10. From this point, unknown `key_hint` frames trigger recovery (GW-2009).
+
+#### 20.12  Connector key-management security (GW-2013)
+
+Key-management messages on the connector are secured as follows:
+
+| Message | Authentication mechanism |
+|---------|------------------------|
+| `MASTER_KEY_INSTALL` | X25519 key agreement binds to gateway's pubkey. `target_key_epoch` prevents cross-gateway replay. `operation_id` prevents same-gateway replay. `expiry_ms` prevents delayed delivery. |
+| `KEY_ESCROW_RESPONSE` | Each escrow blob is individually AES-256-GCM authenticated via AAD binding (GW-2002). Tampered/swapped blobs fail decryption. |
+| `KEY_ESCROW_REQUEST` | Gateway-originated only. Control plane cannot trigger. |
+| `KEY_ESCROW_PUBKEY` | Informational. Admin verifies via out-of-band fingerprint on modem. |
+
+**Rotation step fix:** Step 5 of §20.7 re-encrypts the recovery private
+key (`escrow_keypair.secret_enc`) under the new master key. The
+`pending_rotation` record tracks whether private-key rewrapping has
+completed (`privkey_rewrapped BOOLEAN DEFAULT FALSE`). On crash recovery,
+if `privkey_rewrapped = FALSE`, the private key is re-encrypted before
+migration resumes.
+
+---
+
+## 3  Design Changes — Azure Handler
+
+### 3.1  New section: §8 PSK Key Escrow (azure-handler-design.md)
+
+> **Requirements:** AZH-0600–AZH-0605
+
+#### 8.1  Table schema extensions
+
+**GatewayEscrow table** (new):
+
+| Column | Type | Description |
+|--------|------|-------------|
+| PartitionKey | string | Gateway identifier (fixed "gateway") |
+| RowKey | string | `"pubkey"` or `"salt"` |
+| PublicKey | binary | X25519 public key (32 bytes) |
+| KeyEpoch | int64 | Monotonic epoch |
+| Salt | binary | KDF salt (16 bytes) |
+| KdfParams | string | JSON: `{"m_cost":65536,"t_cost":3,"p_cost":1,"version":1}` |
+| CreatedAt | int64 | Unix milliseconds |
+
+**ActualNodeState table extension** (existing table):
+
+| Column | Type | Description |
+|--------|------|-------------|
+| EncryptedPskEscrow | binary/null | Opaque escrow blob from gateway |
+| EscrowKeyVersion | int64/null | Key version of the escrow blob |
+
+**ActualPhoneState table** (new):
+
+| Column | Type | Description |
+|--------|------|-------------|
+| PartitionKey | string | Gateway identifier |
+| RowKey | string | Phone ID |
+| EncryptedPskEscrow | binary | Opaque escrow blob |
+| EscrowKeyVersion | int64 | Key version |
+| TimestampMs | int64 | Last update timestamp |
+
+#### 8.2  Message handling
+
+**`KEY_ESCROW_PUBKEY` (upstream, msg_type `0x10`):**
+- Upsert `GatewayEscrow` row with RowKey `"pubkey"`.
+- Only update if incoming `key_epoch` ≥ stored epoch (monotonic guard).
+
+**`ACTUAL_STATE` with `encrypted_psk_escrow` (upstream):**
+- For `entity_kind = "node"`: store blob in `ActualNodeState` row.
+- For `entity_kind = "phone"`: store blob in `ActualPhoneState` row.
+- The handler MUST NOT decrypt or inspect blob contents.
+
+**`KEY_ESCROW_REQUEST` (upstream, msg_type `0x11`):**
+- Query `ActualNodeState` and `ActualPhoneState` for rows matching
+  the requested `key_hint` (stored as a column alongside the escrow blob).
+- Return matching blobs as `KEY_ESCROW_RESPONSE` (msg_type `0x12`) via
+  the downstream queue.
+- Cap at 16 candidates.
+
+**`MASTER_KEY_INSTALL` relay (downstream):**
+- The handler does not originate `MASTER_KEY_INSTALL` messages. These are
+  authored by the admin SPA and placed directly into the downstream queue
+  (or relayed through a dedicated admin API endpoint on the handler).
+- The handler relays them verbatim without decryption.
+
+#### 8.3  Salt first-writer-wins (AZH-0603)
+
+On receiving a gateway ACTUAL_STATE with `escrow_salt`:
+- If no `GatewayEscrow` row with RowKey `"salt"` exists, create it.
+- If a row exists, ignore the incoming salt (first-writer-wins).
+- On subsequent gateway-scoped DESIRED_STATE emissions (e.g., after
+  reconnect), include the stored salt so the gateway can adopt it.
+
+#### 8.4  Key hint index
+
+To efficiently serve `KEY_ESCROW_REQUEST`, the handler stores `key_hint`
+as an indexed column in both `ActualNodeState` and `ActualPhoneState`.
+The column is populated from the `key_hint` field within the escrow blob
+metadata (CBOR key 5 of the EscrowBlob). Since the handler must not
+decrypt the blob, the `key_hint` is also sent as a top-level field in
+the ACTUAL_STATE message alongside `encrypted_psk_escrow`.
+
+---
+
+## 4  Design Changes — Admin CLI
+
+### 4.1  New section: §11 Key Management Commands (admin-design.md)
+
+> **Requirements:** ADMIN-0900–ADMIN-0902
+
+#### 11.1  `sonde-admin key rotate`
+
+Subcommand for master key rotation:
+
+```
+sonde-admin key rotate [--gateway-url <url>] [--azure-endpoint <url>]
+```
+
+Flow:
+1. Fetch salt from Azure (or prompt to generate new salt for first rotation).
+2. Fetch gateway's recovery public key from Azure.
+3. Compute and display 6-word BIP-39 fingerprint.
+4. Prompt: "Verify this fingerprint matches the modem display. Continue? [y/N]"
+5. Prompt for passphrase (masked, minimum 20 characters or 6 words).
+6. Derive master key: `Argon2id(passphrase, salt, m=65536, t=3, p=1)`.
+7. Generate ephemeral X25519 keypair for key encapsulation.
+8. Compute shared secret: `X25519(ephemeral_secret, gateway_public_key)`.
+9. Derive encryption key: `HKDF-SHA-256(shared_secret, "sonde-escrow-v1", ...)`.
+10. Encrypt master key with derived encryption key.
+11. Build `MASTER_KEY_INSTALL` message with operation_id, rotation_counter,
+    expiry (5 minutes from now).
+12. Send via Azure downstream queue (or direct gRPC if local).
+13. Poll escrow status until `ready` or timeout.
+
+Passphrase and all derived keys are `Zeroizing`-wrapped.
+
+#### 11.2  `sonde-admin key fingerprint`
+
+Display-only command:
+
+```
+sonde-admin key fingerprint [--azure-endpoint <url>]
+```
+
+Fetches the gateway's public key from Azure and displays the 6-word
+BIP-39 fingerprint. No confirmation or key operations.
+
+#### 11.3  `sonde-admin key status`
+
+```
+sonde-admin key status [--gateway-url <url>] [--azure-endpoint <url>]
+```
+
+Displays escrow state, key version, escrowed PSK counts, and KDF params.
+
+---
+
+## 5  Design Changes — Modem
+
+### 5.1  Fingerprint display page (modem-design.md §9a extension)
+
+No modem firmware changes are required. The modem is a passive display
+sink (MD-0703). The gateway renders the fingerprint page using the
+existing reliable display-transfer subprotocol.
+
+The gateway adds a "Key Fingerprint" page to the display page rotation
+(GW-1101b). Layout for 128×64 OLED at 6px-wide font (~21 chars/row):
+
+```
+Row 1 (y=8):   word1  word2
+Row 2 (y=28):  word3  word4
+Row 3 (y=48):  word5  word6
+```
+
+Words are center-aligned per row. The page title "KEY FINGERPRINT" is
+rendered in smaller font at the top if space permits, or the words
+fill the screen.
+
+---
+
+## 6  Design Changes — Security Model
+
+### 6.1  New subsection: security.md §2.3.2 PSK key escrow
+
+**Key hierarchy:**
+
+```
+passphrase + salt ──► Argon2id ──► master_key (32 bytes)
+                                      │
+                              ┌───────┴────────┐
+                              ▼                ▼
+                    Encrypt(PSK_node1)  Encrypt(PSK_node2) ...
+                              │                │
+                              ▼                ▼
+                       Azure Storage    Azure Storage
+                     (encrypted blobs)  (encrypted blobs)
+```
+
+**Master key delivery:**
+
+```
+Admin ──► Argon2id(passphrase, salt) ──► master_key
+                                              │
+                          X25519(ephemeral, gw_pubkey)
+                                  │
+                          HKDF + AES-256-GCM
+                                  │
+                                  ▼
+                      encrypted_master_key ──► Azure ──► Gateway
+                                                              │
+                                                   X25519(gw_privkey, ephemeral)
+                                                              │
+                                                      HKDF + AES-256-GCM
+                                                              │
+                                                              ▼
+                                                        master_key
+```
+
+**Threat analysis:**
+
+| Threat | Mitigation | Residual risk |
+|--------|------------|---------------|
+| Azure compromise → PSK disclosure | PSKs encrypted with master key; master key never in Azure | None (AES-256-GCM) |
+| Azure compromise → master key disclosure | Master key encrypted with gateway's public key; private key on gateway | None (X25519 + AES-256-GCM) |
+| Azure MITM on public key | 6-word BIP-39 fingerprint verified by admin on modem display (66-bit work factor) | Targeted collision requires ~2^66 operations |
+| Offline passphrase brute-force | Argon2id (64 MiB memory-hard) + ≥77-bit entropy | Computationally infeasible |
+| key_hint amplification (radio→cloud) | Rate limiting: 1 request/key_hint/60s; max 16 candidates | Bounded amplification factor |
+| Rotation crash → split-brain keys | Two-key window + key_version tracking + auto-resume | Temporary degraded state, auto-recoverable |
+| Gateway physical compromise | Exposes master key in memory → all PSKs | Accepted; HSM/enclave as future enhancement |
+| Passphrase loss | Irrecoverable by design | Accepted; admin retention requirement |
+
+---
+
+## 7  Validation Changes — Gateway
+
+### New test series: T-2000 (PSK Key Escrow)
+
+#### T-2000  Recovery keypair generation
+
+**Covers:** GW-2000
+**Method:** Unit test
+
+**Steps:**
+1. Create `SqliteStorage` with a master key.
+2. Verify no keypair exists initially.
+3. Call keypair generation.
+4. Verify keypair is persisted and retrievable.
+5. Restart with same master key — verify same keypair is loaded (not regenerated).
+6. Restart with different master key — verify new keypair is generated with incremented epoch.
+
+**Pass criteria:** Keypair persists across restarts with same master key; regenerated with different master key.
+
+---
+
+#### T-2001  Public key publication via connector
+
+**Covers:** GW-2001
+**Method:** Integration test
+
+**Steps:**
+1. Start gateway with escrow keypair.
+2. Connect a mock connector consumer.
+3. Verify `KEY_ESCROW_PUBKEY` (msg_type `0x10`) is received.
+4. Verify it contains public_key, key_epoch, created_at, fingerprint_words.
+5. Verify fingerprint_words matches independent computation.
+
+**Pass criteria:** Public key message emitted on startup with correct fields.
+
+---
+
+#### T-2002  Escrow blob format — round-trip
+
+**Covers:** GW-2002
+**Method:** Unit test
+
+**Steps:**
+1. Create an EscrowBlob for a node PSK with known values.
+2. Encrypt with a master key.
+3. Verify CBOR-encoded size ≤ 150 bytes.
+4. Decrypt with same master key — verify PSK matches.
+5. Decrypt with wrong master key — verify authentication failure.
+6. Tamper with subject_id in AAD — verify decryption failure.
+7. Swap blob between two different node_ids — verify decryption failure.
+
+**Pass criteria:** Round-trip succeeds; wrong key, tampered AAD, and swapped blobs all fail.
+
+---
+
+#### T-2003  Escrow blob in ACTUAL_STATE
+
+**Covers:** GW-2003
+**Method:** Integration test
+
+**Steps:**
+1. Register a node with escrow enabled (key_version > 0).
+2. Verify ACTUAL_STATE contains `encrypted_psk_escrow` (CBOR key 12).
+3. Verify the blob is a valid EscrowBlob with correct subject_id and key_hint.
+4. Register a phone PSK — verify phone-scoped ACTUAL_STATE emitted.
+5. With escrow disabled (key_version = 0), verify field is null.
+
+**Pass criteria:** Escrow blobs present when enabled, null when disabled.
+
+---
+
+#### T-2004  Escrow lifecycle state machine
+
+**Covers:** GW-2004
+**Method:** Unit test + integration test
+
+**Steps:**
+1. Fresh gateway — verify state is `disabled`.
+2. Perform first `MASTER_KEY_INSTALL` — verify state transitions through
+   `bootstrapping` → `ready`.
+3. Perform another rotation — verify `rotation_in_progress` → `ready`.
+4. Simulate crash during rotation — verify state is `degraded` on restart.
+5. Verify auto-resume completes and state becomes `ready`.
+
+**Pass criteria:** All state transitions match the state machine diagram.
+
+---
+
+#### T-2005  Key version tracking
+
+**Covers:** GW-2005
+**Method:** Unit test
+
+**Steps:**
+1. Register a node — verify `key_version = 0`.
+2. Perform key rotation — verify all nodes updated to `key_version = 1`.
+3. Perform another rotation — verify `key_version = 2`.
+4. Verify `key_version` is monotonically increasing (never decremented).
+
+**Pass criteria:** Key versions increment correctly.
+
+---
+
+#### T-2006  Master key rotation — happy path
+
+**Covers:** GW-2006
+**Method:** Integration test
+
+**Steps:**
+1. Start gateway with 3 registered nodes and 1 phone PSK.
+2. Send valid `MASTER_KEY_INSTALL` message.
+3. Verify all PSK records are re-encrypted with new key version.
+4. Verify old master key no longer decrypts any PSK record.
+5. Verify new master key decrypts all PSK records.
+6. Verify escrow blobs re-emitted via ACTUAL_STATE.
+7. Verify escrow state is `ready`.
+
+**Pass criteria:** All PSKs migrated; old key unusable; new blobs emitted.
+
+---
+
+#### T-2006a  Master key rotation — validation failures
+
+**Covers:** GW-2006
+**Method:** Unit test
+
+**Steps:**
+1. Send `MASTER_KEY_INSTALL` with wrong `target_key_epoch` — verify rejection.
+2. Send `MASTER_KEY_INSTALL` with duplicate `operation_id` — verify rejection.
+3. Send `MASTER_KEY_INSTALL` with expired `expiry_ms` — verify rejection.
+
+**Pass criteria:** All three messages rejected with appropriate error logs.
+
+---
+
+#### T-2007  Crash-safe key rotation
+
+**Covers:** GW-2007
+**Method:** Integration test
+
+**Steps:**
+1. Start gateway with 10 registered nodes.
+2. Begin key rotation, simulate crash after 5 nodes migrated.
+3. Restart gateway — verify `pending_rotation` detected.
+4. Verify escrow state is `degraded`.
+5. Verify auto-resume migrates remaining 5 nodes.
+6. Verify state transitions to `ready`.
+7. Verify all 10 nodes have new `key_version`.
+
+**Pass criteria:** Partial rotation is resumed and completed after crash.
+
+---
+
+#### T-2008  Salt management — first-writer-wins
+
+**Covers:** GW-2008
+**Method:** Integration test
+
+**Steps:**
+1. Start gateway with no local salt and no Azure salt — verify salt generated.
+2. Restart gateway with Azure salt available but no local salt — verify
+   Azure salt adopted.
+3. Verify local and Azure salts match after adoption.
+4. Start another gateway with a different local salt — verify warning logged
+   and local salt used.
+
+**Pass criteria:** First-writer-wins semantics upheld; conflict detected.
+
+---
+
+#### T-2009  Unknown node recovery request
+
+**Covers:** GW-2009
+**Method:** Integration test
+
+**Steps:**
+1. Start gateway with escrow `ready`, empty local registry.
+2. Send a valid encrypted WAKE frame from a previously-escrowed node.
+3. Verify `KEY_ESCROW_REQUEST` emitted with correct `key_hint`.
+4. Send the same key_hint within 60 seconds — verify request is NOT re-emitted
+   (rate limit).
+5. Wait 60 seconds, send again — verify request IS re-emitted.
+6. With escrow `disabled`, send unknown frame — verify silent discard only.
+
+**Pass criteria:** Rate-limited recovery requests when enabled; silent discard when disabled.
+
+---
+
+#### T-2010  PSK recovery from escrowed blob
+
+**Covers:** GW-2010
+**Method:** Integration test
+
+**Steps:**
+1. Start gateway with escrow `ready`, empty registry, known master key.
+2. Send WAKE frame from node whose PSK is escrowed.
+3. Gateway emits `KEY_ESCROW_REQUEST`.
+4. Respond with `KEY_ESCROW_RESPONSE` containing the correct escrow blob.
+5. Verify node is registered locally.
+6. Verify WAKE frame is processed (COMMAND response sent).
+7. Verify ACTUAL_STATE emitted with escrow blob.
+
+**Pass criteria:** Node recovered and operational after escrow response.
+
+---
+
+#### T-2010a  PSK recovery — multiple candidates with collision
+
+**Covers:** GW-2010
+**Method:** Unit test
+
+**Steps:**
+1. Create two nodes with colliding key_hints (different PSKs).
+2. Send recovery response with both escrow blobs.
+3. Verify the correct PSK is identified by trial-decryption.
+
+**Pass criteria:** Correct node registered despite key_hint collision.
+
+---
+
+#### T-2010b  PSK recovery — expired buffer
+
+**Covers:** GW-2010
+**Method:** Unit test
+
+**Steps:**
+1. Send WAKE from unknown node.
+2. Wait 31 seconds (past 30s TTL).
+3. Send recovery response.
+4. Verify frame is discarded with warning log.
+
+**Pass criteria:** Expired recovery entries are cleaned up.
+
+---
+
+#### T-2011  Fingerprint computation determinism
+
+**Covers:** GW-2011
+**Method:** Unit test
+
+**Steps:**
+1. Compute fingerprint for a known public key.
+2. Verify result matches expected 6 words.
+3. Verify same public key always produces same words.
+4. Verify different public key produces different words.
+
+**Pass criteria:** Deterministic, reproducible fingerprint computation.
+
+---
+
+#### T-2012  Replacement gateway bootstrap — end-to-end
+
+**Covers:** GW-2012
+**Method:** Integration test
+
+**Steps:**
+1. Start a replacement gateway with empty DB.
+2. Verify escrow state is `disabled`.
+3. Verify fingerprint displayed on modem.
+4. Send WAKE from a node whose PSK is escrowed in Azure.
+5. Verify frame is silently discarded (no `KEY_ESCROW_REQUEST` emitted).
+6. Perform `MASTER_KEY_INSTALL` with the correct passphrase-derived master key.
+7. Verify escrow state transitions to `ready`.
+8. Send same WAKE again.
+9. Verify `KEY_ESCROW_REQUEST` emitted.
+10. Respond with escrowed blob.
+11. Verify node is recovered and COMMAND response sent.
+
+**Pass criteria:** Full replacement bootstrap succeeds; recovery blocked until key installed.
+
+---
+
+#### T-2013  Connector key-management security
+
+**Covers:** GW-2013
+**Method:** Unit test + integration test
+
+**Steps:**
+1. Send `MASTER_KEY_INSTALL` encrypted with a different gateway's public key
+   — verify decryption failure.
+2. Send `MASTER_KEY_INSTALL` with replayed `operation_id` — verify rejection.
+3. Send `KEY_ESCROW_RESPONSE` with a tampered escrow blob — verify blob
+   discarded, other valid candidates still processed.
+4. Send unsolicited `KEY_ESCROW_RESPONSE` with no matching request — verify
+   discarded.
+5. Verify recovery private key is re-encrypted after rotation (restart
+   gateway with new master key, verify keypair loads successfully).
+
+**Pass criteria:** All security checks enforced; private key survives rotation.
+
+---
+
+## 8  Validation Changes — Azure Handler
+
+#### T-AZH-0600  Escrow blob storage from ACTUAL_STATE
+
+**Covers:** AZH-0600
+**Method:** Integration test
+
+**Steps:**
+1. Send ACTUAL_STATE with `encrypted_psk_escrow` for a node.
+2. Verify blob stored in ActualNodeState table.
+3. Send ACTUAL_STATE for a phone — verify stored in ActualPhoneState table.
+4. Send updated blob (new key_version) — verify previous blob overwritten.
+
+**Pass criteria:** Blobs stored and updated correctly.
+
+---
+
+#### T-AZH-0601  Recovery serving by key_hint
+
+**Covers:** AZH-0601
+**Method:** Integration test
+
+**Steps:**
+1. Store escrow blobs for 3 nodes (2 with same key_hint, 1 different).
+2. Send `KEY_ESCROW_REQUEST` for the colliding key_hint.
+3. Verify response contains exactly 2 candidate blobs.
+4. Send request for the unique key_hint — verify 1 candidate.
+5. Send request for unknown key_hint — verify empty candidate list.
+
+**Pass criteria:** Correct candidate sets returned.
+
+---
+
+#### T-AZH-0602  Gateway public key storage
+
+**Covers:** AZH-0602
+**Method:** Integration test
+
+**Steps:**
+1. Send `KEY_ESCROW_PUBKEY` with epoch 1.
+2. Verify stored in GatewayEscrow table.
+3. Send `KEY_ESCROW_PUBKEY` with epoch 2 — verify updated.
+4. Send `KEY_ESCROW_PUBKEY` with epoch 1 (stale) — verify NOT updated.
+
+**Pass criteria:** Monotonic epoch guard enforced.
+
+---
+
+#### T-AZH-0603  Salt first-writer-wins
+
+**Covers:** AZH-0603
+**Method:** Integration test
+
+**Steps:**
+1. Send ACTUAL_STATE with salt — verify stored.
+2. Send ACTUAL_STATE with different salt — verify NOT overwritten.
+3. Verify original salt returned to gateway.
+
+**Pass criteria:** First salt preserved; subsequent writes ignored.
+
+---
+
+#### T-AZH-0604  MASTER_KEY_INSTALL relay
+
+**Covers:** AZH-0604
+**Method:** Integration test
+
+**Steps:**
+1. Place `MASTER_KEY_INSTALL` message in downstream queue.
+2. Verify message relayed to gateway verbatim.
+3. Verify handler did not decrypt or modify the payload.
+
+**Pass criteria:** Opaque relay without inspection.
+
+---
+
+#### T-AZH-0605  Escrow state observability
+
+**Covers:** AZH-0605
+**Method:** Integration test
+
+**Steps:**
+1. Store gateway-scoped ACTUAL_STATE with escrow_state = "ready".
+2. Query escrow state — verify "ready" returned.
+3. Update to "rotation_in_progress" — verify updated.
+
+**Pass criteria:** Escrow state queryable.
+
+---
+
+## 9  Validation Changes — Admin CLI
+
+#### T-0900  Key rotation — happy path
+
+**Covers:** ADMIN-0900
+**Method:** Integration test (mock Azure + mock gateway)
+
+**Steps:**
+1. Run `sonde-admin key rotate` with mock Azure returning salt + public key.
+2. Verify fingerprint displayed.
+3. Confirm fingerprint, enter valid passphrase.
+4. Verify `MASTER_KEY_INSTALL` message sent to downstream queue.
+5. Verify passphrase zeroed from memory after use.
+
+**Pass criteria:** Rotation message sent correctly.
+
+---
+
+#### T-0900a  Key rotation — fingerprint rejection
+
+**Covers:** ADMIN-0900
+**Method:** Unit test
+
+**Steps:**
+1. Run key rotate, deny fingerprint confirmation.
+2. Verify no `MASTER_KEY_INSTALL` message sent.
+3. Verify command exits with error.
+
+**Pass criteria:** Aborted rotation sends nothing.
+
+---
+
+#### T-0900b  Key rotation — weak passphrase rejection
+
+**Covers:** ADMIN-0900
+**Method:** Unit test
+
+**Steps:**
+1. Run key rotate with passphrase "abc" (too short).
+2. Verify rejection with entropy warning.
+
+**Pass criteria:** Weak passphrases rejected.
+
+---
+
+#### T-0901  Fingerprint display
+
+**Covers:** ADMIN-0901
+**Method:** Unit test
+
+**Steps:**
+1. Run `sonde-admin key fingerprint` with known public key.
+2. Verify 6-word fingerprint displayed.
+3. Verify matches gateway-side computation for same key.
+
+**Pass criteria:** Consistent fingerprint across admin and gateway.
+
+---
+
+#### T-0902  Escrow status display
+
+**Covers:** ADMIN-0902
+**Method:** Integration test
+
+**Steps:**
+1. Run `sonde-admin key status` with mock Azure returning escrow state.
+2. Verify state, key version, and PSK counts displayed.
+
+**Pass criteria:** Status information displayed correctly.
+
+---
+
+## 10  Invariant Check
+
+| Existing invariant | Preserved? | Notes |
+|--------------------|------------|-------|
+| PSKs never in plaintext outside gateway memory | ✅ | Escrow blobs are AES-256-GCM encrypted |
+| Connector messages are CBOR with integer keys | ✅ | New message types follow same convention |
+| Unknown keys ignored by receivers | ✅ | New ACTUAL_STATE key 12 ignored by old receivers |
+| DESIRED_STATE is complete replacement | ✅ | New escrow messages use separate msg_types |
+| Storage trait is async | ✅ | New methods follow same pattern |
+| Master key via KeyProvider | ✅ | Rotation updates the key provider store; trait unchanged |
+| Modem is passive display sink | ✅ | Fingerprint rendered by gateway, not modem |
+| Silent discard for unknown nodes (GW-1002) | ✅ | Recovery is additive; failed recovery still discards silently |
+
+---
+
+## 11  Completeness Check
+
+| Requirement | Design section | Validation test(s) |
+|-------------|---------------|-------------------|
+| GW-2000 | §20.2 | T-2000 |
+| GW-2001 | §20.2, §2.3 | T-2001 |
+| GW-2002 | §20.3 | T-2002 |
+| GW-2003 | §20.4, §2.3 | T-2003 |
+| GW-2004 | §20.5 | T-2004 |
+| GW-2005 | §20.6 | T-2005 |
+| GW-2006 | §20.7 | T-2006, T-2006a |
+| GW-2007 | §20.7 | T-2007 |
+| GW-2008 | §20.8 | T-2008 |
+| GW-2009 | §20.9 | T-2009 |
+| GW-2010 | §20.9 | T-2010, T-2010a, T-2010b |
+| GW-2011 | §20.10 | T-2011 |
+| GW-2012 | §20.11 | T-2012 |
+| GW-2013 | §20.12 | T-2013 |
+| AZH-0600 | §8.1, §8.2 | T-AZH-0600 |
+| AZH-0601 | §8.2, §8.4 | T-AZH-0601 |
+| AZH-0602 | §8.2 | T-AZH-0602 |
+| AZH-0603 | §8.3 | T-AZH-0603 |
+| AZH-0604 | §8.2 | T-AZH-0604 |
+| AZH-0605 | §8.2 | T-AZH-0605 |
+| ADMIN-0900 | §11.1 | T-0900, T-0900a, T-0900b |
+| ADMIN-0901 | §11.2 | T-0901 |
+| ADMIN-0902 | §11.3 | T-0902 |
+
+All requirements have design sections and validation tests. ✅
+
+---
+
+## 12  Conflict Detection
+
+No contradictions found between:
+- New escrow message types and existing DESIRED_STATE/ACTUAL_STATE semantics.
+- New Storage trait methods and existing trait contract.
+- New ACTUAL_STATE fields and existing field numbering (key 12 is unused).
+- Escrow lifecycle states and existing gateway startup/shutdown sequences.
+- Fingerprint display page and existing modem display page navigation.

--- a/docs/evolve-887-specification.md
+++ b/docs/evolve-887-specification.md
@@ -37,7 +37,7 @@
 
 ### 2.1  New section: §20 PSK Key Escrow (gateway-design.md)
 
-> **Requirements:** GW-2000–GW-2011
+> **Requirements:** GW-2000–GW-2013
 
 #### 20.1  Overview
 
@@ -109,6 +109,9 @@ pub enum SubjectKind {
 }
 ```
 
+`SubjectKind` is encoded as a CBOR `tstr` on the wire: `"node"` or `"phone"`
+(matching GW-2002 field 3).
+
 CBOR encoding uses integer keys (1–8) as defined in GW-2002. The AAD for
 AES-256-GCM encryption is the CBOR-encoded map of fields 1–5 (escrow_version,
 key_version, subject_kind, subject_id, key_hint). This binds the ciphertext
@@ -137,7 +140,9 @@ Escrow blobs are emitted:
 - After key rotation (re-encrypted blobs for all subjects).
 - On connector reconnection (full state replay).
 
-When escrow state is `disabled`, the field is `null`.
+When escrow state is `disabled`, both `encrypted_psk_escrow` (key 12) and
+`escrow_key_hint` (key 13) are `null` (or omitted). During `bootstrapping`,
+blobs for PSKs not yet re-encrypted are also `null`.
 
 #### 20.5  Escrow lifecycle state machine (GW-2004)
 
@@ -315,7 +320,7 @@ The BIP-39 wordlist fingerprint is computed as:
 fn compute_fingerprint(public_key: &[u8; 32]) -> [&'static str; 6] {
     let hash = sha256(public_key);
     let mut words = [""; 6];
-    // Extract 66 bits (6 × 11-bit indices) from hash bytes 0..8
+    // Extract 66 bits (6 × 11-bit indices) from hash bytes 0–8 (9 bytes, 72 bits; 66 used)
     let bits = u128::from_be_bytes([
         hash[0], hash[1], hash[2], hash[3],
         hash[4], hash[5], hash[6], hash[7],
@@ -423,6 +428,7 @@ New field in node-scoped ACTUAL_STATE:
 | Field | CBOR key | Type | Description |
 |-------|----------|------|-------------|
 | `encrypted_psk_escrow` | 12 | bstr/null | CBOR-encoded EscrowBlob |
+| `escrow_key_hint` | 13 | uint/null | `key_hint` (u16) from escrow blob metadata, for Azure indexing without inspecting the encrypted blob |
 
 New `entity_kind = "phone"` for phone PSK escrow.
 
@@ -563,6 +569,18 @@ On receiving a gateway ACTUAL_STATE with `escrow_salt`:
 - If a row exists, ignore the incoming salt (first-writer-wins).
 - On subsequent gateway-scoped DESIRED_STATE emissions (e.g., after
   reconnect), include the stored salt so the gateway can adopt it.
+
+**Gateway-scoped DESIRED_STATE fields for salt adoption:**
+
+| Field | CBOR key (in `desired_state`) | Type | Description |
+|-------|-------------------------------|------|-------------|
+| `escrow_salt` | 1 | bstr/null | KDF salt (16 bytes) from Azure, or null if none stored |
+| `escrow_kdf_params` | 2 | map/null | `{1: m_cost, 2: t_cost, 3: p_cost, 4: kdf_version}` |
+
+The gateway inspects these fields on each DESIRED_STATE receipt. If the
+gateway has no local salt and the DESIRED_STATE provides one, it adopts
+the values. If both exist and differ, the gateway logs a warning and
+keeps its local salt (local is authoritative).
 
 #### 8.4  Key hint index
 


### PR DESCRIPTION
## Summary

Design specification for PSK key escrow to enable gateway replacement without re-pairing nodes. Azure stores encrypted PSK blobs; the master key is derived from an admin-chosen passphrase via Argon2id and never leaves the gateway/admin tool.

## Documents

- **\docs/evolve-887-requirements.md\** — Requirements patch (14 gateway + 6 Azure handler + 3 admin requirements)
- **\docs/evolve-887-specification.md\** — Design + validation patch (architecture, CBOR schemas, 30+ test cases)

## Key Design Decisions

1. **Master key lifecycle**: Gateway uses raw 32-byte master keys. Passphrase → Argon2id → master key happens only in admin tool / SPA.
2. **Escrow via existing connector**: Encrypted PSK blobs travel as new field in \ACTUAL_STATE\ (CBOR key 12).
3. **Auto-heal recovery**: Unknown \key_hint\ → \KEY_ESCROW_REQUEST\ → Azure responds with escrowed blob → gateway decrypts + registers node.
4. **New connector message types** (\