### PR TITLE
deploy: run docker-compose containers as root

### DIFF
--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -144,6 +144,12 @@ docker compose down -v
   The device code is displayed on the modem's screen. Check
   `docker compose logs bootstrap` for the URL and code if needed.
 
+### Containers run as root
+
+All services currently run as `root` (`user: "0:0"`) because the container
+images do not yet create non-root users with the correct file ownership.
+This will be revised once the images support running as an unprivileged user.
+
 ### Security: Docker socket access
 
 The bootstrap service mounts `/var/run/docker.sock` because it needs to

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -18,6 +18,7 @@ services:
   gateway:
     image: ghcr.io/alan-jowett/sonde-gateway:${SONDE_IMAGE_TAG:-latest}
     container_name: sonde-gateway
+    user: "0:0"
     command:
       - "--db"
       - "/var/lib/sonde/sonde.db"
@@ -60,6 +61,7 @@ services:
   bootstrap:
     image: ghcr.io/alan-jowett/sonde-azure-companion:${SONDE_IMAGE_TAG:-latest}
     container_name: sonde-bootstrap
+    user: "0:0"
     entrypoint: ["sonde-azure-companion"]
     command:
       - "--admin-socket"
@@ -89,6 +91,7 @@ services:
   companion:
     image: ghcr.io/alan-jowett/sonde-azure-companion:${SONDE_IMAGE_TAG:-latest}
     container_name: sonde-companion
+    user: "0:0"
     entrypoint: ["sonde-azure-companion"]
     command:
       - "--connector-socket"


### PR DESCRIPTION
The container images do not yet create non-root users with correct file ownership, so all three services (gateway, bootstrap, companion) need `user: "0:0"`` to function.

### Changes
- Added `user: "0:0"`` to all three services in `docker-compose.yml`
- Added a Troubleshooting note in `README.md` explaining this temporary requirement