### PR TITLE
fix: reconcile `current_program_hash` on WAKE when PROGRAM_ACK was lost

### DIFF
--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1055,9 +1055,11 @@ impl Gateway {
                     .await
                 {
                     Ok(true) => {
+                        let ph_hex: String =
+                            program_hash.iter().map(|b| format!("{b:02x}")).collect();
                         info!(
                             node_id = %node.node_id,
-                            program_hash = %program_hash.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+                            program_hash = %ph_hex,
                             "WAKE reconciliation: node reports assigned program \
                              — updated `current_program_hash` (lost PROGRAM_ACK recovery)"
                         );
@@ -1065,7 +1067,8 @@ impl Gateway {
                     Ok(false) => {
                         debug!(
                             node_id = %node.node_id,
-                            "WAKE reconciliation: assigned_program_hash changed concurrently — skipped"
+                            "WAKE reconciliation skipped: condition no longer holds \
+                             (concurrent reassignment or already reconciled)"
                         );
                     }
                     Err(e) => {

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1032,6 +1032,53 @@ impl Gateway {
             "COMMAND selected"
         );
 
+        // ── Lost-PROGRAM_ACK recovery (#961) ────────────────────────────
+        //
+        // If the node reports a program hash in its WAKE that matches the
+        // assigned hash but differs from the stored `current_program_hash`,
+        // the most likely explanation is a lost PROGRAM_ACK: the node
+        // installed the program successfully but the ACK was dropped over
+        // the radio.  Reconcile the stored hash so that downstream paths
+        // (decoder enrichment, handler routing) use the correct program.
+        //
+        // The conditional storage update is atomic: it only writes
+        // `current_program_hash` if `assigned_program_hash` still equals
+        // the WAKE-reported hash, preventing clobber of concurrent
+        // reassignments.
+        if let Some(assigned) = &node.assigned_program_hash {
+            if assigned.as_slice() == program_hash.as_slice()
+                && node.current_program_hash.as_deref() != Some(program_hash.as_slice())
+            {
+                match self
+                    .storage
+                    .reconcile_current_program_hash(&node.node_id, &program_hash)
+                    .await
+                {
+                    Ok(true) => {
+                        info!(
+                            node_id = %node.node_id,
+                            program_hash = %program_hash.iter().map(|b| format!("{b:02x}")).collect::<String>(),
+                            "WAKE reconciliation: node reports assigned program \
+                             — updated `current_program_hash` (lost PROGRAM_ACK recovery)"
+                        );
+                    }
+                    Ok(false) => {
+                        debug!(
+                            node_id = %node.node_id,
+                            "WAKE reconciliation: assigned_program_hash changed concurrently — skipped"
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            node_id = %node.node_id,
+                            error = %e,
+                            "WAKE reconciliation: failed to persist current_program_hash"
+                        );
+                    }
+                }
+            }
+        }
+
         // 6. Encode GatewayMessage::Command response
         // Peek at deferred reply for NOP commands; remove only after successful AEAD.
         let command_blob = if matches!(command_payload, CommandPayload::Nop) {

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1176,7 +1176,22 @@ impl Storage for SqliteStorage {
                     params![program_hash, node_id],
                 )
                 .map_err(map_err)?;
-            Ok(rows > 0)
+            if rows > 0 {
+                return Ok(true);
+            }
+            let exists = conn
+                .query_row(
+                    "SELECT 1 FROM nodes WHERE node_id = ?1",
+                    params![node_id],
+                    |_row| Ok(()),
+                )
+                .optional()
+                .map_err(map_err)?;
+            if exists.is_some() {
+                Ok(false)
+            } else {
+                Err(StorageError::NotFound(format!("node `{node_id}`")))
+            }
         })
         .await
     }

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1158,6 +1158,29 @@ impl Storage for SqliteStorage {
         .await
     }
 
+    async fn reconcile_current_program_hash(
+        &self,
+        node_id: &str,
+        program_hash: &[u8],
+    ) -> Result<bool, StorageError> {
+        let node_id = node_id.to_string();
+        let program_hash = program_hash.to_vec();
+        self.with_conn(move |conn| {
+            let rows = conn
+                .execute(
+                    "UPDATE nodes
+                     SET current_program_hash = ?1
+                     WHERE node_id = ?2
+                       AND assigned_program_hash = ?1
+                       AND (current_program_hash IS NOT ?1)",
+                    params![program_hash, node_id],
+                )
+                .map_err(map_err)?;
+            Ok(rows > 0)
+        })
+        .await
+    }
+
     // ── Program library ────────────────────────────────────────
 
     async fn get_program(&self, hash: &[u8]) -> Result<Option<ProgramRecord>, StorageError> {

--- a/crates/sonde-gateway/src/storage.rs
+++ b/crates/sonde-gateway/src/storage.rs
@@ -110,6 +110,24 @@ pub trait Storage: Send + Sync {
         firmware_abi_version: u32,
         firmware_version: &str,
     ) -> Result<(), StorageError>;
+    /// Atomically set `current_program_hash` for a node, but only if the
+    /// node's `assigned_program_hash` still equals the given `program_hash`.
+    ///
+    /// This is used for lost-PROGRAM_ACK recovery during WAKE processing: the
+    /// node reports a program hash in its WAKE that matches the assigned hash,
+    /// proving it has already installed the program even though the gateway
+    /// never received the PROGRAM_ACK.
+    ///
+    /// The conditional check on `assigned_program_hash` prevents a stale WAKE
+    /// snapshot from overwriting a concurrent reassignment.
+    ///
+    /// Returns `Ok(true)` if the update was applied, `Ok(false)` if the
+    /// assigned hash no longer matches (no change made), or an error.
+    async fn reconcile_current_program_hash(
+        &self,
+        node_id: &str,
+        program_hash: &[u8],
+    ) -> Result<bool, StorageError>;
     /// Insert a node only if no node with the same `node_id` exists.
     ///
     /// Returns `true` if the node was inserted, `false` if it already existed.
@@ -376,6 +394,25 @@ impl Storage for InMemoryStorage {
                 Ok(true)
             }
         }
+    }
+
+    async fn reconcile_current_program_hash(
+        &self,
+        node_id: &str,
+        program_hash: &[u8],
+    ) -> Result<bool, StorageError> {
+        let mut nodes = self.nodes.write().await;
+        let node = nodes
+            .get_mut(node_id)
+            .ok_or_else(|| StorageError::NotFound(format!("node `{node_id}`")))?;
+        if node.assigned_program_hash.as_deref() != Some(program_hash) {
+            return Ok(false);
+        }
+        if node.current_program_hash.as_deref() == Some(program_hash) {
+            return Ok(false);
+        }
+        node.current_program_hash = Some(program_hash.to_vec());
+        Ok(true)
     }
 
     async fn delete_node(&self, node_id: &str) -> Result<(), StorageError> {

--- a/crates/sonde-gateway/src/storage.rs
+++ b/crates/sonde-gateway/src/storage.rs
@@ -121,8 +121,9 @@ pub trait Storage: Send + Sync {
     /// The conditional check on `assigned_program_hash` prevents a stale WAKE
     /// snapshot from overwriting a concurrent reassignment.
     ///
-    /// Returns `Ok(true)` if the update was applied, `Ok(false)` if the
-    /// assigned hash no longer matches (no change made), or an error.
+    /// Returns `Ok(true)` if the update was applied, `Ok(false)` if no update
+    /// was needed (assigned hash no longer matches, or `current_program_hash`
+    /// already equals `program_hash`), or an error.
     async fn reconcile_current_program_hash(
         &self,
         node_id: &str,

--- a/crates/sonde-gateway/tests/behavioral_gaps.rs
+++ b/crates/sonde-gateway/tests/behavioral_gaps.rs
@@ -1305,10 +1305,13 @@ async fn t0700_registry_entry_all_fields_present() {
         Some(3700),
         "runtime battery must be updated by WAKE"
     );
-    // `current_program_hash` is only set via PROGRAM_ACK, not WAKE.
+    // After #961 fix: when the WAKE-reported hash matches
+    // `assigned_program_hash`, the gateway reconciles `current_program_hash`
+    // to recover from lost PROGRAM_ACK scenarios.
     assert_eq!(
-        stored.current_program_hash, None,
-        "current_program_hash must not be set by WAKE alone"
+        stored.current_program_hash.as_deref(),
+        Some(program_hash.as_slice()),
+        "current_program_hash must be reconciled when WAKE hash matches assigned hash"
     );
 }
 

--- a/crates/sonde-gateway/tests/phase2b.rs
+++ b/crates/sonde-gateway/tests/phase2b.rs
@@ -1301,3 +1301,157 @@ async fn t0607a_wake_retry_preserves_chunked_transfer_end_to_end() {
         "expected log message about WAKE retry reuse"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+//  T-09xx: Lost PROGRAM_ACK recovery (#961)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// T-0900: When a node's WAKE-reported program hash matches the assigned
+/// hash but differs from the stored `current_program_hash`, the gateway
+/// must reconcile the stored hash (lost PROGRAM_ACK recovery).
+#[tokio::test]
+#[traced_test]
+async fn t0900_wake_reconciles_current_program_hash_on_lost_ack() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let gw = make_gateway(storage.clone());
+
+    let node = TestNode::new("node-900", 0x0900, [0x90; 32]);
+    let old_hash = store_test_program(&storage, b"old-program").await;
+    let new_hash = store_test_program(&storage, b"new-program").await;
+
+    let mut record = node.to_record();
+    record.assigned_program_hash = Some(new_hash.clone());
+    // Simulate a lost PROGRAM_ACK: current is still the old hash.
+    record.current_program_hash = Some(old_hash.clone());
+    storage.upsert_node(&record).await.unwrap();
+
+    // Node sends WAKE reporting the NEW (assigned) hash — it installed the
+    // program but the ACK was lost.
+    let (_, _, payload) = do_wake(&gw, &node, 1, &new_hash).await;
+    assert!(
+        matches!(payload, CommandPayload::Nop),
+        "should be Nop since WAKE hash == assigned hash"
+    );
+
+    // Verify the stored record was reconciled.
+    let stored = storage.get_node("node-900").await.unwrap().unwrap();
+    assert_eq!(
+        stored.current_program_hash.as_deref(),
+        Some(new_hash.as_slice()),
+        "current_program_hash must be reconciled to the assigned hash"
+    );
+
+    assert!(
+        logs_contain("WAKE reconciliation"),
+        "expected log message about WAKE reconciliation"
+    );
+}
+
+/// T-0901: When the WAKE-reported hash does NOT match the assigned hash,
+/// reconciliation must not occur — only a full chunked transfer + ACK
+/// should update `current_program_hash`.
+#[tokio::test]
+async fn t0901_wake_does_not_reconcile_mismatched_hash() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let gw = make_gateway(storage.clone());
+
+    let node = TestNode::new("node-901", 0x0901, [0x91; 32]);
+    let assigned_hash = store_test_program(&storage, b"assigned-901").await;
+    let stale_hash = vec![0x42u8; 32];
+
+    let mut record = node.to_record();
+    record.assigned_program_hash = Some(assigned_hash.clone());
+    record.current_program_hash = None;
+    storage.upsert_node(&record).await.unwrap();
+
+    // Node sends WAKE with the stale hash (not the assigned hash).
+    let (_, _, payload) = do_wake(&gw, &node, 1, &stale_hash).await;
+    assert!(
+        matches!(payload, CommandPayload::UpdateProgram { .. }),
+        "should trigger UpdateProgram since WAKE hash != assigned hash"
+    );
+
+    // current_program_hash must NOT be set.
+    let stored = storage.get_node("node-901").await.unwrap().unwrap();
+    assert_eq!(
+        stored.current_program_hash, None,
+        "current_program_hash must not be set when WAKE hash does not match assigned hash"
+    );
+}
+
+/// T-0902: When `current_program_hash` is None and the WAKE hash matches
+/// the assigned hash, reconciliation sets it (first-boot scenario).
+#[tokio::test]
+async fn t0902_wake_reconciles_from_none() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let gw = make_gateway(storage.clone());
+
+    let node = TestNode::new("node-902", 0x0902, [0x92; 32]);
+    let program_hash = store_test_program(&storage, b"first-boot").await;
+
+    let mut record = node.to_record();
+    record.assigned_program_hash = Some(program_hash.clone());
+    record.current_program_hash = None;
+    storage.upsert_node(&record).await.unwrap();
+
+    // Node sends WAKE with the assigned hash.
+    let (_, _, payload) = do_wake(&gw, &node, 1, &program_hash).await;
+    assert!(matches!(payload, CommandPayload::Nop));
+
+    let stored = storage.get_node("node-902").await.unwrap().unwrap();
+    assert_eq!(
+        stored.current_program_hash.as_deref(),
+        Some(program_hash.as_slice()),
+        "current_program_hash must be set from None when WAKE hash matches assigned"
+    );
+}
+
+/// T-0903: Reconciliation preserves firmware metadata that was updated
+/// in the same WAKE cycle (narrow update must not clobber other fields).
+#[tokio::test]
+async fn t0903_reconciliation_preserves_firmware_metadata() {
+    let storage = Arc::new(InMemoryStorage::new());
+    let gw = make_gateway(storage.clone());
+
+    let node = TestNode::new("node-903", 0x0903, [0x93; 32]);
+    let program_hash = store_test_program(&storage, b"metadata-test").await;
+
+    let mut record = node.to_record();
+    record.assigned_program_hash = Some(program_hash.clone());
+    record.current_program_hash = None;
+    record.firmware_abi_version = Some(1);
+    record.firmware_version = Some("0.1.0".to_string());
+    storage.upsert_node(&record).await.unwrap();
+
+    // WAKE with abi_version=5 and the assigned hash.
+    let frame = node.build_wake(1, 5, &program_hash, 3500);
+    let resp = gw
+        .process_frame(&frame, node.peer_address())
+        .await
+        .expect("expected COMMAND response");
+    let (_, msg) = decode_response(&resp, &node.psk);
+    assert!(matches!(
+        msg,
+        GatewayMessage::Command {
+            payload: CommandPayload::Nop,
+            ..
+        }
+    ));
+
+    let stored = storage.get_node("node-903").await.unwrap().unwrap();
+    assert_eq!(
+        stored.current_program_hash.as_deref(),
+        Some(program_hash.as_slice()),
+        "current_program_hash must be reconciled"
+    );
+    assert_eq!(
+        stored.firmware_abi_version,
+        Some(5),
+        "firmware_abi_version must not be clobbered by reconciliation"
+    );
+    assert_eq!(
+        stored.firmware_version.as_deref(),
+        Some(TEST_FIRMWARE_VERSION),
+        "firmware_version must not be clobbered by reconciliation"
+    );
+}


### PR DESCRIPTION
Closes #961

## Problem

When a node completes a chunked program transfer but the `PROGRAM_ACK` is lost over the radio, the gateway's stored `current_program_hash` becomes permanently stale. The node reports the correct hash in subsequent WAKE messages, but the gateway never updates the stored value.

This breaks **decoder enrichment**: `handle_app_data_core` looks up the decoder image using the stale `current_program_hash`, finding the old program record (which may lack a decoder section) instead of the new one.

Observed on a live deployment where `sonde-admin node list -v` showed mismatched assigned/current hashes, gateway logs showed `COMMAND selected command_type="Nop"` (correct — node already has the program), but the decoder was never invoked.

## Fix

Add a narrow `reconcile_current_program_hash` storage method that atomically sets `current_program_hash` **only when** `assigned_program_hash` still matches the WAKE-reported hash. This:

- Avoids full-record `upsert_node` which could clobber concurrent reassignments or firmware metadata updated earlier in the same WAKE cycle
- Uses a conditional SQL `UPDATE ... WHERE assigned_program_hash = ?1` to prevent race conditions with concurrent reassignment via the connector API

The reconciliation runs in the WAKE handler after command selection: if the WAKE-reported hash equals `assigned_program_hash` but differs from the stored `current_program_hash`, the gateway treats the WAKE as implicit proof that the node installed the program.

## Changes

| File | Change |
|------|--------|
| `storage.rs` | New `reconcile_current_program_hash()` trait method |
| `sqlite_storage.rs` | Atomic conditional SQL implementation |
| `storage.rs` (InMemory) | Matching in-memory implementation for tests |
| `engine.rs` | Reconciliation logic after COMMAND selection in WAKE handler |
| `behavioral_gaps.rs` | Updated `t0700` assertion (WAKE now reconciles when hash matches) |
| `phase2b.rs` | 4 new tests: lost ACK recovery, mismatch negative, None-to-set, metadata preservation |

## Testing

- `t0900`: Lost PROGRAM_ACK recovery — WAKE with assigned hash reconciles `current_program_hash`
- `t0901`: Negative — WAKE with non-assigned hash does NOT reconcile
- `t0902`: First-boot — reconciles from `None` when WAKE hash matches assigned
- `t0903`: Firmware metadata preservation — reconciliation does not clobber `firmware_abi_version` or `firmware_version`
- Full `cargo test --workspace` and `cargo clippy --workspace -- -D warnings` pass