### PR TITLE
fix(ci): prevent gateway container manifest from being skipped

### DIFF
--- a/.github/workflows/gateway-container.yml
+++ b/.github/workflows/gateway-container.yml
@@ -248,7 +248,7 @@ jobs:
   manifest:
     name: Publish multi-arch manifest
     needs: [build]
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    if: always() && needs.build.result == 'success' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

The \
ightly\ tag on \ghcr.io/alan-jowett/sonde-gateway\ has been stuck at May 7th. The **Publish multi-arch manifest** step in \gateway-container.yml\ is silently skipped every nightly run.

## Root cause

When \
ightly-release.yml\ calls \gateway-container.yml\ via \workflow_call\, \uild_same_run_artifacts\ defaults to \alse\ (the caller supplies modem-firmware and bpf-test-programs artifacts). This means the internal \modem-firmware\ and \pf-test-programs\ jobs are **skipped**.

The \uild\ job correctly uses \lways()\ to override the transitive skip. However, the downstream \manifest\ job did **not** use \lways()\ — GitHub Actions propagates skipped-ancestor status through the entire dependency graph, so \manifest\ was skipped even though \uild\ succeeded.

The Azure companion and bootstrap container workflows are unaffected because their \uild\ jobs have no conditionally-skipped ancestors.

## Fix

Add \lways() && needs.build.result == 'success'\ to the \manifest\ job's \if\ condition, so it runs whenever \uild\ succeeds regardless of skipped ancestors — matching the pattern already used by the \uild\ job itself.