### PR TITLE
Fix BLE pairing specs: modem connection target, retired timeout, zeroing semantics

### DIFF
--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -14,7 +14,7 @@
 The BLE pairing tool is a cross-platform application that provisions Sonde nodes over Bluetooth Low Energy.  It implements two protocol phases:
 
 1. **Phase 1 — Gateway pairing** (one-time): the tool connects to a gateway's BLE service, authenticates via BLE LESC, registers as a pairing agent, and receives a phone PSK over the secure BLE link.
-2. **Phase 2 — Node provisioning** (per node): the tool generates a node PSK, constructs an encrypted pairing payload, and writes it to the modem's Node Provisioning BLE GATT service.  The modem bridges the payload to the target node over ESP-NOW.
+2. **Phase 2 — Node provisioning** (per node): the tool generates a node PSK, constructs an encrypted pairing payload, and writes it to a node's BLE service.  The node stores the payload and relays it to the gateway over ESP-NOW on next boot.
 
 The tool is a Rust-first application following a Tauri-style architecture: all protocol logic, cryptography, and persistence live in a shared Rust crate (`sonde-pair`), with a thin UI shell invoking Rust commands.  The core crate has no platform dependencies and is testable with mocked BLE transport and storage (PT-0101, PT-0102, PT-0104).
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -427,13 +427,15 @@ The transport guarantees cleanup on all paths:
 
 ### 5.6  LESC enforcement
 
-After connecting, both `pair_with_gateway()` (Phase 1) and `provision_node()` (Phase 2) call `enforce_lesc()` to verify that the BLE pairing method meets security requirements (PT-0904, PT-0106).  Both phases connect to the **modem** (which supports LESC Numeric Comparison), not directly to the node.  The function queries `BleTransport::pairing_method()`:
+After connecting, `pair_with_gateway()` (Phase 1) calls `enforce_lesc()` to verify that the BLE pairing method meets security requirements (PT-0904, PT-0106).  Phase 1 connects to the **modem**, which supports LESC Numeric Comparison.  The function queries `BleTransport::pairing_method()`:
 
 - **`NumericComparison`** — accepted (LESC Numeric Comparison confirmed).
 - **`None` (not observable)** — accepted (the OS enforced pairing; the transport cannot distinguish the method).
 - **`JustWorks`** or **`Unknown`** — rejected.  The transport is immediately disconnected and `PairingError::InsecurePairingMethod` is returned.
 
 This check runs before any protocol messages are exchanged, ensuring that an insecure BLE link is never used to transmit key material.
+
+`provision_node()` (Phase 2) does **not** call `enforce_lesc()`.  Phase 2 connects directly to the **node**, which uses LESC Just Works (ND-0904) because nodes are headless devices with no display or input for Numeric Comparison.  LESC Just Works still provides link-layer encryption but does not protect against active MITM — this residual risk is accepted for headless nodes per the protocol spec (ble-pairing-protocol.md §8.2).
 
 ### 5.7  Mock BLE transport
 

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -193,12 +193,11 @@ The Phase 2 state machine implements the node provisioning flow from [ble-pairin
 │                         │──── ACK(0x02) ─────► Error("storage error")
 └────┬────────────────────┘                      disconnect
      │ ACK(0x00)
-     │ zero node_psk, ephemeral keys, shared secret, AES key
+     │ disconnect
      ▼
 ┌─────────────────┐
-│  Disconnect     │
 │  Success        │ return node_id, node_key_hint, rf_channel
-└─────────────────┘
+└─────────────────┘  (node_psk zeroed on drop via Zeroizing)
 ```
 
 **Key design decisions:**

--- a/docs/ble-pairing-tool-design.md
+++ b/docs/ble-pairing-tool-design.md
@@ -14,7 +14,7 @@
 The BLE pairing tool is a cross-platform application that provisions Sonde nodes over Bluetooth Low Energy.  It implements two protocol phases:
 
 1. **Phase 1 — Gateway pairing** (one-time): the tool connects to a gateway's BLE service, authenticates via BLE LESC, registers as a pairing agent, and receives a phone PSK over the secure BLE link.
-2. **Phase 2 — Node provisioning** (per node): the tool generates a node PSK, constructs an encrypted pairing payload, and writes it to a node's BLE service.  The node stores the payload and relays it to the gateway over ESP-NOW on next boot.
+2. **Phase 2 — Node provisioning** (per node): the tool generates a node PSK, constructs an encrypted pairing payload, and writes it to the modem's Node Provisioning BLE GATT service.  The modem bridges the payload to the target node over ESP-NOW.
 
 The tool is a Rust-first application following a Tauri-style architecture: all protocol logic, cryptography, and persistence live in a shared Rust crate (`sonde-pair`), with a thin UI shell invoking Rust commands.  The core crate has no platform dependencies and is testable with mocked BLE transport and storage (PT-0101, PT-0102, PT-0104).
 
@@ -204,7 +204,7 @@ The Phase 2 state machine implements the node provisioning flow from [ble-pairin
 **Key design decisions:**
 
 - All validation and payload construction happen *before* the BLE write.  The tool rejects invalid inputs (empty `node_id`, `rf_channel` out of range, payload > 202 bytes) without touching BLE (PT-0403, PT-0406).
-- `node_psk` is never persisted to disk.  It exists only in memory during provisioning and is zeroed via `Zeroizing` after the `NODE_PROVISION` write succeeds (PT-0408, PT-0804).
+- `node_psk` is never persisted to disk.  It exists only in memory during provisioning and is wrapped in `Zeroizing`, so it is zeroed on drop when `provision_node()` returns — in both success and error paths (PT-0408, PT-0804).
 - The pairing request payload is encrypted with `phone_psk` (AES-256-GCM, AAD = `"sonde-pairing-v2"`) and wrapped in a complete ESP-NOW `PEER_REQUEST` frame (PT-0402).
 
 ### 4.4  Pre-provisioning test state machine
@@ -510,7 +510,7 @@ All intermediate cryptographic material is explicitly zeroed after use:
 
 | Material | Lifetime | Zeroed when |
 |---|---|---|
-| Node PSK (Phase 2) | Generated → `NODE_PROVISION` written | After `NODE_ACK(0x00)` received |
+| Node PSK (Phase 2) | Generated → `provision_node()` return | On drop (`Zeroizing` wrapper) when `provision_node()` returns |
 | Phone PSK (Phase 1) | Received over BLE LESC → persisted | After caller persistence completes |
 
 All values above are wrapped in `Zeroizing<[u8; N]>` to ensure zeroing on drop even in error paths.

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -345,11 +345,11 @@ Before starting node provisioning, the tool MUST verify that it holds a valid ph
 **Source:** ble-pairing-protocol.md §3.4
 
 **Description:**  
-On operator selection of a node device, the tool MUST connect, negotiate ATT MTU ≥ 247, and accept BLE LESC pairing. If MTU < 247, the tool MUST disconnect and report an error.
+On operator selection of a node device, the tool MUST connect to the **modem's** Node Provisioning BLE GATT service (the modem bridges BLE to nodes over ESP-NOW), negotiate ATT MTU ≥ 247, and accept BLE LESC pairing. If MTU < 247, the tool MUST disconnect and report an error.
 
 **Acceptance criteria:**
 
-1. The tool connects to the selected node.
+1. The tool connects to the modem's Node Provisioning BLE GATT service.
 2. MTU ≥ 247 is negotiated.
 3. If MTU < 247, the tool disconnects and reports "MTU too low".
 
@@ -443,11 +443,11 @@ The tool MUST assemble the `NODE_PROVISION` body as `node_key_hint[2] ‖ node_p
 **Source:** security.md §2.1
 
 **Description:**  
-After a successful `NODE_PROVISION` write, the tool MUST zero `node_psk` from memory via `zeroize::Zeroizing`. The tool has no further use for it. All AES-256-GCM key material (AES key, nonce) MUST also be zeroed.
+The tool MUST wrap `node_psk` in `zeroize::Zeroizing` so that it is zeroed on drop when `provision_node()` returns — in both success and error paths. The tool has no further use for it. All AES-256-GCM key material (AES key, nonce) MUST also be zeroed.
 
 **Acceptance criteria:**
 
-1. `node_psk` is zeroed after the `NODE_PROVISION` write succeeds.
+1. `node_psk` is wrapped in `Zeroizing` and zeroed when `provision_node()` returns.
 2. All intermediate cryptographic material is zeroed after use.
 3. No node PSK values are persisted to disk.
 
@@ -924,7 +924,7 @@ BLE connections, GATT subscriptions, and platform BLE resources MUST be released
 **Source:** ble-pairing-protocol.md §3.4, §5, §6
 
 **Description:**  
-All timeouts MUST be deterministic and explicitly configured to the following values: `GW_INFO_RESPONSE` 45 s, `PHONE_REGISTERED` 30 s, `NODE_ACK` 5 s, BLE scan default 30 s, BLE connection establishment 30 s.
+All timeouts MUST be deterministic and explicitly configured to the following values: `PHONE_REGISTERED` 30 s, `NODE_ACK` 5 s, BLE scan default 30 s, BLE connection establishment 30 s.
 
 **Acceptance criteria:**
 

--- a/docs/ble-pairing-tool-requirements.md
+++ b/docs/ble-pairing-tool-requirements.md
@@ -345,11 +345,11 @@ Before starting node provisioning, the tool MUST verify that it holds a valid ph
 **Source:** ble-pairing-protocol.md §3.4
 
 **Description:**  
-On operator selection of a node device, the tool MUST connect to the **modem's** Node Provisioning BLE GATT service (the modem bridges BLE to nodes over ESP-NOW), negotiate ATT MTU ≥ 247, and accept BLE LESC pairing. If MTU < 247, the tool MUST disconnect and report an error.
+On operator selection of a node device, the tool MUST connect, negotiate ATT MTU ≥ 247, and accept BLE LESC pairing. If MTU < 247, the tool MUST disconnect and report an error.
 
 **Acceptance criteria:**
 
-1. The tool connects to the modem's Node Provisioning BLE GATT service.
+1. The tool connects to the selected node.
 2. MTU ≥ 247 is negotiated.
 3. If MTU < 247, the tool disconnects and reports "MTU too low".
 


### PR DESCRIPTION
## Summary

Fixes three spec-drift findings across `ble-pairing-tool-requirements.md` and `ble-pairing-tool-design.md`. The fourth finding (F-BLE-010, silent retries code fix) was filed as a separate issue #997.

### F-BLE-007 — Connect target (no change needed)

PT-0401 originally said the tool connects to the selected node. Review confirmed this is correct — the Node Provisioning Service (FE50) is hosted by the **node** in pairing mode, not the modem. The modem only hosts the Gateway Pairing Service (FE60) for Phase 1. No spec change needed for PT-0401.

Additionally, design §5.6 (LESC enforcement) incorrectly stated both Phase 1 and Phase 2 call `enforce_lesc()` and connect to the modem. Fixed to clarify that only Phase 1 calls `enforce_lesc()`; Phase 2 connects to the node and uses LESC Just Works (ND-0904). Also updated the Phase 2 state machine diagram to reflect `Zeroizing`-based zeroing semantics.

### F-BLE-009 — `GW_INFO_RESPONSE` timeout (fix-spec)

PT-1002 listed `GW_INFO_RESPONSE 45s` in the timeout table. This flow was retired (issue #495); design and validation already reflect this.

**Fix:** Removed `GW_INFO_RESPONSE` from PT-1002 timeout list.

### F-BLE-011 — `node_psk` zeroing timing (fix-spec)

PT-0408 said `node_psk` is zeroed after successful `NODE_PROVISION` write. Design §6.8 said after `NODE_ACK(0x00)` received. Code wraps `node_psk` in `Zeroizing` — it's zeroed on scope exit when `provision_node()` returns, covering both success and error paths.

**Fix:** Updated PT-0408, design §4.3, and design §6.8 to match the actual `Zeroizing` wrapper semantics.

### F-BLE-010 — Silent retries (separate issue)

Code fix for the BLE write retry loop in `btleplug_transport.rs` was filed separately as #997.

Fixes #988