### PR TITLE
feat(web-ui): add sensor series display customization

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -856,6 +856,43 @@ async function renderPrograms() {
 }
 
 // 8. Sensor Data Tab (WEB-0700)
+
+// Series display overrides persisted in localStorage.
+// Shape: { [seriesKey]: { displayName, scaleDivisor, unitSuffix } }
+const SERIES_OVERRIDES_KEY = 'sonde_series_overrides';
+
+function loadSeriesOverrides() {
+  try {
+    const raw = localStorage.getItem(SERIES_OVERRIDES_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch { return {}; }
+}
+
+function saveSeriesOverrides(overrides) {
+  localStorage.setItem(SERIES_OVERRIDES_KEY, JSON.stringify(overrides));
+}
+
+function getSeriesDisplayLabel(series) {
+  const overrides = loadSeriesOverrides();
+  const o = overrides[series.key];
+  return (o && o.displayName) ? o.displayName : series.label;
+}
+
+function applySeriesScale(value, seriesKey) {
+  const overrides = loadSeriesOverrides();
+  const o = overrides[seriesKey];
+  if (o && o.scaleDivisor && o.scaleDivisor !== 0) {
+    return value / o.scaleDivisor;
+  }
+  return value;
+}
+
+function getSeriesUnitSuffix(seriesKey) {
+  const overrides = loadSeriesOverrides();
+  const o = overrides[seriesKey];
+  return (o && o.unitSuffix) ? o.unitSuffix : '';
+}
+
 const SENSOR_STATE = {
   timeRange: '24h',
   viewMode: 'graph',
@@ -1043,18 +1080,27 @@ function renderSensorChart(allSeries) {
     return;
   }
 
-  const datasets = selected.slice(0, 20).map((series, i) => ({
-    label: series.label,
-    nodeId: series.nodeId,
-    programHash: series.programHash,
-    readingName: series.readingName,
-    data: downsamplePoints(series.points, 500),
-    borderColor: CHART_COLORS[i % CHART_COLORS.length],
-    backgroundColor: 'transparent',
-    borderWidth: 1.5,
-    pointRadius: series.points.length > 100 ? 0 : 2,
-    tension: 0.1,
-  }));
+  const datasets = selected.slice(0, 20).map((series, i) => {
+    const scaledPoints = downsamplePoints(series.points, 500).map((p) => ({
+      x: p.x,
+      y: applySeriesScale(p.y, series.key),
+    }));
+    const suffix = getSeriesUnitSuffix(series.key);
+    return {
+      label: getSeriesDisplayLabel(series),
+      nodeId: series.nodeId,
+      programHash: series.programHash,
+      readingName: series.readingName,
+      seriesKey: series.key,
+      unitSuffix: suffix,
+      data: scaledPoints,
+      borderColor: CHART_COLORS[i % CHART_COLORS.length],
+      backgroundColor: 'transparent',
+      borderWidth: 1.5,
+      pointRadius: series.points.length > 100 ? 0 : 2,
+      tension: 0.1,
+    };
+  });
 
   APP.sensorChart = new Chart(canvas, {
     type: 'line',
@@ -1081,7 +1127,13 @@ function renderSensorChart(allSeries) {
           },
         },
         y: {
-          title: { display: true, text: 'Value' },
+          title: {
+            display: true,
+            text: (() => {
+              const suffixes = [...new Set(datasets.map((d) => d.unitSuffix).filter(Boolean))];
+              return suffixes.length === 1 ? `Value (${suffixes[0]})` : 'Value';
+            })(),
+          },
         },
       },
       plugins: {
@@ -1093,7 +1145,8 @@ function renderSensorChart(allSeries) {
             },
             label(item) {
               const ds = item.dataset;
-              const parts = [`Node: ${ds.nodeId || '—'}`, `Program: ${ds.programHash || '—'}`, `${ds.readingName || '—'}: ${item.parsed.y}`];
+              const suffix = ds.unitSuffix || '';
+              const parts = [`Node: ${ds.nodeId || '—'}`, `Program: ${ds.programHash || '—'}`, `${ds.readingName || '—'}: ${item.parsed.y}${suffix}`];
               return parts;
             },
           },
@@ -1155,6 +1208,90 @@ function renderSensorTable(rows, nodeIdMap) {
       </table>
     </div>
   `;
+}
+
+function showSeriesEditDialog(seriesKey, rawLabel, allSeries) {
+  // Remove any existing dialog
+  const existing = document.getElementById('series-edit-dialog');
+  if (existing) existing.remove();
+
+  const overrides = loadSeriesOverrides();
+  const current = overrides[seriesKey] || {};
+
+  const dialog = document.createElement('div');
+  dialog.id = 'series-edit-dialog';
+  dialog.className = 'series-edit-overlay';
+  dialog.innerHTML = `
+    <div class="series-edit-panel panel">
+      <h3>Edit Series Display</h3>
+      <p class="muted small">Raw label: ${escapeHtml(rawLabel)}</p>
+      <div class="stack">
+        <label>
+          Display Name
+          <input type="text" id="series-edit-name" placeholder="${escapeHtml(rawLabel)}"
+                 value="${escapeHtml(current.displayName || '')}">
+        </label>
+        <label>
+          Scale Divisor
+          <input type="number" id="series-edit-divisor" step="any" placeholder="1"
+                 value="${current.scaleDivisor || ''}">
+          <span class="muted small">e.g. 1000 to convert milli-units → units</span>
+        </label>
+        <label>
+          Unit Suffix
+          <input type="text" id="series-edit-unit" placeholder=""
+                 value="${escapeHtml(current.unitSuffix || '')}">
+          <span class="muted small">e.g. °C, %, hPa — appended to values</span>
+        </label>
+        <div style="display:flex;gap:0.5rem;justify-content:flex-end">
+          <button type="button" class="secondary" id="series-edit-reset">Reset to Default</button>
+          <button type="button" class="secondary" id="series-edit-cancel">Cancel</button>
+          <button type="button" class="primary" id="series-edit-save">Save</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(dialog);
+
+  dialog.addEventListener('click', (e) => {
+    if (e.target === dialog) dialog.remove();
+  });
+
+  document.getElementById('series-edit-cancel').addEventListener('click', () => {
+    dialog.remove();
+  });
+
+  document.getElementById('series-edit-reset').addEventListener('click', async () => {
+    const ov = loadSeriesOverrides();
+    delete ov[seriesKey];
+    saveSeriesOverrides(ov);
+    dialog.remove();
+    await renderSensorData();
+  });
+
+  document.getElementById('series-edit-save').addEventListener('click', async () => {
+    const ov = loadSeriesOverrides();
+    const name = document.getElementById('series-edit-name').value.trim();
+    const divisorStr = document.getElementById('series-edit-divisor').value.trim();
+    const unit = document.getElementById('series-edit-unit').value.trim();
+
+    const divisor = divisorStr ? Number(divisorStr) : 0;
+
+    if (name || (divisor && divisor !== 0) || unit) {
+      ov[seriesKey] = {
+        displayName: name || '',
+        scaleDivisor: (divisor && Number.isFinite(divisor) && divisor !== 0) ? divisor : 0,
+        unitSuffix: unit || '',
+      };
+    } else {
+      delete ov[seriesKey];
+    }
+
+    saveSeriesOverrides(ov);
+    dialog.remove();
+    await renderSensorData();
+  });
 }
 
 async function renderSensorData() {
@@ -1232,7 +1369,10 @@ async function renderSensorData() {
       const checked = SENSOR_STATE.selectedSeries.has(s.key) ? ' checked' : '';
       const plottable = s.points.length > 0;
       const suffix = plottable ? '' : ' <span class="muted">(no numeric data)</span>';
-      return `<label class="sensor-series-label"><input type="checkbox" value="${escapeHtml(s.key)}"${checked}${plottable ? '' : ' disabled'}> ${escapeHtml(s.label)}${suffix}</label>`;
+      const displayLabel = getSeriesDisplayLabel(s);
+      const hasOverride = displayLabel !== s.label;
+      const overrideTitle = hasOverride ? ` title="Raw: ${escapeHtml(s.label)}"` : '';
+      return `<label class="sensor-series-label"${overrideTitle}><input type="checkbox" value="${escapeHtml(s.key)}"${checked}${plottable ? '' : ' disabled'}> ${escapeHtml(displayLabel)}${suffix}</label><button type="button" class="sensor-series-edit-btn" data-series-key="${escapeHtml(s.key)}" data-series-label="${escapeHtml(s.label)}" title="Edit display settings">✏️</button>`;
     }).join('');
 
     const autoRefreshChecked = SENSOR_STATE.autoRefresh ? ' checked' : '';
@@ -1298,6 +1438,14 @@ async function renderSensorData() {
         if (SENSOR_STATE.viewMode === 'graph') {
           renderSensorChart(allSeries);
         }
+      });
+    }
+
+    for (const btn of contentEl.querySelectorAll('.sensor-series-edit-btn')) {
+      btn.addEventListener('click', () => {
+        const seriesKey = btn.dataset.seriesKey;
+        const rawLabel = btn.dataset.seriesLabel;
+        showSeriesEditDialog(seriesKey, rawLabel, allSeries);
       });
     }
 

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -1142,8 +1142,8 @@ function renderSensorChart(allSeries) {
           title: {
             display: true,
             text: (() => {
-              const suffixes = [...new Set(datasets.map((d) => d.unitSuffix).filter(Boolean))];
-              return suffixes.length === 1 ? `Value (${suffixes[0]})` : 'Value';
+              const suffixes = [...new Set(datasets.map((d) => d.unitSuffix))];
+              return suffixes.length === 1 && suffixes[0] ? `Value (${suffixes[0]})` : 'Value';
             })(),
           },
         },
@@ -1158,8 +1158,7 @@ function renderSensorChart(allSeries) {
             label(item) {
               const ds = item.dataset;
               const suffix = ds.unitSuffix || '';
-              const parts = [`Node: ${ds.nodeId || '—'}`, `Program: ${ds.programHash || '—'}`, `${ds.readingName || '—'}: ${item.parsed.y}${suffix}`];
-              return parts;
+              return `${ds.label}: ${item.parsed.y}${suffix}`;
             },
           },
         },
@@ -1271,15 +1270,43 @@ function showSeriesEditDialog(seriesKey, rawLabel) {
 
   document.body.appendChild(dialog);
 
+  const previousFocus = document.activeElement;
   const nameInput = document.getElementById('series-edit-name');
   if (nameInput) nameInput.focus();
 
+  function closeDialog() {
+    dialog.remove();
+    if (previousFocus && typeof previousFocus.focus === 'function') {
+      previousFocus.focus();
+    }
+  }
+
+  // Focus trap: cycle through focusable elements within the dialog
+  dialog.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      closeDialog();
+      return;
+    }
+    if (e.key !== 'Tab') return;
+    const focusable = dialog.querySelectorAll('input, button, [tabindex]:not([tabindex="-1"])');
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
+
   dialog.addEventListener('click', (e) => {
-    if (e.target === dialog) dialog.remove();
+    if (e.target === dialog) closeDialog();
   });
 
   document.getElementById('series-edit-cancel').addEventListener('click', () => {
-    dialog.remove();
+    closeDialog();
   });
 
   document.getElementById('series-edit-reset').addEventListener('click', async () => {
@@ -1289,7 +1316,7 @@ function showSeriesEditDialog(seriesKey, rawLabel) {
       alert('Failed to save settings — browser storage may be full or disabled.');
       return;
     }
-    dialog.remove();
+    closeDialog();
     await renderSensorData();
   });
 
@@ -1315,7 +1342,7 @@ function showSeriesEditDialog(seriesKey, rawLabel) {
       alert('Failed to save settings — browser storage may be full or disabled.');
       return;
     }
-    dialog.remove();
+    closeDialog();
     await renderSensorData();
   });
 }

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -864,32 +864,41 @@ const SERIES_OVERRIDES_KEY = 'sonde_series_overrides';
 function loadSeriesOverrides() {
   try {
     const raw = localStorage.getItem(SERIES_OVERRIDES_KEY);
-    return raw ? JSON.parse(raw) : {};
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
+    return parsed;
   } catch { return {}; }
 }
 
 function saveSeriesOverrides(overrides) {
-  localStorage.setItem(SERIES_OVERRIDES_KEY, JSON.stringify(overrides));
+  try {
+    localStorage.setItem(SERIES_OVERRIDES_KEY, JSON.stringify(overrides));
+  } catch {
+    // Storage disabled or quota exceeded — surface to caller via return value
+    return false;
+  }
+  return true;
 }
 
-function getSeriesDisplayLabel(series) {
-  const overrides = loadSeriesOverrides();
-  const o = overrides[series.key];
+function getSeriesDisplayLabel(series, overrides) {
+  const ov = overrides || loadSeriesOverrides();
+  const o = ov[series.key];
   return (o && o.displayName) ? o.displayName : series.label;
 }
 
-function applySeriesScale(value, seriesKey) {
-  const overrides = loadSeriesOverrides();
-  const o = overrides[seriesKey];
-  if (o && o.scaleDivisor && o.scaleDivisor !== 0) {
-    return value / o.scaleDivisor;
+function getSeriesScale(seriesKey, overrides) {
+  const ov = overrides || loadSeriesOverrides();
+  const o = ov[seriesKey];
+  if (o && typeof o.scaleDivisor === 'number' && Number.isFinite(o.scaleDivisor) && o.scaleDivisor !== 0) {
+    return o.scaleDivisor;
   }
-  return value;
+  return null;
 }
 
-function getSeriesUnitSuffix(seriesKey) {
-  const overrides = loadSeriesOverrides();
-  const o = overrides[seriesKey];
+function getSeriesUnitSuffix(seriesKey, overrides) {
+  const ov = overrides || loadSeriesOverrides();
+  const o = ov[seriesKey];
   return (o && o.unitSuffix) ? o.unitSuffix : '';
 }
 
@@ -1080,14 +1089,17 @@ function renderSensorChart(allSeries) {
     return;
   }
 
+  const overrides = loadSeriesOverrides();
+
   const datasets = selected.slice(0, 20).map((series, i) => {
+    const divisor = getSeriesScale(series.key, overrides);
     const scaledPoints = downsamplePoints(series.points, 500).map((p) => ({
       x: p.x,
-      y: applySeriesScale(p.y, series.key),
+      y: divisor ? p.y / divisor : p.y,
     }));
-    const suffix = getSeriesUnitSuffix(series.key);
+    const suffix = getSeriesUnitSuffix(series.key, overrides);
     return {
-      label: getSeriesDisplayLabel(series),
+      label: getSeriesDisplayLabel(series, overrides),
       nodeId: series.nodeId,
       programHash: series.programHash,
       readingName: series.readingName,
@@ -1210,17 +1222,22 @@ function renderSensorTable(rows, nodeIdMap) {
   `;
 }
 
-function showSeriesEditDialog(seriesKey, rawLabel, allSeries) {
+function showSeriesEditDialog(seriesKey, rawLabel) {
   // Remove any existing dialog
   const existing = document.getElementById('series-edit-dialog');
   if (existing) existing.remove();
 
   const overrides = loadSeriesOverrides();
   const current = overrides[seriesKey] || {};
+  const safeDivisor = (typeof current.scaleDivisor === 'number' && Number.isFinite(current.scaleDivisor))
+    ? current.scaleDivisor : '';
 
   const dialog = document.createElement('div');
   dialog.id = 'series-edit-dialog';
   dialog.className = 'series-edit-overlay';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-label', 'Edit series display settings');
   dialog.innerHTML = `
     <div class="series-edit-panel panel">
       <h3>Edit Series Display</h3>
@@ -1234,7 +1251,7 @@ function showSeriesEditDialog(seriesKey, rawLabel, allSeries) {
         <label>
           Scale Divisor
           <input type="number" id="series-edit-divisor" step="any" placeholder="1"
-                 value="${current.scaleDivisor || ''}">
+                 value="${safeDivisor}">
           <span class="muted small">e.g. 1000 to convert milli-units → units</span>
         </label>
         <label>
@@ -1254,6 +1271,9 @@ function showSeriesEditDialog(seriesKey, rawLabel, allSeries) {
 
   document.body.appendChild(dialog);
 
+  const nameInput = document.getElementById('series-edit-name');
+  if (nameInput) nameInput.focus();
+
   dialog.addEventListener('click', (e) => {
     if (e.target === dialog) dialog.remove();
   });
@@ -1265,7 +1285,10 @@ function showSeriesEditDialog(seriesKey, rawLabel, allSeries) {
   document.getElementById('series-edit-reset').addEventListener('click', async () => {
     const ov = loadSeriesOverrides();
     delete ov[seriesKey];
-    saveSeriesOverrides(ov);
+    if (!saveSeriesOverrides(ov)) {
+      alert('Failed to save settings — browser storage may be full or disabled.');
+      return;
+    }
     dialog.remove();
     await renderSensorData();
   });
@@ -1288,7 +1311,10 @@ function showSeriesEditDialog(seriesKey, rawLabel, allSeries) {
       delete ov[seriesKey];
     }
 
-    saveSeriesOverrides(ov);
+    if (!saveSeriesOverrides(ov)) {
+      alert('Failed to save settings — browser storage may be full or disabled.');
+      return;
+    }
     dialog.remove();
     await renderSensorData();
   });
@@ -1365,14 +1391,16 @@ async function renderSensorData() {
       <button type="button" class="secondary sensor-view-btn${SENSOR_STATE.viewMode === 'table' ? ' active' : ''}" data-view="table">Table</button>
     `;
 
+    const pickerOverrides = loadSeriesOverrides();
     const seriesCheckboxes = allSeries.map((s) => {
       const checked = SENSOR_STATE.selectedSeries.has(s.key) ? ' checked' : '';
       const plottable = s.points.length > 0;
       const suffix = plottable ? '' : ' <span class="muted">(no numeric data)</span>';
-      const displayLabel = getSeriesDisplayLabel(s);
+      const displayLabel = getSeriesDisplayLabel(s, pickerOverrides);
       const hasOverride = displayLabel !== s.label;
       const overrideTitle = hasOverride ? ` title="Raw: ${escapeHtml(s.label)}"` : '';
-      return `<label class="sensor-series-label"${overrideTitle}><input type="checkbox" value="${escapeHtml(s.key)}"${checked}${plottable ? '' : ' disabled'}> ${escapeHtml(displayLabel)}${suffix}</label><button type="button" class="sensor-series-edit-btn" data-series-key="${escapeHtml(s.key)}" data-series-label="${escapeHtml(s.label)}" title="Edit display settings">✏️</button>`;
+      const ariaLabel = `Edit display settings for ${displayLabel}`;
+      return `<label class="sensor-series-label"${overrideTitle}><input type="checkbox" value="${escapeHtml(s.key)}"${checked}${plottable ? '' : ' disabled'}> ${escapeHtml(displayLabel)}${suffix}</label><button type="button" class="sensor-series-edit-btn" data-series-key="${escapeHtml(s.key)}" data-series-label="${escapeHtml(s.label)}" title="Edit display settings" aria-label="${escapeHtml(ariaLabel)}">✏️</button>`;
     }).join('');
 
     const autoRefreshChecked = SENSOR_STATE.autoRefresh ? ' checked' : '';
@@ -1445,7 +1473,7 @@ async function renderSensorData() {
       btn.addEventListener('click', () => {
         const seriesKey = btn.dataset.seriesKey;
         const rawLabel = btn.dataset.seriesLabel;
-        showSeriesEditDialog(seriesKey, rawLabel, allSeries);
+        showSeriesEditDialog(seriesKey, rawLabel);
       });
     }
 

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -1328,6 +1328,13 @@ function showSeriesEditDialog(seriesKey, rawLabel) {
 
     const divisor = divisorStr ? Number(divisorStr) : 0;
 
+    if (divisorStr && (!Number.isFinite(divisor) || divisor === 0)) {
+      const divisorInput = document.getElementById('series-edit-divisor');
+      if (divisorInput) divisorInput.focus();
+      alert('Scale divisor must be a finite non-zero number.');
+      return;
+    }
+
     if (name || (divisor && divisor !== 0) || unit) {
       ov[seriesKey] = {
         displayName: name || '',
@@ -1427,7 +1434,7 @@ async function renderSensorData() {
       const hasOverride = displayLabel !== s.label;
       const overrideTitle = hasOverride ? ` title="Raw: ${escapeHtml(s.label)}"` : '';
       const ariaLabel = `Edit display settings for ${displayLabel}`;
-      return `<label class="sensor-series-label"${overrideTitle}><input type="checkbox" value="${escapeHtml(s.key)}"${checked}${plottable ? '' : ' disabled'}> ${escapeHtml(displayLabel)}${suffix}</label><button type="button" class="sensor-series-edit-btn" data-series-key="${escapeHtml(s.key)}" data-series-label="${escapeHtml(s.label)}" title="Edit display settings" aria-label="${escapeHtml(ariaLabel)}">✏️</button>`;
+      return `<span class="sensor-series-item"><label class="sensor-series-label"${overrideTitle}><input type="checkbox" value="${escapeHtml(s.key)}"${checked}${plottable ? '' : ' disabled'}> ${escapeHtml(displayLabel)}${suffix}</label><button type="button" class="sensor-series-edit-btn" data-series-key="${escapeHtml(s.key)}" data-series-label="${escapeHtml(s.label)}" title="Edit display settings" aria-label="${escapeHtml(ariaLabel)}">✏️</button></span>`;
     }).join('');
 
     const autoRefreshChecked = SENSOR_STATE.autoRefresh ? ' checked' : '';

--- a/deploy/web-ui/style.css
+++ b/deploy/web-ui/style.css
@@ -161,6 +161,11 @@ code { font-family: Consolas, "Courier New", monospace; }
   vertical-align: middle;
 }
 .sensor-series-edit-btn:hover { opacity: 1; }
+.sensor-series-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+}
 .series-edit-overlay {
   position: fixed;
   inset: 0;

--- a/deploy/web-ui/style.css
+++ b/deploy/web-ui/style.css
@@ -150,3 +150,28 @@ code { font-family: Consolas, "Courier New", monospace; }
   padding: 0;
 }
 .chart-container { position: relative; height: 400px; }
+.sensor-series-edit-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 0.2rem;
+  font-size: 0.85rem;
+  line-height: 1;
+  opacity: 0.5;
+  vertical-align: middle;
+}
+.sensor-series-edit-btn:hover { opacity: 1; }
+.series-edit-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.series-edit-panel {
+  width: 100%;
+  max-width: 420px;
+  margin: 1rem;
+}

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -292,7 +292,7 @@ configuration.
 
 ## 10. Sensor Data (WEB-0700)
 
-> **Requirements:** WEB-0700, WEB-0701, WEB-0702
+> **Requirements:** WEB-0700, WEB-0701, WEB-0702, WEB-0703
 
 ### 10.1  Data source
 
@@ -348,3 +348,35 @@ A toggle switches between graph and table views. The table displays all
 Raw Payload (truncated). Sorted by timestamp descending (newest first).
 Rows with empty `decoded_readings` display "—" in the Decoded Readings
 column.
+
+### 10.4  Series display customization (WEB-0703)
+
+Each series in the series selector has a ✏️ edit button that opens a modal
+dialog for customizing how the series is displayed:
+
+- **Display name** — override the default
+  `truncHash(nodeId) / truncHash(programHash) / readingName` label with a
+  friendly name (e.g., "Office Temperature"). The original raw label is
+  shown in a hover tooltip and in the edit dialog.
+- **Scale divisor** — divide raw values by a constant before plotting.
+  For example, a divisor of `1000` converts milli-degrees (21500) to
+  degrees (21.5). A divisor of `0` or empty means no scaling.
+- **Unit suffix** — a string appended to values in tooltips and, when all
+  selected series share the same suffix, in the Y-axis title
+  (e.g., `°C`, `%`, `hPa`).
+
+A **Reset to Default** button clears overrides for the series.
+
+#### Persistence
+
+Overrides are stored in `localStorage` under the key
+`sonde_series_overrides` as a JSON object keyed by series key
+(`partitionKey|programHash|readingName`). Each entry has the shape:
+
+```json
+{ "displayName": "string", "scaleDivisor": number, "unitSuffix": "string" }
+```
+
+Overrides survive page reloads and browser restarts. They are scoped to
+the browser origin (per localStorage rules) and are not shared across
+devices.

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -58,3 +58,9 @@
 | T-WEB-0704 | WEB-0702 | Table view shows all SensorData columns | Manual/E2E | Planned |
 | T-WEB-0705 | WEB-0702 | SPA handles empty `decoded_readings` gracefully (shows "—") | Manual/E2E | Planned |
 | T-WEB-0706 | WEB-0701 | SPA displays string-encoded int64 values (above `Number.MAX_SAFE_INTEGER`) correctly and renders in-range values as numbers | Manual | Planned |
+| T-WEB-0707 | WEB-0703 | Series edit dialog opens when ✏️ button is clicked and pre-fills saved overrides | Manual | Planned |
+| T-WEB-0708 | WEB-0703 | Custom display name replaces default label in series picker, chart legend, and tooltip | Manual | Planned |
+| T-WEB-0709 | WEB-0703 | Scale divisor transforms plotted values (e.g., 1000 converts 21500 → 21.5) | Manual | Planned |
+| T-WEB-0710 | WEB-0703 | Unit suffix appears in tooltip values and Y-axis title when all series share the same suffix | Manual | Planned |
+| T-WEB-0711 | WEB-0703 | Overrides persist across page reloads via `localStorage` | Manual | Planned |
+| T-WEB-0712 | WEB-0703 | Reset to Default clears overrides and restores original label/scale | Manual | Planned |


### PR DESCRIPTION
## Summary

Adds the ability for admins to customize how sensor data series are displayed in the web UI chart.

### Features

1. **Editable display name** — rename series like \\Sonde-mi / 99709304 / temp_mc\\ to friendly labels like \\Office Temperature\\
2. **Scale divisor** — convert raw units (e.g. enter \\1000\\ to transform milli-degrees → degrees: 21500 → 21.5)
3. **Unit suffix** — append units like \\°C\\ to tooltip values and Y-axis label
4. **localStorage persistence** — overrides survive page reloads (stored under \\sonde_series_overrides\\ key)

### UI Changes

- ✏️ edit button next to each series checkbox in the series picker
- Modal dialog with fields for display name, scale divisor, and unit suffix
- **Reset to Default** button to clear per-series overrides
- Hover tooltip on renamed series shows the original raw label

### Files Changed

- \\deploy/web-ui/app.js\\ — override logic, scaled chart datasets, edit dialog
- \\deploy/web-ui/style.css\\ — edit button and modal overlay styles