### PR TITLE
fix(test-programs): avoid signed division in sensor decoders

### DIFF
--- a/test-programs/sht40_sensor.c
+++ b/test-programs/sht40_sensor.c
@@ -210,8 +210,12 @@ int decode(struct decoder_context *ctx)
         ((__u32)data[21] << 24)
     );
 
-    /* Convert to millidegrees Fahrenheit: mF = mC * 9 / 5 + 32000 */
-    __s32 temp_mf = temp_mc * 9 / 5 + 32000;
+    /* Convert to millidegrees Fahrenheit: mF = mC * 9 / 5 + 32000
+     * BPF doesn't support signed division, so handle sign separately. */
+    __u32 abs_mc = (temp_mc < 0) ? (__u32)(-temp_mc) : (__u32)temp_mc;
+    __u32 abs_mf = abs_mc * 9u / 5u;
+    __s32 signed_mf = (temp_mc < 0) ? -(__s32)abs_mf : (__s32)abs_mf;
+    __s32 temp_mf = signed_mf + 32000;
 
     char name_temp[] = "temp_mc";
     emit_reading(name_temp, 7, (__s64)temp_mc);

--- a/test-programs/tmp102_sensor.c
+++ b/test-programs/tmp102_sensor.c
@@ -121,8 +121,12 @@ int decode(struct decoder_context *ctx)
         ((__u32)data[5] << 24)
     );
 
-    /* Convert to millidegrees Fahrenheit: mF = mC * 9 / 5 + 32000 */
-    __s32 temp_mf = temp_mc * 9 / 5 + 32000;
+    /* Convert to millidegrees Fahrenheit: mF = mC * 9 / 5 + 32000
+     * BPF doesn't support signed division, so handle sign separately. */
+    __u32 abs_mc_val = (temp_mc < 0) ? (__u32)(-temp_mc) : (__u32)temp_mc;
+    __u32 abs_mf = abs_mc_val * 9u / 5u;
+    __s32 signed_mf = (temp_mc < 0) ? -(__s32)abs_mf : (__s32)abs_mf;
+    __s32 temp_mf = signed_mf + 32000;
 
     /* Emit the temperature reading in millidegrees Celsius. */
     char name_temp[] = "temp_mc";


### PR DESCRIPTION
BPF does not support signed division. The Fahrenheit conversion `temp_mc * 9 / 5` in both `tmp102_sensor` and `sht40_sensor` decoders used a signed `__s32` dividend, which clang rejects with `unsupported signed division`.

Handle the sign manually (extract absolute value, divide unsigned, re-apply sign) — the same pattern already used in the `program` sections of these files for the Celsius conversion.
