### PR TITLE
fix(bpf): tag pointers loaded from context via ContextPointerField

### DIFF
--- a/crates/sonde-bpf/src/interpreter.rs
+++ b/crates/sonde-bpf/src/interpreter.rs
@@ -620,7 +620,17 @@ pub fn execute_program_no_maps(
     instruction_budget: u64,
 ) -> Result<u64, BpfError> {
     // SAFETY: maps and ctx_ptrs are empty — no raw pointer invariants to uphold.
-    unsafe { execute_program(prog, ctx, helpers, &[], read_only_ctx, instruction_budget, &[]) }
+    unsafe {
+        execute_program(
+            prog,
+            ctx,
+            helpers,
+            &[],
+            read_only_ctx,
+            instruction_budget,
+            &[],
+        )
+    }
 }
 
 /// Execute a BPF program.

--- a/crates/sonde-bpf/src/interpreter.rs
+++ b/crates/sonde-bpf/src/interpreter.rs
@@ -647,6 +647,11 @@ pub fn execute_program_no_maps(
 ///   executed before the program is terminated with
 ///   [`BpfError::InstructionBudgetExceeded`].  Pass [`UNLIMITED_BUDGET`] to
 ///   disable metering.
+/// * `ctx_ptrs` — context pointer field descriptors.  Each entry declares
+///   a u64 offset within `ctx` that holds a pointer to a memory region.
+///   When `LD_DW_REG` loads from that offset, the result is tagged with the
+///   described region so the BPF program can dereference it.  Pass `&[]`
+///   when the context contains no embedded pointers.
 ///
 /// # Returns
 /// The value of `r0` when the program exits.

--- a/crates/sonde-bpf/src/interpreter.rs
+++ b/crates/sonde-bpf/src/interpreter.rs
@@ -158,6 +158,25 @@ pub struct MapRegion {
     pub data_end: u64,
 }
 
+/// Describes a u64 field within the context buffer that holds a pointer
+/// to a memory region.
+///
+/// When `LD_DW_REG` loads from the context at the byte offset described by
+/// `offset`, the loaded value is tagged with `region` instead of being
+/// treated as a plain scalar.  This enables C-compiled BPF programs that
+/// use the standard `ctx->data` / `ctx->data_end` pattern.
+///
+/// The match is computed as `effective_address - ctx_base == offset`, so
+/// it works regardless of whether the source register points at ctx_base
+/// or has been adjusted via pointer arithmetic.
+#[derive(Clone, Copy, Debug)]
+pub struct ContextPointerField {
+    /// Byte offset within the context buffer where the u64 pointer lives.
+    pub offset: u16,
+    /// Region descriptor to attach to the loaded pointer value.
+    pub region: Region,
+}
+
 // ── Spill tracker ───────────────────────────────────────────────────
 
 const MAX_SPILL_SLOTS: usize = 32;
@@ -600,8 +619,8 @@ pub fn execute_program_no_maps(
     read_only_ctx: bool,
     instruction_budget: u64,
 ) -> Result<u64, BpfError> {
-    // SAFETY: maps is empty — no raw pointer invariants to uphold.
-    unsafe { execute_program(prog, ctx, helpers, &[], read_only_ctx, instruction_budget) }
+    // SAFETY: maps and ctx_ptrs are empty — no raw pointer invariants to uphold.
+    unsafe { execute_program(prog, ctx, helpers, &[], read_only_ctx, instruction_budget, &[]) }
 }
 
 /// Execute a BPF program.
@@ -630,12 +649,18 @@ pub fn execute_program_no_maps(
 /// - The map storage must not alias `ctx` or the interpreter's internal
 ///   BPF stack.
 ///
+/// Each [`ContextPointerField`] in `ctx_ptrs` must satisfy:
+/// - `region.base..region.end` covers a valid, live allocation that
+///   remains valid for the duration of this call.
+/// - The described region must not alias the interpreter's internal
+///   BPF stack.
+///
 /// Violating these invariants may cause undefined behavior, because the
-/// interpreter dereferences addresses within the declared map bounds via
+/// interpreter dereferences addresses within the declared bounds via
 /// raw pointers.
 ///
-/// If `maps` is empty (no map access), these requirements are trivially
-/// satisfied and the call is safe.
+/// If `maps` and `ctx_ptrs` are both empty, these requirements are
+/// trivially satisfied and the call is safe.
 ///
 /// # Zero-allocation guarantee
 /// All interpreter state (registers, call stack, BPF stack) lives on the
@@ -648,6 +673,7 @@ pub unsafe fn execute_program(
     maps: &[MapRegion],
     read_only_ctx: bool,
     instruction_budget: u64,
+    ctx_ptrs: &[ContextPointerField],
 ) -> Result<u64, BpfError> {
     let num_insns = prog.len() / INSN_SIZE;
     if !prog.len().is_multiple_of(INSN_SIZE) {
@@ -814,6 +840,33 @@ pub unsafe fn execute_program(
                     } else {
                         reg[dst] = TaggedReg::scalar(val);
                     }
+                } else if matches!(
+                    reg[src].region,
+                    Some(Region {
+                        tag: RegionTag::Context | RegionTag::Memory,
+                        ..
+                    })
+                ) {
+                    // Context pointer field tagging: when loading a u64 from
+                    // the context at a known pointer-field offset, tag the
+                    // result so that the BPF program can dereference it.
+                    let addr = reg[src].value.wrapping_add_signed(insn.off as i64);
+                    let ctx_off = addr.wrapping_sub(ctx_base);
+                    let tagged = if ctx_off.wrapping_add(8) <= ctx.len() as u64 {
+                        ctx_ptrs.iter().find_map(|cpf| {
+                            if ctx_off == cpf.offset as u64 {
+                                Some(TaggedReg {
+                                    value: val,
+                                    region: Some(cpf.region),
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                    } else {
+                        None
+                    };
+                    reg[dst] = tagged.unwrap_or_else(|| TaggedReg::scalar(val));
                 } else {
                     reg[dst] = TaggedReg::scalar(val);
                 }

--- a/crates/sonde-bpf/tests/helper_trust_boundary_tests.rs
+++ b/crates/sonde-bpf/tests/helper_trust_boundary_tests.rs
@@ -84,7 +84,7 @@ fn test_ld_dw_imm_src1_valid_map_index() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET) };
+    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET, &[]) };
     assert_eq!(result.unwrap(), 0x42);
 }
 
@@ -119,7 +119,7 @@ fn test_ld_dw_imm_src1_out_of_bounds() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, &[], &[m0, m1], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, &[], &[m0, m1], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidMapIndex { index: 5, .. })),
         "out-of-bounds map index must yield InvalidMapIndex, got: {result:?}"
@@ -170,7 +170,7 @@ fn test_map_value_or_null_returns_null_is_scalar() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::NonDereferenceableAccess { .. })),
         "dereferencing scalar(0) must yield NonDereferenceableAccess, got: {result:?}"
@@ -221,7 +221,7 @@ fn test_map_value_or_null_returns_valid_ptr_is_map_value() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert_eq!(
         result.unwrap(),
         1,
@@ -265,7 +265,7 @@ fn test_map_value_or_null_returns_out_of_bounds_ptr() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(
             result,
@@ -303,7 +303,7 @@ fn test_map_value_or_null_returns_ptr_just_past_end() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::MemoryAccessViolation { .. })),
         "pointer just past valid end must yield MemoryAccessViolation, got: {result:?}"
@@ -336,7 +336,7 @@ fn test_map_value_or_null_returns_ptr_before_start() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::MemoryAccessViolation { .. })),
         "pointer before data_start must yield MemoryAccessViolation, got: {result:?}"
@@ -370,7 +370,7 @@ fn test_map_value_or_null_exact_boundary_succeeds() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert_eq!(
         result.unwrap(),
         1,
@@ -407,7 +407,7 @@ fn test_invalid_helper_argument_scalar_for_map_descriptor() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidHelperArgument { arg: 1, .. })),
         "scalar in map_arg register must yield InvalidHelperArgument, got: {result:?}"
@@ -454,7 +454,7 @@ fn test_invalid_helper_argument_map_value_for_map_descriptor() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidHelperArgument { arg: 1, .. })),
         "MapValue tag in map_arg register must yield InvalidHelperArgument, got: {result:?}"
@@ -514,7 +514,7 @@ fn test_helper_call_clobbers_r1_r5_tags() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidHelperArgument { arg: 1, .. })),
         "R1 tag should be clobbered after first helper call, got: {result:?}"
@@ -544,7 +544,7 @@ fn test_map_value_or_null_null_skips_map_arg_validation() {
     ]);
     let mut ctx = [];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
     assert_eq!(
         result.unwrap(),
         0,
@@ -568,7 +568,7 @@ fn test_map_descriptor_not_dereferenceable() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET) };
+    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::NonDereferenceableAccess { .. })),
         "dereferencing MapDescriptor must fail, got: {result:?}"
@@ -591,7 +591,7 @@ fn test_map_descriptor_arithmetic_rejected() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET) };
+    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidPointerArithmetic { .. })),
         "arithmetic on MapDescriptor must yield InvalidPointerArithmetic, got: {result:?}"

--- a/crates/sonde-bpf/tests/helper_trust_boundary_tests.rs
+++ b/crates/sonde-bpf/tests/helper_trust_boundary_tests.rs
@@ -84,7 +84,8 @@ fn test_ld_dw_imm_src1_valid_map_index() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result =
+        unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET, &[]) };
     assert_eq!(result.unwrap(), 0x42);
 }
 
@@ -118,8 +119,17 @@ fn test_ld_dw_imm_src1_out_of_bounds() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, &[], &[m0, m1], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            &[],
+            &[m0, m1],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert!(
         matches!(result, Err(BpfError::InvalidMapIndex { index: 5, .. })),
         "out-of-bounds map index must yield InvalidMapIndex, got: {result:?}"
@@ -169,8 +179,17 @@ fn test_map_value_or_null_returns_null_is_scalar() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert!(
         matches!(result, Err(BpfError::NonDereferenceableAccess { .. })),
         "dereferencing scalar(0) must yield NonDereferenceableAccess, got: {result:?}"
@@ -220,8 +239,17 @@ fn test_map_value_or_null_returns_valid_ptr_is_map_value() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert_eq!(
         result.unwrap(),
         1,
@@ -264,8 +292,17 @@ fn test_map_value_or_null_returns_out_of_bounds_ptr() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert!(
         matches!(
             result,
@@ -302,8 +339,17 @@ fn test_map_value_or_null_returns_ptr_just_past_end() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert!(
         matches!(result, Err(BpfError::MemoryAccessViolation { .. })),
         "pointer just past valid end must yield MemoryAccessViolation, got: {result:?}"
@@ -335,8 +381,17 @@ fn test_map_value_or_null_returns_ptr_before_start() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert!(
         matches!(result, Err(BpfError::MemoryAccessViolation { .. })),
         "pointer before data_start must yield MemoryAccessViolation, got: {result:?}"
@@ -369,8 +424,17 @@ fn test_map_value_or_null_exact_boundary_succeeds() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert_eq!(
         result.unwrap(),
         1,
@@ -406,8 +470,17 @@ fn test_invalid_helper_argument_scalar_for_map_descriptor() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert!(
         matches!(result, Err(BpfError::InvalidHelperArgument { arg: 1, .. })),
         "scalar in map_arg register must yield InvalidHelperArgument, got: {result:?}"
@@ -453,8 +526,17 @@ fn test_invalid_helper_argument_map_value_for_map_descriptor() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert!(
         matches!(result, Err(BpfError::InvalidHelperArgument { arg: 1, .. })),
         "MapValue tag in map_arg register must yield InvalidHelperArgument, got: {result:?}"
@@ -513,8 +595,17 @@ fn test_helper_call_clobbers_r1_r5_tags() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert!(
         matches!(result, Err(BpfError::InvalidHelperArgument { arg: 1, .. })),
         "R1 tag should be clobbered after first helper call, got: {result:?}"
@@ -543,8 +634,17 @@ fn test_map_value_or_null_null_skips_map_arg_validation() {
         insn(ebpf::EXIT, 0, 0, 0, 0),         // exit with r0 = 0
     ]);
     let mut ctx = [];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, helpers, &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            helpers,
+            &[map],
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert_eq!(
         result.unwrap(),
         0,
@@ -568,7 +668,8 @@ fn test_map_descriptor_not_dereferenceable() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result =
+        unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::NonDereferenceableAccess { .. })),
         "dereferencing MapDescriptor must fail, got: {result:?}"
@@ -591,7 +692,8 @@ fn test_map_descriptor_arithmetic_rejected() {
         insn(ebpf::EXIT, 0, 0, 0, 0),
     ]);
     let mut ctx = [];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET, &[]) };
+    let result =
+        unsafe { execute_program(&prog, &mut ctx, &[], &[map], false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidPointerArithmetic { .. })),
         "arithmetic on MapDescriptor must yield InvalidPointerArithmetic, got: {result:?}"

--- a/crates/sonde-bpf/tests/tagged_register_tests.rs
+++ b/crates/sonde-bpf/tests/tagged_register_tests.rs
@@ -1002,16 +1002,16 @@ fn ctx_pointer_field_adjusted_base() {
     // r2 += 8         — adjust to point at offset 8
     // r3 = *(u64 *)(r2 + 0)  — load input_end from adjusted ptr
     //   (effective ctx offset = 8, should match ctx_ptrs[1])
-    // r1 = *(u64 *)(r1 + 0)  — load input_data
-    // r0 = *(u8 *)(r1 + 0)   — dereference input_data
+    // r3 += -1        — point to last blob byte (input_end - 1)
+    // r0 = *(u8 *)(r3 + 0)   — dereference: succeeds only if r3 is tagged
     // exit
     #[rustfmt::skip]
     let prog: Vec<u8> = vec![
         ebpf::MOV64_REG,  0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r2 = r1
         ebpf::ADD64_IMM,  0x02, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, // r2 += 8
         ebpf::LD_DW_REG,  0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r3 = *(u64 *)(r2 + 0)
-        ebpf::LD_DW_REG,  0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r1 = *(u64 *)(r1 + 0)
-        ebpf::LD_B_REG,   0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r0 = *(u8 *)(r1 + 0)
+        ebpf::ADD64_IMM,  0x03, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, // r3 += -1
+        ebpf::LD_B_REG,   0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r0 = *(u8 *)(r3 + 0)
         ebpf::EXIT,       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
     ];
 

--- a/crates/sonde-bpf/tests/tagged_register_tests.rs
+++ b/crates/sonde-bpf/tests/tagged_register_tests.rs
@@ -78,7 +78,7 @@ fn t_bpf_002_store_via_map_descriptor() {
         data_end: map_ptr + 64,
     }];
     assert!(matches!(
-        unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET) },
+        unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET, &[]) },
         Err(BpfError::NonDereferenceableAccess { .. })
     ));
     drop(map_buf);
@@ -239,7 +239,7 @@ fn t_bpf_009_map_descriptor_add() {
         data_end: map_ptr + 64,
     }];
     assert!(matches!(
-        unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET) },
+        unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET, &[]) },
         Err(BpfError::InvalidPointerArithmetic { .. })
     ));
     drop(map_buf);
@@ -559,7 +559,7 @@ fn t_bpf_024_map_value_or_null_returns_null() {
         ret: HelperReturn::MapValueOrNull { map_arg: 1 },
     }];
     assert!(matches!(
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET) },
+        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) },
         Err(BpfError::NonDereferenceableAccess { .. })
     ));
     drop(map_buf);
@@ -598,7 +598,7 @@ fn t_bpf_025_map_value_or_null_returns_valid() {
         ret: HelperReturn::MapValueOrNull { map_arg: 1 },
     }];
     let result =
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET) };
+        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) };
     assert_eq!(result.unwrap(), 0xBB);
     drop(map_buf);
 }
@@ -635,7 +635,7 @@ fn t_bpf_026_helper_returns_oob_pointer() {
         ret: HelperReturn::MapValueOrNull { map_arg: 1 },
     }];
     assert!(matches!(
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET) },
+        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) },
         Err(BpfError::MemoryAccessViolation { .. })
     ));
     drop(map_buf);
@@ -672,7 +672,7 @@ fn t_bpf_027_helper_expects_map_descriptor_gets_scalar() {
         ret: HelperReturn::MapValueOrNull { map_arg: 1 },
     }];
     assert!(matches!(
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET) },
+        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) },
         Err(BpfError::InvalidHelperArgument { .. })
     ));
     drop(map_buf);
@@ -699,7 +699,7 @@ fn t_bpf_028_ld_dw_imm_negative_map_index() {
         data_start: map_ptr,
         data_end: map_ptr + 64,
     }];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET) };
+    let result = unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidMapIndex { index: -1, .. })),
         "expected InvalidMapIndex with index=-1, got {:?}",
@@ -735,7 +735,7 @@ fn t_bpf_029_ld_dw_imm_out_of_bounds_map_index() {
             data_end: map_ptr_1 + 64,
         },
     ];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET) };
+    let result = unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidMapIndex { index: 5, .. })),
         "expected InvalidMapIndex with index=5, got {:?}",
@@ -782,9 +782,194 @@ fn t_bpf_030_ld_dw_imm_map_descriptor_happy_path() {
     // verify the MapDescriptor tag on R1. If the tag were missing, the call
     // would fail with InvalidHelperArgument.
     assert_eq!(
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET) }
+        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) }
             .unwrap(),
         1
     );
     drop(map_buf);
+}
+
+// ── Context pointer field tests ─────────────────────────────────────
+
+use sonde_bpf::interpreter::{ContextPointerField, Region, RegionTag};
+
+/// Load a u64 pointer from ctx offset 0, then dereference it.
+/// Without ContextPointerField this would fail with NonDereferenceableAccess.
+#[test]
+fn ctx_pointer_field_load_and_deref() {
+    // Context layout: [ptr_to_data (u64)] [data: 0xAB]
+    let header_size = 8usize;
+    let mut ctx = vec![0u8; header_size + 1];
+    ctx[header_size] = 0xAB;
+
+    let data_addr = ctx.as_ptr() as u64 + header_size as u64;
+    let data_end = data_addr + 1;
+    ctx[0..8].copy_from_slice(&data_addr.to_le_bytes());
+
+    let ctx_ptrs = [ContextPointerField {
+        offset: 0,
+        region: Region {
+            tag: RegionTag::Memory,
+            base: data_addr,
+            end: data_end,
+        },
+    }];
+
+    // r2 = *(u64 *)(r1 + 0)   — load data pointer (tagged via ctx_ptrs)
+    // r3 = *(u8 *)(r2 + 0)    — dereference the loaded pointer
+    // r0 = r3
+    // exit
+    #[rustfmt::skip]
+    let prog: Vec<u8> = vec![
+        ebpf::LD_DW_REG, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r2 = *(u64 *)(r1 + 0)
+        ebpf::LD_B_REG,  0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r3 = *(u8 *)(r2 + 0)
+        ebpf::MOV64_REG, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r0 = r3
+        ebpf::EXIT,      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    ];
+
+    let result = unsafe {
+        execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &ctx_ptrs)
+    };
+    assert_eq!(result.unwrap(), 0xAB);
+}
+
+/// Without ctx_ptrs, loading a pointer from context and dereferencing it
+/// must fail with NonDereferenceableAccess.
+#[test]
+fn ctx_pointer_field_absent_fails() {
+    let header_size = 8usize;
+    let mut ctx = vec![0u8; header_size + 1];
+    ctx[header_size] = 0xAB;
+
+    let data_addr = ctx.as_ptr() as u64 + header_size as u64;
+    ctx[0..8].copy_from_slice(&data_addr.to_le_bytes());
+
+    // Same program as above, but no ctx_ptrs.
+    #[rustfmt::skip]
+    let prog: Vec<u8> = vec![
+        ebpf::LD_DW_REG, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r2 = *(u64 *)(r1 + 0)
+        ebpf::LD_B_REG,  0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r3 = *(u8 *)(r2 + 0)
+        ebpf::MOV64_REG, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r0 = r3
+        ebpf::EXIT,      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    ];
+
+    let result = unsafe {
+        execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &[])
+    };
+    assert!(matches!(
+        result,
+        Err(BpfError::NonDereferenceableAccess { pc: 1 })
+    ));
+}
+
+/// Decoder-style program: load data_start and data_end from context,
+/// bounds-check, then read bytes from the data region.
+#[test]
+fn ctx_pointer_field_decoder_pattern() {
+    // Context: [input_data (u64)] [input_end (u64)] [blob: 0x01, 0x02, 0x03]
+    let header_size = 16usize;
+    let blob = [0x01u8, 0x02, 0x03];
+    let mut ctx = vec![0u8; header_size + blob.len()];
+    ctx[header_size..].copy_from_slice(&blob);
+
+    let blob_addr = ctx.as_ptr() as u64 + header_size as u64;
+    let blob_end = blob_addr + blob.len() as u64;
+    ctx[0..8].copy_from_slice(&blob_addr.to_le_bytes());
+    ctx[8..16].copy_from_slice(&blob_end.to_le_bytes());
+
+    let data_region = Region {
+        tag: RegionTag::Memory,
+        base: blob_addr,
+        end: blob_end,
+    };
+    let ctx_ptrs = [
+        ContextPointerField {
+            offset: 0,
+            region: data_region,
+        },
+        ContextPointerField {
+            offset: 8,
+            region: data_region,
+        },
+    ];
+
+    // Mimics the decoder assembly from the bug report:
+    //   r2 = *(u64 *)(r1 + 8)    — load input_end
+    //   r1 = *(u64 *)(r1 + 0)    — load input_data
+    //   r3 = r1
+    //   r3 += 3
+    //   if r3 > r2 goto exit_zero
+    //   r0 = *(u8 *)(r1 + 2)     — read third byte
+    //   exit
+    //   exit_zero: r0 = 0; exit
+    #[rustfmt::skip]
+    let prog: Vec<u8> = vec![
+        ebpf::LD_DW_REG,  0x12, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, // r2 = *(u64 *)(r1 + 8)
+        ebpf::LD_DW_REG,  0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r1 = *(u64 *)(r1 + 0)
+        ebpf::MOV64_REG,  0x13, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r3 = r1
+        ebpf::ADD64_IMM,  0x03, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, // r3 += 3
+        ebpf::JGT_REG,    0x23, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, // if r3 > r2 goto +2
+        ebpf::LD_B_REG,   0x10, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, // r0 = *(u8 *)(r1 + 2)
+        ebpf::EXIT,       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+        0xb7,             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r0 = 0  (MOV64_IMM)
+        ebpf::EXIT,       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    ];
+
+    let result = unsafe {
+        execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &ctx_ptrs)
+    };
+    assert_eq!(result.unwrap(), 0x03);
+}
+
+/// Context pointer field with adjusted base register (r2 = r1 + 8,
+/// then load from r2 + 0 should match offset 8).
+#[test]
+fn ctx_pointer_field_adjusted_base() {
+    let header_size = 16usize;
+    let blob = [0x42u8];
+    let mut ctx = vec![0u8; header_size + blob.len()];
+    ctx[header_size..].copy_from_slice(&blob);
+
+    let blob_addr = ctx.as_ptr() as u64 + header_size as u64;
+    let blob_end = blob_addr + blob.len() as u64;
+    ctx[0..8].copy_from_slice(&blob_addr.to_le_bytes());
+    ctx[8..16].copy_from_slice(&blob_end.to_le_bytes());
+
+    let data_region = Region {
+        tag: RegionTag::Memory,
+        base: blob_addr,
+        end: blob_end,
+    };
+    let ctx_ptrs = [
+        ContextPointerField {
+            offset: 0,
+            region: data_region,
+        },
+        ContextPointerField {
+            offset: 8,
+            region: data_region,
+        },
+    ];
+
+    // r2 = r1         — copy ctx pointer
+    // r2 += 8         — adjust to point at offset 8
+    // r3 = *(u64 *)(r2 + 0)  — load input_end from adjusted ptr
+    //   (effective ctx offset = 8, should match ctx_ptrs[1])
+    // r1 = *(u64 *)(r1 + 0)  — load input_data
+    // r0 = *(u8 *)(r1 + 0)   — dereference input_data
+    // exit
+    #[rustfmt::skip]
+    let prog: Vec<u8> = vec![
+        ebpf::MOV64_REG,  0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r2 = r1
+        ebpf::ADD64_IMM,  0x02, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, // r2 += 8
+        ebpf::LD_DW_REG,  0x23, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r3 = *(u64 *)(r2 + 0)
+        ebpf::LD_DW_REG,  0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r1 = *(u64 *)(r1 + 0)
+        ebpf::LD_B_REG,   0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // r0 = *(u8 *)(r1 + 0)
+        ebpf::EXIT,       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    ];
+
+    let result = unsafe {
+        execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &ctx_ptrs)
+    };
+    assert_eq!(result.unwrap(), 0x42);
 }

--- a/crates/sonde-bpf/tests/tagged_register_tests.rs
+++ b/crates/sonde-bpf/tests/tagged_register_tests.rs
@@ -559,7 +559,17 @@ fn t_bpf_024_map_value_or_null_returns_null() {
         ret: HelperReturn::MapValueOrNull { map_arg: 1 },
     }];
     assert!(matches!(
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) },
+        unsafe {
+            execute_program(
+                &prog,
+                &mut ctx,
+                &helpers,
+                &maps,
+                false,
+                UNLIMITED_BUDGET,
+                &[],
+            )
+        },
         Err(BpfError::NonDereferenceableAccess { .. })
     ));
     drop(map_buf);
@@ -597,8 +607,17 @@ fn t_bpf_025_map_value_or_null_returns_valid() {
         func: helper_func,
         ret: HelperReturn::MapValueOrNull { map_arg: 1 },
     }];
-    let result =
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) };
+    let result = unsafe {
+        execute_program(
+            &prog,
+            &mut ctx,
+            &helpers,
+            &maps,
+            false,
+            UNLIMITED_BUDGET,
+            &[],
+        )
+    };
     assert_eq!(result.unwrap(), 0xBB);
     drop(map_buf);
 }
@@ -635,7 +654,17 @@ fn t_bpf_026_helper_returns_oob_pointer() {
         ret: HelperReturn::MapValueOrNull { map_arg: 1 },
     }];
     assert!(matches!(
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) },
+        unsafe {
+            execute_program(
+                &prog,
+                &mut ctx,
+                &helpers,
+                &maps,
+                false,
+                UNLIMITED_BUDGET,
+                &[],
+            )
+        },
         Err(BpfError::MemoryAccessViolation { .. })
     ));
     drop(map_buf);
@@ -672,7 +701,17 @@ fn t_bpf_027_helper_expects_map_descriptor_gets_scalar() {
         ret: HelperReturn::MapValueOrNull { map_arg: 1 },
     }];
     assert!(matches!(
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) },
+        unsafe {
+            execute_program(
+                &prog,
+                &mut ctx,
+                &helpers,
+                &maps,
+                false,
+                UNLIMITED_BUDGET,
+                &[],
+            )
+        },
         Err(BpfError::InvalidHelperArgument { .. })
     ));
     drop(map_buf);
@@ -699,7 +738,8 @@ fn t_bpf_028_ld_dw_imm_negative_map_index() {
         data_start: map_ptr,
         data_end: map_ptr + 64,
     }];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET, &[]) };
+    let result =
+        unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidMapIndex { index: -1, .. })),
         "expected InvalidMapIndex with index=-1, got {:?}",
@@ -735,7 +775,8 @@ fn t_bpf_029_ld_dw_imm_out_of_bounds_map_index() {
             data_end: map_ptr_1 + 64,
         },
     ];
-    let result = unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET, &[]) };
+    let result =
+        unsafe { execute_program(&prog, &mut ctx, &[], &maps, false, UNLIMITED_BUDGET, &[]) };
     assert!(
         matches!(result, Err(BpfError::InvalidMapIndex { index: 5, .. })),
         "expected InvalidMapIndex with index=5, got {:?}",
@@ -782,8 +823,18 @@ fn t_bpf_030_ld_dw_imm_map_descriptor_happy_path() {
     // verify the MapDescriptor tag on R1. If the tag were missing, the call
     // would fail with InvalidHelperArgument.
     assert_eq!(
-        unsafe { execute_program(&prog, &mut ctx, &helpers, &maps, false, UNLIMITED_BUDGET, &[]) }
-            .unwrap(),
+        unsafe {
+            execute_program(
+                &prog,
+                &mut ctx,
+                &helpers,
+                &maps,
+                false,
+                UNLIMITED_BUDGET,
+                &[],
+            )
+        }
+        .unwrap(),
         1
     );
     drop(map_buf);
@@ -827,9 +878,8 @@ fn ctx_pointer_field_load_and_deref() {
         ebpf::EXIT,      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
     ];
 
-    let result = unsafe {
-        execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &ctx_ptrs)
-    };
+    let result =
+        unsafe { execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &ctx_ptrs) };
     assert_eq!(result.unwrap(), 0xAB);
 }
 
@@ -853,9 +903,7 @@ fn ctx_pointer_field_absent_fails() {
         ebpf::EXIT,      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
     ];
 
-    let result = unsafe {
-        execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &[])
-    };
+    let result = unsafe { execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &[]) };
     assert!(matches!(
         result,
         Err(BpfError::NonDereferenceableAccess { pc: 1 })
@@ -915,9 +963,8 @@ fn ctx_pointer_field_decoder_pattern() {
         ebpf::EXIT,       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
     ];
 
-    let result = unsafe {
-        execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &ctx_ptrs)
-    };
+    let result =
+        unsafe { execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &ctx_ptrs) };
     assert_eq!(result.unwrap(), 0x03);
 }
 
@@ -968,8 +1015,7 @@ fn ctx_pointer_field_adjusted_base() {
         ebpf::EXIT,       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
     ];
 
-    let result = unsafe {
-        execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &ctx_ptrs)
-    };
+    let result =
+        unsafe { execute_program(&prog, &mut ctx, &[], &[], true, UNLIMITED_BUDGET, &ctx_ptrs) };
     assert_eq!(result.unwrap(), 0x42);
 }

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -329,16 +329,13 @@ fn decoder_helpers() -> Vec<HelperDescriptor> {
 /// on the verifier to guarantee that pointer arguments are within valid
 /// memory regions.
 ///
-/// # Context ABI limitation
+/// # Context ABI
 ///
 /// The decoder context provides `{ input_data, input_end }` pointers at
-/// offsets 0 and 8. Currently, `sonde-bpf` does not tag pointers loaded
-/// from context via `LDX` — they are treated as scalars. This means
-/// C-compiled decoders that dereference `ctx->input_data` will fail with
-/// `NonDereferenceableAccess`. Decoders must access the raw blob via the
-/// context pointer (r1) directly using bounded offsets (r1 is already tagged
-/// by the interpreter as a context region). Extending `sonde-bpf` to support
-/// data/data_end context-pointer tagging is tracked as a future enhancement.
+/// offsets 0 and 8.  [`ContextPointerField`](interpreter::ContextPointerField)
+/// descriptors tell the interpreter to tag these loaded values as pointers
+/// into the blob region, enabling C-compiled decoders that use
+/// `ctx->input_data` / `ctx->input_end` to work correctly.
 ///
 /// # Safety
 ///
@@ -460,33 +457,47 @@ pub unsafe fn execute_decoder(
     let blob_end_addr = blob_addr + raw_blob.len() as u64;
     ctx_buf[8..16].copy_from_slice(&blob_end_addr.to_le_bytes());
 
+    // Context pointer fields: tell the interpreter that the u64 values at
+    // offsets 0 and 8 are pointers into the blob region so that BPF
+    // programs can dereference ctx->input_data after loading it.
+    let data_region = interpreter::Region {
+        tag: interpreter::RegionTag::Memory,
+        base: blob_addr,
+        end: blob_end_addr,
+    };
+    let ctx_ptrs = [
+        interpreter::ContextPointerField {
+            offset: 0,
+            region: data_region,
+        },
+        interpreter::ContextPointerField {
+            offset: 8,
+            region: data_region,
+        },
+    ];
+
     // Install thread-local state and execute.
     let guard = DecoderStateGuard::install(map_infos);
     let helpers = decoder_helpers();
 
-    let result = if map_regions.is_empty() {
-        interpreter::execute_program_no_maps(
+    // SAFETY:
+    // - Each MapRegion's data_start..data_end covers valid, live heap
+    //   allocations (the Vec<u8> in map_backing). They do not alias ctx_buf
+    //   or the interpreter's stack. The map_backing Vecs outlive this call.
+    // - Each ContextPointerField region covers blob_addr..blob_end_addr
+    //   which is a sub-range of ctx_buf (offset 16..). ctx_buf is live for
+    //   the duration of this call and does not alias the BPF stack.
+    // - When map_regions is empty the MapRegion invariants are trivially met.
+    let result = unsafe {
+        interpreter::execute_program(
             &image.bytecode,
             &mut ctx_buf,
             &helpers,
+            &map_regions,
             true, // read_only_ctx
             DECODER_INSTRUCTION_BUDGET,
+            &ctx_ptrs,
         )
-    } else {
-        // SAFETY: each MapRegion's data_start..data_end covers valid, live
-        // heap allocations (the Vec<u8> in map_backing). They do not alias
-        // ctx_buf or the interpreter's stack. The map_backing Vecs outlive
-        // the execute_program call.
-        unsafe {
-            interpreter::execute_program(
-                &image.bytecode,
-                &mut ctx_buf,
-                &helpers,
-                &map_regions,
-                true, // read_only_ctx
-                DECODER_INSTRUCTION_BUDGET,
-            )
-        }
     };
 
     match result {

--- a/crates/sonde-gateway/src/decoder.rs
+++ b/crates/sonde-gateway/src/decoder.rs
@@ -461,7 +461,7 @@ pub unsafe fn execute_decoder(
     // offsets 0 and 8 are pointers into the blob region so that BPF
     // programs can dereference ctx->input_data after loading it.
     let data_region = interpreter::Region {
-        tag: interpreter::RegionTag::Memory,
+        tag: interpreter::RegionTag::Context,
         base: blob_addr,
         end: blob_end_addr,
     };

--- a/crates/sonde-node/src/sonde_bpf_adapter.rs
+++ b/crates/sonde-node/src/sonde_bpf_adapter.rs
@@ -146,6 +146,7 @@ impl BpfInterpreter for SondeBpfInterpreter {
                 &self.map_regions,
                 true, // read_only_ctx
                 instruction_budget,
+                &[], // no context pointer fields on node
             )
         };
 


### PR DESCRIPTION
## Problem

BPF programs compiled from C that use the standard `ctx->input_data` / `ctx->input_end` pattern fail at runtime with `NonDereferenceableAccess` even though they pass Prevail verification. This blocks all C-compiled decoder programs.

**Root cause:** The interpreter's `mem_load` returns `TaggedReg::scalar(value)` for all values loaded from memory. When a decoder loads `input_data` (offset 0) and `input_end` (offset 8) from the context struct, the resulting registers are untagged scalars — any subsequent dereference fails.

## Solution

Add `ContextPointerField` — a descriptor that tells the interpreter which u64 fields within the context buffer hold pointers and what memory region they refer to.

During `LD_DW_REG` from a context region, the interpreter computes the effective context offset (`effective_address - ctx_base`) and, if it matches a declared field, tags the loaded value with the described region. This works regardless of whether the source register points at `ctx_base` or has been adjusted via pointer arithmetic.

### Changes

| File | Change |
|------|--------|
| `interpreter.rs` | New `ContextPointerField` type; `execute_program` gains `ctx_ptrs` parameter; `LD_DW_REG` tags loads from matching context offsets |
| `decoder.rs` | Declares fields for `input_data` (offset 0) and `input_end` (offset 8); always uses `execute_program` so `ctx_ptrs` are available in both map and no-map paths |
| `sonde_bpf_adapter.rs` | Passes `&[]` (node does not need context pointer tagging yet) |
| Test files | 4 new tests: basic load+deref, absent-field fails, decoder pattern, adjusted-base-register |

### Safety

- `ContextPointerField.region` carries the same safety requirements as `MapRegion`: the described region must cover a valid, live allocation for the call duration and must not alias the BPF stack. Safety docs updated accordingly.
- Decoder regions point into `ctx_buf[16..]` (the appended blob), which is live and non-aliasing.

## Testing

- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test --workspace` — all pass (4 new tests added)

Closes #928