### PR TITLE
fix: force linux/amd64 platform for bootstrap container

### DIFF
--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -2149,8 +2149,13 @@ async fn run_bootstrap_deployment_with_docker_and_image(
     bootstrap_image: &str,
 ) -> Result<(ServicePrincipalStateFile, StorageQueuesConfigFile), CompanionError> {
     eprintln!("Pulling bootstrap image...");
+    // The bootstrap image (azure-cli + SWA CLI) is x86_64-only: the
+    // StaticSitesClient binary that the SWA CLI downloads at runtime has
+    // no ARM build. Force linux/amd64 so Docker uses QEMU emulation on
+    // non-x86 hosts (e.g. Armbian on aarch64).
     let pull_opts = CreateImageOptionsBuilder::default()
         .from_image(bootstrap_image)
+        .platform("linux/amd64")
         .build();
     let mut pull_stream = docker.create_image(Some(pull_opts), None, None);
     while let Some(result) = pull_stream.next().await {
@@ -2168,6 +2173,7 @@ async fn run_bootstrap_deployment_with_docker_and_image(
             Some(
                 CreateContainerOptionsBuilder::default()
                     .name(&container_name)
+                    .platform("linux/amd64")
                     .build(),
             ),
             ContainerCreateBody {
@@ -3960,10 +3966,15 @@ mod tests {
                 "DELETE /containers/test-container".to_string(),
             ]
         );
+        assert!(requests[0].url.query().is_some_and(|query| query
+            .contains("fromImage=sonde-azure-bootstrap%3Atest-override")
+            && query.contains("platform=linux%2Famd64")));
         assert!(
-            requests[0].url.query().is_some_and(
-                |query| query.contains("fromImage=sonde-azure-bootstrap%3Atest-override")
-            )
+            requests[1]
+                .url
+                .query()
+                .is_some_and(|query| query.contains("platform=linux%2Famd64")),
+            "container create must specify platform=linux/amd64"
         );
         let create_body = String::from_utf8(requests[1].body.clone()).unwrap();
         assert!(create_body.contains("COMPANION_CERT_BASE64=dummy-cert-base64"));


### PR DESCRIPTION
The bootstrap image (azure-cli + SWA CLI) is x86_64-only — the `StaticSitesClient` binary that the SWA CLI downloads at runtime has no ARM build. On ARM hosts (e.g. Armbian on aarch64) the binary fails with "cannot execute binary file" (exit code 126).

Forces `platform("linux/amd64")` on both the image pull and container create so Docker uses QEMU emulation on non-x86 hosts. On x86_64 hosts this is a no-op.
