### PR TITLE
Add milli-Fahrenheit emission to SHT40 and TMP102 decoders

### DIFF
--- a/test-programs/sht40_sensor.c
+++ b/test-programs/sht40_sensor.c
@@ -210,8 +210,14 @@ int decode(struct decoder_context *ctx)
         ((__u32)data[21] << 24)
     );
 
+    /* Convert to millidegrees Fahrenheit: mF = mC * 9 / 5 + 32000 */
+    __s32 temp_mf = temp_mc * 9 / 5 + 32000;
+
     char name_temp[] = "temp_mc";
     emit_reading(name_temp, 7, (__s64)temp_mc);
+
+    char name_tempf[] = "temp_mf";
+    emit_reading(name_tempf, 7, (__s64)temp_mf);
 
     char name_rh[] = "rh_mpermille";
     emit_reading(name_rh, 12, (__s64)rh_mpermille);

--- a/test-programs/tmp102_sensor.c
+++ b/test-programs/tmp102_sensor.c
@@ -121,9 +121,16 @@ int decode(struct decoder_context *ctx)
         ((__u32)data[5] << 24)
     );
 
+    /* Convert to millidegrees Fahrenheit: mF = mC * 9 / 5 + 32000 */
+    __s32 temp_mf = temp_mc * 9 / 5 + 32000;
+
     /* Emit the temperature reading in millidegrees Celsius. */
     char name_temp[] = "temp_mc";
     emit_reading(name_temp, 7, (__s64)temp_mc);
+
+    /* Emit the temperature reading in millidegrees Fahrenheit. */
+    char name_tempf[] = "temp_mf";
+    emit_reading(name_tempf, 7, (__s64)temp_mf);
 
     return 0;
 }


### PR DESCRIPTION
Both decoders now compute `temp_mf` from the existing `temp_mc` (`mF = mC * 9 / 5 + 32000`) and emit it as an additional named reading via `emit_reading`. The sensor-side payloads are unchanged — the conversion happens entirely in the decoder sections.