### PR TITLE
fix: address all 8 gateway trifecta audit findings

### DIFF
--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -553,6 +553,9 @@ Returns bytes from the stored CBOR program image for the requested chunk. Last c
 
 All gateway instances in a failover group serve identical bytes for the same hash (GW-1004).
 
+**Stateless chunk serving and cross-wake resumption (GW-0301):**
+Chunk serving is entirely stateless — the gateway does not track per-node transfer progress. Each `WAKE` that triggers a `CHUNK` command simply uses the `chunk_index` reported by the node to look up the corresponding byte range in the stored program image. Because the gateway holds no transfer state, a node that restarts from `chunk_index = 0` (e.g., after power loss or reboot) receives the first chunk again without error or special handling. Transfer resumption across multiple wake cycles is inherently supported: the node advances its own `chunk_index` and the gateway serves whatever chunk is requested, regardless of prior history.
+
 ---
 
 ## 9  Handler router

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -553,8 +553,8 @@ Returns bytes from the stored CBOR program image for the requested chunk. Last c
 
 All gateway instances in a failover group serve identical bytes for the same hash (GW-1004).
 
-**Stateless chunk serving and cross-wake resumption (GW-0301):**
-Chunk serving is entirely stateless — the gateway does not track per-node transfer progress. Each `GET_CHUNK { chunk_index }` request simply looks up the corresponding byte range in the stored program image and returns a `CHUNK` response. Because the gateway holds no transfer state, a node that restarts from `chunk_index = 0` (e.g., after power loss or reboot) receives the first chunk again without error or special handling. Transfer resumption across multiple wake cycles is inherently supported: the node advances its own `chunk_index` and the gateway serves whatever chunk is requested, regardless of prior history.
+**Cross-wake transfer resumption (GW-0301):**
+Within a single wake cycle, the gateway tracks active-transfer parameters in a `ChunkedTransfer` session (program hash, chunk size, chunk count). Each `GET_CHUNK { chunk_index }` request is served by looking up the corresponding byte range in the stored program image using these session parameters — the gateway does not track per-chunk delivery progress. Across wake cycles, no transfer state is persisted: when a node re-wakes, a new session is created based on the current assignment state. A node that restarts from `chunk_index = 0` (e.g., after power loss) simply initiates a fresh `ChunkedTransfer` session and receives chunks from the beginning without error. Transfer completion across multiple wake cycles is inherently supported because the node drives its own `chunk_index` progression.
 
 ---
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -554,7 +554,7 @@ Returns bytes from the stored CBOR program image for the requested chunk. Last c
 All gateway instances in a failover group serve identical bytes for the same hash (GW-1004).
 
 **Stateless chunk serving and cross-wake resumption (GW-0301):**
-Chunk serving is entirely stateless — the gateway does not track per-node transfer progress. Each `WAKE` that triggers a `CHUNK` command simply uses the `chunk_index` reported by the node to look up the corresponding byte range in the stored program image. Because the gateway holds no transfer state, a node that restarts from `chunk_index = 0` (e.g., after power loss or reboot) receives the first chunk again without error or special handling. Transfer resumption across multiple wake cycles is inherently supported: the node advances its own `chunk_index` and the gateway serves whatever chunk is requested, regardless of prior history.
+Chunk serving is entirely stateless — the gateway does not track per-node transfer progress. Each `GET_CHUNK { chunk_index }` request simply looks up the corresponding byte range in the stored program image and returns a `CHUNK` response. Because the gateway holds no transfer state, a node that restarts from `chunk_index = 0` (e.g., after power loss or reboot) receives the first chunk again without error or special handling. Transfer resumption across multiple wake cycles is inherently supported: the node advances its own `chunk_index` and the gateway serves whatever chunk is requested, regardless of prior history.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -128,14 +128,14 @@ A configurable stub handler process (or in-process mock) that:
 
 **Procedure:**
 1. Send a valid WAKE.
-2. Capture all COMMAND responses for a bounded window (e.g., 500 ms) after the WAKE.
-3. Assert: exactly one COMMAND is received (no duplicates within the window).
+2. Capture all COMMAND responses until the wake cycle ends (i.e., until the next WAKE is sent or the session is torn down).
+3. Assert: exactly one COMMAND is received for this WAKE (no duplicates).
 4. Assert: response header `nonce` matches the WAKE nonce.
 5. Assert: CBOR payload contains `command_type`, `starting_seq`, and `timestamp_ms`.
 6. Assert: `timestamp_ms` is a reasonable UTC value (within 5 seconds of test clock).
 7. Send at least 4 additional WAKEs, each with a distinct nonce, collecting all `starting_seq` values.
-8. Assert: the collected `starting_seq` values are not monotonically increasing or decreasing (rules out simple counters).
-9. Assert: no two `starting_seq` values are identical (fresh value each time).
+8. Assert: no two `starting_seq` values are identical (fresh value each time).
+9. Assert: the consecutive deltas between `starting_seq` values are not all equal (rules out simple incrementing counters).
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -132,6 +132,9 @@ A configurable stub handler process (or in-process mock) that:
 3. Assert: response header `nonce` matches the WAKE nonce.
 4. Assert: CBOR payload contains `command_type`, `starting_seq`, and `timestamp_ms`.
 5. Assert: `timestamp_ms` is a reasonable UTC value (within 5 seconds of test clock).
+6. Assert: exactly one COMMAND is emitted for this WAKE (no duplicates).
+7. Send a second WAKE with a different nonce.
+8. Assert: the `starting_seq` in the second COMMAND differs from the first (fresh random value).
 
 ---
 
@@ -144,6 +147,7 @@ A configurable stub handler process (or in-process mock) that:
 2. Trigger a chunked transfer.
 3. Capture all outbound CHUNK frames.
 4. Assert: every outbound frame ≤ 250 bytes.
+5. Assert: every outbound frame's plaintext payload (frame minus 11-byte header and 16-byte GCM tag) ≤ 223 bytes.
 
 ---
 
@@ -194,6 +198,8 @@ A configurable stub handler process (or in-process mock) that:
 2. Send WAKE from that node.
 3. Assert: COMMAND response has `command_type = 0x03` (UPDATE_SCHEDULE).
 4. Assert: payload includes `interval_s = 120`.
+5. Query the node's status via the admin API.
+6. Assert: the recorded schedule interval for the node is 120 seconds.
 
 ---
 
@@ -475,9 +481,11 @@ A configurable stub handler process (or in-process mock) that:
 **Validates:** GW-0500, GW-0505
 
 **Procedure:**
-1. Complete a WAKE handshake. Send APP_DATA with blob `[0x01, 0x02, 0x03]`.
-2. Assert: handler receives a DATA message with correct `msg_type`, `request_id`, `node_id`, `program_hash`, `data`, and `timestamp`.
-3. Assert: `data` matches the original blob.
+1. Register a node with a known admin-assigned `node_id` (e.g., `"sensor-alpha"`) that is distinct from the node's PSK, key hint, or any internal identifier.
+2. Complete a WAKE handshake. Send APP_DATA with blob `[0x01, 0x02, 0x03]`.
+3. Assert: handler receives a DATA message with correct `msg_type`, `request_id`, `node_id`, `program_hash`, `data`, and `timestamp`.
+4. Assert: `data` matches the original blob.
+5. Assert: `node_id` in the DATA message equals the admin-assigned identifier (`"sensor-alpha"`), not the PSK, key hint, or any cryptographic material.
 
 ---
 
@@ -1728,6 +1736,8 @@ A configurable stub handler process (or in-process mock) that:
 6. Assert: the connector API is bound to a local-only transport (Unix domain socket or Windows named pipe) distinct from the admin API endpoint.
 7. Assert: no TCP listener is opened for the connector API.
 8. Open a second connector client while the fresh connector session from step 4 remains active and assert the second connection is rejected or closed without disrupting the active connector session.
+9. While the connector session from step 4 remains active, perform an operator flow via the `GatewayAdmin` gRPC API (e.g., register a node, list nodes, or open a pairing window).
+10. Assert: the operator flow succeeds normally, confirming `GatewayAdmin` remains fully functional while a connector session is active.
 
 ---
 
@@ -1791,6 +1801,8 @@ A configurable stub handler process (or in-process mock) that:
 4. Assert: the connector client receives exactly one upstream actual-state/status message for that `WAKE`.
 5. Assert: the message contains the expected `node_id`, current and assigned program hashes, `schedule_interval_s`, `battery_mv`, `firmware_abi_version`, `firmware_version`, and a recent timestamp.
 6. Assert: the message is emitted only after the gateway has updated the node's latest-known status.
+7. Trigger a gateway-scoped status change that materially affects reconciliation (e.g., remove the assigned program for the node via admin API, or disconnect and reconnect the connector).
+8. Assert: the connector client receives an upstream status update reflecting the gateway-scoped change.
 
 ---
 
@@ -2272,11 +2284,15 @@ A configurable stub handler process (or in-process mock) that:
 
 ### T-1200  Ed25519 keypair generation on first startup
 
+**Validates:** GW-1200 (retired)
+
 > **RETIRED (issue #495).** The gateway no longer generates an Ed25519 identity keypair. Phone registration uses a direct PSK exchange; no asymmetric cryptography is required.
 
 ---
 
 ### T-1201  Gateway ID generation and persistence
+
+**Validates:** GW-1201 (retired)
 
 > **RETIRED (issue #495).** The gateway no longer generates or persists a `gateway_id`. Identity is established through phone PSKs issued during BLE pairing.
 
@@ -2284,17 +2300,23 @@ A configurable stub handler process (or in-process mock) that:
 
 ### T-1202  Ed25519 to X25519 conversion and low-order rejection
 
+**Validates:** GW-1202 (retired)
+
 > **RETIRED (issue #495).** X25519 / ECDH key agreement is no longer used. The phone generates the PSK directly and transmits it over the authenticated BLE channel.
 
 ---
 
 ### T-1203  REQUEST_GW_INFO happy path
 
+**Validates:** GW-1206 (retired)
+
 > **RETIRED (issue #495).** The `REQUEST_GW_INFO` / `GW_INFO_RESPONSE` exchange has been removed. The simplified BLE pairing flow uses `REGISTER_PHONE` / `PHONE_REGISTERED` only.
 
 ---
 
 ### T-1204  GW_INFO_RESPONSE signature fails with wrong challenge
+
+**Validates:** GW-1206 (retired)
 
 > **RETIRED (issue #495).** `GW_INFO_RESPONSE` and Ed25519 signatures have been removed from the BLE pairing flow.
 
@@ -2655,7 +2677,25 @@ A configurable stub handler process (or in-process mock) that:
 
 ### T-1223  Ed25519 seed replication
 
+**Validates:** GW-1203 (retired)
+
 > **RETIRED (issue #495).** Ed25519 identity and `gateway_id` have been removed. State replication is covered by T-1002 (export/import round-trip) and T-1005b.
+
+---
+
+### T-1223a  Phone HMAC verification
+
+**Validates:** GW-1213 (retired)
+
+> **RETIRED (issue #495).** AEAD decryption (AES-256-GCM) provides authentication. A separate phone HMAC verification step is no longer needed. Phone authentication is covered by T-1210 (PEER_REQUEST decryption happy path) and T-1213 (Phone AEAD with revoked PSK).
+
+---
+
+### T-1223b  PEER_REQUEST frame HMAC verification
+
+**Validates:** GW-1214 (retired)
+
+> **RETIRED (issue #495).** Frame-level HMAC-SHA256 is replaced by AES-256-GCM authenticated encryption. Frame AEAD verification is covered by T-1214 (PEER_REQUEST frame AEAD verification).
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -133,8 +133,9 @@ A configurable stub handler process (or in-process mock) that:
 4. Assert: response header `nonce` matches the WAKE nonce.
 5. Assert: CBOR payload contains `command_type`, `starting_seq`, and `timestamp_ms`.
 6. Assert: `timestamp_ms` is a reasonable UTC value (within 5 seconds of test clock).
-7. Send a second WAKE with a different nonce.
-8. Assert: the `starting_seq` in the second COMMAND differs from the first (fresh random value).
+7. Send at least 4 additional WAKEs, each with a distinct nonce, collecting all `starting_seq` values.
+8. Assert: the collected `starting_seq` values are not monotonically increasing or decreasing (rules out simple counters).
+9. Assert: no two `starting_seq` values are identical (fresh value each time).
 
 ---
 
@@ -147,7 +148,7 @@ A configurable stub handler process (or in-process mock) that:
 2. Trigger a chunked transfer.
 3. Capture all outbound CHUNK frames.
 4. Assert: every outbound frame ≤ 250 bytes.
-5. Assert: every outbound frame's plaintext payload (frame minus 11-byte header and 16-byte GCM tag) ≤ 223 bytes.
+5. Assert: the ciphertext region of every outbound frame (frame length minus 11-byte header minus 16-byte GCM tag) ≤ 223 bytes.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -128,11 +128,11 @@ A configurable stub handler process (or in-process mock) that:
 
 **Procedure:**
 1. Send a valid WAKE.
-2. Capture the COMMAND response.
-3. Assert: response header `nonce` matches the WAKE nonce.
-4. Assert: CBOR payload contains `command_type`, `starting_seq`, and `timestamp_ms`.
-5. Assert: `timestamp_ms` is a reasonable UTC value (within 5 seconds of test clock).
-6. Assert: exactly one COMMAND is emitted for this WAKE (no duplicates).
+2. Capture all COMMAND responses for a bounded window (e.g., 500 ms) after the WAKE.
+3. Assert: exactly one COMMAND is received (no duplicates within the window).
+4. Assert: response header `nonce` matches the WAKE nonce.
+5. Assert: CBOR payload contains `command_type`, `starting_seq`, and `timestamp_ms`.
+6. Assert: `timestamp_ms` is a reasonable UTC value (within 5 seconds of test clock).
 7. Send a second WAKE with a different nonce.
 8. Assert: the `starting_seq` in the second COMMAND differs from the first (fresh random value).
 
@@ -1801,7 +1801,7 @@ A configurable stub handler process (or in-process mock) that:
 4. Assert: the connector client receives exactly one upstream actual-state/status message for that `WAKE`.
 5. Assert: the message contains the expected `node_id`, current and assigned program hashes, `schedule_interval_s`, `battery_mv`, `firmware_abi_version`, `firmware_version`, and a recent timestamp.
 6. Assert: the message is emitted only after the gateway has updated the node's latest-known status.
-7. Trigger a gateway-scoped status change that materially affects reconciliation (e.g., remove the assigned program for the node via admin API, or disconnect and reconnect the connector).
+7. While the connector session remains continuously connected, trigger a gateway-scoped status change that materially affects reconciliation (e.g., remove or change the node's assigned program or schedule interval via the admin API).
 8. Assert: the connector client receives an upstream status update reflecting the gateway-scoped change.
 
 ---


### PR DESCRIPTION
Closes #1003

Addresses all 8 findings from the gateway trifecta audit (145 requirements, 8 findings, 131 clean).

## Changes

### Validation (gateway-validation.md)

| Finding | Req | Type | Fix |
|---------|-----|------|-----|
| F-GW-001 | GW-0103 | D7 | T-0105: assert exactly one COMMAND per WAKE and fresh random \starting_seq\ |
| F-GW-002 | GW-0104 | D7 | T-0106: assert 223-byte usable payload budget |
| F-GW-003 | GW-0203 | D7 | T-0203: post-condition admin API check for recorded schedule |
| F-GW-005 | GW-0505 | D7 | T-0500: register with known \
ode_id\, assert admin-assigned value in DATA |
| F-GW-006 | GW-0810 | D7 | T-0818: operator flow via \GatewayAdmin\ while connector active |
| F-GW-007 | GW-0812 | D7 | T-0820: gateway-scoped status change triggers connector update |
| F-GW-008 | GW-1200–1214 | D2 | Added \Validates:\ lines to 6 existing retired entries + 2 new retired traces (T-1223a/GW-1213, T-1223b/GW-1214) |

### Design (gateway-design.md)

| Finding | Req | Type | Fix |
|---------|-----|------|-----|
| F-GW-004 | GW-0301 | D1 | §8.3: explicit stateless chunk serving and cross-wake resumption text |