### PR TITLE
fix: skip bootstrap when valid state exists, add \--force\ flag

### DIFF
--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -187,6 +187,10 @@ struct BootstrapArgs {
     /// DNS zone name for the custom domain (defaults to custom_domain_name for apex domains).
     #[arg(long, env = "SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME")]
     custom_domain_dns_zone_name: Option<String>,
+
+    /// Force re-provisioning even when valid bootstrap state already exists.
+    #[arg(long, env = "SONDE_AZURE_BOOTSTRAP_FORCE")]
+    force: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2284,6 +2288,16 @@ async fn bootstrap(
 ) -> Result<(), CompanionError> {
     std::fs::create_dir_all(state_dir)?;
 
+    if !args.force {
+        if let Some(generation) = active_state_generation_name(state_dir)? {
+            eprintln!(
+                "Bootstrap state already present (generation `{generation}`); \
+                 skipping. Use --force to re-deploy."
+            );
+            return Ok(());
+        }
+    }
+
     let staging_dir = prepare_staging_dir(state_dir)?;
 
     if let Err(err) = display_progress(admin_socket, "Generating cert...").await {
@@ -2803,18 +2817,19 @@ mod tests {
     #[cfg(unix)]
     use super::validate_certificate_matches_private_key;
     use super::{
-        check_runtime_ready, cleanup_staging, commit_staging, default_bootstrap_image,
-        downstream_body_to_connector_payload, extract_device_code, extract_xml_element,
-        generate_certificate, load_runtime_config, load_runtime_credential_state, load_signing_key,
-        parse_bicep_outputs, parse_queue_message_xml, prepare_staging_dir, pump_downstream_once,
-        pump_upstream_once, read_framed, resolve_bootstrap_image, resolve_effective_state_dir,
-        resolve_login_endpoint, resolve_state_relative_path,
-        run_bootstrap_deployment_with_docker_and_image, trim_buffer_to_max_len, urlencoding_encode,
-        validate_display_lines, write_framed, ClientAssertionCredential, CompanionError,
-        DownstreamConsumer, RuntimeConfig, RuntimeCredentialState, ServicePrincipalStateFile,
-        StorageQueuesConfigFile, UpstreamPublisher, ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME,
-        CONNECTOR_MAX_FRAME_LENGTH, DEFAULT_LOGIN_ENDPOINT, KEY_PEM_FILENAME,
-        SERVICE_PRINCIPAL_STATE_FILENAME, STATE_GENERATION_PREFIX, STORAGE_QUEUES_CONFIG_FILENAME,
+        active_state_generation_name, check_runtime_ready, cleanup_staging, commit_staging,
+        default_bootstrap_image, downstream_body_to_connector_payload, extract_device_code,
+        extract_xml_element, generate_certificate, load_runtime_config,
+        load_runtime_credential_state, load_signing_key, parse_bicep_outputs,
+        parse_queue_message_xml, prepare_staging_dir, pump_downstream_once, pump_upstream_once,
+        read_framed, resolve_bootstrap_image, resolve_effective_state_dir, resolve_login_endpoint,
+        resolve_state_relative_path, run_bootstrap_deployment_with_docker_and_image,
+        trim_buffer_to_max_len, urlencoding_encode, validate_display_lines, write_framed,
+        ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
+        RuntimeCredentialState, ServicePrincipalStateFile, StorageQueuesConfigFile,
+        UpstreamPublisher, ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH,
+        DEFAULT_LOGIN_ENDPOINT, KEY_PEM_FILENAME, SERVICE_PRINCIPAL_STATE_FILENAME,
+        STAGING_DIR_NAME, STATE_GENERATION_PREFIX, STORAGE_QUEUES_CONFIG_FILENAME,
     };
     #[cfg(windows)]
     use super::{
@@ -3957,6 +3972,7 @@ mod tests {
             custom_domain_name: None,
             custom_domain_dns_resource_group: None,
             custom_domain_dns_zone_name: None,
+            force: false,
         };
 
         let err = run_bootstrap_deployment_with_docker_and_image(
@@ -4424,12 +4440,122 @@ mod tests {
             custom_domain_name: None,
             custom_domain_dns_resource_group: None,
             custom_domain_dns_zone_name: None,
+            force: false,
         };
 
         let err = super::bootstrap("/tmp/sonde-missing-admin.sock", temp.path(), args)
             .await
             .unwrap_err();
         assert!(!temp.path().join(".staging").exists());
+        assert!(matches!(err, CompanionError::TonicTransport(_)));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_skips_when_valid_state_exists() {
+        let temp = TempDir::new().unwrap();
+
+        // Create valid bootstrap-complete state via staging + commit.
+        let staging_dir = prepare_staging_dir(temp.path()).unwrap();
+        std::fs::write(staging_dir.join(CERT_PEM_FILENAME), b"cert").unwrap();
+        std::fs::write(staging_dir.join(KEY_PEM_FILENAME), b"key").unwrap();
+        std::fs::write(
+            staging_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME),
+            serde_json::to_vec(&ServicePrincipalStateFile {
+                tenant_id: "t".to_string(),
+                client_id: "c".to_string(),
+                login_endpoint: None,
+                certificate_path: CERT_PEM_FILENAME.to_string(),
+                private_key_path: KEY_PEM_FILENAME.to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            staging_dir.join(STORAGE_QUEUES_CONFIG_FILENAME),
+            serde_json::to_vec(&StorageQueuesConfigFile {
+                queue_endpoint: "https://q.example.net".to_string(),
+                upstream_queue: "up".to_string(),
+                downstream_queue: "down".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        commit_staging(&staging_dir, temp.path()).unwrap();
+
+        let generation_before = active_state_generation_name(temp.path()).unwrap().unwrap();
+
+        let args = super::BootstrapArgs {
+            azure_location: "westus2".to_string(),
+            azure_project_name: "sonde".to_string(),
+            azure_subscription_id: None,
+            bootstrap_image: None,
+            custom_domain_name: None,
+            custom_domain_dns_resource_group: None,
+            custom_domain_dns_zone_name: None,
+            force: false,
+        };
+
+        // Should succeed without contacting any external service.
+        super::bootstrap("/tmp/sonde-missing-admin.sock", temp.path(), args)
+            .await
+            .unwrap();
+
+        // State must be unchanged — no new generation created, no staging dir.
+        let generation_after = active_state_generation_name(temp.path()).unwrap().unwrap();
+        assert_eq!(generation_before, generation_after);
+        assert!(!temp.path().join(STAGING_DIR_NAME).exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bootstrap_force_overrides_early_exit() {
+        let temp = TempDir::new().unwrap();
+
+        // Create valid bootstrap-complete state.
+        let staging_dir = prepare_staging_dir(temp.path()).unwrap();
+        std::fs::write(staging_dir.join(CERT_PEM_FILENAME), b"cert").unwrap();
+        std::fs::write(staging_dir.join(KEY_PEM_FILENAME), b"key").unwrap();
+        std::fs::write(
+            staging_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME),
+            serde_json::to_vec(&ServicePrincipalStateFile {
+                tenant_id: "t".to_string(),
+                client_id: "c".to_string(),
+                login_endpoint: None,
+                certificate_path: CERT_PEM_FILENAME.to_string(),
+                private_key_path: KEY_PEM_FILENAME.to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            staging_dir.join(STORAGE_QUEUES_CONFIG_FILENAME),
+            serde_json::to_vec(&StorageQueuesConfigFile {
+                queue_endpoint: "https://q.example.net".to_string(),
+                upstream_queue: "up".to_string(),
+                downstream_queue: "down".to_string(),
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        commit_staging(&staging_dir, temp.path()).unwrap();
+
+        let args = super::BootstrapArgs {
+            azure_location: "westus2".to_string(),
+            azure_project_name: "sonde".to_string(),
+            azure_subscription_id: None,
+            bootstrap_image: None,
+            custom_domain_name: None,
+            custom_domain_dns_resource_group: None,
+            custom_domain_dns_zone_name: None,
+            force: true,
+        };
+
+        // With --force, bootstrap should NOT skip — it will attempt to proceed
+        // and fail because there's no admin socket, proving the early-exit was
+        // bypassed.
+        let err = super::bootstrap("/tmp/sonde-missing-admin.sock", temp.path(), args)
+            .await
+            .unwrap_err();
         assert!(matches!(err, CompanionError::TonicTransport(_)));
     }
 

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -232,7 +232,7 @@ transport and the runtime bridge semantics already defined in section 5.
 ## 4  Bootstrap flow
 
 > **Requirements:** AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204, AZC-0205, AZC-0300,
-> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0407, AZC-0408, AZC-0409
+> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0407, AZC-0408, AZC-0409, AZC-0411
 
 ### 4.1  Bootstrap trigger
 
@@ -254,6 +254,14 @@ service auto-start path is fail-closed before bootstrap-complete state exists.
 When bootstrap is required, the Azure companion performs this sequence:
 
 1. Invoke `sonde-azure-companion bootstrap`.
+   - **Early-exit guard (AZC-0411):** Before any provisioning work, check
+     whether valid bootstrap-complete state already exists by calling
+     `active_state_generation_name(state_dir)`. If it returns `Some(…)` and
+     the `--force` flag is not set, print a diagnostic message to stderr
+     (e.g., "Bootstrap state already present; skipping. Use --force to
+     re-deploy.") and return success immediately. This allows
+     `docker compose up -d` to skip redundant bootstrap on restart.
+     If `--force` is set, proceed with the full sequence below.
 2. Display "Generating cert…" on the modem display via the admin API.
 3. Generate a self-signed ECDSA P-256 X.509 certificate and private key using
    Rust crypto libraries. The certificate has a 2-year default validity period.
@@ -340,7 +348,7 @@ non-zero status. It does not continue to a console-only fallback.
 ## 5  Rust binary interface
 
 > **Requirements:** AZC-0100, AZC-0102, AZC-0103, AZC-0104, AZC-0105, AZC-0201, AZC-0202, AZC-0205, AZC-0300, AZC-0301, AZC-0302, AZC-0304, AZC-0305,
-> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0410
+> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0410, AZC-0411
 
 The `sonde-azure-companion` binary exposes three cross-platform runtime modes
 plus Windows service-management entrypoints:
@@ -353,7 +361,10 @@ plus Windows service-management entrypoints:
    artifact creation (`service-principal.json`, `storage-queues.json`,
    certificate PEM, private-key PEM). The Rust code monitors the bootstrap
    container's output to extract the device code and display it on the modem
-   via the gateway admin API.
+   via the gateway admin API. If valid bootstrap-complete state already exists
+   and `--force` is not passed, the subcommand exits successfully without
+   performing any provisioning work (AZC-0411). Accepts `--force` (env:
+   `SONDE_AZURE_BOOTSTRAP_FORCE`) to override this early-exit behavior.
 3. **`display-message`** — helper mode used by bootstrap logic to call the
    gateway admin `ShowModemDisplayMessage` RPC with 1 to 4 lines of text.
 4. **`install`** *(Windows)* — registers or updates the native Windows service

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -265,6 +265,8 @@ AZC-0205.
 5. The earlier `bootstrap-auth` subcommand name is no longer accepted.
 6. Invoking `sonde-azure-companion bootstrap` from the Windows native binary performs the same end-to-end provisioning lifecycle as the Linux bootstrap path, subject to the same Docker and Azure prerequisites.
 7. By default, the unified bootstrap path launches the version-tagged `sonde-azure-bootstrap` image that matches the companion release version.
+8. If valid bootstrap-complete state already exists in the state directory and the `--force` flag is not passed, the `bootstrap` subcommand exits successfully without performing any provisioning work. This allows `docker compose up -d` to skip redundant bootstrap on restart.
+9. If valid bootstrap-complete state already exists and `--force` is passed, the `bootstrap` subcommand proceeds with the full provisioning lifecycle as if no state existed.
 
 ---
 
@@ -749,22 +751,22 @@ container.
 **Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771) AC-2, AZP-0300
 
 **Description:**
-Re-running the unified `bootstrap` subcommand on an already-provisioned system
-MUST be safe. Bootstrap MUST re-generate the certificate, re-run the Bicep
-deployment, and re-write the runtime artifacts. The Bicep deployment is
-inherently idempotent; certificate regeneration updates the Entra application
-credential. Bootstrap MUST use a staging approach so that a failed re-bootstrap
-does not corrupt the existing working state.
+Re-running the unified `bootstrap` subcommand with `--force` on an
+already-provisioned system MUST be safe. Forced bootstrap MUST re-generate the
+certificate, re-run the Bicep deployment, and re-write the runtime artifacts.
+The Bicep deployment is inherently idempotent; certificate regeneration updates
+the Entra application credential. Bootstrap MUST use a staging approach so that
+a failed re-bootstrap does not corrupt the existing working state.
 
 **Acceptance criteria:**
 
-1. Re-running bootstrap on a system with existing provisioning artifacts succeeds without errors.
-2. Re-bootstrap regenerates the certificate and private key.
-3. Re-bootstrap re-runs the Bicep deployment with the new certificate.
-4. Re-bootstrap updates `service-principal.json` with any changed values.
-5. The runtime can start successfully after re-bootstrap.
-6. If re-bootstrap fails at any phase after authentication, the previous working state remains intact.
-7. No staging artifacts remain in the state volume after a failed re-bootstrap.
+1. Re-running bootstrap with `--force` on a system with existing provisioning artifacts succeeds without errors.
+2. Forced re-bootstrap regenerates the certificate and private key.
+3. Forced re-bootstrap re-runs the Bicep deployment with the new certificate.
+4. Forced re-bootstrap updates `service-principal.json` with any changed values.
+5. The runtime can start successfully after forced re-bootstrap.
+6. If forced re-bootstrap fails at any phase after authentication, the previous working state remains intact.
+7. No staging artifacts remain in the state volume after a failed forced re-bootstrap.
 
 ---
 
@@ -853,3 +855,33 @@ deploy SPA content to the Static Web App.
 6. Re-running bootstrap updates the SPA content and Entra configuration idempotently.
 7. If SPA deployment fails, bootstrap exits non-zero and does not report success.
 8. The Entra app registration exposes `api://<clientId>/user_impersonation` as an API scope after bootstrap.
+
+---
+
+### AZC-0411  Bootstrap `--force` flag
+
+**Priority:** Must
+**Source:** [issue #953](https://github.com/Alan-Jowett/sonde/issues/953)
+
+**Description:**
+The `bootstrap` subcommand MUST accept a `--force` flag (also settable via the
+`SONDE_AZURE_BOOTSTRAP_FORCE` environment variable). When valid
+bootstrap-complete state already exists in the state directory:
+
+- Without `--force`, the subcommand prints a diagnostic message to stderr and
+  exits successfully without performing any provisioning work.
+- With `--force`, the subcommand performs the full provisioning lifecycle
+  unconditionally, as described in AZC-0201.
+
+This ensures that `docker compose up -d` after a previous successful bootstrap
+does not force the operator through interactive Azure device-code
+authentication unnecessarily, while still allowing explicit re-provisioning
+when needed (e.g., credential rotation).
+
+**Acceptance criteria:**
+
+1. `BootstrapArgs` includes a `--force` boolean flag with a default of `false`.
+2. The `--force` flag is also settable via the `SONDE_AZURE_BOOTSTRAP_FORCE` environment variable.
+3. When valid state exists and `--force` is not set, bootstrap prints a message to stderr indicating that state already exists and exits with status 0.
+4. When valid state exists and `--force` is set, bootstrap performs the full provisioning lifecycle.
+5. When no valid state exists, bootstrap performs the full provisioning lifecycle regardless of the `--force` flag.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -483,12 +483,12 @@
 
 ### T-AZC-0407  Re-bootstrap on already-provisioned system succeeds
 
-**Validates:** AZC-0407
+**Validates:** AZC-0407, AZC-0411
 
 **Procedure:**
 1. Run bootstrap to completion with stubbed services, creating all runtime artifacts.
 2. Record the certificate fingerprint and `service-principal.json` content.
-3. Re-run bootstrap with the same stubbed services.
+3. Re-run bootstrap with `--force` and the same stubbed services.
 4. Assert: bootstrap completes successfully.
 5. Assert: the certificate PEM file has been regenerated (different fingerprint).
 6. Assert: `service-principal.json` has been rewritten.
@@ -642,3 +642,42 @@
 9. Assert: if SPA deployment fails, bootstrap exits non-zero.
 10. Re-run bootstrap with the same stubbed outputs.
 11. Assert: the SPA deployment and Entra configuration succeed idempotently (including the API scope exposure in step 8).
+
+---
+
+### T-AZC-0419  Bootstrap skips deployment when valid state exists
+
+**Validates:** AZC-0411, AZC-0201 AC-8
+
+**Procedure:**
+1. Prepare a state directory with valid bootstrap-complete state (`.current-state` marker pointing to a valid generation directory).
+2. Run `sonde-azure-companion bootstrap` without `--force`.
+3. Assert: bootstrap exits with status 0.
+4. Assert: bootstrap prints a message to stderr indicating state already exists and that `--force` can be used to re-deploy.
+5. Assert: no certificate generation, Docker API calls, or Bicep deployment occur.
+6. Assert: the existing state files are not modified.
+
+---
+
+### T-AZC-0420  Bootstrap `--force` overrides early-exit
+
+**Validates:** AZC-0411
+
+**Procedure:**
+1. Prepare a state directory with valid bootstrap-complete state.
+2. Run `sonde-azure-companion bootstrap --force` with stubbed services.
+3. Assert: bootstrap performs the full provisioning lifecycle (certificate generation, Docker API calls, Bicep deployment).
+4. Assert: bootstrap completes successfully.
+5. Assert: the state directory contains a new generation with fresh artifacts.
+
+---
+
+### T-AZC-0421  Bootstrap `--force` via environment variable
+
+**Validates:** AZC-0411 AC-2
+
+**Procedure:**
+1. Prepare a state directory with valid bootstrap-complete state.
+2. Set `SONDE_AZURE_BOOTSTRAP_FORCE=true` and run `sonde-azure-companion bootstrap` (without the CLI `--force` flag) with stubbed services.
+3. Assert: bootstrap performs the full provisioning lifecycle.
+4. Assert: bootstrap completes successfully.


### PR DESCRIPTION
## Problem

Running \docker compose up -d\ always re-runs the \ootstrap\ service, which performs interactive Azure device-code authentication and Bicep deployment — even when the companion state volume already contains valid bootstrap-complete state.

## Solution

The \ootstrap\ subcommand now checks for existing valid state before performing any provisioning work. When \.current-state\ points to a valid generation directory and \--force\ is not set, bootstrap prints a diagnostic to stderr and exits successfully.

A new \--force\ flag (also settable via \SONDE_AZURE_BOOTSTRAP_FORCE\ env var) allows explicit re-provisioning when needed (e.g., credential rotation).

## Changes

### Implementation (\crates/sonde-azure-companion/src/main.rs\)
- Added \--force\ flag to \BootstrapArgs\ (default \alse\, env: \SONDE_AZURE_BOOTSTRAP_FORCE\)
- Added early-exit guard in \ootstrap()\ — skips when valid state exists and \!force\
- 2 new tests: \ootstrap_skips_when_valid_state_exists\, \ootstrap_force_overrides_early_exit\

### Specifications
- **AZC-0201 AC-8,9**: early-exit behavior for \ootstrap\ subcommand
- **AZC-0407**: scoped to forced re-bootstrap (with \--force\)
- **AZC-0411** (new): \--force\ flag requirement with acceptance criteria
- **Design §4.2**: early-exit guard step before provisioning sequence
- **T-AZC-0407**: updated to use \--force\ for re-bootstrap test
- **T-AZC-0419/0420/0421** (new): skip, force-override, and env-var validation tests

## Testing

- 63 unit tests pass ✅
- clippy clean ✅

Closes #953