### PR TITLE
fix(deploy): default docker-compose image tag to nightly

### DIFF
--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -7,9 +7,9 @@
 #   cp .env.example .env
 
 # ── Image version ────────────────────────────────────────────────────
-# Tag applied to all GHCR images.  Use "latest", "nightly", or a
-# specific version like "0.5.0".
-# SONDE_IMAGE_TAG=latest
+# Tag applied to all GHCR images.  Use "nightly" (default, tracks main),
+# "latest" (last release), or a specific version like "0.5.0".
+# SONDE_IMAGE_TAG=nightly
 
 # ── Gateway ──────────────────────────────────────────────────────────
 # Serial port for the ESP-NOW modem (host device path).
@@ -36,7 +36,7 @@
 
 # (Optional) Override the bootstrap container image.  Defaults to the
 # same tag as the other images (SONDE_IMAGE_TAG).
-# SONDE_AZURE_BOOTSTRAP_IMAGE=ghcr.io/alan-jowett/sonde-azure-bootstrap:latest
+# SONDE_AZURE_BOOTSTRAP_IMAGE=ghcr.io/alan-jowett/sonde-azure-bootstrap:nightly
 
 # ── Azure companion (optional overrides) ─────────────────────────────
 # These are normally populated by the bootstrap step and read from

--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -100,7 +100,7 @@ See [`.env.example`](.env.example) for the full list with documentation.
 
 | Variable | Description |
 |----------|-------------|
-| `SONDE_IMAGE_TAG` | Container image tag (default: `latest`) |
+| `SONDE_IMAGE_TAG` | Container image tag (default: `nightly`) |
 | `SONDE_ESPNOW_CHANNEL` | ESP-NOW radio channel 1–14 (default: `1`) |
 | `SONDE_AZURE_SUBSCRIPTION_ID` | Azure subscription override |
 | `SONDE_AZURE_BOOTSTRAP_IMAGE` | Bootstrap container image override |

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   # ── sonde-gateway ──────────────────────────────────────────────────
   # The gateway manages sensor nodes over ESP-NOW radio via the USB modem.
   gateway:
-    image: ghcr.io/alan-jowett/sonde-gateway:${SONDE_IMAGE_TAG:-latest}
+    image: ghcr.io/alan-jowett/sonde-gateway:${SONDE_IMAGE_TAG:-nightly}
     container_name: sonde-gateway
     user: "0:0"
     command:
@@ -59,7 +59,7 @@ services:
   # deploys Bicep templates, and writes state files consumed by the
   # companion service.
   bootstrap:
-    image: ghcr.io/alan-jowett/sonde-azure-companion:${SONDE_IMAGE_TAG:-latest}
+    image: ghcr.io/alan-jowett/sonde-azure-companion:${SONDE_IMAGE_TAG:-nightly}
     container_name: sonde-bootstrap
     user: "0:0"
     entrypoint: ["sonde-azure-companion"]
@@ -75,7 +75,7 @@ services:
       - "${SONDE_AZURE_PROJECT_NAME:-sonde}"
     environment:
       - SONDE_AZURE_SUBSCRIPTION_ID
-      - SONDE_AZURE_BOOTSTRAP_IMAGE=${SONDE_AZURE_BOOTSTRAP_IMAGE:-ghcr.io/alan-jowett/sonde-azure-bootstrap:${SONDE_IMAGE_TAG:-latest}}
+      - SONDE_AZURE_BOOTSTRAP_IMAGE=${SONDE_AZURE_BOOTSTRAP_IMAGE:-ghcr.io/alan-jowett/sonde-azure-bootstrap:${SONDE_IMAGE_TAG:-nightly}}
     volumes:
       - sonde-runtime:/var/run/sonde:ro
       - sonde-companion-state:/var/lib/sonde-azure-companion
@@ -89,7 +89,7 @@ services:
   # Long-running Azure connector.  Bridges the gateway to Azure Storage
   # Queues for cloud-based program distribution and telemetry.
   companion:
-    image: ghcr.io/alan-jowett/sonde-azure-companion:${SONDE_IMAGE_TAG:-latest}
+    image: ghcr.io/alan-jowett/sonde-azure-companion:${SONDE_IMAGE_TAG:-nightly}
     container_name: sonde-companion
     user: "0:0"
     entrypoint: ["sonde-azure-companion"]


### PR DESCRIPTION
The \latest\ tag is only pushed on release tags (e.g. \0.5.0\), so \\\ pulled a stale image that predated
\--connector-socket\ and \--channel\, causing the gateway container to crash on startup.

Change the default from \latest\ to \
ightly\ so docker-compose tracks
the current \main\ branch builds.  Users who want the last known-good release can still set \SONDE_IMAGE_TAG=latest\ in their \.env\.