### PR TITLE
feat: add custom domain support for SPA (WEB-0608)

### DIFF
--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -175,6 +175,18 @@ struct BootstrapArgs {
     /// Optional bootstrap image override for development and test workflows.
     #[arg(long, env = "SONDE_AZURE_BOOTSTRAP_IMAGE")]
     bootstrap_image: Option<String>,
+
+    /// Optional custom domain FQDN for the Static Web App (e.g., sondeplatform.com).
+    #[arg(long, env = "SONDE_AZURE_CUSTOM_DOMAIN_NAME")]
+    custom_domain_name: Option<String>,
+
+    /// Resource group containing the Azure DNS zone for the custom domain.
+    #[arg(long, env = "SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP")]
+    custom_domain_dns_resource_group: Option<String>,
+
+    /// DNS zone name for the custom domain (defaults to custom_domain_name for apex domains).
+    #[arg(long, env = "SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME")]
+    custom_domain_dns_zone_name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1409,6 +1421,15 @@ fn build_container_env(cert_base64: &str, args: &BootstrapArgs) -> Vec<String> {
     ];
     if let Some(sub_id) = &args.azure_subscription_id {
         env.push(format!("SONDE_AZURE_SUBSCRIPTION_ID={sub_id}"));
+    }
+    if let Some(domain) = &args.custom_domain_name {
+        env.push(format!("SONDE_AZURE_CUSTOM_DOMAIN_NAME={domain}"));
+    }
+    if let Some(rg) = &args.custom_domain_dns_resource_group {
+        env.push(format!("SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP={rg}"));
+    }
+    if let Some(zone) = &args.custom_domain_dns_zone_name {
+        env.push(format!("SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME={zone}"));
     }
     env
 }
@@ -3933,6 +3954,9 @@ mod tests {
             azure_project_name: "sonde".to_string(),
             azure_subscription_id: None,
             bootstrap_image: Some("sonde-azure-bootstrap:test-override".to_string()),
+            custom_domain_name: None,
+            custom_domain_dns_resource_group: None,
+            custom_domain_dns_zone_name: None,
         };
 
         let err = run_bootstrap_deployment_with_docker_and_image(
@@ -4396,6 +4420,9 @@ mod tests {
             azure_project_name: "sonde".to_string(),
             azure_subscription_id: None,
             bootstrap_image: None,
+            custom_domain_name: None,
+            custom_domain_dns_resource_group: None,
+            custom_domain_dns_zone_name: None,
         };
 
         let err = super::bootstrap("/tmp/sonde-missing-admin.sock", temp.path(), args)

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -206,6 +206,25 @@ if [ -z "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ] && [ -n "${SONDE_AZURE_CUSTOM_DO
     echo "SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP is set but SONDE_AZURE_CUSTOM_DOMAIN_NAME is empty; both are required for custom domain support" >&2
     exit 1
 fi
+# dns-record.bicep only supports apex (naked) domains — the A ALIAS record
+# is hardcoded to '@'.  When an explicit DNS zone name is provided it must
+# match the custom domain name; subdomain bindings are not supported.
+if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME:-}" ] && \
+   [ "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME}" != "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ]; then
+    echo "SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME ($SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME) differs from SONDE_AZURE_CUSTOM_DOMAIN_NAME (${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}); only apex domains are supported" >&2
+    exit 1
+fi
+# Reject values containing whitespace — these are Azure resource identifiers
+# and domain names which structurally cannot have spaces.  Catching this early
+# prevents confusing word-splitting failures in the az CLI invocation below.
+for _cdv in \
+    "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" \
+    "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP:-}" \
+    "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME:-}"; do
+    case "$_cdv" in
+        *[[:space:]]*) echo "custom domain parameter contains whitespace: '$_cdv'" >&2; exit 1 ;;
+    esac
+done
 custom_domain_params=""
 if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ]; then
     custom_domain_params="customDomainName=$SONDE_AZURE_CUSTOM_DOMAIN_NAME"

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -196,13 +196,21 @@ fi
 
 echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2
 deployment_name="sonde-bootstrap-$(date +%Y%m%d%H%M%S)-$$"
+bicep_params="companionCertificateBase64=$COMPANION_CERT_BASE64 location=$SONDE_AZURE_LOCATION project_name=$SONDE_AZURE_PROJECT_NAME"
+if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ]; then
+    bicep_params="$bicep_params customDomainName=$SONDE_AZURE_CUSTOM_DOMAIN_NAME"
+fi
+if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP:-}" ]; then
+    bicep_params="$bicep_params customDomainDnsResourceGroup=$SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP"
+fi
+if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME:-}" ]; then
+    bicep_params="$bicep_params customDomainDnsZoneName=$SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME"
+fi
 deployment_outputs="$(az deployment sub create \
     --name "$deployment_name" \
     --location "$SONDE_AZURE_LOCATION" \
     --template-file /opt/sonde/deploy/bicep/main.bicep \
-    --parameters companionCertificateBase64="$COMPANION_CERT_BASE64" \
-    --parameters location="$SONDE_AZURE_LOCATION" \
-    --parameters project_name="$SONDE_AZURE_PROJECT_NAME" \
+    --parameters $bicep_params \
     --query 'properties.outputs' \
     --output json)"
 
@@ -314,6 +322,32 @@ else
         --headers "Content-Type=application/json" \
         --body "$patch_body"
     echo "Added SPA redirect URI: $redirect_uri" >&2
+fi
+
+# If a custom domain was configured, also register it as a SPA redirect URI
+if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ]; then
+    custom_redirect_uri="https://$SONDE_AZURE_CUSTOM_DOMAIN_NAME"
+    custom_uris="$(az ad app show --id "$app_object_id" \
+        --query 'spa.redirectUris' --output json 2>/dev/null || echo '[]')"
+    if [ -z "$custom_uris" ] || [ "$custom_uris" = "null" ]; then
+        custom_uris="[]"
+    fi
+    custom_uri_exists=0
+    echo "$custom_uris" | jq -e --arg uri "$custom_redirect_uri" 'index($uri) != null' >/dev/null 2>&1 && custom_uri_exists=1
+    if [ "$custom_uri_exists" -eq 1 ]; then
+        echo "Custom domain redirect URI already registered" >&2
+    else
+        custom_merged="$(echo "$custom_uris" | jq -c --arg uri "$custom_redirect_uri" '. + [$uri]')" || {
+            echo "failed to merge custom domain redirect URI" >&2
+            exit 1
+        }
+        custom_patch="$(jq -n -c --argjson uris "$custom_merged" '{"spa":{"redirectUris":$uris}}')"
+        az rest --method PATCH \
+            --url "https://graph.microsoft.com/v1.0/applications/$app_object_id" \
+            --headers "Content-Type=application/json" \
+            --body "$custom_patch"
+        echo "Added custom domain redirect URI: $custom_redirect_uri" >&2
+    fi
 fi
 
 # Add Azure Storage user_impersonation API permission (idempotent)

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -196,21 +196,26 @@ fi
 
 echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2
 deployment_name="sonde-bootstrap-$(date +%Y%m%d%H%M%S)-$$"
-bicep_params="companionCertificateBase64=$COMPANION_CERT_BASE64 location=$SONDE_AZURE_LOCATION project_name=$SONDE_AZURE_PROJECT_NAME"
+custom_domain_params=""
 if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ]; then
-    bicep_params="$bicep_params customDomainName=$SONDE_AZURE_CUSTOM_DOMAIN_NAME"
+    custom_domain_params="customDomainName=$SONDE_AZURE_CUSTOM_DOMAIN_NAME"
 fi
 if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP:-}" ]; then
-    bicep_params="$bicep_params customDomainDnsResourceGroup=$SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP"
+    custom_domain_params="$custom_domain_params customDomainDnsResourceGroup=$SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP"
 fi
 if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME:-}" ]; then
-    bicep_params="$bicep_params customDomainDnsZoneName=$SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME"
+    custom_domain_params="$custom_domain_params customDomainDnsZoneName=$SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME"
 fi
+# shellcheck disable=SC2086 — intentional word-splitting on custom_domain_params;
+# all values are Azure resource identifiers which cannot contain whitespace.
 deployment_outputs="$(az deployment sub create \
     --name "$deployment_name" \
     --location "$SONDE_AZURE_LOCATION" \
     --template-file /opt/sonde/deploy/bicep/main.bicep \
-    --parameters $bicep_params \
+    --parameters "companionCertificateBase64=$COMPANION_CERT_BASE64" \
+                 "location=$SONDE_AZURE_LOCATION" \
+                 "project_name=$SONDE_AZURE_PROJECT_NAME" \
+                 $custom_domain_params \
     --query 'properties.outputs' \
     --output json)"
 
@@ -284,6 +289,20 @@ swa deploy "$web_ui_dir" \
     --deployment-token "$swa_deployment_token" \
     --env production 1>&2
 echo "SPA content deployed to https://$static_web_app_hostname" >&2
+
+# ── Custom domain binding ───────────────────────────────────────────────────
+# Bicep creates the DNS ALIAS record, but the SWA custom domain binding
+# (ownership validation + managed SSL certificate) must be done via the CLI.
+if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ]; then
+    echo "Binding custom domain $SONDE_AZURE_CUSTOM_DOMAIN_NAME to Static Web App $static_web_app_name" >&2
+    # `hostname set` is idempotent — safe to re-run on subsequent deployments.
+    az staticwebapp hostname set \
+        --name "$static_web_app_name" \
+        --resource-group "$resource_group_name" \
+        --hostname "$SONDE_AZURE_CUSTOM_DOMAIN_NAME" \
+        --output none 1>&2
+    echo "Custom domain bound; managed SSL certificate provisioning initiated" >&2
+fi
 
 # ── Entra app configuration ─────────────────────────────────────────────────
 echo "Configuring Entra app registration for Web UI" >&2

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -196,6 +196,16 @@ fi
 
 echo "__SONDE_AZURE_DEPLOYMENT_START__" >&2
 deployment_name="sonde-bootstrap-$(date +%Y%m%d%H%M%S)-$$"
+# Validate custom domain parameter consistency — supplying one without the
+# other silently disables the custom domain feature, which is hard to diagnose.
+if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ] && [ -z "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP:-}" ]; then
+    echo "SONDE_AZURE_CUSTOM_DOMAIN_NAME is set but SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP is empty; both are required for custom domain support" >&2
+    exit 1
+fi
+if [ -z "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ] && [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP:-}" ]; then
+    echo "SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP is set but SONDE_AZURE_CUSTOM_DOMAIN_NAME is empty; both are required for custom domain support" >&2
+    exit 1
+fi
 custom_domain_params=""
 if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ]; then
     custom_domain_params="customDomainName=$SONDE_AZURE_CUSTOM_DOMAIN_NAME"
@@ -339,7 +349,8 @@ else
     az rest --method PATCH \
         --url "https://graph.microsoft.com/v1.0/applications/$app_object_id" \
         --headers "Content-Type=application/json" \
-        --body "$patch_body"
+        --body "$patch_body" \
+        --output none
     echo "Added SPA redirect URI: $redirect_uri" >&2
 fi
 
@@ -364,7 +375,8 @@ if [ -n "${SONDE_AZURE_CUSTOM_DOMAIN_NAME:-}" ]; then
         az rest --method PATCH \
             --url "https://graph.microsoft.com/v1.0/applications/$app_object_id" \
             --headers "Content-Type=application/json" \
-            --body "$custom_patch"
+            --body "$custom_patch" \
+            --output none
         echo "Added custom domain redirect URI: $custom_redirect_uri" >&2
     fi
 fi
@@ -429,7 +441,8 @@ else
     az rest --method PATCH \
         --url "https://graph.microsoft.com/v1.0/applications/$app_object_id" \
         --headers "Content-Type=application/json" \
-        --body "$patch_body"
+        --body "$patch_body" \
+        --output none
     echo "Exposed api://$companion_client_id/user_impersonation scope" >&2
 fi
 

--- a/deploy/bicep/README.md
+++ b/deploy/bicep/README.md
@@ -41,6 +41,11 @@ Azure companion architecture.
 | `desiredStateTableName` | `desiredstate` | Azure handler desired-state table |
 | `functionAppName` | derived | Optional Function App override |
 | `functionPlanName` | derived | Optional Function hosting plan override |
+| `staticWebAppName` | derived | Optional Static Web App name override |
+| `staticWebAppLocation` | `centralus` | Azure region for the Static Web App |
+| `customDomainName` | empty | Custom domain FQDN (e.g., `sondeplatform.com`). Empty = no custom domain |
+| `customDomainDnsResourceGroup` | empty | Resource group containing the Azure DNS zone for the custom domain |
+| `customDomainDnsZoneName` | `customDomainName` | DNS zone name. Defaults to `customDomainName` when empty (correct for apex domains) |
 
 When resource names are derived automatically, the deployment normalizes
 `project_name` to satisfy Azure naming rules for the target resource types.

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -54,6 +54,15 @@ param staticWebAppName string = ''
 @description('Azure region for the Static Web App. Defaults to centralus because Microsoft.Web/staticSites is not available in all regions.')
 param staticWebAppLocation string = 'centralus'
 
+@description('Custom domain FQDN to bind to the Static Web App (e.g., sondeplatform.com). Empty = no custom domain.')
+param customDomainName string = ''
+
+@description('Resource group containing the Azure DNS zone for the custom domain. Required when customDomainName is set.')
+param customDomainDnsResourceGroup string = ''
+
+@description('Azure DNS zone name for the custom domain. Defaults to customDomainName when empty (correct for apex domains).')
+param customDomainDnsZoneName string = ''
+
 var projectSlug = toLower(replace(replace(replace(replace(replace(project_name, '-', ''), '_', ''), ' ', ''), '.', ''), '/', ''))
 var effectiveProjectSlug = empty(projectSlug) ? 'sonde' : projectSlug
 var effectiveResourceGroupName = empty(resource_group_name) ? '${take(effectiveProjectSlug, 84)}-azure' : resource_group_name
@@ -80,6 +89,10 @@ var effectiveFunctionPlanName = empty(functionPlanName)
 var effectiveStaticWebAppName = empty(staticWebAppName)
   ? take('${take(effectiveProjectSlug, 24)}-web-${take(uniqueString(subscription().subscriptionId, effectiveResourceGroupName, 'swa'), 8)}', 40)
   : staticWebAppName
+var effectiveCustomDomainDnsZoneName = empty(customDomainDnsZoneName)
+  ? customDomainName
+  : customDomainDnsZoneName
+var isCustomDomainEnabled = !empty(customDomainName) && !empty(customDomainDnsResourceGroup)
 var tags = {
   project: project_name
 }
@@ -125,6 +138,20 @@ module stack './modules/stack.bicep' = {
     functionAuthTenantId: companionIdentity.outputs.tenantId
     staticWebAppName: effectiveStaticWebAppName
     staticWebAppLocation: staticWebAppLocation
+    customDomainName: isCustomDomainEnabled ? customDomainName : ''
+  }
+}
+
+// DNS records for custom domain — deployed to the external resource group
+// containing the Azure DNS zone.  Only created when custom domain is enabled.
+// Domain ownership validation and binding are handled by deploy.sh via
+// `az staticwebapp hostname set` after DNS propagation.
+module dnsRecord './modules/dns-record.bicep' = if (isCustomDomainEnabled) {
+  name: 'dnsRecord'
+  scope: resourceGroup(customDomainDnsResourceGroup)
+  params: {
+    dnsZoneName: effectiveCustomDomainDnsZoneName
+    staticWebAppResourceId: stack.outputs.staticWebAppResourceId
   }
 }
 
@@ -144,6 +171,7 @@ output functionAppName string = stack.outputs.functionAppName
 output functionPrincipalId string = stack.outputs.functionPrincipalId
 output staticWebAppName string = stack.outputs.staticWebAppName
 output staticWebAppHostname string = stack.outputs.staticWebAppHostname
+output customDomainUrl string = isCustomDomainEnabled ? 'https://${customDomainName}' : ''
 output companionClientId string = companionIdentity.outputs.clientId
 output companionTenantId string = companionIdentity.outputs.tenantId
 output companionServicePrincipalObjectId string = companionIdentity.outputs.servicePrincipalObjectId
@@ -160,5 +188,6 @@ output companionBootstrapValues object = {
   actualStateTable: stack.outputs.actualStateTableName
   desiredStateTable: stack.outputs.desiredStateTableName
   staticWebAppHostname: stack.outputs.staticWebAppHostname
+  customDomainUrl: isCustomDomainEnabled ? 'https://${customDomainName}' : ''
   note: 'The deployment registers the supplied certificate public material on the Entra app. The matching PEM certificate and private key remain caller-managed local artifacts for sonde-azure-companion bootstrap.'
 }

--- a/deploy/bicep/modules/dns-record.bicep
+++ b/deploy/bicep/modules/dns-record.bicep
@@ -9,7 +9,7 @@ param dnsZoneName string
 @description('Resource ID of the Static Web App to alias.')
 param staticWebAppResourceId string
 
-resource dnsZone 'Microsoft.Network/dnsZones@2023-07-01-preview' existing = {
+resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' existing = {
   name: dnsZoneName
 }
 
@@ -17,7 +17,7 @@ resource dnsZone 'Microsoft.Network/dnsZones@2023-07-01-preview' existing = {
 // dynamic IP addresses.  Azure DNS ALIAS records use targetResource
 // instead of a static IP address.  Domain ownership validation is
 // handled by the deploy script via `az staticwebapp hostname set`.
-resource aliasRecord 'Microsoft.Network/dnsZones/A@2023-07-01-preview' = {
+resource aliasRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
   parent: dnsZone
   name: '@'
   properties: {

--- a/deploy/bicep/modules/dns-record.bicep
+++ b/deploy/bicep/modules/dns-record.bicep
@@ -13,10 +13,15 @@ resource dnsZone 'Microsoft.Network/dnsZones@2018-05-01' existing = {
   name: dnsZoneName
 }
 
-// ALIAS A record — resolves the apex domain to the Static Web App's
-// dynamic IP addresses.  Azure DNS ALIAS records use targetResource
-// instead of a static IP address.  Domain ownership validation is
-// handled by the deploy script via `az staticwebapp hostname set`.
+// ALIAS A record at the zone apex — resolves the apex domain to the Static
+// Web App's dynamic IP addresses.  Azure DNS ALIAS records use targetResource
+// instead of a static IP address.  Domain ownership validation is handled by
+// the deploy script via `az staticwebapp hostname set`.
+//
+// NOTE: This module only supports apex (naked) domains.  The record name is
+// hardcoded to '@'.  Subdomain bindings (e.g. app.example.com) require a
+// CNAME record at the subdomain label, which is not implemented here.
+// bootstrap.sh validates that customDomainName == dnsZoneName.
 resource aliasRecord 'Microsoft.Network/dnsZones/A@2018-05-01' = {
   parent: dnsZone
   name: '@'

--- a/deploy/bicep/modules/dns-record.bicep
+++ b/deploy/bicep/modules/dns-record.bicep
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+targetScope = 'resourceGroup'
+
+@description('DNS zone name (e.g., sondeplatform.com).')
+param dnsZoneName string
+
+@description('Resource ID of the Static Web App to alias.')
+param staticWebAppResourceId string
+
+resource dnsZone 'Microsoft.Network/dnsZones@2023-07-01-preview' existing = {
+  name: dnsZoneName
+}
+
+// ALIAS A record — resolves the apex domain to the Static Web App's
+// dynamic IP addresses.  Azure DNS ALIAS records use targetResource
+// instead of a static IP address.  Domain ownership validation is
+// handled by the deploy script via `az staticwebapp hostname set`.
+resource aliasRecord 'Microsoft.Network/dnsZones/A@2023-07-01-preview' = {
+  parent: dnsZone
+  name: '@'
+  properties: {
+    TTL: 3600
+    targetResource: {
+      id: staticWebAppResourceId
+    }
+  }
+}
+
+output aliasRecordFqdn string = aliasRecord.properties.fqdn

--- a/deploy/bicep/modules/stack.bicep
+++ b/deploy/bicep/modules/stack.bicep
@@ -51,6 +51,9 @@ param functionAuthClientId string
 @description('Entra tenant ID for Function App EasyAuth OpenID issuer URL.')
 param functionAuthTenantId string
 
+@description('Custom domain FQDN to bind to the Static Web App. Empty = no custom domain.')
+param customDomainName string = ''
+
 var monitoringWorkspaceName = take('${functionAppName}-logs', 63)
 var monitoringAppInsightsName = take('${functionAppName}-insights', 260)
 
@@ -108,7 +111,9 @@ module functionPlaceholder './function-placeholder.bicep' = {
     programsTableName: storage.outputs.programsTableName
     sensorDataTableName: storage.outputs.sensorDataTableName
     appInsightsConnectionString: monitoring.outputs.connectionString
-    corsAllowedOrigins: ['https://${staticWebApp.outputs.defaultHostname}']
+    corsAllowedOrigins: empty(customDomainName)
+      ? ['https://${staticWebApp.outputs.defaultHostname}']
+      : ['https://${staticWebApp.outputs.defaultHostname}', 'https://${customDomainName}']
     functionAuthClientId: functionAuthClientId
     functionAuthTenantId: functionAuthTenantId
     tags: tags
@@ -159,3 +164,4 @@ output functionAppName string = functionPlaceholder.outputs.functionAppName
 output functionPrincipalId string = functionPlaceholder.outputs.principalId
 output staticWebAppName string = staticWebApp.outputs.name
 output staticWebAppHostname string = staticWebApp.outputs.defaultHostname
+output staticWebAppResourceId string = staticWebApp.outputs.resourceId

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -222,6 +222,7 @@ async function initMsal() {
     auth: {
       clientId: CONFIG.msalClientId,
       authority: CONFIG.msalAuthority,
+      redirectUri: window.location.origin,
     },
     cache: {
       cacheLocation: 'sessionStorage',

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -232,8 +232,8 @@ fi
 
 # If the SWA has a custom domain, also register it as a CORS origin and
 # add its redirect URI to the Entra app registration.
-# The custom domain binding itself is done via `az staticwebapp hostname set`
-# which handles domain ownership validation automatically.
+# The custom domain binding itself is done in bootstrap.sh via
+# `az staticwebapp hostname set` after Bicep provisions the DNS record.
 CUSTOM_DOMAINS="$(az staticwebapp hostname list --name "$SWA_NAME" \
   --resource-group "$RESOURCE_GROUP" --query '[].domainName' -o json 2>/dev/null || echo '[]')"
 for DOMAIN in $(echo "$CUSTOM_DOMAINS" | jq -r '.[]? // empty'); do

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -230,6 +230,53 @@ else
   echo "  Added CORS origin: $SWA_ORIGIN"
 fi
 
+# If the SWA has a custom domain, also register it as a CORS origin and
+# add its redirect URI to the Entra app registration.
+# The custom domain binding itself is done via `az staticwebapp hostname set`
+# which handles domain ownership validation automatically.
+CUSTOM_DOMAINS="$(az staticwebapp hostname list --name "$SWA_NAME" \
+  --resource-group "$RESOURCE_GROUP" --query '[].domainName' -o json 2>/dev/null || echo '[]')"
+for DOMAIN in $(echo "$CUSTOM_DOMAINS" | jq -r '.[]? // empty'); do
+  # Skip the default azurestaticapps.net hostname — already handled above
+  case "$DOMAIN" in *.azurestaticapps.net) continue ;; esac
+
+  CUSTOM_ORIGIN="https://$DOMAIN"
+
+  # CORS origin
+  CORS_NOW="$(az functionapp cors show --name "$FUNCTION_APP" \
+    --resource-group "$RESOURCE_GROUP" --query 'allowedOrigins' -o json 2>/dev/null || echo '[]')"
+  HAS_CUSTOM_CORS=0
+  echo "$CORS_NOW" | jq -e --arg o "$CUSTOM_ORIGIN" 'index($o) != null' >/dev/null 2>&1 && HAS_CUSTOM_CORS=1
+  if [ "$HAS_CUSTOM_CORS" -eq 1 ]; then
+    echo "  CORS origin $CUSTOM_ORIGIN already registered"
+  else
+    az functionapp cors add --name "$FUNCTION_APP" \
+      --resource-group "$RESOURCE_GROUP" \
+      --allowed-origins "$CUSTOM_ORIGIN" --output none
+    echo "  Added CORS origin: $CUSTOM_ORIGIN"
+  fi
+
+  # SPA redirect URI — re-fetch current URIs to avoid stale state
+  URIS_NOW="$(az ad app show --id "$APP_OBJECT_ID" \
+    --query 'spa.redirectUris' -o json 2>/dev/null || echo '[]')"
+  if [ -z "$URIS_NOW" ] || [ "$URIS_NOW" = "null" ]; then
+    URIS_NOW="[]"
+  fi
+  CUSTOM_URI_EXISTS=0
+  echo "$URIS_NOW" | jq -e --arg uri "$CUSTOM_ORIGIN" 'index($uri) != null' >/dev/null 2>&1 && CUSTOM_URI_EXISTS=1
+  if [ "$CUSTOM_URI_EXISTS" -eq 1 ]; then
+    echo "  Redirect URI $CUSTOM_ORIGIN already registered"
+  else
+    MERGED_URIS="$(echo "$URIS_NOW" | jq -c --arg uri "$CUSTOM_ORIGIN" '. + [$uri]')"
+    PATCH_BODY="$(jq -n -c --argjson uris "$MERGED_URIS" '{"spa":{"redirectUris":$uris}}')"
+    az rest --method PATCH \
+      --url "https://graph.microsoft.com/v1.0/applications/$APP_OBJECT_ID" \
+      --headers "Content-Type=application/json" \
+      --body "$PATCH_BODY"
+    echo "  Added redirect URI: $CUSTOM_ORIGIN"
+  fi
+done
+
 echo ""
 echo "=== Assigning Storage Table Data Contributor to deploying user ==="
 DEPLOYER_PRINCIPAL="$(az ad signed-in-user show --query id -o tsv 2>/dev/null || true)"
@@ -258,6 +305,10 @@ npx --yes @azure/static-web-apps-cli deploy "$SCRIPT_DIR" \
 echo ""
 echo "=== Deployment complete ==="
 echo "  URL: https://$SWA_HOSTNAME"
+for DOMAIN in $(echo "$CUSTOM_DOMAINS" | jq -r '.[]? // empty'); do
+  case "$DOMAIN" in *.azurestaticapps.net) continue ;; esac
+  echo "  Custom domain: https://$DOMAIN"
+done
 echo ""
 echo "  To use the SPA, users need 'Storage Table Data Contributor' role"
 echo "  on the storage account. Grant with:"

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -113,7 +113,8 @@ else
   az rest --method PATCH \
     --url "https://graph.microsoft.com/v1.0/applications/$APP_OBJECT_ID" \
     --headers "Content-Type=application/json" \
-    --body "$PATCH_BODY"
+    --body "$PATCH_BODY" \
+    --output none
   echo "  Added redirect URI: $REDIRECT_URI"
 fi
 
@@ -173,7 +174,8 @@ else
   az rest --method PATCH \
     --url "https://graph.microsoft.com/v1.0/applications/$APP_OBJECT_ID" \
     --headers "Content-Type=application/json" \
-    --body "$PATCH_BODY"
+    --body "$PATCH_BODY" \
+    --output none
   echo "  Exposed api://$CLIENT_ID/user_impersonation scope"
 fi
 
@@ -272,7 +274,8 @@ for DOMAIN in $(echo "$CUSTOM_DOMAINS" | jq -r '.[]? // empty'); do
     az rest --method PATCH \
       --url "https://graph.microsoft.com/v1.0/applications/$APP_OBJECT_ID" \
       --headers "Content-Type=application/json" \
-      --body "$PATCH_BODY"
+      --body "$PATCH_BODY" \
+      --output none
     echo "  Added redirect URI: $CUSTOM_ORIGIN"
   fi
 done

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -159,6 +159,10 @@ local `ProgramLibrary`.
 - MSAL.js 2.x with authorization code flow + PKCE.
 - Token caching in browser session storage.
 - Silent token renewal; redirect to login on expiry.
+- `redirectUri` explicitly set to `window.location.origin` so the registered
+  redirect URIs (`https://<swa-hostname>` and, when configured,
+  `https://<customDomain>`) match regardless of which hostname the user
+  accesses.
 - Two token scopes, acquired separately:
   - `https://storage.azure.com/.default` — for Azure Table REST API calls
     (dashboard, desired state, program list, sensor data).
@@ -199,8 +203,13 @@ The script:
    companion Entra app as the identity provider and `Return401` for
    unauthenticated requests
 7. Deploys the web-ui content to the Static Web App using the SWA CLI
+8. If the SWA has custom domains, registers `https://<customDomain>` as an
+   additional SPA redirect URI on the Entra app registration (additive merge
+   with existing URIs)
+9. Adds `https://<customDomain>` as an additional CORS allowed origin on the
+   Function App (additive — does not replace the default hostname origin)
 
-> **Note:** Steps 3–4 mutate the Entra app registration associated with the Azure companion.
+> **Note:** Steps 3–4 and 8–9 mutate the Entra app registration associated with the Azure companion.
 
 After deployment, grant users the `Storage Table Data Contributor` role on the storage account.
 
@@ -287,6 +296,52 @@ The SPA derives the Function App API scope as
 an additional `config.json` field. This works because the companion Entra
 app registration is shared between the SPA and the Function App EasyAuth
 configuration.
+
+---
+
+### 9.5 Custom Domain (WEB-0608)
+
+An optional custom domain can be bound to the Static Web App so operators
+access the SPA via a branded URL (e.g., `https://sondeplatform.com`) instead of
+the Azure-generated `*.azurestaticapps.net` hostname.  The default hostname
+remains functional — both URLs serve the same SPA content.
+
+**Bicep parameters** (all optional — omit to skip custom domain setup):
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `customDomainName` | `''` | FQDN for the custom domain (e.g., `sondeplatform.com`). Empty = no custom domain. |
+| `customDomainDnsResourceGroup` | `''` | Resource group containing the Azure DNS zone for the custom domain. |
+| `customDomainDnsZoneName` | `''` | DNS zone name. Defaults to `customDomainName` when empty (correct for apex domains). |
+
+When `customDomainName` and `customDomainDnsResourceGroup` are both non-empty,
+the deployment:
+
+1. **DNS ALIAS record** (`dns-record.bicep`): Deployed to the DNS resource group
+   (cross-resource-group scope from `main.bicep`).  Creates an ALIAS A record
+   (`targetResource.id` pointing to the SWA resource) for apex domain
+   resolution.  Domain ownership validation is handled separately by the
+   deploy script.
+
+2. **Custom domain binding** (`deploy.sh`): The deploy script discovers
+   custom domains via `az staticwebapp hostname list`.  Azure validates
+   domain ownership via the DNS ALIAS record and automatically provisions
+   a managed SSL certificate.
+
+3. **CORS expansion** (`stack.bicep`): The Function App's `corsAllowedOrigins`
+   array includes both `https://<defaultHostname>` and
+   `https://<customDomainName>` so browser requests from either origin succeed.
+
+4. **Additional outputs** (`main.bicep`): `customDomainUrl` is emitted when
+   a custom domain is configured (e.g., `https://sondeplatform.com`).  The
+   `companionBootstrapValues` output object includes `customDomainUrl` so
+   the bootstrap flow can register the custom domain redirect URI.
+
+> **Note:** The DNS zone must already exist in the specified resource group.
+> The Bicep template creates records within it but does not create the zone
+> itself.  On first deployment, DNS propagation to Azure SWA's validators
+> may take a few minutes; if the custom domain binding fails, re-run the
+> deployment after DNS has propagated.
 
 ---
 

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -45,10 +45,12 @@
 | T-WEB-0505 | WEB-0505 | `ProgramIngest` rejects Storage-scoped token (wrong audience) | Integration | Planned |
 | T-WEB-0506 | WEB-0506 | `ProgramIngest` rejects expired bearer token | Integration | Planned |
 | T-WEB-0507 | WEB-0507 | `ProgramIngest` accepts valid `api://<clientId>/user_impersonation` token | Integration | Planned |
+| T-WEB-0508 | WEB-0508 | MSAL `redirectUri` set to `window.location.origin` so auth works on both default and custom domain hostnames | Manual | Planned |
 | T-WEB-0601 | WEB-0601 | Bicep provisions Static Web App | Infrastructure | Planned |
 | T-WEB-0602 | WEB-0602 | Bicep provisions `programs` table | Infrastructure | Planned |
 | T-WEB-0603 | WEB-0603 | `ProgramIngest` HTTP trigger deployed alongside `UpstreamConnector` | Infrastructure | Planned |
 | T-WEB-0604 | WEB-0604 | CORS configured for SPA origin | Infrastructure | Planned |
+| T-WEB-0604b | WEB-0604 | CORS configured for both default hostname and custom domain origins when custom domain is set | Infrastructure | Planned |
 | T-WEB-0605 | WEB-0605 | Function identity has table contributor on `programs` | Infrastructure | Planned |
 | T-WEB-0606 | WEB-0606 | EasyAuth configured on Function App with Entra ID provider | Infrastructure | Planned |
 | T-WEB-0607 | WEB-0607 | `ProgramIngest` `authLevel` is `anonymous` (auth delegated to EasyAuth) | Infrastructure | Planned |
@@ -64,3 +66,9 @@
 | T-WEB-0710 | WEB-0703 | Unit suffix appears in tooltip values and Y-axis title when all series share the same suffix | Manual | Planned |
 | T-WEB-0711 | WEB-0703 | Overrides persist across page reloads via `localStorage` | Manual | Planned |
 | T-WEB-0712 | WEB-0703 | Reset to Default clears overrides and restores original label/scale | Manual | Planned |
+| T-WEB-0608a | WEB-0608 | Bicep deploys DNS ALIAS record in external resource group pointing to SWA | Infrastructure | Planned |
+| T-WEB-0608b | WEB-0608 | Deploy script binds custom domain to SWA; managed SSL certificate provisioned | Infrastructure | Planned |
+| T-WEB-0608c | WEB-0608 | Custom domain parameters empty → no DNS records or custom domain binding created | Infrastructure | Planned |
+| T-WEB-0609a | WEB-0609 | Deploy script registers custom domain redirect URI on Entra app | Infrastructure | Planned |
+| T-WEB-0609b | WEB-0609 | Deploy script adds custom domain CORS origin to Function App | Infrastructure | Planned |
+| T-WEB-0610 | WEB-0610 | `companionBootstrapValues` output includes `customDomainUrl` field | Infrastructure | Planned |


### PR DESCRIPTION
Add custom domain support for Azure Static Web Apps deployment including DNS ALIAS records, managed SSL certificate provisioning, and Entra app redirect URI registration.