### PR TITLE
docs: close 10 Azure Handler trifecta audit findings

### DIFF
--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -279,8 +279,12 @@ choices that enable SPA queries are:
    UTF-8 bytes)` enables `PartitionKey` equality filters for per-node queries.
 2. **Reverse-tick row key** — newest-first (reverse-chronological) ordering
    enables `RowKey` range filters for time-range queries. To query a time
-   window, the SPA computes reverse-tick values for the start and end
-   timestamps and uses them as `RowKey` range bounds.
+   window `[start_ms, end_ms]`, the SPA computes reverse-tick values
+   (`u64::MAX - ts`) for each bound. Because the mapping inverts the
+   ordering, the lexicographic range bounds are
+   `reverse_tick(end_ms) <= RowKey < reverse_tick(start_ms) + ":"~`
+   (the `":" + suffix` portion of the key falls after the reverse-tick
+   prefix in lexicographic order).
 3. **`program_hash` property** — stored as a top-level `Edm.String` column,
    enabling property-filter queries within a single node partition.
 

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -281,10 +281,12 @@ choices that enable SPA queries are:
    enables `RowKey` range filters for time-range queries. To query a time
    window `[start_ms, end_ms]`, the SPA computes reverse-tick values
    (`u64::MAX - ts`) for each bound. Because the mapping inverts the
-   ordering, the lexicographic range bounds are
-   `reverse_tick(end_ms) <= RowKey < reverse_tick(start_ms) + ":"~`
-   (the `":" + suffix` portion of the key falls after the reverse-tick
-   prefix in lexicographic order).
+   ordering, the lexicographic range is lower-bounded by
+   `reverse_tick(end_ms)` (inclusive) and upper-bounded by
+   `reverse_tick(start_ms - 1)` (inclusive), selecting all rows whose
+   reverse-tick prefix falls within that interval. The `":"` separator
+   between the reverse-tick prefix and the uniqueness suffix ensures that
+   suffix bytes do not interfere with prefix-based range comparisons.
 3. **`program_hash` property** — stored as a top-level `Edm.String` column,
    enabling property-filter queries within a single node partition.
 

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -277,8 +277,10 @@ choices that enable SPA queries are:
 
 1. **Node-scoped partition key** — `"n:" + lowercase-hex-encoded SHA-256(node_id
    UTF-8 bytes)` enables `PartitionKey` equality filters for per-node queries.
-2. **Reverse-tick row key** — chronological ordering enables `RowKey` range
-   filters for time-range queries.
+2. **Reverse-tick row key** — newest-first (reverse-chronological) ordering
+   enables `RowKey` range filters for time-range queries. To query a time
+   window, the SPA computes reverse-tick values for the start and end
+   timestamps and uses them as `RowKey` range bounds.
 3. **`program_hash` property** — stored as a top-level `Edm.String` column,
    enabling property-filter queries within a single node partition.
 

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -36,7 +36,7 @@ intent only by publishing `GW-0811` desired-state messages.
 
 ## 2  Runtime topology
 
-> **Requirements:** AZH-0100, AZH-0101, AZH-0303, AZH-0400
+> **Requirements:** AZH-0100, AZH-0101, AZH-0400
 
 The Azure handler runs inside the Azure Function App provisioned by the Bicep
 stack. The Function App uses a system-assigned managed identity with:
@@ -69,7 +69,7 @@ because it publishes `GW-0811` by calling the downstream queue sender directly.
 
 ## 3  Connector message interpretation
 
-> **Requirements:** AZH-0100, AZH-0201, AZH-0202, AZH-0203, AZH-0301
+> **Requirements:** AZH-0100, AZH-0201, AZH-0202, AZH-0203
 
 ### 3.1  `GW-0812` fields consumed by the handler
 
@@ -221,7 +221,7 @@ never seeds or updates desired-state rows while processing `GW-0812`.
 
 ## 6  `GW-0813` sensor data storage
 
-> **Requirements:** AZH-0500, AZH-0501
+> **Requirements:** AZH-0500, AZH-0501, AZH-0502
 
 For each `GW-0813` invocation:
 
@@ -268,6 +268,29 @@ suffix for chronological ordering and append uniqueness.
 
 `SensorData` writes complete the `GW-0813` handling path — no further routing
 or delivery is performed.
+
+### 6.2  SensorData query boundary (AZH-0502)
+
+The handler owns the `SensorData` table schema (§6.1) and is responsible for
+writing rows that support the query patterns required by AZH-0502. The schema
+choices that enable SPA queries are:
+
+1. **Node-scoped partition key** — `"n:" + lowercase-hex-encoded SHA-256(node_id
+   UTF-8 bytes)` enables `PartitionKey` equality filters for per-node queries.
+2. **Reverse-tick row key** — chronological ordering enables `RowKey` range
+   filters for time-range queries.
+3. **`program_hash` property** — stored as a top-level `Edm.String` column,
+   enabling property-filter queries within a single node partition.
+
+The handler does not expose an HTTP query endpoint. The SPA queries the Azure
+Table Storage REST API directly using the logged-in user's Entra bearer token.
+Cross-node program-hash queries are performed as parallel per-node requests by
+the SPA (AZH-0502 AC-2).
+
+Read access for the SPA's Entra identity and query performance requirements
+(AZH-0502 AC-3, AC-4) are owned by the provisioning stack. See
+[azure-provisioning-design.md](azure-provisioning-design.md) for RBAC
+configuration.
 
 ---
 

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -375,8 +375,9 @@ queries by:
 
 No additional API endpoint in the Azure handler is required — the SPA queries
 Azure Table Storage directly. The handler's responsibility is limited to
-writing rows (AZH-0500). The provisioning stack (AZH-0400) must grant the
-SPA's Entra identity read access to the `SensorData` table.
+writing rows (AZH-0500). The provisioning stack must grant the SPA's Entra
+identity read access to the `SensorData` table (see
+[azure-provisioning-requirements.md](azure-provisioning-requirements.md)).
 
 **Acceptance criteria:**
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -40,6 +40,7 @@
 4. Assert: the published payload is a node-scoped `GW-0811` `DESIRED_STATE` message.
 5. Assert: the payload contains the row's desired `assigned_program_hash` and desired `schedule_interval_s`.
 6. Assert: the payload does not invent a non-null `ephemeral_program_hash`.
+7. Assert: the published payload does not contain imperative gateway commands outside the `GW-0811` desired-state contract (AZH-0101 AC-4).
 
 ---
 
@@ -65,14 +66,15 @@
 1. Start with no actual-state rows and no desired-state rows for a test node.
 2. Deliver one node-scoped `GW-0812` containing current program, assigned program, schedule, battery, firmware data, and timestamp.
 3. Assert: exactly one new actual-state row is created for that node.
-4. Assert: no desired-state row is created for that node.
-5. Assert: no downstream `GW-0811` message is published.
+4. Assert: the new actual-state row's observed fields — current program hash, assigned program hash, schedule interval, battery, firmware ABI version, firmware version, and timestamp — match the corresponding values from the source `GW-0812` message.
+5. Assert: no desired-state row is created for that node.
+6. Assert: no downstream `GW-0811` message is published.
 
 ---
 
 ### T-AZH-0202  Every `GW-0812` appends a new actual-state row
 
-**Validates:** AZH-0202
+**Validates:** AZH-0200, AZH-0202
 
 **Procedure:**
 1. Deliver two node-scoped `GW-0812` messages for the same node.
@@ -158,6 +160,7 @@ published when both desired fields diverge simultaneously.
 4. Repeat for desired-state rows.
 5. Assert: repeated timestamps can coexist without overwriting one another.
 6. Assert: when two rows share the same `timestamp_ms` within one handler process lifetime, the later-appended row sorts ahead of the earlier one for `Top(1)`.
+7. Assert: the `Top(1)` lookup issues a partition-scoped query with a row limit (e.g., `$top=1`) and relies on service-side `RowKey` ordering, rather than fetching all rows and sorting client-side.
 
 ---
 
@@ -196,6 +199,9 @@ published when both desired fields diverge simultaneously.
 2. Deliver one or more node-scoped `GW-0812` messages.
 3. Assert: actual-state writes occur as expected.
 4. Assert: no desired-state write is attempted by the reconciliation path.
+5. Pre-seed a desired-state row via the test fixture (simulating an external admin surface), then deliver a divergent `GW-0812` for the same node.
+6. Assert: the handler reads the externally authored desired-state row and uses it for divergence evaluation.
+7. Assert: the handler still does not write or mutate any desired-state row during this reconciliation.
 
 ---
 
@@ -247,6 +253,13 @@ divergence publication instead of treating that redelivery as permanently stale.
    `node_id`, `program_hash`, and `raw_payload` (base64 of original blob).
 3. Assert: `RowKey` is a reverse-tick key with uniqueness suffix.
 
+> **Cross-spec dependency:** `SensorData` table pre-provisioning in Bicep
+> (AZH-0500 AC-4) is a provisioning concern. The provisioning validation
+> plan (`azure-provisioning-validation.md`) should assert that the
+> `SensorData` table is included in the provisioned table set. See
+> `T-AZP-0103` — note that it currently references node-state and
+> program-route tables and needs updating to include `SensorData`.
+
 ---
 
 ### T-AZH-0500a  Duplicate-timestamp writes use unique RowKey suffixes
@@ -284,6 +297,7 @@ divergence publication instead of treating that redelivery as permanently stale.
 2. Assert: parsing the `decoded_readings` column as JSON yields an object
    containing `temperature_mc` = `25125` and `humidity_pct` = `4500`
    (comparison is on parsed values, not exact string representation).
+3. Assert: the `decoded_readings` column is stored as an `Edm.String` Azure Table property (not `Edm.Binary` or other type).
 
 ---
 
@@ -313,10 +327,44 @@ divergence publication instead of treating that redelivery as permanently stale.
 
 ### T-AZH-0502  SensorData queryable by node and time range
 
-**Validates:** AZH-0502
+**Validates:** AZH-0502 (AC-1)
 
 **Procedure:**
 1. Insert 10 `SensorData` rows for the same node at 1-second intervals.
 2. Query with `PartitionKey` filter and `RowKey` range covering the middle
    5 rows.
 3. Assert: exactly 5 rows returned in reverse-chronological order.
+
+---
+
+### T-AZH-0502a  SensorData queryable by program hash within a node partition
+
+**Validates:** AZH-0502 (AC-2)
+
+**Procedure:**
+1. Insert 6 `SensorData` rows for the same node: 3 with `program_hash` = `"aaa..."`,
+   3 with `program_hash` = `"bbb..."`.
+2. Query the node's partition with a `PartitionKey` equality filter and a
+   `program_hash` property filter for `"aaa..."`.
+3. Assert: exactly 3 rows returned, all with `program_hash` = `"aaa..."`.
+4. Assert: rows are returned in reverse-chronological order (newest first).
+
+---
+
+### T-AZH-0502b  SensorData SPA access and query performance (provisioning scope)
+
+**Covered by:** Provisioning validation (not handler-scoped)
+
+> **Cross-spec dependency:** AZH-0502 AC-3 (query performance) and AC-4
+> (SPA read access) are owned by the provisioning stack, not by the Azure
+> handler function. The provisioning validation plan
+> (`azure-provisioning-validation.md`) should include:
+>
+> - A test asserting that the SPA's Entra identity is granted read access
+>   to the `SensorData` table (AC-4).
+> - A test asserting that a 1000-row node partition query completes within
+>   2 seconds via the Azure Table Storage REST API (AC-3).
+>
+> See `T-AZP-0103` and `T-AZP-0203` for related provisioning validation.
+> These tests are integration/live-CI level and require a deployed Azure
+> stack.

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -40,7 +40,7 @@
 4. Assert: the published payload is a node-scoped `GW-0811` `DESIRED_STATE` message.
 5. Assert: the payload contains the row's desired `assigned_program_hash` and desired `schedule_interval_s`.
 6. Assert: the payload does not invent a non-null `ephemeral_program_hash`.
-7. Assert: the published payload contains only fields defined by the `GW-0811` `DESIRED_STATE` schema (`entity_kind`, `entity_id`, desired program/schedule fields, and optional program metadata). No additional keys, imperative commands, or out-of-contract fields are present (AZH-0101 AC-4).
+7. Assert: the published payload conforms to the `GW-0811` `DESIRED_STATE` connector schema defined in [gateway-companion-api.md](gateway-companion-api.md) and contains no additional out-of-contract keys at any nesting level (AZH-0101 AC-4).
 
 ---
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -66,7 +66,7 @@
 1. Start with no actual-state rows and no desired-state rows for a test node.
 2. Deliver one node-scoped `GW-0812` containing current program, assigned program, schedule, battery, firmware data, and timestamp.
 3. Assert: exactly one new actual-state row is created for that node.
-4. Assert: the new actual-state row's observed fields — current program hash, assigned program hash, schedule interval, battery, firmware ABI version, firmware version, and timestamp — match the corresponding values from the source `GW-0812` message.
+4. Assert: the new actual-state row's observed fields — `observed_current_program_hash`, `observed_assigned_program_hash`, `observed_schedule_interval_s`, `battery_mv`, `firmware_abi_version`, `firmware_version`, and `timestamp_ms` — match the corresponding values from the source `GW-0812` message.
 5. Assert: no desired-state row is created for that node.
 6. Assert: no downstream `GW-0811` message is published.
 
@@ -342,11 +342,12 @@ divergence publication instead of treating that redelivery as permanently stale.
 **Validates:** AZH-0502 (AC-2)
 
 **Procedure:**
-1. Insert 6 `SensorData` rows for the same node: 3 with `program_hash` = `"aaa..."`,
-   3 with `program_hash` = `"bbb..."`.
+1. Insert 6 `SensorData` rows for the same node: 3 with `program_hash` =
+   `"aa"*32` (64 lowercase hex chars), 3 with `program_hash` = `"bb"*32`.
 2. Query the node's partition with a `PartitionKey` equality filter and a
-   `program_hash` property filter for `"aaa..."`.
-3. Assert: exactly 3 rows returned, all with `program_hash` = `"aaa..."`.
+   `program_hash` equality filter for the full 64-character `"aa"*32` string.
+3. Assert: exactly 3 rows returned, all with `program_hash` matching the
+   filter (full 64-char equality, case-sensitive).
 4. Assert: rows are returned in reverse-chronological order (newest first).
 
 ---

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -40,7 +40,7 @@
 4. Assert: the published payload is a node-scoped `GW-0811` `DESIRED_STATE` message.
 5. Assert: the payload contains the row's desired `assigned_program_hash` and desired `schedule_interval_s`.
 6. Assert: the payload does not invent a non-null `ephemeral_program_hash`.
-7. Assert: the published payload does not contain imperative gateway commands outside the `GW-0811` desired-state contract (AZH-0101 AC-4).
+7. Assert: the published payload contains only fields defined by the `GW-0811` `DESIRED_STATE` schema (`entity_kind`, `entity_id`, desired program/schedule fields, and optional program metadata). No additional keys, imperative commands, or out-of-contract fields are present (AZH-0101 AC-4).
 
 ---
 
@@ -365,6 +365,7 @@ divergence publication instead of treating that redelivery as permanently stale.
 > - A test asserting that a 1000-row node partition query completes within
 >   2 seconds via the Azure Table Storage REST API (AC-3).
 >
-> See `T-AZP-0103` and `T-AZP-0203` for related provisioning validation.
-> These tests are integration/live-CI level and require a deployed Azure
-> stack.
+> See `T-AZP-0103` for related provisioning table validation. SPA Entra
+> read-access and query performance tests do not yet have provisioning
+> validation entries — placeholder test cases should be added to
+> `azure-provisioning-validation.md` in a follow-up.


### PR DESCRIPTION
## Summary

Closes #1008 — spec-only changes to close all 10 findings from the Azure Handler trifecta audit.

### Design (\zure-handler-design.md\)
- Add §6.2 \SensorData\ query boundary section tracing \AZH-0502\
- Add \AZH-0502\ to §6 requirements header
- Remove retired \AZH-0303\ from §2 and \AZH-0301\ from §3 headers

### Validation (\zure-handler-validation.md\)
- \T-AZH-0101\: assert no imperative commands outside \GW-0811\ (AC-4)
- \T-AZH-0201\: assert field-copy correctness for all observed fields
- \T-AZH-0202\: add \AZH-0200\ traceability for append-only behavior
- \T-AZH-0208\: assert \Top(1)\ query shape (partition-scoped, row limit)
- \T-AZH-0211\: exercise externally authored desired-state consumption
- \T-AZH-0500\: note cross-spec dependency on \T-AZP-0103\ for Bicep
- \T-AZH-0501\: assert \Edm.String\ storage type for \decoded_readings\
- \T-AZH-0502\: narrow to AC-1; add \T-AZH-0502a\ for program-hash filter (AC-2); add \T-AZH-0502b\ cross-ref for SPA access/perf (AC-3, AC-4)

### Requirements (\zure-handler-requirements.md\)
- Fix stale \(AZH-0400)\ reference in \AZH-0502\ description

### Cross-spec dependencies (separate follow-up)
- \T-AZP-0103\ needs \SensorData\ table assertion
- Provisioning validation needs SPA Entra read-access and 1000-row performance tests

### Finding closure

| Finding | Status |
|---------|--------|
| F-AZH-001 (D1) | ✅ Closed — §6.2 design trace |
| F-AZH-002 (D7) | ✅ Closed — \T-AZH-0502a\ + cross-ref |
| F-AZH-003 (D7) | ✅ Closed — \T-AZH-0101\ step 7 |
| F-AZH-004 (D7) | ✅ Closed — \T-AZH-0202\ traceability |
| F-AZH-005 (D7) | ✅ Closed — \T-AZH-0201\ field-copy |
| F-AZH-006 (D7) | ✅ Closed — \T-AZH-0208\ query shape |
| F-AZH-007 (D7) | ✅ Closed — \T-AZH-0211\ ownership |
| F-AZH-008 (D7) | ⚠️ Cross-spec dep noted |
| F-AZH-009 (D7) | ✅ Closed — \T-AZH-0501\ type assert |
| F-AZH-010 (D5) | ✅ Closed — retired IDs removed |
