### PR TITLE
Remove deprecated \ProgramRoute\ table and app-data queue routing

### DIFF
--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -58,7 +58,6 @@ pub struct RuntimeConfig {
     pub storage_account: String,
     pub actual_state_table: String,
     pub desired_state_table: String,
-    pub program_route_table: String,
     pub programs_table: String,
     pub sensor_data_table: String,
 }
@@ -74,7 +73,6 @@ impl RuntimeConfig {
             storage_account: required_env("SONDE_AZURE_HANDLER_STORAGE_ACCOUNT")?,
             actual_state_table: required_env("SONDE_AZURE_HANDLER_ACTUAL_STATE_TABLE")?,
             desired_state_table: required_env("SONDE_AZURE_HANDLER_DESIRED_STATE_TABLE")?,
-            program_route_table: required_env("SONDE_AZURE_HANDLER_PROGRAM_ROUTE_TABLE")?,
             programs_table: required_env("SONDE_AZURE_HANDLER_PROGRAMS_TABLE")?,
             sensor_data_table: required_env("SONDE_AZURE_HANDLER_SENSOR_DATA_TABLE")?,
         })
@@ -124,12 +122,6 @@ pub struct DesiredStateRow {
     pub desired_assigned_program_hash: Option<Vec<u8>>,
     pub desired_schedule_interval_s: Option<u32>,
     pub timestamp_ms: u64,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProgramRouteRow {
-    pub program_hash: Vec<u8>,
-    pub handler_queue: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -199,10 +191,6 @@ pub trait HandlerStore: Send + Sync {
         &self,
         node_id: &str,
     ) -> Result<Option<DesiredStateRow>, HandlerError>;
-    async fn load_program_route(
-        &self,
-        program_hash: &[u8],
-    ) -> Result<Option<ProgramRouteRow>, HandlerError>;
     async fn load_program_image(
         &self,
         program_hash: &[u8],
@@ -250,7 +238,7 @@ where
                 }
                 Ok(())
             }
-            ConnectorMessage::AppData(app_data) => self.handle_app_data(payload, app_data).await,
+            ConnectorMessage::AppData(app_data) => self.handle_app_data(app_data).await,
             ConnectorMessage::Unsupported(msg_type) => {
                 warn!(msg_type, "ignoring unsupported connector message");
                 Ok(())
@@ -353,13 +341,7 @@ where
             .await
     }
 
-    async fn handle_app_data(
-        &self,
-        raw_payload: &[u8],
-        app_data: AppDataMessage,
-    ) -> Result<(), HandlerError> {
-        // AZH-0500: write SensorData row before ProgramRoute routing.
-        // SensorData writes are independent of routing (azure-handler-design §6.1).
+    async fn handle_app_data(&self, app_data: AppDataMessage) -> Result<(), HandlerError> {
         let decoded_readings = readings_to_json(&app_data.readings);
         let sensor_row = SensorDataRow {
             row_key: next_history_row_key(app_data.timestamp_ms)?,
@@ -369,21 +351,7 @@ where
             raw_payload: app_data.payload,
             decoded_readings,
         };
-        self.store.append_sensor_data(&sensor_row).await?;
-
-        let route = self
-            .store
-            .load_program_route(&sensor_row.program_hash)
-            .await?
-            .ok_or_else(|| {
-                HandlerError::Publish(format!(
-                    "no ProgramRoute row exists for program hash `{}`",
-                    hex::encode(&sensor_row.program_hash)
-                ))
-            })?;
-        self.publisher
-            .publish(&route.handler_queue, raw_payload.to_vec())
-            .await
+        self.store.append_sensor_data(&sensor_row).await
     }
 
     /// Handle a ProgramIngest HTTP trigger invocation (WEB-0300).
@@ -674,7 +642,6 @@ pub fn format_ingest_response(status_code: u16, body: &serde_json::Value) -> ser
 pub struct AzureTablesStore {
     actual_state_table: azure_data_tables::clients::TableClient,
     desired_state_table: azure_data_tables::clients::TableClient,
-    program_route_table: azure_data_tables::clients::TableClient,
     programs_table: azure_data_tables::clients::TableClient,
     sensor_data_table: azure_data_tables::clients::TableClient,
 }
@@ -691,7 +658,6 @@ impl AzureTablesStore {
         Ok(Self {
             actual_state_table: service.table_client(config.actual_state_table.clone()),
             desired_state_table: service.table_client(config.desired_state_table.clone()),
-            program_route_table: service.table_client(config.program_route_table.clone()),
             programs_table: service.table_client(config.programs_table.clone()),
             sensor_data_table: service.table_client(config.sensor_data_table.clone()),
         })
@@ -767,24 +733,6 @@ impl HandlerStore for AzureTablesStore {
                 "query latest desired-state row failed: {e}"
             ))),
             None => Ok(None),
-        }
-    }
-
-    async fn load_program_route(
-        &self,
-        program_hash: &[u8],
-    ) -> Result<Option<ProgramRouteRow>, HandlerError> {
-        let row_key = hex::encode(program_hash);
-        let entity_client = self
-            .program_route_table
-            .partition_key_client("program")
-            .entity_client(row_key);
-        match entity_client.get::<ProgramRouteEntity>().await {
-            Ok(response) => Ok(Some(ProgramRouteRow::try_from(response.entity)?)),
-            Err(e) if is_legacy_not_found(&e) => Ok(None),
-            Err(e) => Err(HandlerError::Store(format!(
-                "query program route failed: {e}"
-            ))),
         }
     }
 
@@ -998,15 +946,6 @@ fn deserialize_u64_flexible<'de, D: serde::Deserializer<'de>>(d: D) -> Result<u6
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
-struct ProgramRouteEntity {
-    #[serde(rename = "PartitionKey")]
-    partition_key: String,
-    #[serde(rename = "RowKey")]
-    row_key: String,
-    handler_queue: String,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
 struct ProgramImageEntity {
     #[serde(rename = "PartitionKey")]
     partition_key: String,
@@ -1100,17 +1039,6 @@ impl TryFrom<DesiredStateRow> for DesiredStateEntity {
             desired_assigned_program_hash: encode_optional_hex(value.desired_assigned_program_hash),
             desired_schedule_interval_s: value.desired_schedule_interval_s,
             timestamp_ms: value.timestamp_ms,
-        })
-    }
-}
-
-impl TryFrom<ProgramRouteEntity> for ProgramRouteRow {
-    type Error = HandlerError;
-
-    fn try_from(value: ProgramRouteEntity) -> Result<Self, Self::Error> {
-        Ok(Self {
-            program_hash: decode_hex_program_hash(value.row_key, "ProgramRoute.RowKey")?,
-            handler_queue: value.handler_queue,
         })
     }
 }
@@ -1569,7 +1497,6 @@ mod tests {
     struct MemoryStore {
         actual_rows: Mutex<HashMap<String, Vec<ActualStateRow>>>,
         desired_rows: Mutex<HashMap<String, Vec<DesiredStateRow>>>,
-        routes: Mutex<HashMap<String, ProgramRouteRow>>,
         program_images: Mutex<HashMap<String, ProgramImageRow>>,
         stored_program_rows: Mutex<Vec<ProgramImageRow>>,
         sensor_data_rows: Mutex<Vec<SensorDataRow>>,
@@ -1660,18 +1587,6 @@ mod tests {
                 }))
         }
 
-        async fn load_program_route(
-            &self,
-            program_hash: &[u8],
-        ) -> Result<Option<ProgramRouteRow>, HandlerError> {
-            Ok(self
-                .routes
-                .lock()
-                .await
-                .get(&hex::encode(program_hash))
-                .cloned())
-        }
-
         async fn load_program_image(
             &self,
             program_hash: &[u8],
@@ -1736,7 +1651,6 @@ mod tests {
     struct FailingStore {
         append_actual_error: Option<String>,
         load_desired_error: Option<String>,
-        load_route_error: Option<String>,
         load_program_image_error: Option<String>,
         latest_actual: Mutex<Option<ActualStateRow>>,
     }
@@ -1772,16 +1686,6 @@ mod tests {
                     Some(60),
                     1234,
                 ))),
-            }
-        }
-
-        async fn load_program_route(
-            &self,
-            _program_hash: &[u8],
-        ) -> Result<Option<ProgramRouteRow>, HandlerError> {
-            match &self.load_route_error {
-                Some(error) => Err(HandlerError::Store(error.clone())),
-                None => Ok(None),
             }
         }
 
@@ -1831,13 +1735,6 @@ mod tests {
             Ok(Some(self.desired.clone()))
         }
 
-        async fn load_program_route(
-            &self,
-            _program_hash: &[u8],
-        ) -> Result<Option<ProgramRouteRow>, HandlerError> {
-            Ok(None)
-        }
-
         async fn load_program_image(
             &self,
             _program_hash: &[u8],
@@ -1880,13 +1777,6 @@ mod tests {
             _node_id: &str,
         ) -> Result<Option<DesiredStateRow>, HandlerError> {
             Ok(Some(self.desired.clone()))
-        }
-
-        async fn load_program_route(
-            &self,
-            _program_hash: &[u8],
-        ) -> Result<Option<ProgramRouteRow>, HandlerError> {
-            Ok(None)
         }
 
         async fn load_program_image(
@@ -2324,47 +2214,6 @@ mod tests {
 
         assert!(store.actual_rows.lock().await.is_empty());
         assert!(store.desired_rows.lock().await.is_empty());
-        assert!(store.routes.lock().await.is_empty());
-        assert!(publisher.sends.lock().await.is_empty());
-    }
-
-    #[tokio::test]
-    async fn app_data_routes_to_mapped_queue() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-        store.routes.lock().await.insert(
-            hex::encode([0x44; 32]),
-            ProgramRouteRow {
-                program_hash: vec![0x44; 32],
-                handler_queue: "handler-q".to_string(),
-            },
-        );
-
-        let payload = sample_app_data(&[0x44; 32], &[1, 2, 3]);
-        handler.handle_payload(&payload).await.unwrap();
-
-        let sends = publisher.sends.lock().await;
-        assert_eq!(sends.len(), 1);
-        assert_eq!(sends[0].0, "handler-q");
-        assert_eq!(sends[0].1, payload);
-    }
-
-    #[tokio::test]
-    async fn unmapped_app_data_fails_closed() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        let err = handler
-            .handle_payload(&sample_app_data(&[0x11; 32], &[9, 8, 7]))
-            .await
-            .unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("no ProgramRoute row exists for program hash"));
         assert!(publisher.sends.lock().await.is_empty());
     }
 
@@ -2571,7 +2420,6 @@ mod tests {
         let store = Arc::new(FailingStore {
             append_actual_error: Some("append failed".to_string()),
             load_desired_error: None,
-            load_route_error: None,
             load_program_image_error: None,
             latest_actual: Mutex::new(None),
         });
@@ -2597,7 +2445,6 @@ mod tests {
         let store = Arc::new(FailingStore {
             append_actual_error: None,
             load_desired_error: Some("desired read failed".to_string()),
-            load_route_error: None,
             load_program_image_error: None,
             latest_actual: Mutex::new(None),
         });
@@ -2619,32 +2466,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn program_route_read_failures_are_surfaced() {
-        let store = Arc::new(FailingStore {
-            append_actual_error: None,
-            load_desired_error: None,
-            load_route_error: Some("route read failed".to_string()),
-            load_program_image_error: None,
-            latest_actual: Mutex::new(None),
-        });
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler =
-            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
-
-        let err = handler
-            .handle_payload(&sample_app_data(&[0x44; 32], &[1, 2, 3]))
-            .await
-            .unwrap_err();
-
-        assert!(err.to_string().contains("route read failed"));
-    }
-
-    #[tokio::test]
     async fn program_image_read_failures_are_surfaced() {
         let store = Arc::new(FailingStore {
             append_actual_error: None,
             load_desired_error: None,
-            load_route_error: None,
             load_program_image_error: Some("program image read failed".to_string()),
             latest_actual: Mutex::new(None),
         });
@@ -3102,12 +2927,6 @@ mod tests {
             ) -> Result<Option<DesiredStateRow>, HandlerError> {
                 Ok(None)
             }
-            async fn load_program_route(
-                &self,
-                _: &[u8],
-            ) -> Result<Option<ProgramRouteRow>, HandlerError> {
-                Ok(None)
-            }
             async fn load_program_image(
                 &self,
                 _: &[u8],
@@ -3247,13 +3066,6 @@ mod tests {
 
         let program_hash = [0x42u8; 32];
         let payload = b"sensor-blob";
-        store.routes.lock().await.insert(
-            hex::encode(program_hash),
-            ProgramRouteRow {
-                program_hash: program_hash.to_vec(),
-                handler_queue: "handler-q".to_string(),
-            },
-        );
 
         let msg = sample_app_data(&program_hash, payload);
         handler.handle_payload(&msg).await.unwrap();
@@ -3277,13 +3089,6 @@ mod tests {
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
 
         let program_hash = [0x42u8; 32];
-        store.routes.lock().await.insert(
-            hex::encode(program_hash),
-            ProgramRouteRow {
-                program_hash: program_hash.to_vec(),
-                handler_queue: "handler-q".to_string(),
-            },
-        );
 
         let msg = sample_app_data(&program_hash, b"blob-1");
         handler.handle_payload(&msg).await.unwrap();
@@ -3306,13 +3111,6 @@ mod tests {
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
 
         let program_hash = [0x42u8; 32];
-        store.routes.lock().await.insert(
-            hex::encode(program_hash),
-            ProgramRouteRow {
-                program_hash: program_hash.to_vec(),
-                handler_queue: "handler-q".to_string(),
-            },
-        );
 
         let msg = sample_app_data_with_readings(
             &program_hash,
@@ -3338,13 +3136,6 @@ mod tests {
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
 
         let program_hash = [0x42u8; 32];
-        store.routes.lock().await.insert(
-            hex::encode(program_hash),
-            ProgramRouteRow {
-                program_hash: program_hash.to_vec(),
-                handler_queue: "handler-q".to_string(),
-            },
-        );
 
         let msg = sample_app_data(&program_hash, b"no-decoder");
         handler.handle_payload(&msg).await.unwrap();
@@ -3365,13 +3156,6 @@ mod tests {
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
 
         let program_hash = [0x42u8; 32];
-        store.routes.lock().await.insert(
-            hex::encode(program_hash),
-            ProgramRouteRow {
-                program_hash: program_hash.to_vec(),
-                handler_queue: "handler-q".to_string(),
-            },
-        );
 
         // 9007199254740993 = MAX_SAFE_INTEGER + 2 (exceeds threshold)
         let above_safe = 9_007_199_254_740_993i64;
@@ -3404,13 +3188,6 @@ mod tests {
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
 
         let program_hash = [0x42u8; 32];
-        store.routes.lock().await.insert(
-            hex::encode(program_hash),
-            ProgramRouteRow {
-                program_hash: program_hash.to_vec(),
-                handler_queue: "handler-q".to_string(),
-            },
-        );
 
         let below_safe = -9_007_199_254_740_993i64;
         let msg = sample_app_data_with_readings(&program_hash, b"raw", &[("neg_big", below_safe)]);
@@ -3424,26 +3201,22 @@ mod tests {
         );
     }
 
-    /// SensorData write happens even when ProgramRoute is missing.
-    /// Per azure-handler-design §6.1, SensorData writes are independent of
-    /// ProgramRoute routing.
+    /// APP_DATA messages write SensorData rows and succeed.
     #[tokio::test]
-    async fn sensor_data_written_even_when_program_route_missing() {
+    async fn app_data_writes_sensor_data_and_succeeds() {
         let store = Arc::new(MemoryStore::default());
         let publisher = Arc::new(RecordingPublisher::default());
         let handler =
             AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
 
         let program_hash = [0x42u8; 32];
-        // No route configured for this program_hash.
         let msg = sample_app_data(&program_hash, b"orphan-data");
-        let result = handler.handle_payload(&msg).await;
+        handler.handle_payload(&msg).await.unwrap();
 
-        // Should fail because no route, but SensorData row should exist.
-        assert!(result.is_err());
         let rows = store.sensor_data_rows.lock().await;
-        assert_eq!(rows.len(), 1, "SensorData row written before route lookup");
+        assert_eq!(rows.len(), 1, "SensorData row written");
         assert_eq!(rows[0].node_id, "node-1");
+        assert!(publisher.sends.lock().await.is_empty());
     }
 
     #[test]

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -12,10 +12,9 @@ Azure companion architecture.
   - Two Storage Queues:
     - `connector-upstream`
     - `desired-state`
-  - Three Azure Table resources for the Azure handler:
+  - Two Azure Table resources for the Azure handler:
     - `actualstate`
     - `desiredstate`
-    - `programroute`
 - An Azure handler Function App on a Classic Consumption plan (`Y1` / `Dynamic`)
 - A system-assigned managed identity on the Function App with:
   - Storage Queue Data Contributor permissions on the Storage Account
@@ -40,7 +39,6 @@ Azure companion architecture.
 | `storageAccountName` | derived | Optional Storage Account override |
 | `actualStateTableName` | `actualstate` | Azure handler actual-state table |
 | `desiredStateTableName` | `desiredstate` | Azure handler desired-state table |
-| `programRouteTableName` | `programroute` | Azure handler program-route table |
 | `functionAppName` | derived | Optional Function App override |
 | `functionPlanName` | derived | Optional Function hosting plan override |
 

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -36,9 +36,6 @@ param actualStateTableName string = ''
 @description('Table name for Azure handler desired-state rows.')
 param desiredStateTableName string = ''
 
-@description('Table name for Azure handler program-route rows.')
-param programRouteTableName string = 'programroute'
-
 @description('Table name for program storage.')
 param programsTableName string = ''
 
@@ -69,9 +66,6 @@ var effectiveActualStateTableName = empty(actualStateTableName)
 var effectiveDesiredStateTableName = empty(desiredStateTableName)
   ? 'desiredstate'
   : desiredStateTableName
-var effectiveProgramRouteTableName = empty(programRouteTableName)
-  ? 'programroute'
-  : programRouteTableName
 var effectiveProgramsTableName = empty(programsTableName) ? 'programs' : programsTableName
 var effectiveSensorDataTableName = empty(sensorDataTableName) ? 'sensordata' : sensorDataTableName
 // Keep the historical `-decoder-` stem as the derived default to avoid replacing
@@ -122,7 +116,6 @@ module stack './modules/stack.bicep' = {
     downstreamQueueName: downstreamQueueName
     actualStateTableName: effectiveActualStateTableName
     desiredStateTableName: effectiveDesiredStateTableName
-    programRouteTableName: effectiveProgramRouteTableName
     programsTableName: effectiveProgramsTableName
     sensorDataTableName: effectiveSensorDataTableName
     functionAppName: effectiveFunctionAppName
@@ -145,7 +138,6 @@ output actualStateTableName string = stack.outputs.actualStateTableName
 output desiredStateTableName string = stack.outputs.desiredStateTableName
 output deploymentContainerName string = stack.outputs.deploymentContainerName
 output deploymentContainerUrl string = stack.outputs.deploymentContainerUrl
-output programRouteTableName string = stack.outputs.programRouteTableName
 output programsTableName string = stack.outputs.programsTableName
 output sensorDataTableName string = stack.outputs.sensorDataTableName
 output functionAppName string = stack.outputs.functionAppName
@@ -167,7 +159,6 @@ output companionBootstrapValues object = {
   deploymentContainerUrl: stack.outputs.deploymentContainerUrl
   actualStateTable: stack.outputs.actualStateTableName
   desiredStateTable: stack.outputs.desiredStateTableName
-  programRouteTable: stack.outputs.programRouteTableName
   staticWebAppHostname: stack.outputs.staticWebAppHostname
   note: 'The deployment registers the supplied certificate public material on the Entra app. The matching PEM certificate and private key remain caller-managed local artifacts for sonde-azure-companion bootstrap.'
 }

--- a/deploy/bicep/modules/function-placeholder.bicep
+++ b/deploy/bicep/modules/function-placeholder.bicep
@@ -30,9 +30,6 @@ param actualStateTableName string
 @description('Azure handler desired-state table name.')
 param desiredStateTableName string
 
-@description('Azure handler program-route table name.')
-param programRouteTableName string
-
 @description('Program storage table name.')
 param programsTableName string
 
@@ -116,10 +113,6 @@ var baseAppSettings = [
         {
           name: 'SONDE_AZURE_HANDLER_DESIRED_STATE_TABLE'
           value: desiredStateTableName
-        }
-        {
-          name: 'SONDE_AZURE_HANDLER_PROGRAM_ROUTE_TABLE'
-          value: programRouteTableName
         }
         {
           name: 'SONDE_AZURE_HANDLER_PROGRAMS_TABLE'

--- a/deploy/bicep/modules/function-rbac.bicep
+++ b/deploy/bicep/modules/function-rbac.bicep
@@ -15,9 +15,6 @@ param actualStateTableName string
 @description('Azure handler desired-state table name.')
 param desiredStateTableName string
 
-@description('Azure handler program-route table name.')
-param programRouteTableName string
-
 @description('Program storage table name.')
 param programsTableName string
 
@@ -44,11 +41,6 @@ resource existingActualStateTable 'Microsoft.Storage/storageAccounts/tableServic
 resource existingDesiredStateTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' existing = {
   parent: existingTableService
   name: desiredStateTableName
-}
-
-resource existingProgramRouteTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' existing = {
-  parent: existingTableService
-  name: programRouteTableName
 }
 
 resource existingProgramsTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' existing = {
@@ -84,16 +76,6 @@ resource functionActualStateTableContributor 'Microsoft.Authorization/roleAssign
 resource functionDesiredStateTableContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid('function-desired-state-table-contributor', functionPrincipalId, storageTableDataContributorRoleId, existingDesiredStateTable.id)
   scope: existingDesiredStateTable
-  properties: {
-    principalId: functionPrincipalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: storageTableDataContributorRoleId
-  }
-}
-
-resource functionProgramRouteTableContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid('function-program-route-table-contributor', functionPrincipalId, storageTableDataContributorRoleId, existingProgramRouteTable.id)
-  scope: existingProgramRouteTable
   properties: {
     principalId: functionPrincipalId
     principalType: 'ServicePrincipal'

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -24,9 +24,6 @@ param actualStateTableName string
 @description('Azure handler desired-state table name.')
 param desiredStateTableName string
 
-@description('Azure handler program-route table name.')
-param programRouteTableName string
-
 @description('Program storage table name.')
 param programsTableName string
 
@@ -68,7 +65,6 @@ module storage './storage.bicep' = {
     storageAccountName: storageAccountName
     actualStateTableName: actualStateTableName
     desiredStateTableName: desiredStateTableName
-    programRouteTableName: programRouteTableName
     programsTableName: programsTableName
     sensorDataTableName: sensorDataTableName
     upstreamQueueName: upstreamQueueName
@@ -109,7 +105,6 @@ module functionPlaceholder './function-placeholder.bicep' = {
     downstreamQueueName: downstreamQueueName
     actualStateTableName: storage.outputs.actualStateTableName
     desiredStateTableName: storage.outputs.desiredStateTableName
-    programRouteTableName: storage.outputs.programRouteTableName
     programsTableName: storage.outputs.programsTableName
     sensorDataTableName: storage.outputs.sensorDataTableName
     appInsightsConnectionString: monitoring.outputs.connectionString
@@ -144,7 +139,6 @@ module functionRbac './function-rbac.bicep' = {
     storageAccountName: storageAccountName
     actualStateTableName: storage.outputs.actualStateTableName
     desiredStateTableName: storage.outputs.desiredStateTableName
-    programRouteTableName: storage.outputs.programRouteTableName
     programsTableName: storage.outputs.programsTableName
     sensorDataTableName: storage.outputs.sensorDataTableName
   }
@@ -159,7 +153,6 @@ output deploymentContainerName string = storage.outputs.deploymentContainerName
 output deploymentContainerUrl string = '${storage.outputs.blobEndpoint}${storage.outputs.deploymentContainerName}'
 output actualStateTableName string = storage.outputs.actualStateTableName
 output desiredStateTableName string = storage.outputs.desiredStateTableName
-output programRouteTableName string = storage.outputs.programRouteTableName
 output programsTableName string = storage.outputs.programsTableName
 output sensorDataTableName string = storage.outputs.sensorDataTableName
 output functionAppName string = functionPlaceholder.outputs.functionAppName

--- a/deploy/bicep/modules/storage.bicep
+++ b/deploy/bicep/modules/storage.bicep
@@ -15,9 +15,6 @@ param actualStateTableName string
 @description('Table name for Azure handler desired-state rows.')
 param desiredStateTableName string
 
-@description('Table name for Azure handler program-route rows.')
-param programRouteTableName string
-
 @description('Table name for program storage.')
 param programsTableName string
 
@@ -114,14 +111,6 @@ resource desiredStateTable 'Microsoft.Storage/storageAccounts/tableServices/tabl
   }
 }
 
-resource programRouteTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
-  parent: tableService
-  name: programRouteTableName
-  properties: {
-    signedIdentifiers: []
-  }
-}
-
 resource programsTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
   parent: tableService
   name: programsTableName
@@ -147,8 +136,6 @@ output actualStateTableName string = actualStateTable.name
 output actualStateTableResourceId string = actualStateTable.id
 output desiredStateTableName string = desiredStateTable.name
 output desiredStateTableResourceId string = desiredStateTable.id
-output programRouteTableName string = programRouteTable.name
-output programRouteTableResourceId string = programRouteTable.id
 output programsTableName string = programsTable.name
 output programsTableResourceId string = programsTable.id
 output sensorDataTableName string = sensorDataTable.name

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -10,7 +10,6 @@ const CONFIG = {
   actualStateTable: 'actualstate',
   desiredStateTable: 'desiredstate',
   programsTable: 'programs',
-  programRouteTable: 'programroute',
   refreshIntervalMs: 30000,
 };
 
@@ -37,7 +36,7 @@ const STORAGE_SCOPES = ['https://storage.azure.com/.default'];
 function functionScopes() {
   return [`api://${CONFIG.msalClientId}/user_impersonation`];
 }
-const TAB_IDS = ['dashboard', 'desired-state', 'programs', 'routes'];
+const TAB_IDS = ['dashboard', 'desired-state', 'programs'];
 const APP = {
   msalApp: null,
   account: null,
@@ -854,113 +853,6 @@ async function renderPrograms() {
   }
 }
 
-// 7. Routes Tab
-function routeRowsTable(routes) {
-  return `
-    <div class="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>Program Hash</th>
-            <th>Handler Queue</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${routes.map((route) => `
-            <tr>
-              <td>${formatHashCell(route.RowKey)}</td>
-              <td>${escapeHtml(route.handler_queue || '—')}</td>
-            </tr>
-          `).join('') || '<tr><td colspan="2" class="muted">No routes found.</td></tr>'}
-        </tbody>
-      </table>
-    </div>
-  `;
-}
-
-async function renderRoutes() {
-  if (!APP.account) {
-    requireAuthenticatedView('Routes');
-    return;
-  }
-
-  const savedMessage = APP.viewMessage;
-  renderCard('Routes', '<p class="muted">Loading routes…</p>');
-  APP.viewMessage = savedMessage;
-
-  try {
-    const [programs, routes] = await Promise.all([
-      listPrograms(),
-      queryTable(CONFIG.programRouteTable, "PartitionKey eq 'program'"),
-    ]);
-
-    const routeMap = new Map(routes.map((route) => [String(route.RowKey || '').toLowerCase(), route]));
-    const programOptions = programs.map((program) => `<option value="${escapeHtml(program.RowKey)}">${escapeHtml(truncHash(program.RowKey))} — ${escapeHtml(program.source_filename || 'unnamed')}</option>`).join('');
-
-    renderCard('Routes', `
-      <div class="panel stack">
-        <form id="route-form" class="form-grid">
-          <label>Program Hash
-            <select name="programHash" required>${programOptions}</select>
-          </label>
-          <label>Handler Queue
-            <input name="handlerQueue" type="text" required>
-          </label>
-          <div>
-            <button type="submit" class="primary">Save Route</button>
-          </div>
-        </form>
-      </div>
-      <div class="panel stack">
-        <h2>Program Routes</h2>
-        ${routeRowsTable(routes)}
-      </div>
-    `);
-
-    const form = document.getElementById('route-form');
-    const programSelect = form?.querySelector('select[name="programHash"]');
-    const queueInput = form?.querySelector('input[name="handlerQueue"]');
-
-    const syncQueue = () => {
-      const selected = String(programSelect?.value || '').toLowerCase();
-      const route = routeMap.get(selected);
-      if (queueInput) {
-        queueInput.value = route?.handler_queue || '';
-      }
-    };
-
-    programSelect?.addEventListener('change', syncQueue);
-    syncQueue();
-
-    form?.addEventListener('submit', async (event) => {
-      event.preventDefault();
-      const selectedHash = String(programSelect?.value || '').trim().toLowerCase();
-      const handlerQueue = String(queueInput?.value || '').trim();
-      if (!selectedHash || !handlerQueue) {
-        showViewMessage('error', 'Program hash and handler queue are required.');
-        await renderRoutes();
-        return;
-      }
-
-      try {
-        const entity = {
-          PartitionKey: 'program',
-          RowKey: selectedHash,
-          handler_queue: handlerQueue,
-        };
-        await upsertEntity(CONFIG.programRouteTable, 'program', selectedHash, entity);
-        showViewMessage('success', 'Program route saved.');
-      } catch (error) {
-        showViewMessage('error', parseErrorPayload(error, 'Failed to save program route.'));
-      }
-
-      await renderRoutes();
-    });
-  } catch (error) {
-    renderError('Routes', error);
-  }
-}
-
 // 9. Tab Router
 function setActiveTab(tabId) {
   APP.activeTab = TAB_IDS.includes(tabId) ? tabId : 'dashboard';
@@ -980,9 +872,6 @@ async function renderActiveTab() {
       break;
     case 'programs':
       await renderPrograms();
-      break;
-    case 'routes':
-      await renderRoutes();
       break;
     case 'dashboard':
     default:

--- a/deploy/web-ui/index.html
+++ b/deploy/web-ui/index.html
@@ -21,7 +21,6 @@
       <button type="button" class="tab-button" data-tab="dashboard">Dashboard</button>
       <button type="button" class="tab-button" data-tab="desired-state">Desired State</button>
       <button type="button" class="tab-button" data-tab="programs">Programs</button>
-      <button type="button" class="tab-button" data-tab="routes">Routes</button>
     </nav>
 
     <main id="content" class="content" tabindex="-1"></main>

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -6,7 +6,7 @@
 > **Scope:** Internal design for the Azure cloud-side handler hosted in the
 > Azure Function App. Covers upstream connector message intake, Azure Table
 > schemas, node-state reconciliation, downstream `GW-0811` publication, and
-> `GW-0813` queue routing.
+> `GW-0813` sensor data storage.
 > **Audience:** Implementers building the Azure Function App and reviewers
 > auditing traceability to the gateway connector contract.
 > **Related:** [azure-handler-requirements.md](azure-handler-requirements.md),
@@ -27,7 +27,7 @@ Azure handler owns the first Sonde-aware cloud logic:
 2. append node-scoped `GW-0812` actual-state messages to actual-state history,
 3. compare the latest eligible actual-state row against the latest desired-state
    row and publish a complete node-scoped `GW-0811` when they diverge, and
-4. route `GW-0813` application-data messages to handler queues by `program_hash`.
+4. store `GW-0813` application-data messages in the `SensorData` table.
 
 The handler does not replace the gateway's reconciler model. It expresses cloud
 intent only by publishing `GW-0811` desired-state messages.
@@ -42,14 +42,12 @@ The Azure handler runs inside the Azure Function App provisioned by the Bicep
 stack. The Function App uses a system-assigned managed identity with:
 
 1. receive permission on the upstream queue,
-2. send permission on the downstream queue,
+2. send permission on the downstream queue, and
 3. append permission on `ActualNodeState`, read permission on
-   `DesiredNodeState`, and read permission on `ProgramRoute`, and
-4. send permission on each pre-provisioned handler queue referenced by the
-   program route table.
+   `DesiredNodeState`, and read/write permission on `SensorData`.
 
-The final permission is an external dependency when a mapped handler queue is
-not provisioned by the Sonde Bicep stack.
+The final permission set covers the handler's own tables. No external handler
+queue permissions are required.
 
 ### 2.1  Trigger model
 
@@ -60,7 +58,7 @@ queue and performs the following dispatch:
 1. decode the top-level connector `msg_type`,
 2. if `msg_type = ACTUAL_STATE` and `entity_kind = "node"`, invoke node-state
    reconciliation,
-3. if `msg_type = APP_DATA`, invoke program-route delivery, and
+3. if `msg_type = APP_DATA`, invoke sensor data storage, and
 4. otherwise log the unsupported or out-of-scope message and complete without
    mutating handler-owned tables.
 
@@ -95,11 +93,9 @@ this document and are therefore logged and ignored by the reconciliation path.
 
 For `APP_DATA`, the handler decodes:
 
-1. `program_hash` for route lookup,
-2. `node_id`, `timestamp_ms`, raw `blob`, and optional `readings` (key 16)
+1. `node_id`, `timestamp_ms`, raw `blob`, and optional `readings` (key 16)
    for `SensorData` table storage (§6.1), and
-3. the raw connector payload bytes for transparent delivery to the handler
-   queue.
+2. `program_hash` for the `SensorData` row's `program_hash` column.
 
 Fields beyond `program_hash` were previously opaque to the handler; the
 `SensorData` feature (AZH-0500) extends the handler's parsing scope.
@@ -108,13 +104,12 @@ Fields beyond `program_hash` were previously opaque to the handler; the
 
 ## 4  Azure Table schemas
 
-> **Requirements:** AZH-0200, AZH-0205, AZH-0206, AZH-0300
+> **Requirements:** AZH-0200, AZH-0205, AZH-0206
 
-The design uses three Azure Tables:
+The design uses two Azure Tables:
 
 1. **`ActualNodeState`** — append-only actual-state history keyed for latest-per-node queries.
 2. **`DesiredNodeState`** — append-only desired-state history keyed for latest-per-node queries.
-3. **`ProgramRoute`** — `program_hash` to handler queue mapping.
 
 ### 4.1  `ActualNodeState` schema
 
@@ -163,22 +158,6 @@ The row contains:
 
 The Azure handler reads this table but does not write it. Admin/control-plane
 surfaces append desired-state rows when requested state changes.
-
-### 4.3  `ProgramRoute` schema
-
-Each row uses:
-
-- `PartitionKey = "program"`
-- `RowKey = <lowercase hex-encoded program_hash>`
-
-The row contains:
-
-| Column | Purpose |
-|--------|---------|
-| `handler_queue` | Storage Queue name for `GW-0813` delivery. |
-
-The table stores only queue references. It does not own queue creation or queue
-policy lifecycle.
 
 ---
 
@@ -240,9 +219,9 @@ never seeds or updates desired-state rows while processing `GW-0812`.
 
 ---
 
-## 6  `GW-0813` routing algorithm
+## 6  `GW-0813` sensor data storage
 
-> **Requirements:** AZH-0300, AZH-0301, AZH-0302, AZH-0303
+> **Requirements:** AZH-0500, AZH-0501
 
 For each `GW-0813` invocation:
 
@@ -255,20 +234,12 @@ For each `GW-0813` invocation:
    retry with the same message produces the same `RowKey` and overwrites
    the existing row rather than appending a duplicate. Do NOT use a hash
    of the raw payload alone, as distinct messages with identical payloads
-   would collide,
-3. look up the `ProgramRoute` row for that hash,
-4. if the row exists, send the original raw connector payload bytes unchanged to
-   the queue named by `handler_queue`, and
-5. if the row is missing, log the missing mapping and fail the invocation so the
-   upstream message is not reported as successfully handled.
-
-The design does not route unmapped application-data messages to a default queue.
-It also does not attempt to create the mapped queue if it does not already
-exist.
+   would collide, and
+3. complete the invocation successfully.
 
 ### 6.1  SensorData table storage (AZH-0500)
 
-In addition to routing `GW-0813` to the handler queue, the Azure handler MUST
+In addition to node-state reconciliation, the Azure handler MUST
 append a row to the `SensorData` table for every `GW-0813` message. This
 provides a queryable time-series store of sensor readings for the SPA.
 
@@ -295,23 +266,22 @@ The `PartitionKey` and `RowKey` follow the same patterns as `ActualNodeState`
 (§4.1) — hashed partition key for safe table keys, reverse-tick plus uniqueness
 suffix for chronological ordering and append uniqueness.
 
-`SensorData` writes are independent of `ProgramRoute` routing — the table is
-populated even if no handler queue is configured for the program hash.
+`SensorData` writes complete the `GW-0813` handling path — no further routing
+or delivery is performed.
 
 ---
 
 ## 7  Failure handling
 
-> **Requirements:** AZH-0302, AZH-0400
+> **Requirements:** AZH-0400
 
 The handler follows a fail-closed rule for all Azure Table and Storage Queue
 operations that determine externally visible control-plane behavior:
 
 1. Table read/write failure aborts the invocation.
 2. Downstream `GW-0811` publish failure aborts the invocation.
-3. Handler-queue publish failure aborts the invocation.
-4. Missing `ProgramRoute` rows are treated as failures, not soft drops.
+3. `SensorData` table append failure aborts the invocation.
 
 This failure model preserves at-least-once retry behavior from the Azure
 Function runtime instead of silently pretending that state was reconciled or
-application data was delivered.
+sensor data was stored.

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -9,9 +9,9 @@
 > Azure Function App provisioned for the Sonde Azure integration. It owns the
 > Azure Table state used for node reconciliation, consumes upstream connector
 > traffic from Storage Queue, emits downstream `GW-0811` desired-state messages,
-> and routes `GW-0813` application-data messages to handler queues. It does not
-> cover the gateway-local Azure companion bridge or Azure resource provisioning
-> beyond the handler's runtime dependencies.
+> and stores `GW-0813` application-data messages in the `SensorData` table. It
+> does not cover the gateway-local Azure companion bridge or Azure resource
+> provisioning beyond the handler's runtime dependencies.
 > **Related:** [gateway-companion-api.md](gateway-companion-api.md),
 > [gateway-requirements.md](gateway-requirements.md),
 > [azure-handler-design.md](azure-handler-design.md),
@@ -24,10 +24,10 @@
 
 | Term | Definition |
 |------|------------|
-| **Azure handler** | The Azure-hosted control-plane process that consumes upstream Sonde connector traffic from Storage Queue and produces downstream desired-state messages or handler-queue deliveries. |
+| **Azure handler** | The Azure-hosted control-plane process that consumes upstream Sonde connector traffic from Storage Queue, produces downstream desired-state messages, and stores application-data messages in the `SensorData` table. |
 | **Actual state row** | One append-only Azure Table row that records a received node-scoped `GW-0812` observation for a Sonde `node_id`. |
 | **Desired state row** | One append-only Azure Table row that records a requested desired state for a Sonde `node_id`. Desired rows are authored by admin/control-plane surfaces, not by the Azure handler reconciliation path. |
-| **Program route row** | One Azure Table row keyed by `program_hash` that names the Storage Queue that should receive `GW-0813` application-data messages for that program. |
+| ~~**Program route row**~~ | _Retired._ Previously mapped `program_hash` to a handler queue for `GW-0813` delivery. Superseded by direct `SensorData` table storage (AZH-0500). |
 | **Observed fields** | The subset of node state reported by `GW-0812` and copied into an actual state row, including current program state, observed schedule as reported by the gateway, firmware data, battery, and check-in time. |
 | **Desired fields** | The cloud-authored fields stored in a desired state row and used to build a complete `GW-0811` `DESIRED_STATE` payload for the node. In v1 this document defines `assigned_program_hash` and `schedule_interval_s`. |
 | **Reverse-tick key** | A row-key prefix derived from `u64::MAX - timestamp_ms`, so newer timestamps sort before older timestamps for `Top(1)` queries within one node partition. |
@@ -65,8 +65,8 @@ logic.
 
 1. The Azure handler accepts raw connector payload bytes from the configured upstream queue.
 2. A node-scoped `GW-0812` message is routed to node-state reconciliation logic.
-3. A `GW-0813` message is routed to application-data delivery logic.
-4. Unsupported or out-of-scope connector messages do not mutate actual-state, desired-state, or program-route tables.
+3. A `GW-0813` message is routed to `SensorData` table storage logic.
+4. Unsupported or out-of-scope connector messages do not mutate actual-state, desired-state, or sensor-data tables.
 
 ---
 
@@ -267,78 +267,13 @@ evaluation or downstream `GW-0811` publication.
 
 ---
 
-## 5  Program-hash routing for `GW-0813`
+## 5  ~~Program-hash routing for `GW-0813`~~ (Retired)
 
-### AZH-0300  Program route mapping table
-
-**Priority:** Must
-**Source:** Azure handler discovery review, GW-0813
-
-**Description:**
-The Azure handler MUST own an Azure Table that stores one program route row per
-`program_hash`. Each row maps the Sonde program hash to the Azure Storage Queue
-queue that should receive `GW-0813` messages for that program.
-
-**Acceptance criteria:**
-
-1. The table stores one route row per `program_hash`.
-2. Each route row identifies the handler queue name for that program.
-3. The Azure handler can look up a route row using the `program_hash` carried by `GW-0813`.
-
----
-
-### AZH-0301  Queue delivery of `GW-0813` messages
-
-**Priority:** Must
-**Source:** Azure handler discovery review, GW-0813
-
-**Description:**
-When the Azure handler receives a `GW-0813` message whose `program_hash` has a
-program route row, it MUST deliver that message to the mapped Azure Storage Queue
-queue. The delivered message body MUST preserve the raw `GW-0813` connector
-payload bytes unchanged.
-
-**Acceptance criteria:**
-
-1. A mapped `GW-0813` is forwarded to the queue named by the corresponding route row.
-2. The queue message body contains the raw `GW-0813` connector payload bytes unchanged.
-3. The Azure handler uses the `program_hash` from the message rather than a node-local default route.
-
----
-
-### AZH-0302  Missing program route rows fail closed
-
-**Priority:** Must
-**Source:** Azure handler discovery review
-
-**Description:**
-If a `GW-0813` message arrives for a `program_hash` that has no program route
-row, the Azure handler MUST log the condition and fail closed. It MUST NOT drop
-the message silently and MUST NOT reroute the message to a default queue.
-
-**Acceptance criteria:**
-
-1. Missing route rows are surfaced through logging, function failure, or both.
-2. The Azure handler does not route an unmapped `GW-0813` message to a shared default queue.
-3. The Azure handler does not report success for an unmapped `GW-0813` message.
-
----
-
-### AZH-0303  Pre-provisioned handler queue boundary
-
-**Priority:** Must
-**Source:** Azure handler discovery review
-
-**Description:**
-The Azure handler MUST treat mapped handler queues as pre-provisioned external
-dependencies. The program route table references those queues, but this
-document's scope does not include queue creation or lifecycle management.
-
-**Acceptance criteria:**
-
-1. The program route table stores queue names rather than queue-creation directives.
-2. The handler design and deployment docs identify mapped handler queues as pre-provisioned dependencies.
-3. Queue provisioning failure is not hidden by silently creating a replacement queue.
+> **Status:** Retired. Program-route-based queue delivery of `GW-0813` messages
+> has been superseded by direct `SensorData` table storage (AZH-0500). The
+> `ProgramRoute` table, handler queue delivery, and related fail-closed
+> semantics are no longer part of the handler. Requirements AZH-0300 through
+> AZH-0303 are retired.
 
 ---
 
@@ -351,18 +286,17 @@ document's scope does not include queue creation or lifecycle management.
 
 **Description:**
 If the Azure handler cannot append to the actual-state table, cannot read the
-desired-state table, cannot read the program route table, cannot publish
-`GW-0811`, or cannot publish a mapped `GW-0813`, it MUST surface the failure
-and fail closed for the affected message.
+desired-state table, cannot publish `GW-0811`, or cannot append to the
+`SensorData` table, it MUST surface the failure and fail closed for the affected
+message.
 
 **Acceptance criteria:**
 
 1. Actual-state table append failures are surfaced through logging, function failure, or both.
 2. Desired-state table read failures are surfaced through logging, function failure, or both.
-3. Program route table read failures are surfaced through logging, function failure, or both.
-4. Downstream `GW-0811` publish failures are surfaced through logging, function failure, or both.
-5. Mapped handler-queue publish failures are surfaced through logging, function failure, or both.
-6. The Azure handler does not silently claim success after a detected storage or broker failure.
+3. Downstream `GW-0811` publish failures are surfaced through logging, function failure, or both.
+4. `SensorData` table append failures are surfaced through logging, function failure, or both.
+5. The Azure handler does not silently claim success after a detected storage or broker failure.
 
 ---
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -4,7 +4,7 @@
 
 > **Document status:** Draft
 > **Scope:** Validation for the Azure Function App that owns Sonde cloud-side
-> node reconciliation and `GW-0813` routing.
+> node reconciliation and `GW-0813` sensor data storage.
 > **Audience:** Implementers and reviewers validating the Azure handler against
 > the connector contract.
 > **Related:** [azure-handler-requirements.md](azure-handler-requirements.md),
@@ -24,8 +24,8 @@
 1. Start the Azure handler against test doubles for Azure Tables and Storage Queue senders.
 2. Deliver one node-scoped `GW-0812`, one `GW-0813`, and one unsupported connector payload through the upstream trigger path.
 3. Assert: the `GW-0812` is routed to node-state reconciliation.
-4. Assert: the `GW-0813` is routed to application-data delivery.
-5. Assert: the unsupported message does not mutate the actual-state, desired-state, or program-route tables.
+4. Assert: the `GW-0813` is routed to sensor data storage.
+5. Assert: the unsupported message does not mutate the actual-state, desired-state, or sensor-data tables.
 
 ---
 
@@ -211,52 +211,11 @@ published when both desired fields diverge simultaneously.
 
 ---
 
-### T-AZH-0300  ProgramRoute rows map `program_hash` to handler queue name
+### ~~T-AZH-0300 through T-AZH-0303~~ (Retired)
 
-**Validates:** AZH-0300
-
-**Procedure:**
-1. Seed a `ProgramRoute` row for a known `program_hash`.
-2. Deliver a `GW-0813` carrying that hash.
-3. Assert: the handler performs a route lookup by `program_hash`.
-4. Assert: the lookup resolves to the expected queue name.
-
----
-
-### T-AZH-0301  `GW-0813` payloads are forwarded unchanged to the mapped queue
-
-**Validates:** AZH-0301
-
-**Procedure:**
-1. Seed a `ProgramRoute` row mapping a test `program_hash` to a test queue.
-2. Deliver a representative `GW-0813` payload through the upstream trigger path.
-3. Assert: exactly one queue message is sent to the mapped queue.
-4. Assert: the queue message body matches the original raw `GW-0813` connector payload bytes byte-for-byte.
-
----
-
-### T-AZH-0302  Missing program routes fail closed
-
-**Validates:** AZH-0302
-
-**Procedure:**
-1. Ensure no `ProgramRoute` row exists for a test `program_hash`.
-2. Deliver a `GW-0813` carrying that hash.
-3. Assert: the handler reports failure through logging, function failure, or both.
-4. Assert: no fallback or default queue delivery occurs.
-
----
-
-### T-AZH-0303  Mapped queues are treated as external dependencies
-
-**Validates:** AZH-0303
-
-**Procedure:**
-1. Configure a `ProgramRoute` row that references a queue name.
-2. Inspect the route storage, handler behavior, and deployment documentation.
-3. Assert: the route stores only the queue reference.
-4. Assert: the handler does not attempt queue creation when processing the route.
-5. Assert: the deployment documentation identifies mapped handler queues as pre-provisioned dependencies.
+> Retired. These test cases validated ProgramRoute-based queue delivery of
+> `GW-0813` messages, which has been superseded by direct `SensorData` table
+> storage (AZH-0500).
 
 ---
 
@@ -265,7 +224,7 @@ published when both desired fields diverge simultaneously.
 **Validates:** AZH-0400
 
 **Procedure:**
-1. Inject one actual-state table append failure, one desired-state table read failure, one program-route table read failure, one downstream `GW-0811` send failure, and one mapped handler-queue send failure in separate sub-cases.
+1. Inject one actual-state table append failure, one desired-state table read failure, one `SensorData` table append failure, and one downstream `GW-0811` send failure in separate sub-cases.
 2. Trigger the corresponding handler path in each sub-case.
 3. Assert: each failure is surfaced through logging, function failure, or both.
 4. Assert: the handler does not report success for the failed message path.

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -148,10 +148,9 @@ local `ProgramLibrary`.
 
 ---
 
-## 7. Program List and Routes (WEB-0400)
+## 7. Program List (WEB-0400)
 
 - Queries `programs` table (`PartitionKey eq 'program'`), displays table with hash, filename, `abi_version`, size, upload time.
-- Program route management: queries `programroute` table, allows insert/update of `handler_queue` for a given program hash.
 
 ---
 
@@ -161,8 +160,8 @@ local `ProgramLibrary`.
 - Token caching in browser session storage.
 - Silent token renewal; redirect to login on expiry.
 - Two token scopes, acquired separately:
-  - `https://storage.azure.com/.default` — for Azure Table/Queue REST API calls
-    (dashboard, desired state, program list).
+  - `https://storage.azure.com/.default` — for Azure Table REST API calls
+    (dashboard, desired state, program list, sensor data).
   - `api://<companionClientId>/user_impersonation` — for `ProgramIngest` Function
     App calls. This token is validated by EasyAuth on the Function App (see §9.4).
 - The SPA calls `acquireTokenSilent` (with popup fallback) for the Function App

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -38,7 +38,6 @@
 | T-WEB-0309 | WEB-0309 | `DESIRED_STATE` includes inline ELF on program divergence | Unit (Rust) | Planned |
 | T-WEB-0310 | WEB-0310 | `DESIRED_STATE` carries key 5 with ELF bytes and keys 6-8 with metadata | Unit (Rust) | Planned |
 | T-WEB-0401 | WEB-0401 | SPA lists programs from `programs` table | Manual/E2E | Planned |
-| T-WEB-0402 | WEB-0402 | SPA creates/edits `programroute` entries | Manual/E2E | Planned |
 | T-WEB-0501 | WEB-0501 | MSAL.js login flow works | Manual | Planned |
 | T-WEB-0502 | WEB-0502 | Storage API calls use bearer token | Integration | Planned |
 | T-WEB-0503 | WEB-0503 | `ProgramIngest` rejects unauthenticated requests (EasyAuth returns 401) | Integration | Planned |


### PR DESCRIPTION
## Summary

Removes the deprecated \ProgramRoute\-based queue delivery system for \GW-0813\ app-data messages. This routing mechanism has been superseded by direct \SensorData\ table storage (AZH-0500).

## Changes

### Azure handler (\sonde-azure-handler\)
- Removed \ProgramRouteRow\, \ProgramRouteEntity\, \load_program_route()\ trait method and all implementations
- Simplified \handle_app_data()\ to write \SensorData\ and return \Ok\ without route lookup or queue forwarding
- Removed \program_route_table\ from \RuntimeConfig\ and \AzureTablesStore\
- Removed route-specific tests; updated SensorData tests to not seed routes
- Replaced \sensor_data_written_even_when_program_route_missing\ with \pp_data_writes_sensor_data_and_succeeds\

### Bicep infrastructure
- Removed \programRouteTable\ resource, params, outputs, and RBAC assignments from storage, stack, function-placeholder, function-rbac, and main modules
- Removed \SONDE_AZURE_HANDLER_PROGRAM_ROUTE_TABLE\ app setting

### SPA (web-ui)
- Removed Routes tab (button, config, render function, tab router case)
- Removed \programRouteTable\ from CONFIG

### Specifications
- Retired AZH-0300 through AZH-0303 and T-AZH-0300 through T-AZH-0303
- Updated AZH-0100, AZH-0400, design §2–§7, validation T-AZH-0100/0400
- Updated web-ui-design.md §7 and web-ui-validation.md test matrix

## What remains unchanged
- Upstream/downstream Storage Queues (companion transport)
- \QueuePublisher\ trait and \StorageQueuePublisher\ (still used for GW-0811 desired-state publishing)
- \AppDataMessage\ / \ConnectorMessage::AppData\ decoding (still needed for SensorData writes)
- SensorData table and all AZH-0500/0501 code

## Verification
- \cargo clippy -p sonde-azure-handler -- -D warnings\ — clean
- \cargo test -p sonde-azure-handler\ — 80 tests pass
- 14 files changed, 61 insertions(+), 595 deletions(-)