### PR TITLE
feat: surface `has_decoder` in program listings

### DIFF
--- a/crates/sonde-admin/src/main.rs
+++ b/crates/sonde-admin/src/main.rs
@@ -578,6 +578,7 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
                                     "size": p.size,
                                     "profile": profile_name(p.verification_profile),
                                     "source_filename": p.source_filename.as_deref(),
+                                    "has_decoder": p.has_decoder,
                                 })
                             })
                             .collect::<Vec<_>>(),
@@ -587,20 +588,23 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
                         println!("No programs stored.");
                     }
                     for p in &programs {
+                        let decoder_tag = if p.has_decoder { ", decoder" } else { "" };
                         if let Some(f) = &p.source_filename {
                             println!(
-                                "  {} {} ({} bytes, {})",
+                                "  {} {} ({} bytes, {}{})",
                                 hex::encode(&p.hash),
                                 f,
                                 p.size,
-                                profile_name(p.verification_profile)
+                                profile_name(p.verification_profile),
+                                decoder_tag
                             );
                         } else {
                             println!(
-                                "  {} ({} bytes, {})",
+                                "  {} ({} bytes, {}{})",
                                 hex::encode(&p.hash),
                                 p.size,
-                                profile_name(p.verification_profile)
+                                profile_name(p.verification_profile),
+                                decoder_tag
                             );
                         }
                     }

--- a/crates/sonde-gateway/proto/admin.proto
+++ b/crates/sonde-gateway/proto/admin.proto
@@ -69,6 +69,7 @@ message ProgramInfo {
     VerificationProfile verification_profile = 3;
     optional uint32 abi_version = 4;
     optional string source_filename = 5;
+    bool has_decoder = 6;
 }
 
 enum VerificationProfile {

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -774,6 +774,7 @@ impl GatewayAdmin for AdminService {
                 verification_profile: profile_to_proto(&p.verification_profile),
                 abi_version: p.abi_version,
                 source_filename: p.source_filename.clone(),
+                has_decoder: p.has_decoder,
             })
             .collect();
         Ok(Response::new(ListProgramsResponse { programs }))

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1321,23 +1321,25 @@ impl Storage for SqliteStorage {
         self.with_conn(|conn| {
             let mut stmt = conn
                 .prepare(
-                    "SELECT hash, size, verification_profile, abi_version, source_filename FROM programs",
+                    "SELECT hash, size, verification_profile, abi_version, source_filename, decoder_image IS NOT NULL FROM programs",
                 )
                 .map_err(map_err)?;
             let rows = stmt
                 .query_map([], |row| {
                     let profile_str: String = row.get(2)?;
-                    Ok((row.get(0)?, row.get(1)?, profile_str, row.get(3)?, row.get(4)?))
+                    let has_decoder: bool = row.get(5)?;
+                    Ok((row.get(0)?, row.get(1)?, profile_str, row.get(3)?, row.get(4)?, has_decoder))
                 })
                 .map_err(map_err)?;
             let mut programs = Vec::new();
             for row in rows {
-                let (hash, size, profile_str, abi_version, source_filename): (
+                let (hash, size, profile_str, abi_version, source_filename, has_decoder): (
                     Vec<u8>,
                     u32,
                     String,
                     Option<u32>,
                     Option<String>,
+                    bool,
                 ) = row.map_err(map_err)?;
                 programs.push(ProgramSummaryRecord {
                     hash,
@@ -1345,6 +1347,7 @@ impl Storage for SqliteStorage {
                     verification_profile: parse_profile(&profile_str)?,
                     abi_version,
                     source_filename: normalize_display_filename(&source_filename),
+                    has_decoder,
                 });
             }
             Ok(programs)

--- a/crates/sonde-gateway/src/storage.rs
+++ b/crates/sonde-gateway/src/storage.rs
@@ -62,6 +62,7 @@ pub struct ProgramSummaryRecord {
     pub verification_profile: crate::program::VerificationProfile,
     pub abi_version: Option<u32>,
     pub source_filename: Option<String>,
+    pub has_decoder: bool,
 }
 
 /// Escrow keypair record for PSK key escrow (GW-2000).
@@ -153,6 +154,7 @@ pub trait Storage: Send + Sync {
                 verification_profile: program.verification_profile,
                 abi_version: program.abi_version,
                 source_filename: program.source_filename,
+                has_decoder: program.decoder_image.is_some(),
             })
             .collect())
     }
@@ -460,6 +462,7 @@ impl Storage for InMemoryStorage {
                 verification_profile: program.verification_profile.clone(),
                 abi_version: program.abi_version,
                 source_filename: program.source_filename.clone(),
+                has_decoder: program.decoder_image.is_some(),
             })
             .collect())
     }

--- a/crates/sonde-gateway/tests/phase2c_admin.rs
+++ b/crates/sonde-gateway/tests/phase2c_admin.rs
@@ -466,6 +466,66 @@ async fn t0802d_ingest_abi_version_round_trip() {
     );
 }
 
+/// T-0802e: `has_decoder` flag in ListPrograms — programs with and without decoder images.
+#[cfg(debug_assertions)] // raw CBOR ingestion only accepted in debug builds
+#[tokio::test]
+async fn t0802e_has_decoder_round_trip() {
+    let h = TestHarness::new();
+
+    // Ingest a program without a decoder image.
+    let cbor_no_dec = make_cbor_image(&[0x11, 0x22]);
+    let resp_no_dec = h
+        .admin
+        .ingest_program(Request::new(IngestProgramRequest {
+            image_data: cbor_no_dec,
+            verification_profile: VerificationProfile::Resident.into(),
+            abi_version: None,
+            source_filename: None,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Directly store a program record WITH a decoder image via storage.
+    let decoder_cbor = make_cbor_image(&[0xDE, 0xC0]);
+    let node_cbor = make_cbor_image(&[0x33, 0x44]);
+    let lib = ProgramLibrary::new();
+    let mut record = lib
+        .ingest_unverified(node_cbor, sonde_gateway::VerificationProfile::Resident)
+        .unwrap();
+    record.decoder_image = Some(decoder_cbor);
+    let hash_with_dec = record.hash.clone();
+    h.storage.store_program(&record).await.unwrap();
+
+    // ListPrograms should show has_decoder correctly for both.
+    let list = h
+        .admin
+        .list_programs(Request::new(Empty {}))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let prog_no_dec = list
+        .programs
+        .iter()
+        .find(|p| p.hash == resp_no_dec.program_hash)
+        .expect("program without decoder not found");
+    assert!(
+        !prog_no_dec.has_decoder,
+        "program without decoder_image must have has_decoder = false"
+    );
+
+    let prog_with_dec = list
+        .programs
+        .iter()
+        .find(|p| p.hash == hash_with_dec)
+        .expect("program with decoder not found");
+    assert!(
+        prog_with_dec.has_decoder,
+        "program with decoder_image must have has_decoder = true"
+    );
+}
+
 /// T-0414: source_filename round-trip through IngestProgram → ListPrograms.
 #[cfg(debug_assertions)] // raw CBOR ingestion only accepted in debug builds
 #[tokio::test]

--- a/docs/admin-design.md
+++ b/docs/admin-design.md
@@ -223,7 +223,7 @@ hash fields returned by the node-oriented RPC response.
 | `node remove` | `RemoveNode` | Yes | `{removed}` | "Removed node: {id}" |
 | `node factory-reset` | `FactoryReset` | Yes | `{factory_reset}` | "Factory reset node: {id}" |
 | `program ingest` | `IngestProgram` | — | `{program_hash, program_size}` | "Ingested program: {hash} ({size} bytes)" |
-| `program list` | `ListPrograms` | — | `[{hash, size, profile, source_filename}]` | Per-program line |
+| `program list` | `ListPrograms` | — | `[{hash, size, profile, source_filename, has_decoder}]` | Per-program line |
 | `program assign` | `AssignProgram` | — | `{assigned: true}` | "Assigned program {hash} to node {id}" |
 | `program remove` | `RemoveProgram` | Yes | `{removed}` | "Removed program: {hash}" |
 | `schedule set` | `SetSchedule` | — | `{node_id, interval_s}` | "Set schedule for {id}: {s}s" |

--- a/docs/admin-requirements.md
+++ b/docs/admin-requirements.md
@@ -344,14 +344,15 @@ as metadata.
 
 **Description:**
 `sonde-admin program list` MUST list all stored programs. Text output shows
-hash, source filename (if available), size, and verification profile. An empty
-library displays "No programs stored."
+hash, source filename (if available), size, verification profile, and decoder
+presence indicator. An empty library displays "No programs stored."
 
 **Acceptance criteria:**
 
 1. Lists programs with metadata.
-2. JSON mode returns an array of program objects including `hash`, `size`, `profile`, and `source_filename`.
+2. JSON mode returns an array of program objects including `hash`, `size`, `profile`, `source_filename`, and `has_decoder`.
 3. Empty library prints "No programs stored." in text mode.
+4. Programs with a decoder image show `has_decoder: true`; programs without show `has_decoder: false`.
 
 ---
 

--- a/docs/admin-validation.md
+++ b/docs/admin-validation.md
@@ -332,6 +332,20 @@ to avoid collisions when tests run in parallel.
 
 ---
 
+### T-0300a  List program `has_decoder` indicator
+
+**Validates:** ADMIN-0301 (AC-4)
+**Category:** New automated (`t0802e_has_decoder_round_trip`, debug-only)
+
+**Procedure:**
+1. Ingest a program without a decoder image.
+2. Store a program with a decoder image via storage.
+3. Call `list_programs()`.
+4. Assert: program without decoder has `has_decoder = false`.
+5. Assert: program with decoder has `has_decoder = true`.
+
+---
+
 ### T-0301  Assign program to node
 
 **Validates:** ADMIN-0302

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -448,6 +448,12 @@ an ELF with the same node program hash but a different decoder replaces the
 existing decoder image (upsert). Ingesting without a decoder for a hash that
 previously had one removes the decoder image.
 
+The `ListPrograms` response includes a `has_decoder` boolean for each program,
+derived from `decoder_image.is_some()`. This surfaces decoder presence in admin
+listings without transferring the full decoder image blob. The `ProgramInfo`
+proto message carries `bool has_decoder = 6`, and the CLI displays `, decoder`
+after the verification profile when `has_decoder` is true.
+
 ### 8.2  Program ingestion
 
 1. Accept pre-compiled BPF ELF (GW-0400).

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -857,7 +857,7 @@ The admin API MUST support: ingesting a BPF ELF file (triggering verification, C
 **Acceptance criteria:**
 
 1. `IngestProgram` accepts an ELF binary and verification profile, returns the program hash on success or a diagnostic on failure.
-2. `ListPrograms` returns all stored programs.
+2. `ListPrograms` returns all stored programs with metadata including whether a decoder image is present (`has_decoder`).
 3. `AssignProgram` sets a node's assigned program hash.
 4. `RemoveProgram` deletes a program from the library.
 5. `IngestProgram` is idempotent with respect to identical ELF content: re-ingesting a program with the same content hash returns the same program hash and does not require clients to handle a distinct "already exists" status code.

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1293,6 +1293,21 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-0803a  ListPrograms `has_decoder` indicator
+
+**Validates:** GW-0802 (AC-2), GW-1902
+
+**Procedure:**
+1. Ingest a program without a decoder section.
+2. Store a program record with a decoder image via storage.
+3. Call `ListPrograms`.
+
+**Expected:**
+1. The program without a decoder has `has_decoder = false`.
+2. The program with a decoder has `has_decoder = true`.
+
+---
+
 ### T-0804  Program ingestion failure via gRPC
 
 **Validates:** GW-0802


### PR DESCRIPTION
## Summary

Closes #960.

Add a `has_decoder` boolean to the program listing pipeline so operators can see whether a stored program includes a `SEC("decoder")` section. This makes decoder-not-running failures easier to diagnose.

## Changes

| Layer | Change |
|-------|--------|
| **Proto** | `bool has_decoder = 6` added to `ProgramInfo` |
| **Storage** | `has_decoder: bool` on `ProgramSummaryRecord`; populated from `decoder_image.is_some()` in trait default, `InMemoryStorage`, and `SqliteStorage` |
| **Admin handler** | Maps `has_decoder` in `list_programs` response |
| **CLI** | Text: appends `, decoder` after profile; JSON: adds `has_decoder` key |

### Example output

**Text:**
```
  abcd1234... tmp102_sensor.o (312 bytes, resident, decoder)
  ef567890... blink.o (128 bytes, ephemeral)
```

**JSON:**
```json
[
  { "hash": "abcd1234...", "size": 312, "profile": "resident", "source_filename": "tmp102_sensor.o", "has_decoder": true },
  { "hash": "ef567890...", "size": 128, "profile": "ephemeral", "source_filename": "blink.o", "has_decoder": false }
]
```

## Specifications updated

- **GW-0802** AC-2: `ListPrograms` now includes `has_decoder`
- **ADMIN-0301**: description and AC-2/AC-4 updated
- **admin-design.md**: command table updated
- **gateway-design.md** section 8.1: new paragraph on decoder listing
- **gateway-validation.md** T-0803a: new test case
- **admin-validation.md** T-0300a: new test case

## Test

`t0802e_has_decoder_round_trip` — stores programs with and without `decoder_image`, asserts `ListPrograms` returns correct `has_decoder` for each.

All workspace tests pass (`cargo test --workspace`), clippy clean, formatted.