### PR TITLE
Fix BLE pairing design doc: PHONE_REGISTERED encryption, stepper mapping, battery_adc range

### DIFF
--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -470,7 +470,7 @@ All cryptographic operations are implemented in `crypto.rs`.  Key material is wr
 
 ### 6.4  AES-256-GCM encryption/decryption
 
-Used for Phase 1 (decrypt `PHONE_REGISTERED`) and Phase 2 (encrypt pairing payload) (PT-1102).
+Used for Phase 2 (encrypt pairing payload) (PT-1102).  Phase 1 does not use AEAD — `PHONE_REGISTERED` is a plaintext ACK (PT-0303).
 
 ```rust
 /// Decrypt AES-256-GCM ciphertext.
@@ -909,7 +909,7 @@ User inputs are validated before any BLE or cryptographic operation (PT-0403, PT
 | `i2c0_sda` | 0–21 when assigned; if assigned then `i2c0_scl` must also be assigned and differ | `phase2.rs` | `PairingError::InvalidPinConfig` |
 | `i2c0_scl` | 0–21 when assigned; if assigned then `i2c0_sda` must also be assigned and differ | `phase2.rs` | `PairingError::InvalidPinConfig` |
 | `one_wire_data` | 0–21 when assigned, or null | `phase2.rs` | `PairingError::InvalidPinConfig` |
-| `battery_adc` | 0–21 when assigned, or null | `phase2.rs` | `PairingError::InvalidPinConfig` |
+| `battery_adc` | 0–4 when assigned (ADC-capable GPIOs), or null | `phase2.rs` | `PairingError::InvalidPinConfig` |
 | `sensor_enable` | 0–21 when assigned, or null | `phase2.rs` | `PairingError::InvalidPinConfig` |
 
 All validation occurs *before* any BLE write, ensuring that invalid inputs never reach the transport layer.
@@ -994,8 +994,8 @@ class Navigator {
 A horizontal stepper bar in `<header>` with three steps:
 
 1. **Gateway** — active during pages 1–3
-2. **Node** — active during pages 4–5
-3. **Done** — active on page 6
+2. **Node** — active during pages 4–6
+3. **Done** — active on page 7
 
 Each step element uses CSS classes:
 - `step--active` — currently active phase (filled/highlighted)

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -1312,7 +1312,7 @@ TestNode {
 
 **Procedure:**
 1. Call `provision_node(...)` with board layout `Some(BoardLayout { i2c0_sda: Some(6), i2c0_scl: Some(7), one_wire_data: Some(3), battery_adc: Some(22), sensor_enable: Some(4) })`.
-2. Assert: the call returns an error indicating that `battery_adc` is not an ADC-capable GPIO (must be 0–4).
+2. Assert: the call returns an error indicating that `battery_adc` is out of range (0–21).
 3. Assert: no NODE_PROVISION message is written to the BLE transport.
 
 ---

--- a/docs/ble-pairing-tool-validation.md
+++ b/docs/ble-pairing-tool-validation.md
@@ -283,7 +283,7 @@ TestNode {
 3. Assert: Gateway step is active on pages 1–3.
 4. Navigate to page 4.
 5. Assert: Gateway step is marked done; Node step is active.
-6. Navigate to page 6.
+6. Navigate to page 7.
 7. Assert: Gateway and Node steps are marked done; Done step is active.
 8. Assert: stepper steps are not clickable.
 
@@ -1312,7 +1312,7 @@ TestNode {
 
 **Procedure:**
 1. Call `provision_node(...)` with board layout `Some(BoardLayout { i2c0_sda: Some(6), i2c0_scl: Some(7), one_wire_data: Some(3), battery_adc: Some(22), sensor_enable: Some(4) })`.
-2. Assert: the call returns an error indicating that `battery_adc` is out of range (0–21).
+2. Assert: the call returns an error indicating that `battery_adc` is not an ADC-capable GPIO (must be 0–4).
 3. Assert: no NODE_PROVISION message is written to the BLE transport.
 
 ---
@@ -1505,7 +1505,7 @@ TestNode {
 2. Assert: Gateway step has `step--active` class; Node and Done are dimmed.
 3. Navigate to page 4 (Node Scan).
 4. Assert: Gateway step has `step--done` class; Node step has `step--active` class; Done is dimmed.
-5. Navigate to page 6 (Done).
+5. Navigate to page 7 (Done).
 6. Assert: Gateway and Node steps have `step--done` class; Done step has `step--active` class.
 
 ---


### PR DESCRIPTION
## Summary

Fixes three spec-drift findings in `ble-pairing-tool-design.md` and matching drift in `ble-pairing-tool-validation.md`.

### F-BLE-006 — `PHONE_REGISTERED` encryption (Critical)

Design §6.4 incorrectly claimed AES-256-GCM is used to decrypt `PHONE_REGISTERED` in Phase 1. Per PT-0303, `PHONE_REGISTERED` is a plaintext ACK — no decryption is required. Code, validation, and requirements all agree on plaintext.

**Fix:** Updated §6.4 to say AES-256-GCM is used only for Phase 2 (encrypt pairing payload).

### F-BLE-008 — Stepper page mapping (High)

Design said \\Done\\ stepper phase is active on page 6. The wizard has 7 pages (page 6 = Diagnostic Review, page 7 = Done), matching requirements PT-1217 and the code (\\main.js\\ maps \\[0,0,0,1,1,1,2]\\).

**Fix:** Updated stepper mapping to Node=4–6, Done=7. Also fixed validation tests T-PT-111 and T-PT-1218b which had the same drift.

### F-BLE-012 — \\attery_adc\\ GPIO range (High)

Design validation table said \\attery_adc\\ range is 0–21. Requirements PT-0409 and code (\\phase2.rs:49-54\\) enforce 0–4 (ADC-capable GPIOs only).

**Fix:** Updated design table and validation test T-PT-1214d to say 0–4.

Fixes #987