### PR TITLE
fix: persistent display flag and bootstrap sub-phase progress

### DIFF
--- a/crates/sonde-admin/src/grpc_client.rs
+++ b/crates/sonde-admin/src/grpc_client.rs
@@ -275,9 +275,10 @@ impl AdminClient {
     pub async fn show_modem_display_message(
         &mut self,
         lines: Vec<String>,
+        persistent: bool,
     ) -> Result<(), tonic::Status> {
         self.inner
-            .show_modem_display_message(ShowModemDisplayMessageRequest { lines })
+            .show_modem_display_message(ShowModemDisplayMessageRequest { lines, persistent })
             .await?;
         Ok(())
     }

--- a/crates/sonde-admin/src/main.rs
+++ b/crates/sonde-admin/src/main.rs
@@ -790,7 +790,9 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
                 }
             }
             ModemAction::Display { lines } => {
-                client.show_modem_display_message(lines.clone()).await?;
+                client
+                    .show_modem_display_message(lines.clone(), false)
+                    .await?;
                 if json {
                     print_json(&serde_json::json!({
                         "lines": lines,

--- a/crates/sonde-admin/tests/integration.rs
+++ b/crates/sonde-admin/tests/integration.rs
@@ -510,7 +510,7 @@ async fn grpc_revoke_nonexistent_phone() {
 async fn grpc_show_modem_display_message_no_modem() {
     let mut client = start_server_and_connect("show_modem_display_message_no_modem").await;
     let result = client
-        .show_modem_display_message(vec!["Device login".to_string()])
+        .show_modem_display_message(vec!["Device login".to_string()], false)
         .await;
     let status = result.expect_err("missing modem transport should fail");
     assert_eq!(status.code(), tonic::Code::Unavailable);

--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -2085,6 +2085,8 @@ async fn stream_container_output(
     let mut stderr_buffer = String::new();
     let mut device_code_displayed = false;
     let mut deployment_displayed = false;
+    let mut handler_displayed = false;
+    let mut entra_displayed = false;
 
     while let Some(result) = logs.next().await {
         match result {
@@ -2096,14 +2098,25 @@ async fn stream_container_output(
                 let text = String::from_utf8_lossy(&message);
                 eprint!("{text}");
                 stderr_buffer.push_str(&text);
-                const MAX_STDERR_BUFFER_LEN: usize = 4096;
-                trim_buffer_to_max_len(&mut stderr_buffer, MAX_STDERR_BUFFER_LEN);
 
+                // Detect markers before trimming so large chunks cannot
+                // push a marker out of the buffer before it is scanned.
                 if !deployment_displayed
                     && stderr_buffer.contains("__SONDE_AZURE_DEPLOYMENT_START__")
                 {
                     display_progress(admin_socket, "Deploying Azure...").await?;
                     deployment_displayed = true;
+                }
+
+                if !handler_displayed && stderr_buffer.contains("__SONDE_AZURE_DEPLOYING_HANDLER__")
+                {
+                    display_progress(admin_socket, "Deploying handler...").await?;
+                    handler_displayed = true;
+                }
+
+                if !entra_displayed && stderr_buffer.contains("__SONDE_AZURE_CONFIGURING_ENTRA__") {
+                    display_progress(admin_socket, "Configuring Entra...").await?;
+                    entra_displayed = true;
                 }
 
                 if !device_code_displayed {
@@ -2112,6 +2125,7 @@ async fn stream_container_output(
                         if let Err(e) = display_message(
                             admin_socket,
                             vec!["Azure login".to_string(), device_code],
+                            true,
                         )
                         .await
                         {
@@ -2122,6 +2136,9 @@ async fn stream_container_output(
                         device_code_displayed = true;
                     }
                 }
+
+                const MAX_STDERR_BUFFER_LEN: usize = 4096;
+                trim_buffer_to_max_len(&mut stderr_buffer, MAX_STDERR_BUFFER_LEN);
             }
             Ok(LogOutput::Console { message }) => {
                 let text = String::from_utf8_lossy(&message);
@@ -2254,17 +2271,21 @@ async fn run_bootstrap_deployment_with_docker_and_image(
     bootstrap_result
 }
 
-async fn display_message(admin_socket: &str, lines: Vec<String>) -> Result<(), CompanionError> {
+async fn display_message(
+    admin_socket: &str,
+    lines: Vec<String>,
+    persistent: bool,
+) -> Result<(), CompanionError> {
     validate_display_lines(&lines)?;
     let mut client = connect_admin(admin_socket).await?;
     client
-        .show_modem_display_message(ShowModemDisplayMessageRequest { lines })
+        .show_modem_display_message(ShowModemDisplayMessageRequest { lines, persistent })
         .await?;
     Ok(())
 }
 
 async fn display_progress(admin_socket: &str, msg: &str) -> Result<(), CompanionError> {
-    display_message(admin_socket, vec![msg.to_string()]).await
+    display_message(admin_socket, vec![msg.to_string()], false).await
 }
 
 async fn report_bootstrap_failure(
@@ -2773,7 +2794,9 @@ async fn run_cli() -> Result<(), CompanionError> {
     match cli.command.clone().unwrap_or(Command::Run) {
         Command::Run => run(&cli.connector_socket, &cli.state_dir).await?,
         Command::Bootstrap(args) => bootstrap(&cli.admin_socket, &cli.state_dir, args).await?,
-        Command::DisplayMessage { lines } => display_message(&cli.admin_socket, lines).await?,
+        Command::DisplayMessage { lines } => {
+            display_message(&cli.admin_socket, lines, false).await?
+        }
         Command::CheckRuntimeReady => {
             check_runtime_ready(&cli.state_dir)?;
         }

--- a/crates/sonde-gateway/proto/admin.proto
+++ b/crates/sonde-gateway/proto/admin.proto
@@ -123,7 +123,13 @@ message ChannelSurveyEntry {
     int32 strongest_rssi = 3;
 }
 message ScanModemChannelsResponse { repeated ChannelSurveyEntry entries = 1; }
-message ShowModemDisplayMessageRequest { repeated string lines = 1; }
+message ShowModemDisplayMessageRequest {
+    repeated string lines = 1;
+    // When true, the message stays on the display indefinitely until replaced
+    // by another ShowModemDisplayMessage call or a BLE pairing session.
+    // When false (default), the gateway restores the version banner after 60 s.
+    bool persistent = 2;
+}
 
 // BLE phone pairing messages (GW-1222).
 message OpenBlePairingRequest {

--- a/crates/sonde-gateway/proto/admin.proto
+++ b/crates/sonde-gateway/proto/admin.proto
@@ -126,7 +126,8 @@ message ScanModemChannelsResponse { repeated ChannelSurveyEntry entries = 1; }
 message ShowModemDisplayMessageRequest {
     repeated string lines = 1;
     // When true, the message stays on the display indefinitely until replaced
-    // by another ShowModemDisplayMessage call or a BLE pairing session.
+    // by another ShowModemDisplayMessage call, a BLE pairing session, a
+    // button-driven status-page navigation, or gateway restart.
     // When false (default), the gateway restores the version banner after 60 s.
     bool persistent = 2;
 }

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -1332,8 +1332,8 @@ impl GatewayAdmin for AdminService {
             .display_state
             .as_ref()
             .ok_or_else(|| Status::unavailable("no modem transport configured"))?;
-        let lines = request.into_inner().lines;
-        show_modem_display_message(display_state, &lines).await?;
+        let inner = request.into_inner();
+        show_modem_display_message(display_state, &inner.lines, inner.persistent).await?;
 
         Ok(Response::new(Empty {}))
     }

--- a/crates/sonde-gateway/src/transient_display.rs
+++ b/crates/sonde-gateway/src/transient_display.rs
@@ -107,6 +107,7 @@ async fn restore_display_failure(state: &ActiveDisplayState, generation: u64) {
 pub async fn show_modem_display_message(
     state: &ActiveDisplayState,
     lines: &[String],
+    persistent: bool,
 ) -> Result<(), Status> {
     if state.controller.session_origin().await.is_some() {
         return Err(Status::failed_precondition(
@@ -132,6 +133,8 @@ pub async fn show_modem_display_message(
         )));
     }
 
-    schedule_display_restore(state, generation);
+    if !persistent {
+        schedule_display_restore(state, generation);
+    }
     Ok(())
 }

--- a/crates/sonde-gateway/tests/admin_display.rs
+++ b/crates/sonde-gateway/tests/admin_display.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 sonde contributors
 
-//! Admin transient display tests (T-0815f through T-0815j).
+//! Admin transient display tests (T-0815f through T-0815l).
 
 mod common;
 
@@ -117,6 +117,8 @@ async fn t0815f_transient_modem_display_via_admin_api() {
             admin
                 .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
                     lines: vec!["Device login".to_string()],
+
+                    persistent: false,
                 }))
                 .await
         }
@@ -136,6 +138,8 @@ async fn t0815f_transient_modem_display_via_admin_api() {
                         "Code".to_string(),
                         "ABCD-EFGH".to_string(),
                     ],
+
+                    persistent: false,
                 }))
                 .await
         }
@@ -170,6 +174,8 @@ async fn t0815g_new_transient_display_request_replaces_older_one() {
             admin
                 .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
                     lines: vec!["First".to_string()],
+
+                    persistent: false,
                 }))
                 .await
         }
@@ -186,6 +192,8 @@ async fn t0815g_new_transient_display_request_replaces_older_one() {
             admin
                 .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
                     lines: vec!["Second".to_string()],
+
+                    persistent: false,
                 }))
                 .await
         }
@@ -218,6 +226,8 @@ async fn t0815h_transient_display_rejected_during_ble_pairing() {
     let err = admin
         .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
             lines: vec!["Blocked".to_string()],
+
+            persistent: false,
         }))
         .await
         .expect_err("display request must fail during active BLE pairing");
@@ -239,6 +249,8 @@ async fn t0815i_transient_display_rejects_invalid_line_count() {
     let err = admin
         .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
             lines: vec![],
+
+            persistent: false,
         }))
         .await
         .expect_err("empty line set must be rejected");
@@ -253,6 +265,8 @@ async fn t0815i_transient_display_rejects_invalid_line_count() {
                 "4".to_string(),
                 "5".to_string(),
             ],
+
+            persistent: false,
         }))
         .await
         .expect_err("more than four lines must be rejected");
@@ -278,6 +292,8 @@ async fn t0815j_transient_display_without_modem_transport_is_unavailable() {
     let err = admin
         .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
             lines: vec!["Unavailable".to_string()],
+
+            persistent: false,
         }))
         .await
         .expect_err("missing modem transport must produce UNAVAILABLE");
@@ -297,6 +313,8 @@ async fn admin_display_failure_restores_gateway_banner() {
             admin
                 .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
                     lines: vec!["Device login".to_string()],
+
+                    persistent: false,
                 }))
                 .await
         }
@@ -325,4 +343,120 @@ async fn admin_display_failure_restores_gateway_banner() {
         .unwrap()
         .expect_err("mismatched ACK must fail the admin display request");
     assert_eq!(err.code(), Code::Internal);
+}
+
+/// T-0815k: A persistent display message stays on screen indefinitely (no 60 s
+/// restore timer) and is replaced when a subsequent non-persistent call arrives.
+#[tokio::test]
+async fn t0815k_persistent_transient_display_message() {
+    tokio::time::pause();
+
+    let (admin, mut server, _controller, _storage) = build_admin_with_modem(6).await;
+    let admin = Arc::new(admin);
+    let mut decoder = FrameDecoder::new();
+    let mut buf = [0u8; 2048];
+
+    // Send a persistent message.
+    let persistent_req = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec!["Azure login".to_string(), "ABCD-EFGH".to_string()],
+                    persistent: true,
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(
+        framebuffer,
+        render_display_message(&["Azure login", "ABCD-EFGH"])
+    );
+    persistent_req.await.unwrap().unwrap();
+
+    // Wait well past the normal 60 s timeout — no banner restore should occur.
+    assert_no_stream_data_while_time_paused(
+        &mut server,
+        &mut buf,
+        Duration::from_secs(120),
+        "persistent message must not be restored after any timeout",
+    )
+    .await;
+
+    // Send a non-persistent replacement message.
+    let replace_req = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec!["Deploying Azure...".to_string()],
+                    persistent: false,
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(framebuffer, render_display_message(&["Deploying Azure..."]));
+    replace_req.await.unwrap().unwrap();
+
+    // The non-persistent replacement should restore the banner after 60 s.
+    tokio::time::advance(Duration::from_secs(60) + Duration::from_millis(100)).await;
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(
+        framebuffer,
+        render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+    );
+}
+
+/// T-0815l: A non-persistent message replaces a persistent one and starts the
+/// normal 60-second restore timer.
+#[tokio::test]
+async fn t0815l_non_persistent_replaces_persistent() {
+    tokio::time::pause();
+
+    let (admin, mut server, _controller, _storage) = build_admin_with_modem(6).await;
+    let admin = Arc::new(admin);
+    let mut decoder = FrameDecoder::new();
+    let mut buf = [0u8; 2048];
+
+    // Send a persistent message.
+    let persistent_req = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec!["Persistent".to_string()],
+                    persistent: true,
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(framebuffer, render_display_message(&["Persistent"]));
+    persistent_req.await.unwrap().unwrap();
+
+    // Send a non-persistent replacement.
+    let replace_req = tokio::spawn({
+        let admin = Arc::clone(&admin);
+        async move {
+            admin
+                .show_modem_display_message(Request::new(ShowModemDisplayMessageRequest {
+                    lines: vec!["Temporary".to_string()],
+                    persistent: false,
+                }))
+                .await
+        }
+    });
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(framebuffer, render_display_message(&["Temporary"]));
+    replace_req.await.unwrap().unwrap();
+
+    // 60 s restore timer must fire for the non-persistent replacement.
+    tokio::time::advance(Duration::from_secs(60) + Duration::from_millis(100)).await;
+    let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+    assert_eq!(
+        framebuffer,
+        render_gateway_version_banner(env!("CARGO_PKG_VERSION"))
+    );
 }

--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -213,6 +213,7 @@ if [ ! -r "$function_package_path" ]; then
     exit 1
 fi
 
+echo "__SONDE_AZURE_DEPLOYING_HANDLER__" >&2
 echo "Deploying bundled Azure handler package to Function App $function_app_name" >&2
 echo "Using deployment target $deployment_container_name ($deployment_container_url)" >&2
 # Explicitly clear linuxFxVersion so the Azure CLI does not warn about
@@ -244,6 +245,7 @@ wait_for_function_activation "$resource_group_name" "$function_app_name" "$activ
 # SPA redirect URIs and CORS origins are configured in Bicep (companion-identity
 # and function-placeholder modules).  Bootstrap only needs to set API permissions
 # and the user_impersonation scope.
+echo "__SONDE_AZURE_CONFIGURING_ENTRA__" >&2
 echo "Configuring Entra app registration for Web UI" >&2
 
 # Resolve the Entra app object ID from the companion client ID

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -290,7 +290,8 @@ When bootstrap is required, the Azure companion performs this sequence:
     format is controlled by the shipped bootstrap artifact for that release.
 11. When the device code is detected, call the gateway admin
     `ShowModemDisplayMessage` RPC with a short prompt plus the exact device
-    code.
+    code and `persistent = true` so the code remains visible until the next
+    phase replaces it.
 12. Wait for the container to finish. On success, `az deployment sub create`
     produces JSON deployment outputs on stdout.
 13. Display "Deploying Azure…" on the modem display (transitions from auth to
@@ -642,13 +643,25 @@ bootstrap does not need Docker socket access.
 
 The bootstrap displays these messages on the modem via the admin API:
 
-| Phase | Modem display | stderr log |
-|-------|--------------|------------|
-| Certificate generation | "Generating cert..." | "Generating ECDSA P-256 self-signed certificate" |
-| Bootstrap image start | "Authenticating..." | "Starting sonde-azure-bootstrap for device-code auth" |
-| Device code received | "Azure login" + device code | "Device auth: open {uri} and enter code {code}" |
-| Bicep deployment | "Deploying Azure..." | "Running Bicep deployment" |
-| Config writing | "Writing config..." | "Writing runtime artifacts to state volume" |
-| SPA deployment | "Deploying Web UI..." | "Deploying Web UI to Static Web App" |
-| Bootstrap complete | "Bootstrap complete" | "Bootstrap completed successfully" |
-| Bootstrap failure | "Bootstrap failed" | Error details |
+| Phase | Modem display | stderr log | `persistent` |
+|-------|--------------|------------|--------------|
+| Certificate generation | "Generating cert..." | "Generating ECDSA P-256 self-signed certificate" | false |
+| Bootstrap image start | "Authenticating..." | "Starting sonde-azure-bootstrap for device-code auth" | false |
+| Device code received | "Azure login" + device code | "Device auth: open {uri} and enter code {code}" | **true** |
+| Bicep deployment | "Deploying Azure..." | "Running Bicep deployment" | false |
+| Handler deployment | "Deploying handler..." | "Deploying bundled Azure handler package" | false |
+| Entra configuration | "Configuring Entra..." | "Configuring Entra app registration for Web UI" | false |
+| Config writing | "Writing config..." | "Writing runtime artifacts to state volume" | false |
+| Bootstrap complete | "Bootstrap complete" | "Bootstrap completed successfully" | false |
+| Bootstrap failure | "Bootstrap failed" | Error details | false |
+
+The device-code display uses `persistent = true` so the code remains visible
+on the OLED until authentication completes and the next phase replaces it,
+avoiding the 60-second timeout that would otherwise clear the screen before
+the operator finishes the device-code login flow.
+
+Sub-phase transitions after Bicep deployment are signaled by the bootstrap
+container via structured stderr markers (`__SONDE_AZURE_DEPLOYING_HANDLER__`
+and `__SONDE_AZURE_CONFIGURING_ENTRA__`). The companion watches for these
+markers alongside the existing `__SONDE_AZURE_DEPLOYMENT_START__` marker and
+updates the modem display accordingly.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -273,13 +273,15 @@ AZC-0205.
 ### AZC-0202  Device code display via gateway admin API
 
 **Priority:** Must
-**Source:** Discovery review, GW-0809
+**Source:** Discovery review, GW-0809, [issue #943](https://github.com/Alan-Jowett/sonde/issues/943)
 
 **Description:**
 When the dedicated bootstrap image's `az login --use-device-code` step produces
 a device code in its output, the Rust bootstrap flow MUST extract the code and
 request a modem display update through the gateway admin API. The displayed
-message MUST include a short prompt and the exact device code. The Azure
+message MUST include a short prompt and the exact device code. The display
+request MUST set `persistent = true` so the device code remains visible until
+authentication completes and the next bootstrap phase replaces it. The Azure
 companion MUST NOT attempt raw modem control or bypass the gateway's display
 ownership rules. Because the bootstrap image tag is version-matched to the
 companion release, the output format is controlled by the shipped bootstrap
@@ -287,10 +289,11 @@ artifact for that release.
 
 **Acceptance criteria:**
 
-1. During bootstrap, the Azure companion calls the admin `ShowModemDisplayMessage` RPC with text that includes both a short prompt and the exact device code.
+1. During bootstrap, the Azure companion calls the admin `ShowModemDisplayMessage` RPC with text that includes both a short prompt and the exact device code, and with `persistent = true`.
 2. The displayed device code matches the value produced by Azure device-code login without modification.
 3. The Azure companion uses the gateway admin socket, not the connector socket, for this display request.
 4. The bootstrap flow does not invoke raw modem serial commands or direct framebuffer upload.
+5. The device code display persists until the next bootstrap phase updates the modem display.
 
 ---
 
@@ -707,21 +710,26 @@ supply them.
 ### AZC-0405  Bootstrap progress display
 
 **Priority:** Must
-**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), AZC-0202
+**Source:** [issue #771](https://github.com/Alan-Jowett/sonde/issues/771), AZC-0202, [issue #943](https://github.com/Alan-Jowett/sonde/issues/943)
 
 **Description:**
 The unified `bootstrap` subcommand MUST report progress for each major phase
 on both the modem display (via the gateway admin API) and stderr. The phases
-include authentication, certificate generation, Azure deployment, and
-completion.
+include authentication, certificate generation, Azure deployment, handler
+deployment, Entra configuration, and completion. The bootstrap container MUST
+emit structured stderr markers at sub-phase transitions so the companion can
+provide granular progress updates beyond the initial "Deploying Azure..." message.
 
 **Acceptance criteria:**
 
 1. Each major bootstrap phase updates the modem display with a short status message via the admin `ShowModemDisplayMessage` RPC.
 2. Each major bootstrap phase logs a status message to stderr.
-3. The authentication phase displays the device code as defined by AZC-0202.
+3. The authentication phase displays the device code as defined by AZC-0202, using `persistent = true`.
 4. Bootstrap completion displays a success message on the modem display.
 5. Bootstrap failure displays an error indication on the modem display before exiting.
+6. The bootstrap container emits `__SONDE_AZURE_DEPLOYING_HANDLER__` on stderr after Bicep deployment completes and before Function App deployment begins.
+7. The bootstrap container emits `__SONDE_AZURE_CONFIGURING_ENTRA__` on stderr before Entra app registration configuration begins.
+8. The Azure companion updates the modem display when each sub-phase marker is detected.
 
 ---
 

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -460,9 +460,9 @@
 
 **Procedure:**
 1. Start a test gateway exposing the admin socket and instrument the admin `ShowModemDisplayMessage` RPC.
-2. Run the bootstrap subcommand with device-flow and Bicep deployment stubbed.
-3. Assert: at least four distinct modem display updates are received during bootstrap.
-4. Assert: the updates include messages for authentication, certificate generation, deployment, and completion phases.
+2. Run the bootstrap subcommand with device-flow and Bicep deployment stubbed, and the bootstrap container stub configured to emit all three stderr markers (`__SONDE_AZURE_DEPLOYMENT_START__`, `__SONDE_AZURE_DEPLOYING_HANDLER__`, `__SONDE_AZURE_CONFIGURING_ENTRA__`).
+3. Assert: at least six distinct modem display updates are received during bootstrap.
+4. Assert: the updates include messages for authentication, certificate generation, deployment, handler deployment, Entra configuration, and completion phases.
 5. Assert: each phase also emits a corresponding stderr log message.
 6. Run the bootstrap subcommand with a forced failure in the Bicep deployment phase.
 7. Assert: the modem displays an error indication before bootstrap exits.
@@ -681,3 +681,30 @@
 2. Set `SONDE_AZURE_BOOTSTRAP_FORCE=true` and run `sonde-azure-companion bootstrap` (without the CLI `--force` flag) with stubbed services.
 3. Assert: bootstrap performs the full provisioning lifecycle.
 4. Assert: bootstrap completes successfully.
+
+---
+
+### T-AZC-0422  Device code display uses persistent flag
+
+**Validates:** AZC-0202, AZC-0405
+
+**Procedure:**
+1. Start a test gateway exposing the admin socket and instrument the admin `ShowModemDisplayMessage` RPC to capture both `lines` and `persistent` fields.
+2. Start the Azure companion bootstrap path with the device-flow endpoint stubbed to emit a known device code.
+3. Assert: the `ShowModemDisplayMessage` call for the device code sets `persistent = true`.
+4. Assert: subsequent progress display calls (e.g., "Deploying Azure...") set `persistent = false` (or omit it).
+5. Assert: the device code message is replaced by the next phase's display update, not by a 60-second timer.
+
+---
+
+### T-AZC-0423  Bootstrap sub-phase markers update modem display
+
+**Validates:** AZC-0405
+
+**Procedure:**
+1. Start a test gateway exposing the admin socket and instrument the admin `ShowModemDisplayMessage` RPC to capture all display updates.
+2. Run the bootstrap subcommand with device-flow and Bicep deployment stubbed. Configure the bootstrap container stub to emit the stderr markers `__SONDE_AZURE_DEPLOYMENT_START__`, `__SONDE_AZURE_DEPLOYING_HANDLER__`, and `__SONDE_AZURE_CONFIGURING_ENTRA__` at appropriate points.
+3. Assert: at least six distinct modem display updates are received during bootstrap (cert, auth, device code, deploying Azure, deploying handler, configuring Entra, writing config, complete).
+4. Assert: "Deploying handler..." is displayed after "Deploying Azure...".
+5. Assert: "Configuring Entra..." is displayed after "Deploying handler...".
+6. Assert: each sub-phase also emits a corresponding stderr log message.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -704,7 +704,7 @@
 **Procedure:**
 1. Start a test gateway exposing the admin socket and instrument the admin `ShowModemDisplayMessage` RPC to capture all display updates.
 2. Run the bootstrap subcommand with device-flow and Bicep deployment stubbed. Configure the bootstrap container stub to emit the stderr markers `__SONDE_AZURE_DEPLOYMENT_START__`, `__SONDE_AZURE_DEPLOYING_HANDLER__`, and `__SONDE_AZURE_CONFIGURING_ENTRA__` at appropriate points.
-3. Assert: at least six distinct modem display updates are received during bootstrap (cert, auth, device code, deploying Azure, deploying handler, configuring Entra, writing config, complete).
+3. Assert: at least eight distinct modem display updates are received during bootstrap (cert, auth, device code, deploying Azure, deploying handler, configuring Entra, writing config, complete).
 4. Assert: "Deploying handler..." is displayed after "Deploying Azure...".
 5. Assert: "Configuring Entra..." is displayed after "Deploying handler...".
 6. Assert: each sub-phase also emits a corresponding stderr log message.

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1041,7 +1041,7 @@ The gRPC server runs on a local socket: a **Unix domain socket** on Linux/macOS 
 | Modem status | `GetModemStatus` | Returns modem status: radio channel, TX/RX/fail counters, uptime. |
 | Set modem channel | `SetModemChannel` | Sets the ESP-NOW radio channel (1–14). Persists the new channel in the database (GW-0808). |
 | Scan channels | `ScanModemChannels` | Scans all WiFi channels for AP activity, returns AP counts and RSSI per channel. |
-| Show transient modem display text | `ShowModemDisplayMessage` | Renders 1–4 gateway-supplied text lines on the modem display for 60 s, then restores the normal gateway banner (GW-0809). |
+| Show transient modem display text | `ShowModemDisplayMessage` | Renders 1–4 gateway-supplied text lines on the modem display. When `persistent` is false (default), restores the normal gateway banner after 60 s; when true, the message remains until replaced (GW-0809). |
 | Open BLE pairing | `OpenBlePairing` | Opens an admin-initiated phone registration window and sends `BLE_ENABLE` to the modem. Server-streaming RPC returning pairing events (passkey, phone connected/disconnected/registered, window closed). |
 | Close BLE pairing | `CloseBlePairing` | Closes the active BLE pairing session and sends `BLE_DISABLE` to the modem. |
 | Confirm BLE pairing | `ConfirmBlePairing` | Accepts or rejects a Numeric Comparison passkey during an admin-initiated BLE pairing session. |
@@ -1394,26 +1394,34 @@ If another `BUTTON_SHORT` arrives before the timeout fires, the gateway advances
 The admin API exposes a gateway-owned transient display override for operator
 prompts such as headless device-login codes. This remains an operator/admin
 workflow; the control-plane connector model in §13A does not introduce a second
-display-control path. The shared helper accepts 1 to 4 text lines and rejects
-the request with `FAILED_PRECONDITION` if a BLE pairing session currently owns
-the display, so pairing passkeys and terminal status screens remain visible.
+display-control path. The shared helper accepts 1 to 4 text lines and an
+optional `persistent` flag, and rejects the request with `FAILED_PRECONDITION`
+if a BLE pairing session currently owns the display, so pairing passkeys and
+terminal status screens remain visible.
 
 On success, the gateway renders the supplied lines with the same centered
 128×64 text renderer used for the startup banner and button-pairing status
 screens, then sends the resulting framebuffer through the existing reliable
 display-transfer path. The RPC returns after that initial display update
-completes; the caller does not remain connected for the 60-second dwell time.
+completes; the caller does not remain connected for any dwell time.
 
-The transient-display path reuses the same display-ownership machinery as
-button-driven status pages: it cancels any active `Nodes` scroll task, resets
-the status-page cycle to the normal starting position, increments
-`display_generation`, and spawns a 60-second restore task tied to the captured
-generation. When that task fires, it restores the default
+When `persistent` is false (the default), the transient-display path reuses the
+same display-ownership machinery as button-driven status pages: it cancels any
+active `Nodes` scroll task, resets the status-page cycle to the normal starting
+position, increments `display_generation`, and spawns a 60-second restore task
+tied to the captured generation. When that task fires, it restores the default
 `Sonde Gateway v<semver>` banner only if its generation is still current and no
 BLE pairing session owns the display. A newer transient-display request, a
 button-driven status-page update, or a pairing display transition invalidates
 the older generation, causing the stale restore task to exit without
 overwriting the newer screen.
+
+When `persistent` is true, the gateway still cancels any active scroll task,
+resets the status-page cycle, and increments `display_generation`, but it does
+**not** spawn the 60-second restore task. The message remains on the display
+until a subsequent `ShowModemDisplayMessage` call (persistent or not), a
+button-driven status-page update, or a BLE pairing session claims the display
+through the normal generation mechanism.
 
 ### 17.5  `PEER_REQUEST` processing
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -975,13 +975,20 @@ The gateway MUST persist the current ESP-NOW radio channel in the database so th
 ### GW-0809  Admin API — transient modem display message
 
 **Priority:** Must  
-**Source:** Issue #771
+**Source:** Issue #771, Issue #943
 
 **Description:**  
 The admin API MUST support a gateway-owned transient display override for the
-modem-attached OLED. The operation accepts 1 to 4 text lines, renders them
-using the gateway's existing centered text renderer, displays the result for 60
-seconds, then restores the normal `Sonde Gateway v<semver>` banner.
+modem-attached OLED. The operation accepts 1 to 4 text lines and an optional
+`persistent` flag. When `persistent` is false (the default), the gateway renders
+the lines using the existing centered text renderer, displays the result for 60
+seconds, then restores the normal `Sonde Gateway v<semver>` banner. When
+`persistent` is true, the gateway displays the message indefinitely — no
+60-second restore timer is started. A persistent message remains visible until
+replaced by another `ShowModemDisplayMessage` call, a BLE pairing session, a
+button-driven status-page navigation, or gateway restart. The `persistent` flag
+suppresses only the automatic timeout, not operator-initiated display
+transitions.
 
 Bootstrap-oriented local clients that need temporary operator-visible display
 control, such as Azure device-auth bootstrap, MUST use this admin RPC rather
@@ -990,7 +997,8 @@ desired-state and upstream runtime traffic.
 
 The RPC MUST return after the initial display update succeeds; it MUST NOT wait
 for the 60-second timeout to expire. A later successful transient-display
-request replaces any earlier one and restarts the 60-second timer.
+request replaces any earlier one and, if the newer request is not persistent,
+restarts the 60-second timer.
 
 To avoid obscuring pairing prompts, the operation MUST fail with
 `FAILED_PRECONDITION` while a BLE pairing session owns the display. If no modem
@@ -998,12 +1006,15 @@ transport is configured, it MUST fail with `UNAVAILABLE`.
 
 **Acceptance criteria:**
 
-1. `ShowModemDisplayMessage` with 1 to 4 lines updates the modem display and returns before the 60-second timeout expires.
+1. `ShowModemDisplayMessage` with 1 to 4 lines and `persistent` false (or omitted) updates the modem display and returns before the 60-second timeout expires.
 2. `ShowModemDisplayMessage` with fewer than 1 line or more than 4 lines returns `INVALID_ARGUMENT`.
-3. If no newer display owner claims the screen, the normal `Sonde Gateway v<semver>` banner is restored after 60 seconds.
-4. A second successful `ShowModemDisplayMessage` received before the first timeout expires replaces the earlier text and restarts the 60-second timeout window.
+3. If no newer display owner claims the screen and `persistent` is false, the normal `Sonde Gateway v<semver>` banner is restored after 60 seconds.
+4. A second successful `ShowModemDisplayMessage` received before the first timeout expires replaces the earlier text and restarts the 60-second timeout window (when the second request is not persistent).
 5. While a BLE pairing session owns the display, `ShowModemDisplayMessage` returns `FAILED_PRECONDITION`.
 6. Without a configured modem transport, `ShowModemDisplayMessage` returns `UNAVAILABLE`.
+7. `ShowModemDisplayMessage` with `persistent` true displays the message and does not start a restore timer; the message remains until replaced by another `ShowModemDisplayMessage` call, a BLE pairing session, or a button-driven status-page navigation. The `persistent` flag suppresses only the automatic 60-second timeout, not operator-initiated display transitions.
+8. A non-persistent `ShowModemDisplayMessage` call replaces an earlier persistent message and starts the normal 60-second restore timer.
+9. After a gateway restart, no persistent message state is preserved; the gateway displays its normal startup banner.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1585,6 +1585,40 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-0815k  Persistent transient display message
+
+**Validates:** GW-0809
+
+**Procedure:**
+1. Start the gateway with a mock or real modem transport that captures display frames.
+2. Call `ShowModemDisplayMessage` with a single-line message and `persistent = true`.
+3. Assert: the RPC returns successfully.
+4. Assert: the modem transport receives a display update corresponding to the requested text.
+5. Wait longer than 60 seconds (or advance paused test time).
+6. Assert: the gateway does **not** restore the default `Sonde Gateway v<semver>` banner — the persistent message remains.
+7. Call `ShowModemDisplayMessage` with a different message and `persistent = false`.
+8. Assert: the second message replaces the persistent one on the modem display.
+9. Wait for the 60-second restore timeout associated with the second (non-persistent) request.
+10. Assert: the gateway restores the default banner after the second message's timeout.
+
+---
+
+### T-0815l  Non-persistent message replaces persistent message
+
+**Validates:** GW-0809
+
+**Procedure:**
+1. Start the gateway with a mock or real modem transport that captures display frames.
+2. Call `ShowModemDisplayMessage` with `persistent = true` and a message.
+3. Assert: the message is displayed.
+4. Call `ShowModemDisplayMessage` with `persistent = false` (default) and a different message.
+5. Assert: the second message replaces the first.
+6. Assert: the 60-second restore timer is started for the second message.
+7. Wait for the 60-second restore timeout.
+8. Assert: the gateway restores the default banner.
+
+---
+
 ### T-0816  Admin CLI JSON output
 
 **Validates:** GW-0806


### PR DESCRIPTION
## Summary

Fixes #943 — device login code display times out before auth completes in headless bootstrap.

Additionally adds granular sub-phase progress reporting during bootstrap so operators don't think the deployment is stuck.

## Changes

### Gateway: persistent display flag (GW-0809 amendment)

- **Proto**: Added \ool persistent = 2\ to \ShowModemDisplayMessageRequest\
- **\	ransient_display.rs\**: \show_modem_display_message()\ accepts \persistent: bool\; when true, skips the 60-second restore timer
- **\dmin.rs\**: Passes persistent field through from gRPC request
- **Tests**: T-0815k (persistent stays >60s, replaced by non-persistent), T-0815l (non-persistent replaces persistent with timer)
- Default (\alse\) preserves existing 60-second timeout behavior — fully backward compatible

### Azure companion: persistent device code + sub-phase detection (AZC-0202, AZC-0405)

- Device code display now sets \persistent = true\ so the code stays visible until auth completes and the next phase replaces it
- Stderr watcher detects two new markers and updates the modem display:
  - \__SONDE_AZURE_DEPLOYING_HANDLER__\ → \Deploying handler...\
  - \__SONDE_AZURE_CONFIGURING_ENTRA__\ → \Configuring Entra...\
- Moved marker detection before \	rim_buffer_to_max_len()\ to prevent large chunks from truncating markers before scanning

### Bootstrap script (\deploy/azure-bootstrap/bootstrap.sh\)

- Emits \__SONDE_AZURE_DEPLOYING_HANDLER__\ before Function App zip deploy
- Emits \__SONDE_AZURE_CONFIGURING_ENTRA__\ before Entra app configuration

### Specification updates

- \gateway-requirements.md\: GW-0809 ACs 7–9 for persistent behavior
- \gateway-design.md\: §17.4c rewritten, operation table updated
- \gateway-validation.md\: T-0815k, T-0815l added
- \zure-companion-requirements.md\: AZC-0202 AC 5, AZC-0405 ACs 6–8
- \zure-companion-design.md\: §8.7 progress table, §4.2 step 11
- \zure-companion-validation.md\: T-AZC-0405 updated, T-AZC-0422/0423 added

## Modem display phases (updated)

| Phase | Display | \persistent\ |
|-------|---------|------------|
| Certificate generation | Generating cert... | false |
| Bootstrap image start | Authenticating... | false |
| Device code received | Azure login + code | **true** |
| Bicep deployment | Deploying Azure... | false |
| Handler deployment | Deploying handler... | false |
| Entra configuration | Configuring Entra... | false |
| Config writing | Writing config... | false |
| Bootstrap complete | Bootstrap complete | false |

## Verification

- \cargo fmt --all\ ✅
- \cargo clippy --workspace -- -D warnings\ ✅
- \cargo test --workspace\ ✅ (all tests pass including new T-0815k, T-0815l)
