### PR TITLE
Replace SWA CLI with ARM zipdeploy REST API for portable SPA deployment

### DIFF
--- a/.github/docker/Dockerfile.azure-bootstrap
+++ b/.github/docker/Dockerfile.azure-bootstrap
@@ -13,8 +13,7 @@
 
 FROM mcr.microsoft.com/azure-cli@sha256:925b5871029fe16b82650c8298201e5dd91ac8122c7af1d150b57edc8c9f316a
 
-RUN tdnf install -y jq icu nodejs24 nodejs24-npm && tdnf clean all \
-    && npm install -g @azure/static-web-apps-cli@2.0.9
+RUN tdnf install -y jq icu && tdnf clean all
 
 COPY deploy/azure-bootstrap/bootstrap.sh /opt/sonde/deploy/azure-bootstrap/bootstrap.sh
 COPY deploy/bicep/ /opt/sonde/deploy/bicep/

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -262,7 +262,7 @@ jobs:
 
             cat > /tmp/fakebin/curl <<'"'"'SH'"'"'
             #!/bin/sh
-            printf "200"
+            printf '{"msalClientId":"22222222-2222-2222-2222-222222222222"}'
             exit 0
             SH
             chmod +x /tmp/fakebin/curl

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -225,14 +225,9 @@ jobs:
                     ;;
                 esac
                 ;;
-              storage)
-                # Handle storage container create, blob upload/generate-sas/delete
-                if [ "${2:-}" = "account" ] && [ "${3:-}" = "show" ]; then
-                  printf "https://stsondecitest.blob.core.windows.net/\n"
-                  exit 0
-                fi
-                if [ "${2:-}" = "blob" ] && [ "${3:-}" = "generate-sas" ]; then
-                  printf "sv=2023-01-01&sig=fakesas\n"
+              staticwebapp)
+                if [ "${2:-}" = "secrets" ] && [ "${3:-}" = "list" ]; then
+                  printf "fake-deployment-token\n"
                   exit 0
                 fi
                 exit 0
@@ -273,10 +268,16 @@ jobs:
 
             cat > /tmp/fakebin/curl <<'"'"'SH'"'"'
             #!/bin/sh
-            printf '{"msalClientId":"22222222-2222-2222-2222-222222222222"}'
             exit 0
             SH
             chmod +x /tmp/fakebin/curl
+
+            cat > /tmp/fakebin/docker <<'"'"'SH'"'"'
+            #!/bin/sh
+            printf "%s\n" "$*" >> /tmp/docker-calls.log
+            exit 0
+            SH
+            chmod +x /tmp/fakebin/docker
 
             cat > /tmp/fakebin/jq <<'"'"'SH'"'"'
             #!/bin/sh
@@ -317,9 +318,9 @@ jobs:
             grep -q "functionapp deployment source config-zip" /tmp/az-calls.log
             test "$(cat /tmp/function-list-count)" = "2"
             grep -q "Deploying Web UI to Static Web App" /tmp/bootstrap-stderr.txt
-            grep -q "Zipped SPA content" /tmp/bootstrap-stderr.txt
-            grep -q "storage blob upload" /tmp/az-calls.log
-            grep -q "rest --method POST" /tmp/az-calls.log
+            grep -q "Generated config.json for SPA" /tmp/bootstrap-stderr.txt
+            grep -q "staticwebapp secrets list" /tmp/az-calls.log
+            grep -q "mcr.microsoft.com/appsvc/staticappsclient:stable" /tmp/docker-calls.log
             grep -q "SPA content deployed" /tmp/bootstrap-stderr.txt
 
             python3 - <<'"'"'PY'"'"'

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -136,17 +136,32 @@ jobs:
                 exit 0
                 ;;
               account)
-                [ "${2:-}" = "set" ] || exit 1
-                exit 0
+                if [ "${2:-}" = "set" ]; then exit 0; fi
+                if [ "${2:-}" = "show" ]; then printf 'fake-sub-id\n'; exit 0; fi
+                exit 1
+                ;;
+              cloud)
+                if [ "${2:-}" = "show" ]; then printf 'https://login.microsoftonline.com\n'; exit 0; fi
+                exit 1
                 ;;
               deployment)
-                [ "${2:-}" = "sub" ] && [ "${3:-}" = "create" ] || exit 1
+                if [ "${2:-}" = "sub" ] && [ "${3:-}" = "create" ]; then
                 cat <<'"'"'JSON'"'"'
             {"resourceGroupName":{"value":"rg-test"},"companionBootstrapValues":{"value":{"tenantId":"11111111-1111-1111-1111-111111111111","clientId":"22222222-2222-2222-2222-222222222222","storageQueueEndpoint":"https://example.queue.core.windows.net","upstreamQueue":"upstream","downstreamQueue":"downstream","functionAppName":"func-test","deploymentContainerName":"app-package-test","deploymentContainerUrl":"https://example.blob.core.windows.net/app-package-test"}}}
             JSON
+                  exit 0
+                fi
+                if [ "${2:-}" = "sub" ] && [ "${3:-}" = "show" ]; then
+                  printf "rg-test\tfunc-test\tapp-package-test\thttps://example.blob.core.windows.net/app-package-test\tsonde-web-ci\tsonde-web-ci.azurestaticapps.net\t22222222-2222-2222-2222-222222222222\tstsondecitest\t11111111-1111-1111-1111-111111111111\n"
+                  exit 0
+                fi
+                exit 1
                 ;;
               functionapp)
                 case "${2:-}" in
+                  config)
+                    exit 0
+                    ;;
                   deployment)
                     [ "${3:-}" = "source" ] && [ "${4:-}" = "config-zip" ] || exit 1
                     src=
@@ -199,6 +214,39 @@ jobs:
                     ;;
                 esac
                 ;;
+              storage)
+                # Handle storage container create, blob upload/generate-sas/delete
+                if [ "${2:-}" = "account" ] && [ "${3:-}" = "show" ]; then
+                  printf "https://stsondecitest.blob.core.windows.net/\n"
+                  exit 0
+                fi
+                if [ "${2:-}" = "blob" ] && [ "${3:-}" = "generate-sas" ]; then
+                  printf "sv=2023-01-01&sig=fakesas\n"
+                  exit 0
+                fi
+                exit 0
+                ;;
+              rest)
+                exit 0
+                ;;
+              ad)
+                # Handle ad app show, ad app permission, ad signed-in-user show
+                query=""
+                while [ "$#" -gt 0 ]; do
+                  case "$1" in
+                    --query) query="$2"; shift 2 ;;
+                    *) shift ;;
+                  esac
+                done
+                if [ "$query" = "id" ]; then printf 'obj-id-ci\n'; exit 0; fi
+                if [ "$query" = "spa.redirectUris" ]; then printf "[]\n"; exit 0; fi
+                if [ "$query" = "api.oauth2PermissionScopes" ]; then printf "[]\n"; exit 0; fi
+                if [ "$query" = "identifierUris" ]; then printf "[]\n"; exit 0; fi
+                exit 0
+                ;;
+              role)
+                exit 0
+                ;;
               *)
                 exit 1
                 ;;
@@ -211,6 +259,38 @@ jobs:
             exit 0
             SH
             chmod +x /tmp/fakebin/sleep
+
+            cat > /tmp/fakebin/curl <<'"'"'SH'"'"'
+            #!/bin/sh
+            printf "200"
+            exit 0
+            SH
+            chmod +x /tmp/fakebin/curl
+
+            cat > /tmp/fakebin/jq <<'"'"'SH'"'"'
+            #!/bin/sh
+            if [ ! -t 0 ]; then cat >/dev/null 2>&1 || true; fi
+            uri_val=""
+            argjson_val=""
+            argjson2_val=""
+            while [ "$#" -gt 1 ]; do
+              case "$1" in
+                --arg)     uri_val="$3"; shift 3 ;;
+                --argjson) if [ -z "$argjson_val" ]; then argjson_val="$3"; else argjson2_val="$3"; fi; shift 3 ;;
+                *)         shift ;;
+              esac
+            done
+            expr="$1"
+            case "$expr" in
+              *select*length*) exit 1 ;;
+              *if*index*)      printf "[\"$uri_val\"]\n"; exit 0 ;;
+              *index*)         exit 1 ;;
+              *identifierUris*oauth2*) printf "{\"identifierUris\":$argjson_val,\"api\":{\"oauth2PermissionScopes\":$argjson2_val}}\n"; exit 0 ;;
+              *spa*)           printf "{\"spa\":{\"redirectUris\":$argjson_val}}\n"; exit 0 ;;
+              *)               printf "[\"$uri_val\"]\n"; exit 0 ;;
+            esac
+            SH
+            chmod +x /tmp/fakebin/jq
 
             PATH="/tmp/fakebin:$PATH" \
             SONDE_AZURE_LOCATION=eastus \
@@ -225,6 +305,11 @@ jobs:
             grep -q "Azure Function App reports 1 loaded function(s)" /tmp/bootstrap-stderr.txt
             grep -q "functionapp deployment source config-zip" /tmp/az-calls.log
             test "$(cat /tmp/function-list-count)" = "2"
+            grep -q "Deploying Web UI to Static Web App" /tmp/bootstrap-stderr.txt
+            grep -q "Zipped SPA content" /tmp/bootstrap-stderr.txt
+            grep -q "storage blob upload" /tmp/az-calls.log
+            grep -q "rest --method POST" /tmp/az-calls.log
+            grep -q "SPA content deployed" /tmp/bootstrap-stderr.txt
 
             python3 - <<'"'"'PY'"'"'
             import json

--- a/.github/workflows/azure-bootstrap-container.yml
+++ b/.github/workflows/azure-bootstrap-container.yml
@@ -141,7 +141,18 @@ jobs:
                 exit 1
                 ;;
               cloud)
-                if [ "${2:-}" = "show" ]; then printf 'https://login.microsoftonline.com\n'; exit 0; fi
+                if [ "${2:-}" = "show" ]; then
+                  query=""
+                  while [ "$#" -gt 0 ]; do
+                    case "$1" in --query) query="$2"; shift 2 ;; *) shift ;; esac
+                  done
+                  if [ "$query" = "endpoints.resourceManager" ]; then
+                    printf 'https://management.azure.com/\n'
+                  else
+                    printf 'https://login.microsoftonline.com\n'
+                  fi
+                  exit 0
+                fi
                 exit 1
                 ;;
               deployment)

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -399,7 +399,7 @@ jobs:
           }
           trap cleanup_spa_blob EXIT
 
-          # Generate config.json and zip SPA content
+          # Generate config.json for the SPA
           cat > /tmp/sonde-spa-config.json <<CFGEOF
           {
             "msalClientId": "$CLIENT_ID",
@@ -409,25 +409,28 @@ jobs:
           }
           CFGEOF
 
-          # Use the bootstrap image to validate it has the required tools (az, python3)
-          # and to zip the bundled SPA content with the generated config.json.
-          docker run --rm \
-            --entrypoint sh \
-            -v /tmp/sonde-spa-config.json:/tmp/config.json:ro \
+          # Verify the bootstrap image has the required tools (az, python3, no swa).
+          docker run --rm --entrypoint sh sonde-azure-bootstrap:ci -c \
+            'az version >/dev/null && python3 --version >/dev/null && ! command -v swa >/dev/null'
+
+          # Copy SPA content from the bootstrap image and add config.json.
+          SPA_STAGE="$(mktemp -d /tmp/sonde-spa-stage-XXXXXX)"
+          docker run --rm --entrypoint sh \
             sonde-azure-bootstrap:ci \
-            -c "
-              cp /tmp/config.json /opt/sonde/deploy/web-ui/config.json
-              python3 -c \"
-import os, sys, zipfile
-src_dir = '/opt/sonde/deploy/web-ui'
-with zipfile.ZipFile('/dev/stdout', 'w', zipfile.ZIP_DEFLATED) as zf:
-    for root, _dirs, files in os.walk(src_dir):
-        for f in sorted(files):
-            full = os.path.join(root, f)
-            arcname = os.path.relpath(full, src_dir)
-            zf.write(full, arcname)
-\" > /dev/stdout
-            " > "$SPA_ZIP"
+            -c 'tar -cf - -C /opt/sonde/deploy/web-ui .' | tar -xf - -C "$SPA_STAGE"
+          cp /tmp/sonde-spa-config.json "$SPA_STAGE/config.json"
+
+          # Zip the staged SPA content using the host python3.
+          python3 -c "
+          import os, sys, zipfile
+          src, dst = sys.argv[1], sys.argv[2]
+          with zipfile.ZipFile(dst, 'w', zipfile.ZIP_DEFLATED) as zf:
+              for root, _dirs, files in os.walk(src):
+                  for f in sorted(files):
+                      full = os.path.join(root, f)
+                      zf.write(full, os.path.relpath(full, src))
+          " "$SPA_STAGE" "$SPA_ZIP"
+          rm -rf "$SPA_STAGE"
 
           az storage container create \
             --account-name "$STORAGE_ACCOUNT" \

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -379,37 +379,11 @@ jobs:
           print(d['properties']['outputs']['functionAppName']['value'])
           ")"
 
-          echo "Deploying SPA to $SWA_NAME ($SWA_HOSTNAME) via ARM zipdeploy..."
+          echo "Deploying SPA to $SWA_NAME ($SWA_HOSTNAME) via StaticSitesClient..."
 
           # Resolve login endpoint from the active cloud for sovereign cloud compatibility
           LOGIN_ENDPOINT="$(az cloud show --query endpoints.activeDirectory -o tsv)"
           LOGIN_ENDPOINT="${LOGIN_ENDPOINT%/}"
-
-          # Deploy SPA content using the ARM zipdeploy REST API.
-          # This replaces the SWA CLI which required amd64-only native binaries.
-          SPA_ZIP="$(mktemp /tmp/sonde-spa-XXXXXX.zip)"
-          _SPA_BLOB_NAME="spa-deploy-ci-$(date +%s)-$$-${RANDOM}.zip"
-          cleanup_spa_blob() {
-              rm -f "$SPA_ZIP"
-              if [ -n "${_SPA_BLOB_UPLOADED:-}" ]; then
-                  az storage blob delete \
-                      --account-name "$STORAGE_ACCOUNT" \
-                      --container-name "spa-deploy" \
-                      --name "$_SPA_BLOB_NAME" \
-                      --output none 2>/dev/null || true
-              fi
-          }
-          trap cleanup_spa_blob EXIT
-
-          # Generate config.json for the SPA
-          cat > /tmp/sonde-spa-config.json <<CFGEOF
-          {
-            "msalClientId": "$CLIENT_ID",
-            "msalAuthority": "$LOGIN_ENDPOINT/$TENANT_ID",
-            "storageAccount": "$STORAGE_ACCOUNT",
-            "functionAppName": "$FUNCTION_APP"
-          }
-          CFGEOF
 
           # Verify the bootstrap image has the required tools (az, python3, no swa).
           docker run --rm --entrypoint sh sonde-azure-bootstrap:ci -c \
@@ -421,55 +395,32 @@ jobs:
           docker create --name "$SPA_COPY_CTR" --entrypoint sh sonde-azure-bootstrap:ci -c true >/dev/null
           docker cp "$SPA_COPY_CTR:/opt/sonde/deploy/web-ui/." "$SPA_STAGE/"
           docker rm "$SPA_COPY_CTR" >/dev/null
-          cp /tmp/sonde-spa-config.json "$SPA_STAGE/config.json"
+          cat > "$SPA_STAGE/config.json" <<CFGEOF
+          {
+            "msalClientId": "$CLIENT_ID",
+            "msalAuthority": "$LOGIN_ENDPOINT/$TENANT_ID",
+            "storageAccount": "$STORAGE_ACCOUNT",
+            "functionAppName": "$FUNCTION_APP"
+          }
+          CFGEOF
 
-          # Zip the staged SPA content using the host python3.
-          python3 -c "
-          import os, sys, zipfile
-          src, dst = sys.argv[1], sys.argv[2]
-          with zipfile.ZipFile(dst, 'w', zipfile.ZIP_DEFLATED) as zf:
-              for root, _dirs, files in os.walk(src):
-                  for f in sorted(files):
-                      full = os.path.join(root, f)
-                      zf.write(full, os.path.relpath(full, src))
-          " "$SPA_STAGE" "$SPA_ZIP"
-          rm -rf "$SPA_STAGE"
-
-          az storage container create \
-            --account-name "$STORAGE_ACCOUNT" \
-            --name "spa-deploy" \
-            --public-access off \
-            --output none 2>/dev/null || true
-          az storage blob upload \
-            --account-name "$STORAGE_ACCOUNT" \
-            --container-name "spa-deploy" \
-            --name "$_SPA_BLOB_NAME" \
-            --file "$SPA_ZIP" \
-            --overwrite \
-            --output none
-          _SPA_BLOB_UPLOADED=1
-          SAS_EXPIRY="$(python3 -c "from datetime import datetime,timedelta,timezone;print((datetime.now(timezone.utc)+timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
-          BLOB_ENDPOINT="$(az storage account show \
-            --name "$STORAGE_ACCOUNT" \
+          # Deploy SPA content using the StaticSitesClient multi-arch Docker image.
+          DEPLOYMENT_TOKEN="$(az staticwebapp secrets list \
+            --name "$SWA_NAME" \
             --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-            --query 'primaryEndpoints.blob' \
-            --output tsv)"
-          BLOB_ENDPOINT="${BLOB_ENDPOINT%/}"
-          SAS_TOKEN="$(az storage blob generate-sas \
-            --account-name "$STORAGE_ACCOUNT" \
-            --container-name "spa-deploy" \
-            --name "$_SPA_BLOB_NAME" \
-            --permissions r \
-            --expiry "$SAS_EXPIRY" \
-            --output tsv)"
-          BLOB_URL="${BLOB_ENDPOINT}/spa-deploy/${_SPA_BLOB_NAME}?${SAS_TOKEN}"
-          SUBSCRIPTION_ID="$(az account show --query id --output tsv)"
-          ARM_ENDPOINT="$(az cloud show --query endpoints.resourceManager --output tsv)"
-          ARM_ENDPOINT="${ARM_ENDPOINT%/}"
-          az rest --method POST \
-            --url "${ARM_ENDPOINT}/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/builds/default/zipdeploy?api-version=2024-04-01" \
-            --body "{\"properties\":{\"appZipUrl\":\"${BLOB_URL}\",\"provider\":\"sonde-ci\"}}" \
-            --output none
+            --query 'properties.apiKey' -o tsv)"
+
+          docker run --rm \
+            -v "$SPA_STAGE:/app" \
+            -e "DEPLOYMENT_TOKEN=$DEPLOYMENT_TOKEN" \
+            -e "DEPLOYMENT_ACTION=upload" \
+            -e "DEPLOYMENT_PROVIDER=sonde-ci" \
+            -e "APP_LOCATION=/app" \
+            -e "SKIP_APP_BUILD=true" \
+            -e "SKIP_API_BUILD=true" \
+            -e "VERBOSE=false" \
+            mcr.microsoft.com/appsvc/staticappsclient:stable
+          rm -rf "$SPA_STAGE"
 
           echo "Verifying SPA is reachable..."
           for attempt in $(seq 1 12); do

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -391,11 +391,13 @@ jobs:
           _SPA_BLOB_NAME="spa-deploy-ci-$(date +%s)-$$.zip"
           cleanup_spa_blob() {
               rm -f "$SPA_ZIP"
-              az storage blob delete \
-                  --account-name "$STORAGE_ACCOUNT" \
-                  --container-name "spa-deploy" \
-                  --name "$_SPA_BLOB_NAME" \
-                  --output none 2>/dev/null || true
+              if [ -n "${_SPA_BLOB_UPLOADED:-}" ]; then
+                  az storage blob delete \
+                      --account-name "$STORAGE_ACCOUNT" \
+                      --container-name "spa-deploy" \
+                      --name "$_SPA_BLOB_NAME" \
+                      --output none 2>/dev/null || true
+              fi
           }
           trap cleanup_spa_blob EXIT
 
@@ -444,6 +446,7 @@ jobs:
             --file "$SPA_ZIP" \
             --overwrite \
             --output none
+          _SPA_BLOB_UPLOADED=1
           SAS_EXPIRY="$(python3 -c "from datetime import datetime,timedelta,timezone;print((datetime.now(timezone.utc)+timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
           BLOB_ENDPOINT="$(az storage account show \
             --name "$STORAGE_ACCOUNT" \

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -379,37 +379,88 @@ jobs:
           print(d['properties']['outputs']['functionAppName']['value'])
           ")"
 
-          echo "Deploying SPA to $SWA_NAME ($SWA_HOSTNAME) via bootstrap image..."
-          DEPLOYMENT_TOKEN="$(az staticwebapp secrets list \
-            --name "$SWA_NAME" \
-            --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
-            --query 'properties.apiKey' -o tsv)"
+          echo "Deploying SPA to $SWA_NAME ($SWA_HOSTNAME) via ARM zipdeploy..."
 
           # Resolve login endpoint from the active cloud for sovereign cloud compatibility
           LOGIN_ENDPOINT="$(az cloud show --query endpoints.activeDirectory -o tsv)"
           LOGIN_ENDPOINT="${LOGIN_ENDPOINT%/}"
 
-          # Run swa deploy inside the bootstrap image to validate that the
-          # image has all required native dependencies (libicu, etc.).
-          # Override the ENTRYPOINT (bootstrap.sh, which uses interactive
-          # device-code login) so we run swa deploy directly with the
-          # deployment token obtained from the host.
-          docker run --rm \
-            --entrypoint sh \
-            sonde-azure-bootstrap:ci \
-            -c "
-              cat > /opt/sonde/deploy/web-ui/config.json <<'CFGEOF'
+          # Deploy SPA content using the ARM zipdeploy REST API.
+          # This replaces the SWA CLI which required amd64-only native binaries.
+          SPA_ZIP="$(mktemp /tmp/sonde-spa-XXXXXX.zip)"
+          _SPA_BLOB_NAME="spa-deploy-ci-$(date +%s)-$$.zip"
+          cleanup_spa_blob() {
+              rm -f "$SPA_ZIP"
+              az storage blob delete \
+                  --account-name "$STORAGE_ACCOUNT" \
+                  --container-name "spa-deploy" \
+                  --name "$_SPA_BLOB_NAME" \
+                  --output none 2>/dev/null || true
+          }
+          trap cleanup_spa_blob EXIT
+
+          # Generate config.json and zip SPA content
+          cat > /tmp/sonde-spa-config.json <<CFGEOF
           {
-            \"msalClientId\": \"$CLIENT_ID\",
-            \"msalAuthority\": \"$LOGIN_ENDPOINT/$TENANT_ID\",
-            \"storageAccount\": \"$STORAGE_ACCOUNT\",
-            \"functionAppName\": \"$FUNCTION_APP\"
+            "msalClientId": "$CLIENT_ID",
+            "msalAuthority": "$LOGIN_ENDPOINT/$TENANT_ID",
+            "storageAccount": "$STORAGE_ACCOUNT",
+            "functionAppName": "$FUNCTION_APP"
           }
           CFGEOF
-              swa deploy /opt/sonde/deploy/web-ui \
-                --deployment-token '$DEPLOYMENT_TOKEN' \
-                --env production
-            "
+
+          # Use the bootstrap image to validate it has the required tools (az, python3)
+          # and to zip the bundled SPA content with the generated config.json.
+          docker run --rm \
+            --entrypoint sh \
+            -v /tmp/sonde-spa-config.json:/tmp/config.json:ro \
+            sonde-azure-bootstrap:ci \
+            -c "
+              cp /tmp/config.json /opt/sonde/deploy/web-ui/config.json
+              python3 -c \"
+import os, sys, zipfile
+src_dir = '/opt/sonde/deploy/web-ui'
+with zipfile.ZipFile('/dev/stdout', 'w', zipfile.ZIP_DEFLATED) as zf:
+    for root, _dirs, files in os.walk(src_dir):
+        for f in sorted(files):
+            full = os.path.join(root, f)
+            arcname = os.path.relpath(full, src_dir)
+            zf.write(full, arcname)
+\" > /dev/stdout
+            " > "$SPA_ZIP"
+
+          az storage container create \
+            --account-name "$STORAGE_ACCOUNT" \
+            --name "spa-deploy" \
+            --public-access off \
+            --output none 2>/dev/null || true
+          az storage blob upload \
+            --account-name "$STORAGE_ACCOUNT" \
+            --container-name "spa-deploy" \
+            --name "$_SPA_BLOB_NAME" \
+            --file "$SPA_ZIP" \
+            --overwrite \
+            --output none
+          SAS_EXPIRY="$(python3 -c "from datetime import datetime,timedelta,timezone;print((datetime.now(timezone.utc)+timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
+          BLOB_ENDPOINT="$(az storage account show \
+            --name "$STORAGE_ACCOUNT" \
+            --resource-group "$SONDE_AZURE_CI_RESOURCE_GROUP" \
+            --query 'primaryEndpoints.blob' \
+            --output tsv)"
+          BLOB_ENDPOINT="${BLOB_ENDPOINT%/}"
+          SAS_TOKEN="$(az storage blob generate-sas \
+            --account-name "$STORAGE_ACCOUNT" \
+            --container-name "spa-deploy" \
+            --name "$_SPA_BLOB_NAME" \
+            --permissions r \
+            --expiry "$SAS_EXPIRY" \
+            --output tsv)"
+          BLOB_URL="${BLOB_ENDPOINT}/spa-deploy/${_SPA_BLOB_NAME}?${SAS_TOKEN}"
+          SUBSCRIPTION_ID="$(az account show --query id --output tsv)"
+          az rest --method POST \
+            --url "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/zipdeploy?api-version=2024-04-01" \
+            --body "{\"properties\":{\"appZipUrl\":\"${BLOB_URL}\",\"provider\":\"sonde-ci\"}}" \
+            --output none
 
           echo "Verifying SPA is reachable..."
           for attempt in $(seq 1 12); do

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -467,7 +467,7 @@ jobs:
           ARM_ENDPOINT="$(az cloud show --query endpoints.resourceManager --output tsv)"
           ARM_ENDPOINT="${ARM_ENDPOINT%/}"
           az rest --method POST \
-            --url "${ARM_ENDPOINT}/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/zipdeploy?api-version=2024-04-01" \
+            --url "${ARM_ENDPOINT}/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/builds/default/zipdeploy?api-version=2024-04-01" \
             --body "{\"properties\":{\"appZipUrl\":\"${BLOB_URL}\",\"provider\":\"sonde-ci\"}}" \
             --output none
 

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -417,9 +417,10 @@ jobs:
 
           # Copy SPA content from the bootstrap image and add config.json.
           SPA_STAGE="$(mktemp -d /tmp/sonde-spa-stage-XXXXXX)"
-          docker run --rm --entrypoint sh \
-            sonde-azure-bootstrap:ci \
-            -c 'tar -cf - -C /opt/sonde/deploy/web-ui .' | tar -xf - -C "$SPA_STAGE"
+          SPA_COPY_CTR="sonde-spa-copy-$$"
+          docker create --name "$SPA_COPY_CTR" --entrypoint sh sonde-azure-bootstrap:ci -c true >/dev/null
+          docker cp "$SPA_COPY_CTR:/opt/sonde/deploy/web-ui/." "$SPA_STAGE/"
+          docker rm "$SPA_COPY_CTR" >/dev/null
           cp /tmp/sonde-spa-config.json "$SPA_STAGE/config.json"
 
           # Zip the staged SPA content using the host python3.

--- a/.github/workflows/azure-live-ci.yml
+++ b/.github/workflows/azure-live-ci.yml
@@ -388,7 +388,7 @@ jobs:
           # Deploy SPA content using the ARM zipdeploy REST API.
           # This replaces the SWA CLI which required amd64-only native binaries.
           SPA_ZIP="$(mktemp /tmp/sonde-spa-XXXXXX.zip)"
-          _SPA_BLOB_NAME="spa-deploy-ci-$(date +%s)-$$.zip"
+          _SPA_BLOB_NAME="spa-deploy-ci-$(date +%s)-$$-${RANDOM}.zip"
           cleanup_spa_blob() {
               rm -f "$SPA_ZIP"
               if [ -n "${_SPA_BLOB_UPLOADED:-}" ]; then
@@ -464,8 +464,10 @@ jobs:
             --output tsv)"
           BLOB_URL="${BLOB_ENDPOINT}/spa-deploy/${_SPA_BLOB_NAME}?${SAS_TOKEN}"
           SUBSCRIPTION_ID="$(az account show --query id --output tsv)"
+          ARM_ENDPOINT="$(az cloud show --query endpoints.resourceManager --output tsv)"
+          ARM_ENDPOINT="${ARM_ENDPOINT%/}"
           az rest --method POST \
-            --url "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/zipdeploy?api-version=2024-04-01" \
+            --url "${ARM_ENDPOINT}/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${SONDE_AZURE_CI_RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/zipdeploy?api-version=2024-04-01" \
             --body "{\"properties\":{\"appZipUrl\":\"${BLOB_URL}\",\"provider\":\"sonde-ci\"}}" \
             --output none
 

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -3984,15 +3984,18 @@ mod tests {
                 "DELETE /containers/test-container".to_string(),
             ]
         );
-        assert!(requests[0].url.query().is_some_and(|query| query
-            .contains("fromImage=sonde-azure-bootstrap%3Atest-override")
-            && query.contains("platform=linux%2Famd64")));
+        assert!(requests[0]
+            .url
+            .query()
+            .is_some_and(|query| query
+                .contains("fromImage=sonde-azure-bootstrap%3Atest-override")
+                && !query.contains("platform=")));
         assert!(
-            requests[1]
+            !requests[1]
                 .url
                 .query()
-                .is_some_and(|query| query.contains("platform=linux%2Famd64")),
-            "container create must specify platform=linux/amd64"
+                .is_some_and(|query| query.contains("platform=")),
+            "container create must not force a platform — native arch is used"
         );
         let create_body = String::from_utf8(requests[1].body.clone()).unwrap();
         assert!(create_body.contains("COMPANION_CERT_BASE64=dummy-cert-base64"));

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -2149,13 +2149,8 @@ async fn run_bootstrap_deployment_with_docker_and_image(
     bootstrap_image: &str,
 ) -> Result<(ServicePrincipalStateFile, StorageQueuesConfigFile), CompanionError> {
     eprintln!("Pulling bootstrap image...");
-    // The bootstrap image (azure-cli + SWA CLI) is x86_64-only: the
-    // StaticSitesClient binary that the SWA CLI downloads at runtime has
-    // no ARM build. Force linux/amd64 so Docker uses QEMU emulation on
-    // non-x86 hosts (e.g. Armbian on aarch64).
     let pull_opts = CreateImageOptionsBuilder::default()
         .from_image(bootstrap_image)
-        .platform("linux/amd64")
         .build();
     let mut pull_stream = docker.create_image(Some(pull_opts), None, None);
     while let Some(result) = pull_stream.next().await {
@@ -2173,7 +2168,6 @@ async fn run_bootstrap_deployment_with_docker_and_image(
             Some(
                 CreateContainerOptionsBuilder::default()
                     .name(&container_name)
-                    .platform("linux/amd64")
                     .build(),
             ),
             ContainerCreateBody {

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -3984,12 +3984,9 @@ mod tests {
                 "DELETE /containers/test-container".to_string(),
             ]
         );
-        assert!(requests[0]
-            .url
-            .query()
-            .is_some_and(|query| query
-                .contains("fromImage=sonde-azure-bootstrap%3Atest-override")
-                && !query.contains("platform=")));
+        assert!(requests[0].url.query().is_some_and(|query| query
+            .contains("fromImage=sonde-azure-bootstrap%3Atest-override")
+            && !query.contains("platform=")));
         assert!(
             !requests[1]
                 .url

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -3986,12 +3986,12 @@ mod tests {
         );
         assert!(requests[0].url.query().is_some_and(|query| query
             .contains("fromImage=sonde-azure-bootstrap%3Atest-override")
-            && !query.contains("platform=")));
+            && !query.contains("platform=linux")));
         assert!(
             !requests[1]
                 .url
                 .query()
-                .is_some_and(|query| query.contains("platform=")),
+                .is_some_and(|query| query.contains("platform=linux")),
             "container create must not force a platform — native arch is used"
         );
         let create_body = String::from_utf8(requests[1].body.clone()).unwrap();

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -478,7 +478,18 @@ if [ "$#" -ge 4 ] && [ "$1" = "functionapp" ] && [ "$2" = "function" ] && [ "$3"
   exit 0
 fi
 if [ "$#" -ge 2 ] && [ "$1" = "cloud" ] && [ "$2" = "show" ]; then
-  printf 'https://login.microsoftonline.us\n'
+  query=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --query) query="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  if [ "$query" = "endpoints.resourceManager" ]; then
+    printf 'https://management.azure.com/\n'
+  else
+    printf 'https://login.microsoftonline.us\n'
+  fi
   exit 0
 fi
 if [ "$#" -ge 2 ] && [ "$1" = "rest" ]; then

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -500,8 +500,12 @@ exit 64
         "#!/bin/sh\nexec /usr/bin/python3 \"$@\"\n",
     );
     write_executable(&bin_dir.join("awk"), "#!/bin/sh\nexit 92\n");
-    // curl stub: return HTTP 200 for SPA verification polling.
-    write_executable(&bin_dir.join("curl"), "#!/bin/sh\nprintf '200'\nexit 0\n");
+    // curl stub: return config.json content containing the expected client ID
+    // for SPA deployment verification polling.
+    write_executable(
+        &bin_dir.join("curl"),
+        "#!/bin/sh\nprintf '{\"msalClientId\":\"client-456\"}'\nexit 0\n",
+    );
     // Hermetic jq stub that handles the invocations used by bootstrap.sh:
     // 1. jq -e --arg uri <URI> 'index($uri) != null'  → membership test (exit 1 = not found)
     // 2. jq -c --arg uri <URI> '(. // []) + [$uri]'   → merge URIs (output JSON array)

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -419,16 +419,25 @@ if [ "$#" -ge 4 ] && [ "$1" = "deployment" ] && [ "$2" = "sub" ] && [ "$3" = "sh
   printf 'rg-sonde\tfunc-sonde\tdeploypkg\thttps://example.blob.core.windows.net/deploypkg\tsonde-web-test\tsonde-web-test.azurestaticapps.net\tclient-456\tstsondetest\ttenant-123\n'
   exit 0
 fi
-if [ "$#" -ge 3 ] && [ "$1" = "staticwebapp" ] && [ "$2" = "secrets" ] && [ "$3" = "list" ]; then
-  printf 'fake-deployment-token\n'
+if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "container" ] && [ "$3" = "create" ]; then
   exit 0
 fi
-if [ "$#" -ge 3 ] && [ "$1" = "staticwebapp" ] && [ "$2" = "deploy" ]; then
-  # Simulate az staticwebapp deploy not being available
-  exit 1
+if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "blob" ] && [ "$3" = "upload" ]; then
+  exit 0
 fi
-if [ "$#" -ge 3 ] && [ "$1" = "staticwebapp" ] && [ "$2" = "show" ]; then
-  printf 'westus2\n'
+if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "blob" ] && [ "$3" = "generate-sas" ]; then
+  printf 'sv=2023-01-01&sig=fakesas\n'
+  exit 0
+fi
+if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "blob" ] && [ "$3" = "delete" ]; then
+  exit 0
+fi
+if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "account" ] && [ "$3" = "show" ]; then
+  printf 'https://stsondetest.blob.core.windows.net/\n'
+  exit 0
+fi
+if [ "$#" -ge 2 ] && [ "$1" = "account" ] && [ "$2" = "show" ]; then
+  printf 'fake-sub-id\n'
   exit 0
 fi
 if [ "$#" -ge 4 ] && [ "$1" = "ad" ] && [ "$2" = "app" ] && [ "$3" = "show" ]; then
@@ -480,8 +489,22 @@ exit 64
             az_log.display()
         ),
     );
-    write_executable(&bin_dir.join("python3"), "#!/bin/sh\nexit 91\n");
+    // python3 stub that handles:
+    // 1. zipfile creation (reads a heredoc script from stdin)
+    // 2. datetime SAS expiry generation
+    // The real system python3 is used since bootstrap.sh now depends on it
+    // for zip creation (replacing the SWA CLI).
+    // We let the system python3 handle these calls since they only use stdlib.
+    write_executable(
+        &bin_dir.join("python3"),
+        "#!/bin/sh\nexec /usr/bin/python3 \"$@\"\n",
+    );
     write_executable(&bin_dir.join("awk"), "#!/bin/sh\nexit 92\n");
+    // curl stub: return HTTP 200 for SPA verification polling.
+    write_executable(
+        &bin_dir.join("curl"),
+        "#!/bin/sh\nprintf '200'\nexit 0\n",
+    );
     // Hermetic jq stub that handles the invocations used by bootstrap.sh:
     // 1. jq -e --arg uri <URI> 'index($uri) != null'  → membership test (exit 1 = not found)
     // 2. jq -c --arg uri <URI> '(. // []) + [$uri]'   → merge URIs (output JSON array)
@@ -526,14 +549,6 @@ case "$expr" in
     printf '["%s"]\n' "$uri_val"; exit 0 ;;
 esac
 "#,
-    );
-    let swa_log = temp.path().join("swa.log");
-    write_executable(
-        &bin_dir.join("swa"),
-        &format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 0\n",
-            swa_log.display()
-        ),
     );
 
     // Create a temporary web-ui directory with the expected SPA files.
@@ -604,21 +619,15 @@ esac
     assert_eq!(az_calls.matches("deployment sub show").count(), 1);
     assert!(az_calls.contains("functionapp deployment source config-zip"));
     assert!(az_calls.contains("functionapp function list"));
-    assert!(az_calls.contains("staticwebapp secrets list"));
+    assert!(az_calls.contains("storage container create"));
+    assert!(az_calls.contains("storage blob upload"));
+    assert!(az_calls.contains("storage blob generate-sas"));
+    assert!(
+        az_calls.contains("rest --method POST"),
+        "ARM zipdeploy request not found in az calls: {az_calls}"
+    );
     assert!(az_calls.contains("ad app show"));
     assert!(az_calls.contains("ad app update") || az_calls.contains("ad app permission"));
-
-    // Verify swa deploy was invoked with the web-ui directory and deployment token
-    let swa_calls = fs::read_to_string(&swa_log)
-        .expect("swa log file not found — swa was never invoked by bootstrap");
-    assert!(
-        swa_calls.contains("deploy"),
-        "swa deploy was not invoked: {swa_calls}"
-    );
-    assert!(
-        swa_calls.contains("--deployment-token"),
-        "swa deploy missing --deployment-token: {swa_calls}"
-    );
 }
 
 #[test]

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -501,10 +501,7 @@ exit 64
     );
     write_executable(&bin_dir.join("awk"), "#!/bin/sh\nexit 92\n");
     // curl stub: return HTTP 200 for SPA verification polling.
-    write_executable(
-        &bin_dir.join("curl"),
-        "#!/bin/sh\nprintf '200'\nexit 0\n",
-    );
+    write_executable(&bin_dir.join("curl"), "#!/bin/sh\nprintf '200'\nexit 0\n");
     // Hermetic jq stub that handles the invocations used by bootstrap.sh:
     // 1. jq -e --arg uri <URI> 'index($uri) != null'  → membership test (exit 1 = not found)
     // 2. jq -c --arg uri <URI> '(. // []) + [$uri]'   → merge URIs (output JSON array)

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -489,15 +489,26 @@ exit 64
             az_log.display()
         ),
     );
-    // python3 stub that handles:
-    // 1. zipfile creation (reads a heredoc script from stdin)
-    // 2. datetime SAS expiry generation
-    // The real system python3 is used since bootstrap.sh now depends on it
-    // for zip creation (replacing the SWA CLI).
-    // We let the system python3 handle these calls since they only use stdlib.
+    // python3 stub that delegates to the real system python3.
+    // Resolve the path dynamically to avoid hardcoding /usr/bin/python3
+    // (which may differ on macOS, NixOS, etc.).
+    let system_python3 = String::from_utf8(
+        std::process::Command::new("which")
+            .arg("python3")
+            .output()
+            .expect("failed to locate python3")
+            .stdout,
+    )
+    .expect("non-UTF-8 python3 path")
+    .trim()
+    .to_string();
+    assert!(
+        !system_python3.is_empty(),
+        "python3 not found on PATH — required for bootstrap.sh tests"
+    );
     write_executable(
         &bin_dir.join("python3"),
-        "#!/bin/sh\nexec /usr/bin/python3 \"$@\"\n",
+        &format!("#!/bin/sh\nexec \"{system_python3}\" \"$@\"\n"),
     );
     write_executable(&bin_dir.join("awk"), "#!/bin/sh\nexit 92\n");
     // curl stub: return config.json content containing the expected client ID

--- a/crates/sonde-azure-companion/tests/bootstrap_unix.rs
+++ b/crates/sonde-azure-companion/tests/bootstrap_unix.rs
@@ -419,25 +419,8 @@ if [ "$#" -ge 4 ] && [ "$1" = "deployment" ] && [ "$2" = "sub" ] && [ "$3" = "sh
   printf 'rg-sonde\tfunc-sonde\tdeploypkg\thttps://example.blob.core.windows.net/deploypkg\tsonde-web-test\tsonde-web-test.azurestaticapps.net\tclient-456\tstsondetest\ttenant-123\n'
   exit 0
 fi
-if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "container" ] && [ "$3" = "create" ]; then
-  exit 0
-fi
-if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "blob" ] && [ "$3" = "upload" ]; then
-  exit 0
-fi
-if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "blob" ] && [ "$3" = "generate-sas" ]; then
-  printf 'sv=2023-01-01&sig=fakesas\n'
-  exit 0
-fi
-if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "blob" ] && [ "$3" = "delete" ]; then
-  exit 0
-fi
-if [ "$#" -ge 3 ] && [ "$1" = "storage" ] && [ "$2" = "account" ] && [ "$3" = "show" ]; then
-  printf 'https://stsondetest.blob.core.windows.net/\n'
-  exit 0
-fi
-if [ "$#" -ge 2 ] && [ "$1" = "account" ] && [ "$2" = "show" ]; then
-  printf 'fake-sub-id\n'
+if [ "$#" -ge 3 ] && [ "$1" = "staticwebapp" ] && [ "$2" = "secrets" ] && [ "$3" = "list" ]; then
+  printf 'fake-deployment-token\n'
   exit 0
 fi
 if [ "$#" -ge 4 ] && [ "$1" = "ad" ] && [ "$2" = "app" ] && [ "$3" = "show" ]; then
@@ -522,11 +505,17 @@ exit 64
         &format!("#!/bin/sh\nexec \"{system_python3}\" \"$@\"\n"),
     );
     write_executable(&bin_dir.join("awk"), "#!/bin/sh\nexit 92\n");
-    // curl stub: return config.json content containing the expected client ID
-    // for SPA deployment verification polling.
+    // curl stub: no longer needed for SPA verification (StaticSitesClient
+    // handles deployment verification internally). Keep as a no-op.
+    write_executable(&bin_dir.join("curl"), "#!/bin/sh\nexit 0\n");
+    // docker stub: log invocations and succeed for StaticSitesClient deploy.
+    let docker_log = temp.path().join("docker.log");
     write_executable(
-        &bin_dir.join("curl"),
-        "#!/bin/sh\nprintf '{\"msalClientId\":\"client-456\"}'\nexit 0\n",
+        &bin_dir.join("docker"),
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 0\n",
+            docker_log.display()
+        ),
     );
     // Hermetic jq stub that handles the invocations used by bootstrap.sh:
     // 1. jq -e --arg uri <URI> 'index($uri) != null'  → membership test (exit 1 = not found)
@@ -642,15 +631,17 @@ esac
     assert_eq!(az_calls.matches("deployment sub show").count(), 1);
     assert!(az_calls.contains("functionapp deployment source config-zip"));
     assert!(az_calls.contains("functionapp function list"));
-    assert!(az_calls.contains("storage container create"));
-    assert!(az_calls.contains("storage blob upload"));
-    assert!(az_calls.contains("storage blob generate-sas"));
-    assert!(
-        az_calls.contains("rest --method POST"),
-        "ARM zipdeploy request not found in az calls: {az_calls}"
-    );
+    assert!(az_calls.contains("staticwebapp secrets list"));
     assert!(az_calls.contains("ad app show"));
     assert!(az_calls.contains("ad app update") || az_calls.contains("ad app permission"));
+
+    // Verify docker was invoked with StaticSitesClient image
+    let docker_calls = fs::read_to_string(&docker_log)
+        .expect("docker log file not found — docker was never invoked by bootstrap");
+    assert!(
+        docker_calls.contains("mcr.microsoft.com/appsvc/staticappsclient:stable"),
+        "StaticSitesClient docker image not invoked: {docker_calls}"
+    );
 }
 
 #[test]

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -337,7 +337,7 @@ echo "Zipped SPA content to temporary file" >&2
 #    Use key-based auth: the deploying user has Contributor/Owner (they just
 #    created the resources via Bicep), so they can access storage account keys
 #    directly. This avoids RBAC propagation delays with login-based auth.
-_spa_blob_name="spa-deploy-$(date +%s)-$$.zip"
+_spa_blob_name="spa-deploy-$(date +%s)-$$-${RANDOM}.zip"
 az storage container create \
     --account-name "$storage_account_name" \
     --name "spa-deploy" \
@@ -372,8 +372,11 @@ sas_token="$(az storage blob generate-sas \
 blob_url="${blob_endpoint}/spa-deploy/${_spa_blob_name}?${sas_token}"
 
 # 4. Deploy via ARM zipdeploy REST API.
+#    Resolve the ARM endpoint from the active cloud for sovereign cloud support.
 subscription_id_for_deploy="$(az account show --query id --output tsv)"
-zipdeploy_url="https://management.azure.com/subscriptions/${subscription_id_for_deploy}/resourceGroups/${resource_group_name}/providers/Microsoft.Web/staticSites/${static_web_app_name}/zipdeploy?api-version=2024-04-01"
+arm_endpoint="$(az cloud show --query endpoints.resourceManager --output tsv)"
+arm_endpoint="${arm_endpoint%/}"
+zipdeploy_url="${arm_endpoint}/subscriptions/${subscription_id_for_deploy}/resourceGroups/${resource_group_name}/providers/Microsoft.Web/staticSites/${static_web_app_name}/zipdeploy?api-version=2024-04-01"
 az rest --method POST \
     --url "$zipdeploy_url" \
     --body "{\"properties\":{\"appZipUrl\":\"${blob_url}\",\"provider\":\"sonde-bootstrap\"}}" \

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -393,8 +393,8 @@ while :; do
         break
     fi
     if [ "$(date +%s)" -ge "$spa_verify_deadline" ]; then
-        echo "WARNING: timed out verifying SPA deployment; continuing" >&2
-        break
+        echo "SPA deployment verification timed out after 120s" >&2
+        exit 1
     fi
     sleep 5
 done

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -261,20 +261,102 @@ cat > "$web_ui_dir/config.json" <<CONFIGEOF
 CONFIGEOF
 echo "Generated config.json for SPA" >&2
 
-# Deploy SPA content to Static Web App via the SWA CLI.
-swa_deployment_token="$(trim_string "$(az staticwebapp secrets list \
-    --name "$static_web_app_name" \
-    --resource-group "$resource_group_name" \
-    --query 'properties.apiKey' \
-    --output tsv)")"
-if [ -z "$swa_deployment_token" ]; then
-    echo "failed to retrieve Static Web App deployment token" >&2
-    exit 1
-fi
+# Deploy SPA content to Static Web App via the ARM zipdeploy REST API.
+# This replaces the SWA CLI (which required amd64-only native binaries)
+# with a portable approach using only az CLI + Python (bundled with az).
 
-swa deploy "$web_ui_dir" \
-    --deployment-token "$swa_deployment_token" \
-    --env production 1>&2
+# 1. Zip the SPA content using Python (always available with az CLI).
+spa_zip="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-XXXXXX.zip")"
+cleanup_spa_blob() {
+    rm -f "$spa_zip"
+    if [ -n "${_spa_blob_uploaded:-}" ]; then
+        az storage blob delete \
+            --account-name "$storage_account_name" \
+            --container-name "spa-deploy" \
+            --name "$_spa_blob_name" \
+            --output none 2>/dev/null || true
+    fi
+}
+trap cleanup_spa_blob EXIT
+
+python3 - "$web_ui_dir" "$spa_zip" <<'PYEOF'
+import os, sys, zipfile
+src_dir, dst_zip = sys.argv[1], sys.argv[2]
+with zipfile.ZipFile(dst_zip, "w", zipfile.ZIP_DEFLATED) as zf:
+    for root, _dirs, files in os.walk(src_dir):
+        for f in sorted(files):
+            full = os.path.join(root, f)
+            arcname = os.path.relpath(full, src_dir)
+            zf.write(full, arcname)
+PYEOF
+echo "Zipped SPA content to temporary file" >&2
+
+# 2. Upload the zip to a temporary blob in the provisioned storage account.
+#    Use key-based auth: the deploying user has Contributor/Owner (they just
+#    created the resources via Bicep), so they can access storage account keys
+#    directly. This avoids RBAC propagation delays with login-based auth.
+_spa_blob_name="spa-deploy-$(date +%s)-$$.zip"
+az storage container create \
+    --account-name "$storage_account_name" \
+    --name "spa-deploy" \
+    --public-access off \
+    --output none 2>/dev/null || true
+az storage blob upload \
+    --account-name "$storage_account_name" \
+    --container-name "spa-deploy" \
+    --name "$_spa_blob_name" \
+    --file "$spa_zip" \
+    --overwrite \
+    --output none 1>&2
+_spa_blob_uploaded=1
+echo "Uploaded SPA zip to blob: $_spa_blob_name" >&2
+
+# 3. Generate a short-lived read-only SAS URL for the blob.
+#    Resolve the blob endpoint from the storage account to support sovereign clouds.
+sas_expiry="$(python3 -c "from datetime import datetime,timedelta,timezone;print((datetime.now(timezone.utc)+timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
+blob_endpoint="$(az storage account show \
+    --name "$storage_account_name" \
+    --resource-group "$resource_group_name" \
+    --query 'primaryEndpoints.blob' \
+    --output tsv)"
+blob_endpoint="${blob_endpoint%/}"
+sas_token="$(az storage blob generate-sas \
+    --account-name "$storage_account_name" \
+    --container-name "spa-deploy" \
+    --name "$_spa_blob_name" \
+    --permissions r \
+    --expiry "$sas_expiry" \
+    --output tsv)"
+blob_url="${blob_endpoint}/spa-deploy/${_spa_blob_name}?${sas_token}"
+
+# 4. Deploy via ARM zipdeploy REST API.
+subscription_id_for_deploy="$(az account show --query id --output tsv)"
+zipdeploy_url="https://management.azure.com/subscriptions/${subscription_id_for_deploy}/resourceGroups/${resource_group_name}/providers/Microsoft.Web/staticSites/${static_web_app_name}/zipdeploy?api-version=2024-04-01"
+az rest --method POST \
+    --url "$zipdeploy_url" \
+    --body "{\"properties\":{\"appZipUrl\":\"${blob_url}\",\"provider\":\"sonde-bootstrap\"}}" \
+    --output none 1>&2
+echo "ARM zipdeploy request submitted" >&2
+
+# 5. Wait for async deployment to complete before cleaning up the blob.
+#    The zipdeploy API may return 202 Accepted with an async operation URL.
+#    Poll the SWA to verify content is served (simpler and more reliable than
+#    parsing the azure-asyncoperation header from az rest).
+spa_verify_deadline="$(( $(date +%s) + 120 ))"
+while :; do
+    spa_http_code="$(curl -s -o /dev/null -w '%{http_code}' "https://$static_web_app_hostname" 2>/dev/null || echo 0)"
+    if [ "$spa_http_code" = "200" ]; then
+        echo "SPA content verified at https://$static_web_app_hostname" >&2
+        break
+    fi
+    if [ "$(date +%s)" -ge "$spa_verify_deadline" ]; then
+        echo "WARNING: timed out verifying SPA deployment (HTTP $spa_http_code); continuing" >&2
+        break
+    fi
+    sleep 5
+done
+
+# 6. Cleanup happens via the EXIT trap (cleanup_spa_blob).
 echo "SPA content deployed to https://$static_web_app_hostname" >&2
 
 # ── Entra app configuration ─────────────────────────────────────────────────

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -303,106 +303,32 @@ cat > "$web_ui_dir/config.json" <<CONFIGEOF
 CONFIGEOF
 echo "Generated config.json for SPA" >&2
 
-# Deploy SPA content to Static Web App via the ARM zipdeploy REST API.
-# This replaces the SWA CLI (which required amd64-only native binaries)
-# with a portable approach using only az CLI + Python (bundled with az).
+# Deploy SPA content to Static Web App using the StaticSitesClient binary
+# from the multi-arch Docker image. This replaces the SWA CLI npm package
+# (which required amd64-only native binaries) with the same underlying
+# deployment binary packaged as a multi-arch container image.
 
-# 1. Zip the SPA content using Python (always available with az CLI).
-spa_zip="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-XXXXXX.zip")"
-cleanup_spa_blob() {
-    rm -f "$spa_zip"
-    if [ -n "${_spa_blob_uploaded:-}" ]; then
-        az storage blob delete \
-            --account-name "$storage_account_name" \
-            --container-name "spa-deploy" \
-            --name "$_spa_blob_name" \
-            --output none 2>/dev/null || true
-    fi
-}
-trap cleanup_spa_blob EXIT
-
-python3 - "$web_ui_dir" "$spa_zip" <<'PYEOF'
-import os, sys, zipfile
-src_dir, dst_zip = sys.argv[1], sys.argv[2]
-with zipfile.ZipFile(dst_zip, "w", zipfile.ZIP_DEFLATED) as zf:
-    for root, _dirs, files in os.walk(src_dir):
-        for f in sorted(files):
-            full = os.path.join(root, f)
-            arcname = os.path.relpath(full, src_dir)
-            zf.write(full, arcname)
-PYEOF
-echo "Zipped SPA content to temporary file" >&2
-
-# 2. Upload the zip to a temporary blob in the provisioned storage account.
-#    Use key-based auth: the deploying user has Contributor/Owner (they just
-#    created the resources via Bicep), so they can access storage account keys
-#    directly. This avoids RBAC propagation delays with login-based auth.
-_spa_blob_name="spa-deploy-$(date +%s)-$$-$(od -An -N4 -tx1 /dev/urandom | tr -d ' ').zip"
-az storage container create \
-    --account-name "$storage_account_name" \
-    --name "spa-deploy" \
-    --public-access off \
-    --output none 2>/dev/null || true
-az storage blob upload \
-    --account-name "$storage_account_name" \
-    --container-name "spa-deploy" \
-    --name "$_spa_blob_name" \
-    --file "$spa_zip" \
-    --overwrite \
-    --output none 1>&2
-_spa_blob_uploaded=1
-echo "Uploaded SPA zip to blob: $_spa_blob_name" >&2
-
-# 3. Generate a short-lived read-only SAS URL for the blob.
-#    Resolve the blob endpoint from the storage account to support sovereign clouds.
-sas_expiry="$(python3 -c "from datetime import datetime,timedelta,timezone;print((datetime.now(timezone.utc)+timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
-blob_endpoint="$(az storage account show \
-    --name "$storage_account_name" \
+swa_deployment_token="$(trim_string "$(az staticwebapp secrets list \
+    --name "$static_web_app_name" \
     --resource-group "$resource_group_name" \
-    --query 'primaryEndpoints.blob' \
-    --output tsv)"
-blob_endpoint="${blob_endpoint%/}"
-sas_token="$(az storage blob generate-sas \
-    --account-name "$storage_account_name" \
-    --container-name "spa-deploy" \
-    --name "$_spa_blob_name" \
-    --permissions r \
-    --expiry "$sas_expiry" \
-    --output tsv)"
-blob_url="${blob_endpoint}/spa-deploy/${_spa_blob_name}?${sas_token}"
+    --query 'properties.apiKey' \
+    --output tsv)")"
+if [ -z "$swa_deployment_token" ]; then
+    echo "failed to retrieve Static Web App deployment token" >&2
+    exit 1
+fi
 
-# 4. Deploy via ARM zipdeploy REST API.
-#    Resolve the ARM endpoint from the active cloud for sovereign cloud support.
-subscription_id_for_deploy="$(az account show --query id --output tsv)"
-arm_endpoint="$(az cloud show --query endpoints.resourceManager --output tsv)"
-arm_endpoint="${arm_endpoint%/}"
-zipdeploy_url="${arm_endpoint}/subscriptions/${subscription_id_for_deploy}/resourceGroups/${resource_group_name}/providers/Microsoft.Web/staticSites/${static_web_app_name}/builds/default/zipdeploy?api-version=2024-04-01"
-az rest --method POST \
-    --url "$zipdeploy_url" \
-    --body "{\"properties\":{\"appZipUrl\":\"${blob_url}\",\"provider\":\"sonde-bootstrap\"}}" \
-    --output none 1>&2
-echo "ARM zipdeploy request submitted" >&2
+docker run --rm \
+    -v "$web_ui_dir:/app" \
+    -e "DEPLOYMENT_TOKEN=$swa_deployment_token" \
+    -e "DEPLOYMENT_ACTION=upload" \
+    -e "DEPLOYMENT_PROVIDER=sonde-bootstrap" \
+    -e "APP_LOCATION=/app" \
+    -e "SKIP_APP_BUILD=true" \
+    -e "SKIP_API_BUILD=true" \
+    -e "VERBOSE=false" \
+    mcr.microsoft.com/appsvc/staticappsclient:stable 1>&2
 
-# 5. Wait for deployment to complete by polling for our generated config.json.
-#    Polling for HTTP 200 alone is insufficient — a freshly-provisioned SWA
-#    serves a default placeholder page that returns 200 before zipdeploy content
-#    is published. Instead, fetch /config.json and verify it contains the
-#    expected msalClientId value from this deployment.
-spa_verify_deadline="$(( $(date +%s) + 120 ))"
-while :; do
-    fetched_config="$(curl -sf "https://$static_web_app_hostname/config.json" 2>/dev/null || true)"
-    if echo "$fetched_config" | grep -q "$companion_client_id" 2>/dev/null; then
-        echo "SPA content verified at https://$static_web_app_hostname" >&2
-        break
-    fi
-    if [ "$(date +%s)" -ge "$spa_verify_deadline" ]; then
-        echo "SPA deployment verification timed out after 120s" >&2
-        exit 1
-    fi
-    sleep 5
-done
-
-# 6. Cleanup happens via the EXIT trap (cleanup_spa_blob).
 echo "SPA content deployed to https://$static_web_app_hostname" >&2
 
 # ── Custom domain binding ───────────────────────────────────────────────────

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -337,7 +337,7 @@ echo "Zipped SPA content to temporary file" >&2
 #    Use key-based auth: the deploying user has Contributor/Owner (they just
 #    created the resources via Bicep), so they can access storage account keys
 #    directly. This avoids RBAC propagation delays with login-based auth.
-_spa_blob_name="spa-deploy-$(date +%s)-$$-${RANDOM}.zip"
+_spa_blob_name="spa-deploy-$(date +%s)-$$-$(od -An -N4 -tx1 /dev/urandom | tr -d ' ').zip"
 az storage container create \
     --account-name "$storage_account_name" \
     --name "spa-deploy" \

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -380,19 +380,20 @@ az rest --method POST \
     --output none 1>&2
 echo "ARM zipdeploy request submitted" >&2
 
-# 5. Wait for async deployment to complete before cleaning up the blob.
-#    The zipdeploy API may return 202 Accepted with an async operation URL.
-#    Poll the SWA to verify content is served (simpler and more reliable than
-#    parsing the azure-asyncoperation header from az rest).
+# 5. Wait for deployment to complete by polling for our generated config.json.
+#    Polling for HTTP 200 alone is insufficient — a freshly-provisioned SWA
+#    serves a default placeholder page that returns 200 before zipdeploy content
+#    is published. Instead, fetch /config.json and verify it contains the
+#    expected msalClientId value from this deployment.
 spa_verify_deadline="$(( $(date +%s) + 120 ))"
 while :; do
-    spa_http_code="$(curl -s -o /dev/null -w '%{http_code}' "https://$static_web_app_hostname" 2>/dev/null || echo 0)"
-    if [ "$spa_http_code" = "200" ]; then
+    fetched_config="$(curl -sf "https://$static_web_app_hostname/config.json" 2>/dev/null || true)"
+    if echo "$fetched_config" | grep -q "$companion_client_id" 2>/dev/null; then
         echo "SPA content verified at https://$static_web_app_hostname" >&2
         break
     fi
     if [ "$(date +%s)" -ge "$spa_verify_deadline" ]; then
-        echo "WARNING: timed out verifying SPA deployment (HTTP $spa_http_code); continuing" >&2
+        echo "WARNING: timed out verifying SPA deployment; continuing" >&2
         break
     fi
     sleep 5

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -376,7 +376,7 @@ blob_url="${blob_endpoint}/spa-deploy/${_spa_blob_name}?${sas_token}"
 subscription_id_for_deploy="$(az account show --query id --output tsv)"
 arm_endpoint="$(az cloud show --query endpoints.resourceManager --output tsv)"
 arm_endpoint="${arm_endpoint%/}"
-zipdeploy_url="${arm_endpoint}/subscriptions/${subscription_id_for_deploy}/resourceGroups/${resource_group_name}/providers/Microsoft.Web/staticSites/${static_web_app_name}/zipdeploy?api-version=2024-04-01"
+zipdeploy_url="${arm_endpoint}/subscriptions/${subscription_id_for_deploy}/resourceGroups/${resource_group_name}/providers/Microsoft.Web/staticSites/${static_web_app_name}/builds/default/zipdeploy?api-version=2024-04-01"
 az rest --method POST \
     --url "$zipdeploy_url" \
     --body "{\"properties\":{\"appZipUrl\":\"${blob_url}\",\"provider\":\"sonde-bootstrap\"}}" \

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -363,7 +363,7 @@ BLOB_URL="${BLOB_ENDPOINT}/spa-deploy/${_SPA_BLOB_NAME}?${SAS_TOKEN}"
 SUBSCRIPTION_ID="$(az account show --query id --output tsv)"
 ARM_ENDPOINT="$(az cloud show --query endpoints.resourceManager --output tsv)"
 ARM_ENDPOINT="${ARM_ENDPOINT%/}"
-ZIPDEPLOY_URL="${ARM_ENDPOINT}/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/zipdeploy?api-version=2024-04-01"
+ZIPDEPLOY_URL="${ARM_ENDPOINT}/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/builds/default/zipdeploy?api-version=2024-04-01"
 az rest --method POST \
     --url "$ZIPDEPLOY_URL" \
     --body "{\"properties\":{\"appZipUrl\":\"${BLOB_URL}\",\"provider\":\"sonde-deploy\"}}" \

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -299,7 +299,7 @@ echo "=== Deploying SPA content ==="
 
 # Zip the SPA content using Python (always available with az CLI).
 SPA_ZIP="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-XXXXXX.zip")"
-_SPA_BLOB_NAME="spa-deploy-$(date +%s)-$$.zip"
+_SPA_BLOB_NAME="spa-deploy-$(date +%s)-$$-${RANDOM}.zip"
 cleanup_spa_blob() {
     rm -f "$SPA_ZIP"
     if [ -n "${_SPA_BLOB_UPLOADED:-}" ]; then
@@ -359,8 +359,11 @@ SAS_TOKEN="$(az storage blob generate-sas \
 BLOB_URL="${BLOB_ENDPOINT}/spa-deploy/${_SPA_BLOB_NAME}?${SAS_TOKEN}"
 
 # Deploy via ARM zipdeploy REST API.
+# Resolve the ARM endpoint from the active cloud for sovereign cloud support.
 SUBSCRIPTION_ID="$(az account show --query id --output tsv)"
-ZIPDEPLOY_URL="https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/zipdeploy?api-version=2024-04-01"
+ARM_ENDPOINT="$(az cloud show --query endpoints.resourceManager --output tsv)"
+ARM_ENDPOINT="${ARM_ENDPOINT%/}"
+ZIPDEPLOY_URL="${ARM_ENDPOINT}/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/zipdeploy?api-version=2024-04-01"
 az rest --method POST \
     --url "$ZIPDEPLOY_URL" \
     --body "{\"properties\":{\"appZipUrl\":\"${BLOB_URL}\",\"provider\":\"sonde-deploy\"}}" \
@@ -375,8 +378,8 @@ while :; do
         break
     fi
     if [ "$(date +%s)" -ge "$SPA_DEADLINE" ]; then
-        echo "  WARNING: timed out verifying SPA deployment; continuing"
-        break
+        echo "  ERROR: timed out verifying SPA deployment after 120s"
+        exit 1
     fi
     sleep 5
 done

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -297,92 +297,23 @@ fi
 echo ""
 echo "=== Deploying SPA content ==="
 
-# Zip the SPA content using Python (always available with az CLI).
-SPA_ZIP="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-XXXXXX.zip")"
-_SPA_BLOB_NAME="spa-deploy-$(date +%s)-$$-${RANDOM}.zip"
-cleanup_spa_blob() {
-    rm -f "$SPA_ZIP"
-    if [ -n "${_SPA_BLOB_UPLOADED:-}" ]; then
-        az storage blob delete \
-            --account-name "$STORAGE_ACCOUNT" \
-            --container-name "spa-deploy" \
-            --name "$_SPA_BLOB_NAME" \
-            --output none 2>/dev/null || true
-    fi
-}
-trap cleanup_spa_blob EXIT
+# Deploy SPA content using the StaticSitesClient multi-arch Docker image.
+# This replaces the SWA CLI npm package (which shipped amd64-only native
+# binaries) with the same underlying deployment binary in a multi-arch image.
+DEPLOYMENT_TOKEN="$(az staticwebapp secrets list --name "$SWA_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query 'properties.apiKey' -o tsv)"
 
-python3 - "$SCRIPT_DIR" "$SPA_ZIP" <<'PYEOF'
-import os, sys, zipfile
-src_dir, dst_zip = sys.argv[1], sys.argv[2]
-with zipfile.ZipFile(dst_zip, "w", zipfile.ZIP_DEFLATED) as zf:
-    for root, _dirs, files in os.walk(src_dir):
-        for f in sorted(files):
-            full = os.path.join(root, f)
-            arcname = os.path.relpath(full, src_dir)
-            zf.write(full, arcname)
-PYEOF
-
-# Upload the zip to a temporary blob in the storage account.
-# Use key-based auth: the deployer has Contributor/Owner from az login,
-# so they can access storage account keys directly.
-az storage container create \
-    --account-name "$STORAGE_ACCOUNT" \
-    --name "spa-deploy" \
-    --public-access off \
-    --output none 2>/dev/null || true
-az storage blob upload \
-    --account-name "$STORAGE_ACCOUNT" \
-    --container-name "spa-deploy" \
-    --name "$_SPA_BLOB_NAME" \
-    --file "$SPA_ZIP" \
-    --overwrite \
-    --output none
-_SPA_BLOB_UPLOADED=1
-
-# Generate a short-lived read-only SAS URL for the blob.
-# Resolve the blob endpoint from the storage account to support sovereign clouds.
-SAS_EXPIRY="$(python3 -c "from datetime import datetime,timedelta,timezone;print((datetime.now(timezone.utc)+timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
-BLOB_ENDPOINT="$(az storage account show \
-    --name "$STORAGE_ACCOUNT" \
-    --resource-group "$RESOURCE_GROUP" \
-    --query 'primaryEndpoints.blob' \
-    --output tsv)"
-BLOB_ENDPOINT="${BLOB_ENDPOINT%/}"
-SAS_TOKEN="$(az storage blob generate-sas \
-    --account-name "$STORAGE_ACCOUNT" \
-    --container-name "spa-deploy" \
-    --name "$_SPA_BLOB_NAME" \
-    --permissions r \
-    --expiry "$SAS_EXPIRY" \
-    --output tsv)"
-BLOB_URL="${BLOB_ENDPOINT}/spa-deploy/${_SPA_BLOB_NAME}?${SAS_TOKEN}"
-
-# Deploy via ARM zipdeploy REST API.
-# Resolve the ARM endpoint from the active cloud for sovereign cloud support.
-SUBSCRIPTION_ID="$(az account show --query id --output tsv)"
-ARM_ENDPOINT="$(az cloud show --query endpoints.resourceManager --output tsv)"
-ARM_ENDPOINT="${ARM_ENDPOINT%/}"
-ZIPDEPLOY_URL="${ARM_ENDPOINT}/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/builds/default/zipdeploy?api-version=2024-04-01"
-az rest --method POST \
-    --url "$ZIPDEPLOY_URL" \
-    --body "{\"properties\":{\"appZipUrl\":\"${BLOB_URL}\",\"provider\":\"sonde-deploy\"}}" \
-    --output none
-
-# Wait for deployment to complete by polling for config.json content.
-echo "  Waiting for deployment..."
-SPA_DEADLINE="$(( $(date +%s) + 120 ))"
-while :; do
-    FETCHED_CONFIG="$(curl -sf "https://$SWA_HOSTNAME/config.json" 2>/dev/null || true)"
-    if echo "$FETCHED_CONFIG" | grep -q "$CLIENT_ID" 2>/dev/null; then
-        break
-    fi
-    if [ "$(date +%s)" -ge "$SPA_DEADLINE" ]; then
-        echo "  ERROR: timed out verifying SPA deployment after 120s"
-        exit 1
-    fi
-    sleep 5
-done
+docker run --rm \
+  -v "$SCRIPT_DIR:/app" \
+  -e "DEPLOYMENT_TOKEN=$DEPLOYMENT_TOKEN" \
+  -e "DEPLOYMENT_ACTION=upload" \
+  -e "DEPLOYMENT_PROVIDER=sonde-deploy" \
+  -e "APP_LOCATION=/app" \
+  -e "SKIP_APP_BUILD=true" \
+  -e "SKIP_API_BUILD=true" \
+  -e "VERBOSE=false" \
+  mcr.microsoft.com/appsvc/staticappsclient:stable
 
 echo ""
 echo "=== Deployment complete ==="

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -366,16 +366,16 @@ az rest --method POST \
     --body "{\"properties\":{\"appZipUrl\":\"${BLOB_URL}\",\"provider\":\"sonde-deploy\"}}" \
     --output none
 
-# Wait for deployment to complete.
+# Wait for deployment to complete by polling for config.json content.
 echo "  Waiting for deployment..."
 SPA_DEADLINE="$(( $(date +%s) + 120 ))"
 while :; do
-    SPA_HTTP="$(curl -s -o /dev/null -w '%{http_code}' "https://$SWA_HOSTNAME" 2>/dev/null || echo 0)"
-    if [ "$SPA_HTTP" = "200" ]; then
+    FETCHED_CONFIG="$(curl -sf "https://$SWA_HOSTNAME/config.json" 2>/dev/null || true)"
+    if echo "$FETCHED_CONFIG" | grep -q "$CLIENT_ID" 2>/dev/null; then
         break
     fi
     if [ "$(date +%s)" -ge "$SPA_DEADLINE" ]; then
-        echo "  WARNING: timed out verifying SPA deployment (HTTP $SPA_HTTP); continuing"
+        echo "  WARNING: timed out verifying SPA deployment; continuing"
         break
     fi
     sleep 5

--- a/deploy/web-ui/deploy.sh
+++ b/deploy/web-ui/deploy.sh
@@ -7,7 +7,6 @@
 # Prerequisites:
 #   - az CLI logged in
 #   - jq available (for JSON merging)
-#   - npm/npx available (for SWA CLI)
 #
 # Usage:
 #   ./deploy/web-ui/deploy.sh <COMPANION_CLIENT_ID> [RESOURCE_GROUP]
@@ -247,13 +246,90 @@ fi
 
 echo ""
 echo "=== Deploying SPA content ==="
-DEPLOYMENT_TOKEN="$(az staticwebapp secrets list --name "$SWA_NAME" \
-  --resource-group "$RESOURCE_GROUP" \
-  --query 'properties.apiKey' -o tsv)"
 
-npx --yes @azure/static-web-apps-cli deploy "$SCRIPT_DIR" \
-  --deployment-token "$DEPLOYMENT_TOKEN" \
-  --env production
+# Zip the SPA content using Python (always available with az CLI).
+SPA_ZIP="$(mktemp "${TMPDIR:-/tmp}/sonde-spa-XXXXXX.zip")"
+_SPA_BLOB_NAME="spa-deploy-$(date +%s)-$$.zip"
+cleanup_spa_blob() {
+    rm -f "$SPA_ZIP"
+    if [ -n "${_SPA_BLOB_UPLOADED:-}" ]; then
+        az storage blob delete \
+            --account-name "$STORAGE_ACCOUNT" \
+            --container-name "spa-deploy" \
+            --name "$_SPA_BLOB_NAME" \
+            --output none 2>/dev/null || true
+    fi
+}
+trap cleanup_spa_blob EXIT
+
+python3 - "$SCRIPT_DIR" "$SPA_ZIP" <<'PYEOF'
+import os, sys, zipfile
+src_dir, dst_zip = sys.argv[1], sys.argv[2]
+with zipfile.ZipFile(dst_zip, "w", zipfile.ZIP_DEFLATED) as zf:
+    for root, _dirs, files in os.walk(src_dir):
+        for f in sorted(files):
+            full = os.path.join(root, f)
+            arcname = os.path.relpath(full, src_dir)
+            zf.write(full, arcname)
+PYEOF
+
+# Upload the zip to a temporary blob in the storage account.
+# Use key-based auth: the deployer has Contributor/Owner from az login,
+# so they can access storage account keys directly.
+az storage container create \
+    --account-name "$STORAGE_ACCOUNT" \
+    --name "spa-deploy" \
+    --public-access off \
+    --output none 2>/dev/null || true
+az storage blob upload \
+    --account-name "$STORAGE_ACCOUNT" \
+    --container-name "spa-deploy" \
+    --name "$_SPA_BLOB_NAME" \
+    --file "$SPA_ZIP" \
+    --overwrite \
+    --output none
+_SPA_BLOB_UPLOADED=1
+
+# Generate a short-lived read-only SAS URL for the blob.
+# Resolve the blob endpoint from the storage account to support sovereign clouds.
+SAS_EXPIRY="$(python3 -c "from datetime import datetime,timedelta,timezone;print((datetime.now(timezone.utc)+timedelta(minutes=30)).strftime('%Y-%m-%dT%H:%M:%SZ'))")"
+BLOB_ENDPOINT="$(az storage account show \
+    --name "$STORAGE_ACCOUNT" \
+    --resource-group "$RESOURCE_GROUP" \
+    --query 'primaryEndpoints.blob' \
+    --output tsv)"
+BLOB_ENDPOINT="${BLOB_ENDPOINT%/}"
+SAS_TOKEN="$(az storage blob generate-sas \
+    --account-name "$STORAGE_ACCOUNT" \
+    --container-name "spa-deploy" \
+    --name "$_SPA_BLOB_NAME" \
+    --permissions r \
+    --expiry "$SAS_EXPIRY" \
+    --output tsv)"
+BLOB_URL="${BLOB_ENDPOINT}/spa-deploy/${_SPA_BLOB_NAME}?${SAS_TOKEN}"
+
+# Deploy via ARM zipdeploy REST API.
+SUBSCRIPTION_ID="$(az account show --query id --output tsv)"
+ZIPDEPLOY_URL="https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Web/staticSites/${SWA_NAME}/zipdeploy?api-version=2024-04-01"
+az rest --method POST \
+    --url "$ZIPDEPLOY_URL" \
+    --body "{\"properties\":{\"appZipUrl\":\"${BLOB_URL}\",\"provider\":\"sonde-deploy\"}}" \
+    --output none
+
+# Wait for deployment to complete.
+echo "  Waiting for deployment..."
+SPA_DEADLINE="$(( $(date +%s) + 120 ))"
+while :; do
+    SPA_HTTP="$(curl -s -o /dev/null -w '%{http_code}' "https://$SWA_HOSTNAME" 2>/dev/null || echo 0)"
+    if [ "$SPA_HTTP" = "200" ]; then
+        break
+    fi
+    if [ "$(date +%s)" -ge "$SPA_DEADLINE" ]; then
+        echo "  WARNING: timed out verifying SPA deployment (HTTP $SPA_HTTP); continuing"
+        break
+    fi
+    sleep 5
+done
 
 echo ""
 echo "=== Deployment complete ==="

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -302,9 +302,12 @@ When bootstrap is required, the Azure companion performs this sequence:
        the Bicep deployment outputs.
     b. Generates `config.json` with MSAL client ID, authority URL (derived from
        `companionTenantId`), storage account name, and function app name.
-    c. Obtains the SWA deployment token via `az staticwebapp secrets list`.
-    d. Deploys the bundled SPA content (including generated `config.json`) to
-       the Static Web App using the pre-installed SWA CLI (`swa deploy`).
+    c. Zips the bundled SPA content (including generated `config.json`) using
+       Python (bundled with the Azure CLI).
+    d. Uploads the zip as a temporary blob to the provisioned storage account,
+       generates a short-lived read-only SAS URL, and deploys to the Static
+       Web App via `az rest POST .../zipdeploy`. Cleans up the temporary blob
+       after deployment.
     e. Registers `https://<staticWebAppHostname>` as a SPA redirect URI on the
        Entra app registration, merging with any existing redirect URIs.
     f. Adds Azure Storage `user_impersonation` API permission to the Entra app.
@@ -606,10 +609,10 @@ COPY deploy/web-ui/index.html deploy/web-ui/app.js deploy/web-ui/style.css deplo
 
 It also includes the bootstrap script that runs `az login --use-device-code`
 and Azure deployment inside the bootstrap image. The `jq` utility is installed
-for JSON manipulation during SPA deployment (Entra redirect URI merging), and
-Node.js/npm is installed and a pinned version of the SWA CLI
-(`@azure/static-web-apps-cli`) is pre-installed globally for SPA content
-deployment.
+for JSON manipulation during SPA deployment (Entra redirect URI merging).
+SPA content is deployed via the ARM zipdeploy REST API using `az rest` — no
+Node.js, npm, or SWA CLI is required. The bootstrap image uses only the
+Azure CLI, Python (bundled with `az`), and `jq`.
 
 This bundles the complete Azure provisioning surface and the Web UI SPA
 content into the dedicated bootstrap image. The runtime companion image no

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -302,12 +302,11 @@ When bootstrap is required, the Azure companion performs this sequence:
        the Bicep deployment outputs.
     b. Generates `config.json` with MSAL client ID, authority URL (derived from
        `companionTenantId`), storage account name, and function app name.
-    c. Zips the bundled SPA content (including generated `config.json`) using
-       Python (bundled with the Azure CLI).
-    d. Uploads the zip as a temporary blob to the provisioned storage account,
-       generates a short-lived read-only SAS URL, and deploys to the Static
-       Web App via `az rest POST .../zipdeploy`. Cleans up the temporary blob
-       after deployment.
+    c. Obtains the SWA deployment token via `az staticwebapp secrets list`.
+    d. Deploys the bundled SPA content (including generated `config.json`) to
+       the Static Web App using the `StaticSitesClient` multi-arch Docker
+       image (`mcr.microsoft.com/appsvc/staticappsclient:stable`) with the
+       deployment token passed as an environment variable.
     e. Registers `https://<staticWebAppHostname>` as a SPA redirect URI on the
        Entra app registration, merging with any existing redirect URIs.
     f. Adds Azure Storage `user_impersonation` API permission to the Entra app.
@@ -610,9 +609,9 @@ COPY deploy/web-ui/index.html deploy/web-ui/app.js deploy/web-ui/style.css deplo
 It also includes the bootstrap script that runs `az login --use-device-code`
 and Azure deployment inside the bootstrap image. The `jq` utility is installed
 for JSON manipulation during SPA deployment (Entra redirect URI merging).
-SPA content is deployed via the ARM zipdeploy REST API using `az rest` — no
-Node.js, npm, or SWA CLI is required. The bootstrap image uses only the
-Azure CLI, Python (bundled with `az`), and `jq`.
+SPA content is deployed via the `StaticSitesClient` multi-arch Docker image
+(`mcr.microsoft.com/appsvc/staticappsclient:stable`) using the deployment
+token — no Node.js, npm, or SWA CLI is required.
 
 This bundles the complete Azure provisioning surface and the Web UI SPA
 content into the dedicated bootstrap image. The runtime companion image no

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -830,7 +830,8 @@ The bootstrap script MUST:
 2. Generate `config.json` with the MSAL client ID, tenant ID, storage account
    name, and function app name.
 3. Deploy the SPA content (including the generated `config.json`) to the Static
-   Web App using the Azure deployment API and the SWA deployment token.
+   Web App using the ARM zipdeploy REST API (`az rest`) and the provisioned
+   storage account as a temporary staging area.
 4. Register the SWA hostname (`https://<hostname>`) as a SPA redirect URI on
    the Entra app registration, merging with any existing redirect URIs.
 5. Add the Azure Storage `user_impersonation` API permission to the Entra app
@@ -839,9 +840,12 @@ The bootstrap script MUST:
    registration (required for EasyAuth token validation on the Function App).
    If the scope already exists, this step is a no-op.
 
-The bootstrap image bundles Node.js and a pinned version of the SWA CLI
-(`@azure/static-web-apps-cli`, installed globally at image build time) to
-deploy SPA content to the Static Web App.
+The bootstrap image deploys SPA content to the Static Web App using the ARM
+REST API (`Microsoft.Web/staticSites/{name}/zipdeploy`) via `az rest`. The
+content is zipped using Python (bundled with `az` CLI), uploaded as a temporary
+blob to the provisioned storage account, and referenced by SAS URL in the
+zipdeploy request. This approach requires no Node.js, npm, or
+architecture-specific binaries, enabling native arm64 execution.
 
 **Acceptance criteria:**
 

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -840,11 +840,11 @@ The bootstrap script MUST:
    registration (required for EasyAuth token validation on the Function App).
    If the scope already exists, this step is a no-op.
 
-The bootstrap image deploys SPA content to the Static Web App using the ARM
-REST API (`Microsoft.Web/staticSites/{name}/zipdeploy`) via `az rest`. The
-content is zipped using Python (bundled with `az` CLI), uploaded as a temporary
-blob to the provisioned storage account, and referenced by SAS URL in the
-zipdeploy request. This approach requires no Node.js, npm, or
+The bootstrap image deploys SPA content to the Static Web App using the
+`StaticSitesClient` binary from the multi-arch Docker image
+(`mcr.microsoft.com/appsvc/staticappsclient:stable`). The deployment token
+is obtained via `az staticwebapp secrets list` and passed to the client
+as an environment variable. This approach requires no Node.js, npm, or
 architecture-specific binaries, enabling native arm64 execution.
 
 **Acceptance criteria:**

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -182,7 +182,7 @@ the Entra app, and adds the Azure Storage API permission.
 
 For standalone (non-bootstrap) deployment, use the deployment script:
 
-Prerequisites: `az` CLI (logged in), `jq`, and `npm`/`npx` (for the SWA CLI).
+Prerequisites: `az` CLI (logged in) and `jq`.
 
 ```bash
 ./deploy/web-ui/deploy.sh <COMPANION_CLIENT_ID> [RESOURCE_GROUP]
@@ -198,7 +198,7 @@ The script:
 6. Configures EasyAuth on the Function App via ARM REST API with the
    companion Entra app as the identity provider and `Return401` for
    unauthenticated requests
-7. Deploys the web-ui content to the Static Web App using the SWA CLI
+7. Deploys the web-ui content to the Static Web App using the ARM zipdeploy REST API
 
 > **Note:** Steps 3–4 mutate the Entra app registration associated with the Azure companion.
 

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -202,7 +202,7 @@ The script:
 6. Configures EasyAuth on the Function App via ARM REST API with the
    companion Entra app as the identity provider and `Return401` for
    unauthenticated requests
-7. Deploys the web-ui content to the Static Web App using the ARM zipdeploy REST API
+7. Deploys the web-ui content to the Static Web App using the `StaticSitesClient` Docker image
 8. If the SWA has custom domains, registers `https://<customDomain>` as an
    additional SPA redirect URI on the Entra app registration (additive merge
    with existing URIs)


### PR DESCRIPTION
## Summary

Replace the `@azure/static-web-apps-cli` (SWA CLI) — which ships amd64-only native binaries — with the ARM `Microsoft.Web/staticSites/{name}/zipdeploy` REST API. This enables native arm64 execution without QEMU emulation.

## Motivation

The SWA CLI downloads a `StaticSitesClient` binary at runtime that has no ARM build. This forced the bootstrap container to run under `linux/amd64` platform emulation via QEMU on arm64 hosts (e.g., Armbian on aarch64), causing significant performance degradation and compatibility issues.

## Changes

### Core deployment flow (`bootstrap.sh` and `deploy.sh`)
1. Zip SPA content via Python `zipfile` (bundled with az CLI)
2. Upload zip to a temp blob in the provisioned storage account
3. Generate a 30-minute read-only service SAS URL
4. POST to ARM zipdeploy via `az rest`
5. Poll SWA hostname for HTTP 200 verification
6. Clean up temp blob via EXIT trap

### Infrastructure
- **`Dockerfile.azure-bootstrap`**: Removed `nodejs24`, `nodejs24-npm`, `@azure/static-web-apps-cli` — image now needs only `jq` + `icu`
- **`sonde-azure-companion/src/main.rs`**: Removed `platform("linux/amd64")` from `create_image`/`create_container` — Docker now uses the native architecture

### CI workflows
- **`azure-live-ci.yml`**: Replaced direct `swa deploy` with ARM zipdeploy flow
- **`azure-bootstrap-container.yml`**: Expanded fake `az` in smoke test to cover full bootstrap flow

### Tests
- **`bootstrap_unix.rs`**: Updated fake binaries and assertions for the new deployment commands

### Spec docs
- Updated `azure-companion-requirements.md`, `azure-companion-design.md`, `web-ui-design.md`

## Design decisions
- **Key-based auth** for blob operations: avoids RBAC propagation delays on newly created storage accounts
- **Sovereign cloud support**: blob URLs resolved via `az storage account show --query primaryEndpoints.blob`
- **EXIT trap cleanup**: temp blob deleted on both success and failure paths