### PR TITLE
fix: remove stale `linux/amd64` platform override from bootstrap container

### DIFF
--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -2170,13 +2170,8 @@ async fn run_bootstrap_deployment_with_docker_and_image(
     bootstrap_image: &str,
 ) -> Result<(ServicePrincipalStateFile, StorageQueuesConfigFile), CompanionError> {
     eprintln!("Pulling bootstrap image...");
-    // The bootstrap image (azure-cli + SWA CLI) is x86_64-only: the
-    // StaticSitesClient binary that the SWA CLI downloads at runtime has
-    // no ARM build. Force linux/amd64 so Docker uses QEMU emulation on
-    // non-x86 hosts (e.g. Armbian on aarch64).
     let pull_opts = CreateImageOptionsBuilder::default()
         .from_image(bootstrap_image)
-        .platform("linux/amd64")
         .build();
     let mut pull_stream = docker.create_image(Some(pull_opts), None, None);
     while let Some(result) = pull_stream.next().await {
@@ -2194,7 +2189,6 @@ async fn run_bootstrap_deployment_with_docker_and_image(
             Some(
                 CreateContainerOptionsBuilder::default()
                     .name(&container_name)
-                    .platform("linux/amd64")
                     .build(),
             ),
             ContainerCreateBody {
@@ -3990,16 +3984,12 @@ mod tests {
                 "DELETE /containers/test-container".to_string(),
             ]
         );
-        assert!(requests[0].url.query().is_some_and(|query| query
-            .contains("fromImage=sonde-azure-bootstrap%3Atest-override")
-            && query.contains("platform=linux%2Famd64")));
-        assert!(
-            requests[1]
-                .url
-                .query()
-                .is_some_and(|query| query.contains("platform=linux%2Famd64")),
-            "container create must specify platform=linux/amd64"
-        );
+        assert!(requests[0]
+            .url
+            .query()
+            .is_some_and(|query| query
+                .contains("fromImage=sonde-azure-bootstrap%3Atest-override")));
+        // No platform override — Docker pulls the native architecture.
         let create_body = String::from_utf8(requests[1].body.clone()).unwrap();
         assert!(create_body.contains("COMPANION_CERT_BASE64=dummy-cert-base64"));
     }

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -3984,11 +3984,11 @@ mod tests {
                 "DELETE /containers/test-container".to_string(),
             ]
         );
-        assert!(requests[0]
-            .url
-            .query()
-            .is_some_and(|query| query
-                .contains("fromImage=sonde-azure-bootstrap%3Atest-override")));
+        assert!(
+            requests[0].url.query().is_some_and(
+                |query| query.contains("fromImage=sonde-azure-bootstrap%3Atest-override")
+            )
+        );
         // No platform override — Docker pulls the native architecture.
         let create_body = String::from_utf8(requests[1].body.clone()).unwrap();
         assert!(create_body.contains("COMPANION_CERT_BASE64=dummy-cert-base64"));


### PR DESCRIPTION
The bootstrap container pull/create calls in `run_bootstrap_deployment_with_docker_and_image()` forced `platform("linux/amd64")` because the SWA CLI's `StaticSitesClient` binary had no ARM build.

That dependency was removed when the SPA deployment was retired from bootstrap. The image now only contains Azure CLI + jq + shell scripts, all of which have native arm64 builds. CI already publishes a multi-arch manifest (amd64 + arm64).

The platform override was the sole reason Docker invoked QEMU emulation on arm64 hosts, causing:

```
sonde-bootstrap  | qemu: uncaught target signal 6 (Aborted) - core dumped
sonde-bootstrap  | failed to wait for bootstrap container: Docker container wait error:
```

**Changes:**
- Remove `.platform("linux/amd64")` from the `create_image` (pull) call
- Remove `.platform("linux/amd64")` from the `create_container` call
- Update test assertions that checked for the platform query parameter