### PR TITLE
docs(node): remediate trifecta audit findings

### DIFF
--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -41,7 +41,7 @@ The firmware is **uniform across all nodes** — application behavior is defined
 
 ## 3  Module architecture
 
-The node firmware is divided into twelve functional modules arranged in two tiers. The upper tier handles the data path: Transport (ESP-NOW radio), Protocol Codec (frame encode/decode), Wake Cycle Engine (session state machine), and BPF Runtime (program execution). The lower tier provides platform services: HAL (I2C/SPI/GPIO/ADC buses), Key Store (PSK in dedicated flash partition), Program Store (A/B flash partitions), Map Storage (RTC SRAM), Auth (AEAD encryption/decryption and key-hint derivation), Node AEAD (`AeadProvider` implementation), and BLE Pairing (LESC Just Works provisioning and PEER_REQUEST registration). A horizontal Sleep Manager spans the bottom of the firmware, managing deep sleep, wake intervals, and RTC memory. Data flows left-to-right in the upper tier; the Wake Cycle Engine coordinates all lower-tier modules.
+The node firmware is divided into twelve functional modules arranged in two tiers. The upper tier handles the data path: Transport (ESP-NOW radio), Protocol Codec (frame encode/decode), Wake Cycle Engine (session state machine), and BPF Runtime (program execution). The lower tier provides platform services: HAL (I2C/SPI/GPIO/ADC buses), Key Store (PSK and credentials in NVS), Program Store (A/B flash partitions), Map Storage (RTC SRAM), Auth (AEAD encryption/decryption and key-hint derivation), Node AEAD (`AeadProvider` implementation), and BLE Pairing (LESC Just Works provisioning and PEER_REQUEST registration). A horizontal Sleep Manager spans the bottom of the firmware, managing deep sleep, wake intervals, and RTC memory. Data flows left-to-right in the upper tier; the Wake Cycle Engine coordinates all lower-tier modules.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -70,7 +70,7 @@ The node firmware is divided into twelve functional modules arranged in two tier
 | **Transport** | ESP-NOW send/receive, frame size enforcement | ND-0100, ND-0103 |
 | **Protocol Codec** | Frame serialization/deserialization, CBOR encoding | ND-0101, ND-0102 |
 | **Wake Cycle Engine** | State machine: WAKE → COMMAND → transfer/execute → sleep | ND-0200–0203, ND-0608a, ND-0700–0702 |
-| **Key Store** | PSK storage in dedicated flash partition, pairing, factory reset | ND-0400, ND-0402 |
+| **Key Store** | PSK and credential storage in NVS, pairing, factory reset | ND-0400, ND-0402, ND-0403, ND-0403a |
 | **Program Store** | A/B flash partitions, program image decoding, LDDW resolution | ND-0500–0503, ND-0501a |
 | **BPF Runtime** | `sonde-bpf` interpreter, helper dispatch, execution constraints | ND-0504–0506, ND-0600–0606 |
 | **Map Storage** | Sleep-persistent maps in RTC slow SRAM | ND-0603, ND-0606 |
@@ -88,7 +88,7 @@ The wake cycle engine is the central state machine. It runs once per wake and th
 
 ### 4.1  State machine
 
-The state machine has five main states plus three alternate boot paths. Starting from BOOT, the node checks RTC-retained pre-provisioning test state, then reads credentials from the `key` flash partition (§6.1) and the `reg_complete` flag from NVS (§6.1a) to determine the boot path (ND-0900): (1) staged pre-provisioning test command present → enter pre-provisioning test mode (§15.8); (2) no PSK in key partition or pairing button held ≥ 500 ms → enter BLE pairing mode (§15); (3) PSK present but `reg_complete` not set → enter PEER_REQUEST registration (§15.7); (4) PSK present and `reg_complete` set → enter WAKE SEND. WAKE SEND transmits a WAKE frame and waits for a COMMAND response (retrying up to 3 times); if all retries fail it goes directly to SLEEP. On receiving a COMMAND, the node enters DISPATCH COMMAND, which branches on the command type: NOP proceeds to BPF execution; UPDATE_PROGRAM or RUN_EPHEMERAL initiates chunked transfer before BPF execution; UPDATE_SCHEDULE stores the new interval and proceeds to BPF execution; REBOOT restarts the firmware. After BPF execution — which may perform APP_DATA exchanges with the gateway — the node enters SLEEP.
+The state machine has five main states plus three alternate boot paths. Starting from BOOT, the node checks RTC-retained pre-provisioning test state, then reads credentials from NVS (§6.1) and the `reg_complete` flag (§6.1a) to determine the boot path (ND-0900): (1) staged pre-provisioning test command present → enter pre-provisioning test mode (§15.8); (2) no PSK in NVS or pairing button held ≥ 500 ms → enter BLE pairing mode (§15); (3) PSK present but `reg_complete` not set → enter PEER_REQUEST registration (§15.7); (4) PSK present and `reg_complete` set → enter WAKE SEND. WAKE SEND transmits a WAKE frame and waits for a COMMAND response (retrying up to 3 times); if all retries fail it goes directly to SLEEP. On receiving a COMMAND, the node enters DISPATCH COMMAND, which branches on the command type: NOP proceeds to BPF execution; UPDATE_PROGRAM or RUN_EPHEMERAL initiates chunked transfer before BPF execution; UPDATE_SCHEDULE stores the new interval and proceeds to BPF execution; REBOOT restarts the firmware. After BPF execution — which may perform APP_DATA exchanges with the gateway — the node enters SLEEP.
 
 ```
 ┌─────────┐
@@ -208,38 +208,51 @@ Uses `sonde_protocol::decode_frame()` and `sonde_protocol::open_frame()`:
 
 ## 6  Key store
 
-### 6.1  Flash partition layout
+### 6.1  NVS credential layout
 
-| Partition | Contents | Size |
+All node credentials are stored in NVS (namespace `sonde`) per ND-0400 and ND-0916. The Key Store trait (§3.1) abstracts the NVS API so that test harnesses can substitute an in-memory implementation.
+
+| NVS key | Type | Contents |
 |---|---|---|
-| `key` | 256-bit PSK + key_hint (2 bytes) + magic (4 bytes) | 4 KB sector |
-| `program_a` | Resident program image (CBOR) | 4 KB |
-| `program_b` | Resident program image (CBOR, A/B swap) | 4 KB |
-| `schedule` | Base wake interval (u32) + active partition flag | 4 KB sector |
+| `magic` | blob | 4-byte provisioning sentinel |
+| `key_hint` | blob | 2-byte key hint (big-endian) |
+| `psk` | blob | 256-bit PSK |
+| `channel` | u32 | RF channel |
+| `interval` | u32 | Base wake interval (seconds) |
+| `active_p` | u32 | Active program partition flag (0 = A, 1 = B) |
 
-The magic bytes in the key partition indicate whether a PSK is provisioned. An erased (all 0xFF) partition means unpaired.
+The magic bytes indicate whether a PSK is provisioned. An absent or all-0xFF magic means unpaired.
 
-### 6.2  Factory reset
-
-Factory reset (ND-0402, ND-0917) erases:
-1. `key` partition (PSK + key_hint + magic → all 0xFF).
-2. NVS pairing keys (`peer_payload`, `reg_complete` → erased).
-3. RTC slow SRAM (map data → zeroed).
-4. Both program partitions (`program_a`, `program_b` → erased).
-5. Schedule partition → reset to default interval.
-
-After reset, the magic bytes are missing → firmware detects unpaired state → enters BLE pairing mode on next boot.
+Program images are stored in dedicated flash partitions (§7) because they are large (up to 4 KB each) and written infrequently. The `schedule` partition stores the active-partition flag as a redundant backup; the NVS `active_p` key is authoritative.
 
 ### 6.1a  NVS layout for BLE pairing (ND-0916)
 
-BLE pairing artifacts are stored in NVS. ND-0916 defines the complete NVS layout including both pre-existing keys (`magic`, `key_hint`, `psk`, `channel`, `interval`, `active_p`, `prog_a`, `prog_b`) and pairing-specific keys:
+BLE pairing artifacts are stored in NVS alongside the core credentials:
 
 | NVS key | Type | Contents |
 |---|---|---|
 | `peer_payload` | blob | Encrypted payload for PEER_REQUEST (erased after first WAKE/COMMAND) |
 | `reg_complete` | u32 | Registration complete flag (1 = registered with gateway) |
 
-> **Note:** The `key` partition layout in §6.1 is the original design-level storage for PSK/key_hint/magic. The requirements (ND-0916) describe all credential fields as NVS keys. Implementations may use either raw flash partitions or NVS for the core credentials — the Key Store trait (§3.1) abstracts this choice. The BLE-specific keys (`peer_payload`, `reg_complete`) always use NVS. Factory reset erases both (§6.2).
+### 6.1b  Secure boot and flash encryption (ND-0403 / ND-0403a)
+
+Secure boot and flash encryption are ESP-IDF platform features that protect the firmware and credential store at rest. They are configured via `sdkconfig.defaults` options (`CONFIG_SECURE_BOOT`, `CONFIG_SECURE_FLASH_ENC_ENABLED`) and provisioned during initial flashing. The node firmware itself does not implement these mechanisms — it relies on the ESP-IDF bootloader and flash encryption hardware. When enabled:
+
+- **Secure boot (ND-0403):** Only firmware images signed with the OEM key can execute. The bootloader rejects unsigned or tampered images at boot.
+- **Flash encryption (ND-0403a):** The NVS partition (including the PSK) is encrypted at rest using the hardware flash encryption key. The firmware reads credentials transparently — ESP-IDF decrypts on the fly.
+
+These features are optional (`SHOULD` priority). The firmware operates correctly without them; enabling them is an operator deployment decision.
+
+### 6.2  Factory reset
+
+Factory reset (ND-0402, ND-0917) erases:
+1. NVS credential keys (`magic`, `key_hint`, `psk`, `channel`, `interval`, `active_p` → erased).
+2. NVS pairing keys (`peer_payload`, `reg_complete` → erased).
+3. RTC slow SRAM (map data → zeroed).
+4. Both program partitions (`program_a`, `program_b` → erased).
+5. Schedule partition → reset to default interval.
+
+After reset, the magic bytes are missing → firmware detects unpaired state → enters BLE pairing mode on next boot.
 
 ---
 
@@ -272,8 +285,11 @@ pub struct MapDef {
     pub key_size: u32,
     pub value_size: u32,
     pub max_entries: u32,
+    pub initial_data: Option<Vec<u8>>,   // CBOR key 5 — optional initial data for entry 0
 }
 ```
+
+When `initial_data` is present and its length equals `value_size`, the firmware writes it to map entry 0 after allocation (ND-0607). Maps without `initial_data` (absent or empty key 5) remain zero-filled. If the `initial_data` length does not match `value_size`, the data is ignored and the map remains zero-filled; a `debug!()` diagnostic may be emitted.
 
 ### 7.3  LDDW relocation resolution
 
@@ -287,6 +303,8 @@ This must happen **before** BPF execution.
 ### 7.4  Ephemeral programs
 
 Ephemeral programs are stored in RAM (heap allocation), not flash. They are decoded and executed immediately, then the allocation is freed. The resident program is unaffected.
+
+Ephemeral program images that declare map definitions MUST be rejected at decode time (ND-0503 AC4). Ephemeral programs are read-only and single-execution — map allocation in RTC SRAM is not performed for them. If the decoded CBOR image contains a non-empty `maps` array, the firmware discards the image and does not execute it.
 
 ---
 
@@ -405,9 +423,14 @@ Each call increments the sequence number, ensuring independent replay protection
 1. Copy the blob into the async queue (backed by RTC slow SRAM on ESP32; survives deep sleep).
 2. Return 0 on success, or a non-zero error code if the queue is full.
 
-The queued messages are drained at the start of the next wake cycle (§4.2 step 3 and step 7). If exactly one message is queued and fits within the WAKE payload budget, it is piggybacked on the WAKE frame as `blob` (CBOR key 10), saving a round-trip. If multiple messages are queued or the single message exceeds the budget, all queued messages are sent as individual APP_DATA frames before BPF execution, but only on NOP cycles — non-NOP commands (UpdateProgram, RunEphemeral, Reboot) skip the overflow drain to avoid contending for radio time with command-specific traffic.
+The queued messages are drained at the start of the next wake cycle (§4.2 step 3 and step 7). If exactly one message is queued and fits within the WAKE payload budget, it is piggybacked on the WAKE frame as `blob` (CBOR key 10), saving a round-trip. If multiple messages are queued or the single message exceeds the budget, all queued messages are sent as individual APP_DATA frames before BPF execution, but only on NOP cycles. The overflow drain behavior varies by command type (ND-0611):
 
-The async queue is backed by sleep-retained RAM (RTC slow SRAM on ESP32, heap-allocated in tests) and passed to `run_wake_cycle()` as `&mut AsyncQueue`. It survives deep sleep so that blobs queued in cycle N are available for piggybacking in cycle N+1's WAKE. It is lost on reboot (RTC SRAM is cleared on power-on reset). The queue is cleared when UPDATE_PROGRAM or RUN_EPHEMERAL is received, since a new program load invalidates blobs produced by the old program. The queue capacity is a compile-time constant (10 messages, ~2.2 KB of RTC SRAM).
+- **NOP:** Drain all queued messages as APP_DATA frames before BPF execution.
+- **UPDATE_SCHEDULE:** Skip overflow drain; queued blobs remain in the queue for the next NOP cycle.
+- **UPDATE_PROGRAM / RUN_EPHEMERAL:** Skip overflow drain **and** clear the queue (ND-0609 AC3). Old program blobs are semantically invalid after a program change.
+- **REBOOT:** Queue is lost — RTC SRAM is cleared on power-on reset (ND-0609 AC4).
+
+The async queue is backed by sleep-retained RAM (RTC slow SRAM on ESP32, heap-allocated in tests) and passed to `run_wake_cycle()` as `&mut AsyncQueue`. It survives deep sleep so that blobs queued in cycle N are available for piggybacking in cycle N+1's WAKE. The queue capacity is a compile-time constant (10 messages, ~2.2 KB of RTC SRAM).
 
 #### RTC layout
 
@@ -605,11 +628,11 @@ All inbound protocol errors result in **silent discard** — the node does not s
 1. ESP-IDF initialization (clocks, peripherals, wifi/ESP-NOW).
 2. Task watchdog timer is configured and the main task is registered (ND-0919): `CONFIG_ESP_TASK_WDT_EN=y`, 20 s timeout, panic-on-expiry. The main task calls `esp_task_wdt_add()` at startup and `esp_task_wdt_delete()` after the wake cycle completes. If the wake cycle hangs, the watchdog triggers a hardware reset. For long-running modes (BLE pairing), the polling loop calls `esp_task_wdt_reset()` on each iteration to prevent spurious resets while still detecting hangs within a single 20 s polling window.
 3. Sample pairing button GPIO for 500 ms (ND-0901).
-4. Read key partition: check magic bytes and load credentials if present. Read NVS `reg_complete` flag (§6.1a).
+4. Read NVS credentials (§6.1): check magic bytes and load PSK/key_hint/channel if present. Read `reg_complete` flag (§6.1a).
 5. Determine boot path (ND-0900):
-   a. No valid PSK in key partition OR pairing button held ≥ 500 ms → enter BLE pairing mode (§15). Does not return.
-   b. PSK present in key partition, `reg_complete` NOT set in NVS → enter PEER_REQUEST registration (§15.7). Does not return (sleeps after listen window).
-   c. PSK present in key partition, `reg_complete` set in NVS → continue to step 6 (normal WAKE cycle).
+   a. No valid PSK in NVS OR pairing button held ≥ 500 ms → enter BLE pairing mode (§15). Does not return.
+   b. PSK present in NVS, `reg_complete` NOT set → enter PEER_REQUEST registration (§15.7). Does not return (sleeps after listen window).
+   c. PSK present in NVS, `reg_complete` set → continue to step 6 (normal WAKE cycle).
 6. Read schedule partition: load base interval and active program partition flag.
 7. Read active program partition: decode CBOR image header, extract program hash.
    - No program → set `program_hash` to zero-length.
@@ -676,7 +699,7 @@ The main loop polls for pending GATT writes and disconnection events at 100 ms i
 
 ### 15.6  Platform-independent handler
 
-The GATT write payload is parsed and handled by a platform-independent pairing-command handler in the `ble_pairing` module. `NODE_PROVISION` handling remains responsible for parsing the five provisioning fields (`node_key_hint`, `node_psk`, `rf_channel`, `payload_len`, `encrypted_payload`), validating `payload_len` before reading `encrypted_payload`, and persisting credentials: PSK and key hint to the `key` flash partition (§6.1), and `channel`, `peer_payload`, `reg_complete` to NVS (§6.1a, ND-0916). If any NVS write fails, the handler MUST respond with `NODE_ACK(0x02)` (storage error) and ensure no partial credentials remain in NVS — any keys written before the failure are erased so the node does not boot into an inconsistent state (ND-0908). `RUN_TEST_COMMAND` handling validates and stages one pending pre-provisioning test command in RTC-retained state and returns `RUN_TEST_ACK`. `READ_TEST_RESULT` handling returns the latest retained result as `TEST_RESULT` without clearing it. This keeps provisioning and pre-provisioning test logic testable on the host. The ESP-specific `esp_ble_pairing` module handles only NimBLE initialization, GATT plumbing, and the event loop.
+The GATT write payload is parsed and handled by a platform-independent pairing-command handler in the `ble_pairing` module. `NODE_PROVISION` handling remains responsible for parsing the five provisioning fields (`node_key_hint`, `node_psk`, `rf_channel`, `payload_len`, `encrypted_payload`), validating `payload_len` before reading `encrypted_payload`, and persisting credentials: PSK, key hint, and magic to NVS (§6.1), and `channel`, `peer_payload`, `reg_complete` to NVS (§6.1a, ND-0916). If any NVS write fails, the handler MUST respond with `NODE_ACK(0x02)` (storage error) and ensure no partial credentials remain in NVS — any keys written before the failure are erased so the node does not boot into an inconsistent state (ND-0908). `RUN_TEST_COMMAND` handling validates and stages one pending pre-provisioning test command in RTC-retained state and returns `RUN_TEST_ACK`. `READ_TEST_RESULT` handling returns the latest retained result as `TEST_RESULT` without clearing it. This keeps provisioning and pre-provisioning test logic testable on the host. The ESP-specific `esp_ble_pairing` module handles only NimBLE initialization, GATT plumbing, and the event loop.
 
 ### 15.7  Post-provisioning registration (PEER_REQUEST / PEER_ACK)
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -684,7 +684,7 @@ When exactly one message is in the async queue and it fits within the WAKE paylo
 **Source:** protocol.md §5.1
 
 **Description:**  
-When the async queue contains messages that cannot be piggybacked on WAKE and the gateway responds with a NOP command, the node MUST send each queued message as a separate APP_DATA frame before BPF execution, using the standard sequence number mechanism. Messages MUST NOT be split or concatenated. On non-NOP cycles (UpdateProgram, RunEphemeral, UpdateSchedule, Reboot), the overflow drain is skipped — queued blobs remain in the queue for the next cycle to avoid contending for radio time with command-specific traffic.
+When the async queue contains messages that cannot be piggybacked on WAKE and the gateway responds with a NOP command, the node MUST send each queued message as a separate APP_DATA frame before BPF execution, using the standard sequence number mechanism. Messages MUST NOT be split or concatenated. On non-NOP cycles (UpdateSchedule), the overflow drain is skipped — queued blobs remain in the queue for the next NOP cycle to avoid contending for radio time with command-specific traffic. On program-change commands (UpdateProgram, RunEphemeral), the queue is cleared entirely per ND-0609 because old program blobs are semantically invalid. On Reboot, the queue is lost because RTC SRAM is cleared on power-on reset (ND-0609).
 
 **Acceptance criteria:**
 
@@ -692,7 +692,9 @@ When the async queue contains messages that cannot be piggybacked on WAKE and th
 2. Sequence numbers increment correctly.
 3. No message splitting or concatenation.
 4. Overflow drain occurs only on NOP cycles, before BPF execution.
-5. Non-NOP commands do not drain the queue (blobs are retried on the next NOP cycle).
+5. UpdateSchedule does not drain the queue (blobs are retried on the next NOP cycle).
+6. UpdateProgram and RunEphemeral clear the queue (ND-0609 AC3); blobs are discarded, not retried.
+7. Reboot causes the queue to be lost (ND-0609 AC4).
 
 ---
 

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -100,6 +100,19 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
+### T-N102a  Tampered header causes AEAD verification failure
+
+**Validates:** ND-0102, ND-0300
+
+**Procedure:**
+1. Capture a valid outbound frame (e.g., WAKE).
+2. Flip one bit in the 11-byte header (e.g., toggle bit 0 of the `msg_type` byte at offset 2).
+3. Attempt to decrypt the frame using the node's PSK with the tampered header as AAD.
+4. Assert: AES-256-GCM verification fails (authentication error, not CBOR decode error).
+5. Assert: the frame is discarded.
+
+---
+
 ### T-N103  Frame size enforcement
 
 **Validates:** ND-0103
@@ -434,6 +447,36 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
+### T-N404a  Secure boot rejects unsigned firmware
+
+**Validates:** ND-0403
+
+**Procedure:**
+1. Build a node firmware image with secure boot enabled in `sdkconfig.defaults` (`CONFIG_SECURE_BOOT=y`).
+2. Flash the signed firmware to a device with secure boot provisioned.
+3. Assert: the signed firmware boots successfully.
+4. Flash an unsigned or tampered firmware image to the same device.
+5. Assert: the bootloader rejects the unsigned image and the node does not boot.
+
+> **Note:** This test requires target hardware with secure boot fuses provisioned. It is verified as a platform deployment test, not as part of the host-based test suite.
+
+---
+
+### T-N404b  Flash encryption protects PSK at rest
+
+**Validates:** ND-0403a
+
+**Procedure:**
+1. Build a node firmware image with flash encryption enabled in `sdkconfig.defaults` (`CONFIG_SECURE_FLASH_ENC_ENABLED=y`).
+2. Provision the node with a known PSK via BLE pairing.
+3. Assert: the firmware boots and completes a wake cycle using the provisioned PSK.
+4. Read the raw NVS flash partition contents via JTAG or `esptool.py read_flash`.
+5. Assert: the PSK bytes are not present in plaintext in the raw flash dump.
+
+> **Note:** This test requires target hardware with flash encryption fuses provisioned.
+
+---
+
 ## 7  Program transfer and execution tests
 
 ### T-N500  Complete chunked transfer
@@ -529,6 +572,18 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 4. Assert: program executes.
 5. Assert: after execution, ephemeral program memory is freed.
 6. Assert: resident program is unaffected.
+
+---
+
+### T-N505a  Ephemeral program with maps rejected
+
+**Validates:** ND-0503 (AC4)
+
+**Procedure:**
+1. Build a program image containing bytecode and a non-empty `maps` array (e.g., one `MapDef` with `map_type=0`, `key_size=4`, `value_size=4`, `max_entries=1`).
+2. Mock gateway responds with RUN_EPHEMERAL and transfers the image.
+3. Assert: the node rejects the program at decode time — no BPF execution occurs.
+4. Assert: the resident program is unaffected (next NOP cycle executes the resident program normally).
 
 ---
 
@@ -1543,6 +1598,18 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
+### T-N1015a  Non-I/O helpers do not emit DEBUG logs
+
+**Validates:** ND-1010 (AC2)
+
+**Procedure:**
+1. Configure the node with DEBUG-level logging enabled.
+2. Install a program that calls non-I/O helpers: `map_lookup_elem`, `map_update_elem`, `get_time`, `get_battery_mv`, `delay_us`, `set_next_wake`, `bpf_trace_printk`.
+3. Run wake cycle.
+4. Assert: no DEBUG-level log lines are emitted for these helper calls (only I/O helpers produce DEBUG logs).
+
+---
+
 ### T-N1016  GPIO state after sleep preparation
 
 **Validates:** ND-1013
@@ -1681,7 +1748,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ### T-N1019  Build-type quiet strips INFO call-sites
 
-**Validates:** ND-1012
+**Validates:** ND-1012 (AC2, AC5)
 
 **Procedure:**
 1. Build the node firmware with the default `quiet` feature (no `verbose`).
@@ -1692,7 +1759,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ### T-N1020  Build-type verbose retains INFO and DEBUG
 
-**Validates:** ND-1012
+**Validates:** ND-1012 (AC3)
 
 **Procedure:**
 1. Build the node firmware with `--features esp,verbose --no-default-features`.
@@ -1700,6 +1767,37 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 3. Capture serial output.
 4. Assert: INFO-level operational logs (boot reason, wake cycle, WAKE sent) are present.
 5. Assert: DEBUG-level logs are visible when triggered (e.g., BPF helper I/O).
+
+### T-N1020a  Debug build retains TRACE call-sites
+
+**Validates:** ND-1012 (AC1)
+
+**Procedure:**
+1. Build the node firmware with `cfg(debug_assertions)` enabled (debug profile).
+2. Boot the node and complete a wake cycle with the runtime log level set to TRACE.
+3. Capture serial output.
+4. Assert: TRACE-level log lines are present (compile-time maximum is TRACE, so `trace!()` call-sites are compiled in and visible at TRACE runtime level).
+
+### T-N1020b  Runtime default log level
+
+**Validates:** ND-1012 (AC4)
+
+**Procedure:**
+1. Build the node firmware in debug mode (or with `verbose` feature).
+2. Boot the node without any explicit runtime log-level override.
+3. Capture serial output.
+4. Assert: the default runtime log level is INFO — INFO and above are visible, DEBUG and TRACE are not (unless explicitly lowered).
+5. Build with default `quiet` feature.
+6. Boot the node without any explicit runtime log-level override.
+7. Assert: the default runtime log level is WARN — only WARN and ERROR are visible.
+
+### T-N1020c  Quiet and verbose features are mutually exclusive
+
+**Validates:** ND-1012 (AC6)
+
+**Procedure:**
+1. Attempt to build the node firmware with both `quiet` and `verbose` features enabled: `--features esp,quiet,verbose`.
+2. Assert: the build fails with a compile-time error (e.g., `compile_error!` or conflicting `cfg` attributes).
 
 ### T-N1021  Error diagnostic includes operation and subsystem error
 
@@ -1801,6 +1899,18 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 3. Assert: the node enters BLE advertising successfully.
 
 > **Note:** This test requires target hardware with the NimBLE stack.
+
+---
+
+### T-N918c  sdkconfig.defaults sets main task stack size
+
+**Validates:** ND-0918 (AC1)
+
+**Procedure:**
+1. Open `crates/sonde-node/sdkconfig.defaults`.
+2. Assert: the file contains `CONFIG_ESP_MAIN_TASK_STACK_SIZE=16384` (or a value ≥ 16384).
+
+> **Note:** This is a static inspection test, not a runtime test. It verifies the build configuration prerequisite for T-N918a and T-N918b.
 
 ---
 
@@ -2316,6 +2426,20 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
+### T-N1103a  Wrong message type ignored during diagnostic listen window
+
+**Validates:** ND-1102 (AC3)
+
+**Procedure:**
+1. Boot node into BLE pairing mode and stage a valid `RUN_TEST_COMMAND` for `DIAG_FRAME`.
+2. Allow the node to reboot into test mode.
+3. During the listen window, send an ESP-NOW frame with `msg_type` ≠ `0x85` (e.g., `0x01` WAKE) at header offset 2.
+4. Assert: the node ignores the frame and continues listening.
+5. Then send a valid frame with `msg_type=0x85` (DIAG_REPLY).
+6. Assert: the node accepts the DIAG_REPLY and stores the result.
+
+---
+
 ### T-N1102a  BLE not active during pre-provisioning test execution
 
 **Validates:** ND-1102 (AC4)
@@ -2325,6 +2449,22 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 2. Allow the node to reboot into test mode.
 3. During the test-mode ESP-NOW phase, attempt a BLE scan.
 4. Assert: the node is NOT advertising BLE services during test execution.
+
+---
+
+### T-N1102b  Replacing a previously staged unexecuted command
+
+**Validates:** ND-1101 (AC — replacing staged command)
+
+**Procedure:**
+1. Boot node into BLE pairing mode.
+2. Send `RUN_TEST_COMMAND` A (e.g., `DIAG_FRAME` with `rf_channel=6` and payload `[0xAA; 50]`).
+3. Assert: `RUN_TEST_ACK(status=0x00)` received.
+4. Without disconnecting or rebooting, send `RUN_TEST_COMMAND` B (e.g., `DIAG_FRAME` with `rf_channel=11` and payload `[0xBB; 50]`).
+5. Assert: `RUN_TEST_ACK(status=0x00)` received.
+6. Disconnect BLE. Allow the node to reboot into test mode.
+7. Assert: the node executes command B (broadcasts on channel 11 with payload `[0xBB; 50]`).
+8. Assert: command A is not executed (no broadcast on channel 6 with payload `[0xAA; 50]`).
 
 ---
 
@@ -2367,6 +2507,20 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 4. Assert: the receiver counts exactly 4 broadcasts (1 initial + 3 retries).
 5. Assert: the time between consecutive broadcasts is approximately 2.2 seconds (2 s listen + 200 ms backoff).
 6. After the node reboots back into BLE pairing mode, assert the retained result reports a timeout.
+
+---
+
+### T-N1106a  Reply on first attempt terminates retry loop
+
+**Validates:** ND-1103 (AC4)
+
+**Procedure:**
+1. Boot node into BLE pairing mode and stage a valid `RUN_TEST_COMMAND`.
+2. Set up an ESP-NOW receiver that counts broadcasts AND replies with a `DIAG_REPLY` (`msg_type=0x85`) immediately after the first broadcast.
+3. Allow the node to reboot into test mode and execute the command.
+4. Assert: the receiver counts exactly 1 broadcast (no retries — the reply terminated the loop).
+5. After the node reboots back, send `READ_TEST_RESULT`.
+6. Assert: `TEST_RESULT(status=0x00)` with the reply frame.
 
 ---
 
@@ -2438,26 +2592,26 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 |---|---|
 | ND-0100 | T-N100 |
 | ND-0101 | T-N101, T-N919 |
-| ND-0102 | T-N102 |
+| ND-0102 | T-N102, T-N102a |
 | ND-0103 | T-N103, T-N104, T-N920 |
 | ND-0200 | T-N200, T-N201, T-N921 |
 | ND-0201 | T-N202, T-N202a, T-N202b, T-N203 |
 | ND-0202 | T-N204, T-N205, T-N206, T-N207, T-N922 |
 | ND-0203 | T-N205, T-N208, T-N209, T-N210, T-N923 |
-| ND-0300 | T-N606a, T-N606b (AEAD path) |
+| ND-0300 | T-N102a, T-N606a, T-N606b (AEAD path) |
 | ND-0301 | T-N301, T-N924 |
 | ND-0302 | T-N302, T-N303, T-N304, T-N925 |
 | ND-0303 | T-N305, T-N926 |
 | ND-0304 | T-N306, T-N927 |
 | ND-0400 | T-N100, T-N400, T-N401 |
 | ND-0402 | T-N404 |
-| ND-0403 | *(verified by secure boot platform tests)* |
-| ND-0403a | *(verified by flash encryption platform tests)* |
+| ND-0403 | T-N404a |
+| ND-0403a | T-N404b |
 | ND-0500 | T-N500, T-N500a, T-N500b |
 | ND-0501 | T-N501, T-N502 |
 | ND-0501a | T-N503, T-N928 |
 | ND-0502 | T-N504 |
-| ND-0503 | T-N505 |
+| ND-0503 | T-N505, T-N505a |
 | ND-0504 | T-N506 |
 | ND-0505 | T-N507, T-N508, T-N509, T-N929 |
 | ND-0506 | T-N508, T-N510 |
@@ -2492,7 +2646,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0915 | T-N917, T-N917a |
 | ND-0916 | T-N918 |
 | ND-0917 | T-N906 |
-| ND-0918 | T-N918a, T-N918b *(plus sdkconfig.defaults inspection)* |
+| ND-0918 | T-N918a, T-N918b, T-N918c |
 | ND-0919 | T-N942, T-N942a |
 | ND-0608 | T-N0607a, T-N0607b, T-N0607c, T-N0607d, T-N0607e, T-N0607f, T-N0607g |
 | ND-0608a | T-N202b, T-N0608a, T-N0608b, T-N0608c |
@@ -2513,17 +2667,17 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-1007 | T-N1008 |
 | ND-1008 | T-N1012, T-N1013, T-N1013a |
 | ND-1009 | T-N1009, T-N1010, T-N1011, T-N1011a, T-N1011b |
-| ND-1010 | T-N1015 |
+| ND-1010 | T-N1015, T-N1015a |
 | ND-1011 | T-N1017, T-N1018 |
-| ND-1012 | T-N1019, T-N1020 |
+| ND-1012 | T-N1019, T-N1020, T-N1020a, T-N1020b, T-N1020c |
 | ND-1013 | T-N1016 |
 | ND-1014 | T-N1021, T-N1021a, T-N1021b, T-N1021c |
 | ND-1015 | T-N1022 |
 | ND-1016 | T-N1023 |
 | ND-1100 | T-N1100, T-N1101, T-N1101a, T-N1101b, T-N1109, T-N1110 |
-| ND-1101 | T-N1100, T-N1102 |
-| ND-1102 | T-N1102, T-N1102a, T-N1103, T-N1104 |
-| ND-1103 | T-N1105, T-N1106 |
+| ND-1101 | T-N1100, T-N1102, T-N1102b |
+| ND-1102 | T-N1102, T-N1102a, T-N1103, T-N1103a, T-N1104 |
+| ND-1103 | T-N1105, T-N1106, T-N1106a |
 | ND-1104 | T-N1104, T-N1104a, T-N1105, T-N1107, T-N1108 |
 | ND-1105 | T-N1104, T-N1105, T-N1106 |
 | ND-1106 | T-N1107, T-N1109 |


### PR DESCRIPTION
## Summary

Aligns node requirements, design, and validation specs to close all 11 findings from the trifecta audit.

### Design (\
ode-design.md\)

| Finding | Severity | Change |
|---------|----------|--------|
| F-ND-001 | High | Make NVS normative for all credential storage — removed \key\ partition references per ND-0400/ND-0916 |
| F-ND-002 | Medium | Add §6.1b for secure boot (ND-0403) and flash encryption (ND-0403a) as ESP-IDF platform features |
| F-ND-003 | High | §7.4 requires ephemeral programs with maps rejected at decode time (ND-0503 AC4) |
| F-ND-004 | High | \MapDef\ includes \initial_data: Option<Vec<u8>>\ with handling rules per ND-0607 |
| F-ND-005 | High | §8.6 distinguishes NOP drain / UpdateSchedule skip / program-load clear / reboot loss |

### Requirements (\
ode-requirements.md\)

| Finding | Change |
|---------|--------|
| F-ND-005 | ND-0611 ACs refined from 5→7, cross-referencing ND-0609 for program-load clear and reboot loss |

### Validation (\
ode-validation.md\)

| Finding | Severity | New test(s) |
|---------|----------|-------------|
| F-ND-002 | Medium | T-N404a (secure boot), T-N404b (flash encryption) |
| F-ND-003 | High | T-N505a (ephemeral with maps rejected) |
| F-ND-006 | Medium | T-N102a (tampered header AEAD failure) |
| F-ND-007 | Medium | T-N918c (\sdkconfig.defaults\ inspection) |
| F-ND-008 | Low | T-N1015a (non-I/O helpers emit no DEBUG logs) |
| F-ND-009 | Medium | T-N1020a/b/c (debug TRACE, runtime defaults, mutual exclusion) |
| F-ND-010 | Medium | T-N1102b (replace previously staged command) |
| F-ND-011 | Medium | T-N1103a (wrong \msg_type\ ignored), T-N1106a (first-attempt reply terminates retry) |

Appendix A traceability table updated for all new test cases.

Closes #1004