### PR TITLE
docs: remediate 35 Web UI trifecta audit findings

### DIFF
--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -343,7 +343,8 @@ separate line on a time-series chart. The X-axis is time (derived from
 - Maximum 1000 rows per query (`$top=1000`). For longer time ranges,
   the SPA downsamples client-side: fetch up to 1000 rows for the
   requested window, then downsample to a maximum of 500 points per
-  series (e.g., pick one point per pixel or per time bucket).
+  series (e.g., divide the time range into 500 equal buckets and
+  pick one representative point per bucket).
 - Int64 values exceeding `Number.MAX_SAFE_INTEGER` (2^53 - 1) are displayed
   as strings. The Azure handler encodes such values as JSON strings in the
   `decoded_readings` column (see AZH-0501 AC-5). The SPA MUST handle both

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -498,10 +498,11 @@ responses (e.g., `#code=…`). To prevent conflicts:
 
 1. **Before MSAL init:** If the current URL hash does not contain
    MSAL-related tokens (`code=`, `error=`, `access_token=`), the hash is
-   temporarily saved and cleared so MSAL does not misinterpret a routing
-   hash as an auth response.
+   temporarily saved and cleared via `history.replaceState()` so MSAL does
+   not misinterpret a routing hash as an auth response.
 2. **After MSAL processes the redirect:** The saved routing hash is restored
-   via `window.location.hash`.
+   via `history.replaceState()` (not `window.location.hash`, which would
+   add a spurious history entry).
 3. **Auth hashes** (containing `code=`, `error=`, or `access_token=`) are
    left intact for MSAL to consume.
 

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -342,8 +342,8 @@ separate line on a time-series chart. The X-axis is time (derived from
   the admin selects which to display via the series selector.
 - Maximum 1000 rows per query (`$top=1000`). For longer time ranges,
   the SPA downsamples client-side: fetch up to 1000 rows for the
-  requested window, then thin the data points to a displayable density
-  (e.g., pick one point per pixel or per time bucket).
+  requested window, then downsample to a maximum of 500 points per
+  series (e.g., pick one point per pixel or per time bucket).
 - Int64 values exceeding `Number.MAX_SAFE_INTEGER` (2^53 - 1) are displayed
   as strings. The Azure handler encodes such values as JSON strings in the
   `decoded_readings` column (see AZH-0501 AC-5). The SPA MUST handle both
@@ -464,3 +464,63 @@ When the user switches to a different environment:
 5. MSAL-related `sessionStorage` keys are cleared (keys starting with `msal.` or containing `.login.` or `.acquireToken.`) — other session data is preserved
 6. A new MSAL instance is initialized with the new environment's credentials
 7. The active tab is re-rendered
+
+---
+
+## 12. Cross-Cutting Concerns
+
+### 12.1 HTML Output Escaping (WEB-CC-02)
+
+All user-supplied and server-sourced values rendered into HTML MUST pass
+through an `escapeHtml()` function before insertion. The function replaces
+the following five characters with their HTML entity equivalents:
+
+| Character | Entity |
+|-----------|--------|
+| `&` | `&amp;` |
+| `<` | `&lt;` |
+| `>` | `&gt;` |
+| `"` | `&quot;` |
+| `'` | `&#39;` |
+
+Replacement MUST be applied in the order shown (ampersand first) to avoid
+double-encoding. Every code path that builds HTML from dynamic values —
+including table cells, tooltips, modal content, and status indicators —
+MUST route through `escapeHtml()`. Raw string interpolation into `innerHTML`
+is prohibited for any value originating from Azure Table responses, URL
+parameters, or user input fields.
+
+### 12.2 MSAL Hash Routing Compatibility (WEB-CC-03)
+
+The SPA uses URL hash fragments for tab routing (e.g., `#dashboard`,
+`#programs`). MSAL.js also uses hash fragments for authorization code
+responses (e.g., `#code=…`). To prevent conflicts:
+
+1. **Before MSAL init:** If the current URL hash does not contain
+   MSAL-related tokens (`code=`, `error=`, `access_token=`), the hash is
+   temporarily saved and cleared so MSAL does not misinterpret a routing
+   hash as an auth response.
+2. **After MSAL processes the redirect:** The saved routing hash is restored
+   via `window.location.hash`.
+3. **Auth hashes** (containing `code=`, `error=`, or `access_token=`) are
+   left intact for MSAL to consume.
+
+### 12.3 Popup Window Detection (WEB-CC-04)
+
+When MSAL.js opens a popup for interactive login, the SPA is loaded again
+inside the popup window. To avoid unnecessary API calls and duplicate
+rendering in the popup:
+
+- At `DOMContentLoaded`, the SPA checks `window.opener && window.opener !== window`.
+- If the check is true, the SPA skips calling `init()` entirely — no MSAL
+  initialization, no table queries, no UI rendering.
+- The popup page exists solely to receive the auth redirect and relay the
+  result back to the parent window via MSAL's internal messaging.
+
+---
+
+## 13. Revision History
+
+| Date | Author | Description |
+|------|--------|-------------|
+| 2026-05-19 | Trifecta remediation (#1012) | Added §12 (cross-cutting concerns: HTML escaping, MSAL hash routing, popup detection). Fixed §10.2 downsample cap to 500 points per series. |

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -52,32 +52,32 @@ and verifies one or more acceptance criteria.
 
 | Requirement | Test Cases |
 |-------------|------------|
-| WEB-0101 | T-WEB-0101 |
-| WEB-0102 | T-WEB-0102 |
-| WEB-0103 | T-WEB-0103 |
+| WEB-0101 | T-WEB-0101, T-WEB-0101b, T-WEB-0101c |
+| WEB-0102 | T-WEB-0102, T-WEB-0102b, T-WEB-0102c |
+| WEB-0103 | T-WEB-0103, T-WEB-0103b |
 | WEB-0104 | T-WEB-0104, T-WEB-0105, T-WEB-0106, T-WEB-0107, T-WEB-0108 |
-| WEB-0201 | T-WEB-0201 |
-| WEB-0202 | T-WEB-0202 |
-| WEB-0203 | T-WEB-0203 |
-| WEB-0204 | T-WEB-0204 |
+| WEB-0201 | T-WEB-0201, T-WEB-0201b, T-WEB-0201c |
+| WEB-0202 | T-WEB-0202, T-WEB-0202b, T-WEB-0202c |
+| WEB-0203 | T-WEB-0203, T-WEB-0203b |
+| WEB-0204 | T-WEB-0204, T-WEB-0204b |
 | WEB-0205 | T-WEB-0205 |
 | WEB-0206 | T-WEB-0206 |
-| WEB-0207 | T-WEB-0207 |
-| WEB-0301 | T-WEB-0301 |
+| WEB-0207 | T-WEB-0207, T-WEB-0207b |
+| WEB-0301 | T-WEB-0301, T-WEB-0301b |
 | WEB-0302 | T-WEB-0302 |
-| WEB-0303 | T-WEB-0303 |
+| WEB-0303 | T-WEB-0303, T-WEB-0303b |
 | WEB-0304 | T-WEB-0304 |
-| WEB-0305 | T-WEB-0305 |
+| WEB-0305 | T-WEB-0305, T-WEB-0305b |
 | WEB-0306 | T-WEB-0306 |
 | WEB-0307 | T-WEB-0307a, T-WEB-0307b |
 | WEB-0308 | T-WEB-0308 |
-| WEB-0309 | T-WEB-0309 |
-| WEB-0310 | T-WEB-0310 |
-| WEB-0401 | T-WEB-0401 |
-| WEB-0501 | T-WEB-0501 |
-| WEB-0502 | T-WEB-0502 |
+| WEB-0309 | T-WEB-0309, T-WEB-0309b |
+| WEB-0310 | T-WEB-0310, T-WEB-0310b, T-WEB-0310c, T-WEB-0310d |
+| WEB-0401 | T-WEB-0401, T-WEB-0401b, T-WEB-0401c |
+| WEB-0501 | T-WEB-0501, T-WEB-0501b, T-WEB-0501c |
+| WEB-0502 | T-WEB-0502, T-WEB-0502b |
 | WEB-0503 | T-WEB-0503 |
-| WEB-0504 | T-WEB-0504 |
+| WEB-0504 | T-WEB-0504, T-WEB-0504b |
 | WEB-0505 | T-WEB-0505 |
 | WEB-0506 | T-WEB-0506 |
 | WEB-0507 | T-WEB-0507 |
@@ -86,25 +86,25 @@ and verifies one or more acceptance criteria.
 | WEB-0603 | T-WEB-0603 |
 | WEB-0604 | T-WEB-0604 |
 | WEB-0605 | T-WEB-0605 |
-| WEB-0606 | T-WEB-0606 |
+| WEB-0606 | T-WEB-0606, T-WEB-0606b, T-WEB-0606c, T-WEB-0606d, T-WEB-0606e |
 | WEB-0607 | T-WEB-0607 |
-| WEB-0700 | T-WEB-0701 |
-| WEB-0701 | T-WEB-0702, T-WEB-0703, T-WEB-0706, T-WEB-0713, T-WEB-0714, T-WEB-0715 |
-| WEB-0702 | T-WEB-0704, T-WEB-0705 |
-| WEB-0703 | T-WEB-0707, T-WEB-0708, T-WEB-0709, T-WEB-0710, T-WEB-0711, T-WEB-0712 |
+| WEB-0700 | T-WEB-0701, T-WEB-0701b |
+| WEB-0701 | T-WEB-0702, T-WEB-0703, T-WEB-0706, T-WEB-0713, T-WEB-0714, T-WEB-0715, T-WEB-0702b, T-WEB-0703b |
+| WEB-0702 | T-WEB-0704, T-WEB-0705, T-WEB-0704b, T-WEB-0704c |
+| WEB-0703 | T-WEB-0707, T-WEB-0708, T-WEB-0709, T-WEB-0710, T-WEB-0711, T-WEB-0712, T-WEB-0707b |
 | WEB-0800 | T-WEB-0801, T-WEB-0802, T-WEB-0803, T-WEB-0804, T-WEB-0805, T-WEB-0806 |
 | WEB-0801 | T-WEB-0802 |
 | WEB-0802 | T-WEB-0806, T-WEB-0807, T-WEB-0808, T-WEB-0809 |
-| WEB-0803 | T-WEB-0801 |
-| WEB-0804 | T-WEB-0805 |
-| WEB-0805 | T-WEB-0804 |
-| WEB-0806 | T-WEB-0803 |
-| WEB-0901 | T-WEB-0901 |
-| WEB-0902 | T-WEB-0902 |
-| WEB-CC-01 | T-WEB-CC-01 |
-| WEB-CC-02 | T-WEB-CC-02 |
-| WEB-CC-03 | T-WEB-CC-03 |
-| WEB-CC-04 | T-WEB-CC-04 |
+| WEB-0803 | T-WEB-0801, T-WEB-0801b |
+| WEB-0804 | T-WEB-0805, T-WEB-0805b |
+| WEB-0805 | T-WEB-0804, T-WEB-0804b |
+| WEB-0806 | T-WEB-0803, T-WEB-0803b, T-WEB-0803c, T-WEB-0803d, T-WEB-0803d2, T-WEB-0803e, T-WEB-0803f, T-WEB-0803g |
+| WEB-0901 | T-WEB-0901, T-WEB-0901b, T-WEB-0901c |
+| WEB-0902 | T-WEB-0902, T-WEB-0902b |
+| WEB-CC-01 | T-WEB-CC-01, T-WEB-CC-01b |
+| WEB-CC-02 | T-WEB-CC-02, T-WEB-CC-02b |
+| WEB-CC-03 | T-WEB-CC-03, T-WEB-CC-03b |
+| WEB-CC-04 | T-WEB-CC-04, T-WEB-CC-04b |
 
 ---
 
@@ -115,8 +115,13 @@ and verifies one or more acceptance criteria.
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
 | T-WEB-0101 | WEB-0101 | SPA renders node table from `actualstate` query | Manual/E2E | Planned |
+| T-WEB-0101b | WEB-0101 | Nodes sorted alphabetically by `node_id` | Manual/E2E | Planned |
+| T-WEB-0101c | WEB-0101 | Empty `actualstate` table displays "No node state found." | Manual/E2E | Planned |
 | T-WEB-0102 | WEB-0102 | All nine required columns displayed | Manual/E2E | Planned |
+| T-WEB-0102b | WEB-0102 | Program hashes truncated to 8-char hex with full-hash tooltip | Manual/E2E | Planned |
+| T-WEB-0102c | WEB-0102 | "Last Seen" shows relative time (e.g., "5m ago") | Manual/E2E | Planned |
 | T-WEB-0103 | WEB-0103 | Auto-refresh polls at configured interval (30s default) | Manual | Planned |
+| T-WEB-0103b | WEB-0103 | Auto-refresh cancelled when navigating to a different tab | Manual | Planned |
 | T-WEB-0104 | WEB-0104 | Divergence indicator shown when desired-state row exists and actual differs from desired | Manual/E2E | Planned |
 | T-WEB-0105 | WEB-0104 | Unassigned program (desired row exists, program hash empty/missing) shows Diverged while node still reports a current program | Manual/E2E | Planned |
 | T-WEB-0106 | WEB-0104 | Node with no desired-state row shows Aligned even if actual state reports a program | Manual/E2E | Planned |
@@ -126,43 +131,63 @@ and verifies one or more acceptance criteria.
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
 | T-WEB-0201 | WEB-0201 | Set desired schedule writes correct row with `Edm.Int32` type | Integration | Planned |
+| T-WEB-0201b | WEB-0201 | Schedule input enforces min=1 and step=1 | Manual | Planned |
+| T-WEB-0201c | WEB-0201 | Empty schedule field omits `desired_schedule_interval_s` from entity | Integration | Planned |
 | T-WEB-0202 | WEB-0202 | Assign program hash writes correct row with lowercase hex | Integration | Planned |
+| T-WEB-0202b | WEB-0202 | Program Hash field is a `<select>` dropdown populated from `programs` table | Manual/E2E | Planned |
+| T-WEB-0202c | WEB-0202 | Selecting "No program target" omits `desired_assigned_program_hash` from entity | Integration | Planned |
 | T-WEB-0203 | WEB-0203 | RowKey uses reverse-timestamp format (3 colon-separated 16-char hex segments) | Unit (JS) | Planned |
+| T-WEB-0203b | WEB-0203 | First RowKey segment is bitwise complement of current `timestamp_ms` | Unit (JS) | Planned |
 | T-WEB-0204 | WEB-0204 | PartitionKey = `n:{SHA-256(node_id)}` via SubtleCrypto | Unit (JS) | Planned |
+| T-WEB-0204b | WEB-0204 | SHA-256 hash input is the UTF-8 encoding of `node_id` | Unit (JS) | Planned |
 | T-WEB-0205 | WEB-0205 | `timestamp_ms` stored as `Edm.Int64` | Integration | Planned |
 | T-WEB-0206 | WEB-0206 | Node ID field is a dropdown-only control populated from latest `actualstate` nodes; arbitrary node IDs cannot be entered or submitted | Manual/E2E | Planned |
 | T-WEB-0207 | WEB-0207 | Selecting a node pre-populates Schedule and Program Hash (desired state preferred over actual state) | Manual/E2E | Planned |
+| T-WEB-0207b | WEB-0207 | Pre-populated hash not in dropdown defaults to "No program target" | Manual/E2E | Planned |
 
 ### 5.3  Program Ingest
 
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
 | T-WEB-0301 | WEB-0301 | `ProgramIngest` accepts ELF + metadata via JSON POST | Unit (Rust) | Pass |
+| T-WEB-0301b | WEB-0301 | Missing `elf` field returns HTTP 400 | Unit (Rust) | Pass |
 | T-WEB-0302 | WEB-0302 | Prevail verification runs; invalid ELF rejected | Unit (Rust) | Pass |
 | T-WEB-0303 | WEB-0303 | Program hash matches gateway computation | Unit (Rust) | Pass |
+| T-WEB-0303b | WEB-0303 | Re-ingesting same ELF produces same hash (idempotent) | Unit (Rust) | Planned |
 | T-WEB-0304 | WEB-0304 | Program stored in `programs` table with all fields | Integration | Planned |
 | T-WEB-0305 | WEB-0305 | Success returns hash+metadata; failure returns diagnostics | Unit (Rust) | Pass |
+| T-WEB-0305b | WEB-0305 | Failure returns JSON error with appropriate HTTP status code | Unit (Rust) | Planned |
 | T-WEB-0306 | WEB-0306 | Oversized programs rejected (>1 MB → HTTP 413) | Unit (Rust) | Pass |
 | T-WEB-0307a | WEB-0307 | Empty ELF rejected | Unit (Rust) | Pass |
 | T-WEB-0307b | WEB-0307 | Multi-program ELF rejected | Unit (Rust) | Planned |
 | T-WEB-0308 | WEB-0308 | `source_filename` normalized to basename | Unit (Rust) | Pass |
 | T-WEB-0309 | WEB-0309 | `DESIRED_STATE` includes inline ELF on program divergence | Unit (Rust) | Planned |
+| T-WEB-0309b | WEB-0309 | Gateway receives inline ELF and runs Prevail re-verification | Integration | Planned |
 | T-WEB-0310 | WEB-0310 | `DESIRED_STATE` carries key 5 with ELF bytes and keys 6–8 with metadata | Unit (Rust) | Planned |
+| T-WEB-0310b | WEB-0310 | Key 6 carries verification profile value | Unit (Rust) | Planned |
+| T-WEB-0310c | WEB-0310 | Key 7 carries source filename | Unit (Rust) | Planned |
+| T-WEB-0310d | WEB-0310 | Key 8 carries ABI version | Unit (Rust) | Planned |
 
 ### 5.4  Program List
 
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
 | T-WEB-0401 | WEB-0401 | SPA lists programs from `programs` table with correct columns | Manual/E2E | Planned |
+| T-WEB-0401b | WEB-0401 | Programs sorted by `created_at` descending (newest first) | Manual/E2E | Planned |
+| T-WEB-0401c | WEB-0401 | Empty programs table displays "No programs found." | Manual/E2E | Planned |
 
 ### 5.5  Authentication
 
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
 | T-WEB-0501 | WEB-0501 | MSAL.js login flow works (popup, PKCE) | Manual | Planned |
+| T-WEB-0501b | WEB-0501 | Token cache uses `sessionStorage` | Manual | Planned |
+| T-WEB-0501c | WEB-0501 | Active account tracked and displayed in header | Manual | Planned |
 | T-WEB-0502 | WEB-0502 | Storage API calls include bearer token | Integration | Planned |
+| T-WEB-0502b | WEB-0502 | `acquireTokenSilent` attempted first; falls back to `acquireTokenPopup` | Manual | Planned |
 | T-WEB-0503 | WEB-0503 | `ProgramIngest` rejects unauthenticated requests (EasyAuth returns 401) | Integration | Planned |
 | T-WEB-0504 | WEB-0504 | SPA acquires Function App-scoped token for `ProgramIngest` calls | Manual | Planned |
+| T-WEB-0504b | WEB-0504 | Bearer token sent on `POST /api/programs/ingest` | Manual | Planned |
 | T-WEB-0505 | WEB-0505 | `ProgramIngest` rejects Storage-scoped token (wrong audience) | Integration | Planned |
 | T-WEB-0506 | WEB-0506 | `ProgramIngest` rejects expired bearer token | Integration | Planned |
 | T-WEB-0507 | WEB-0507 | `ProgramIngest` accepts valid `api://<clientId>/user_impersonation` token | Integration | Planned |
@@ -177,6 +202,10 @@ and verifies one or more acceptance criteria.
 | T-WEB-0604 | WEB-0604 | CORS configured for GitHub Pages and `sondeplatform.com` origins | Infrastructure | Planned |
 | T-WEB-0605 | WEB-0605 | Function identity has table contributor on `programs` | Infrastructure | Planned |
 | T-WEB-0606 | WEB-0606 | EasyAuth configured on Function App with Entra ID provider | Infrastructure | Planned |
+| T-WEB-0606b | WEB-0606 | `platform.enabled` is `true` | Infrastructure | Planned |
+| T-WEB-0606c | WEB-0606 | `unauthenticatedClientAction` is `Return401` | Infrastructure | Planned |
+| T-WEB-0606d | WEB-0606 | `azureActiveDirectory.enabled` is `true` | Infrastructure | Planned |
+| T-WEB-0606e | WEB-0606 | `allowedAudiences` includes both `api://<clientId>` and bare `<clientId>` | Infrastructure | Planned |
 | T-WEB-0607 | WEB-0607 | `ProgramIngest` `authLevel` is `anonymous` (auth delegated to EasyAuth) | Infrastructure | Planned |
 
 ### 5.7  Sensor Data
@@ -184,12 +213,18 @@ and verifies one or more acceptance criteria.
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
 | T-WEB-0701 | WEB-0700 | Sensor Data tab appears in tab bar and loads data from `sensordata` table | Manual/E2E | Planned |
+| T-WEB-0701b | WEB-0700 | Loading indicator displayed while fetching sensor data | Manual/E2E | Planned |
 | T-WEB-0702 | WEB-0701 | Time-series graph renders lines per (node, program, reading) | Manual/E2E | Planned |
+| T-WEB-0702b | WEB-0701 | X-axis is time (from `timestamp_ms`); Y-axis is reading value | Manual/E2E | Planned |
 | T-WEB-0703 | WEB-0701 | Time range selector filters data correctly | Manual/E2E | Planned |
+| T-WEB-0703b | WEB-0701 | Default time range is 24h | Manual/E2E | Planned |
 | T-WEB-0704 | WEB-0702 | Table view shows all sensor data columns | Manual/E2E | Planned |
+| T-WEB-0704b | WEB-0702 | Sensor data table sorted by timestamp descending | Manual/E2E | Planned |
+| T-WEB-0704c | WEB-0702 | Raw Payload truncated to 40 characters with full-value tooltip | Manual/E2E | Planned |
 | T-WEB-0705 | WEB-0702 | SPA handles empty `decoded_readings` gracefully (shows "—") | Manual/E2E | Planned |
 | T-WEB-0706 | WEB-0701 | SPA displays string-encoded int64 values (above `Number.MAX_SAFE_INTEGER`) correctly and renders in-range values as numbers | Manual | Planned |
 | T-WEB-0707 | WEB-0703 | Series edit dialog opens when ✏️ button is clicked and pre-fills saved overrides | Manual | Planned |
+| T-WEB-0707b | WEB-0703 | Series edit dialog has focus trapping and closes on Escape | Manual | Planned |
 | T-WEB-0708 | WEB-0703 | Custom display name replaces default label in series picker, chart legend, and tooltip | Manual | Planned |
 | T-WEB-0709 | WEB-0703 | Scale divisor transforms plotted values (e.g., 1000 converts 21500 → 21.5) | Manual | Planned |
 | T-WEB-0710 | WEB-0703 | Unit suffix appears in tooltip values and Y-axis title when all series share the same suffix | Manual | Planned |
@@ -201,10 +236,20 @@ and verifies one or more acceptance criteria.
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
 | T-WEB-0801 | WEB-0803 | First load with no environments shows full-screen setup modal; main UI is inaccessible | Manual | Planned |
+| T-WEB-0801b | WEB-0803 | Setup modal cannot be closed without adding an environment (no Close button) | Manual | Planned |
 | T-WEB-0802 | WEB-0801 | Adding an environment persists all fields to `localStorage` under `sonde_environments` | Manual | Planned |
 | T-WEB-0803 | WEB-0806 | Switching environment re-initializes MSAL, clears session, and refreshes active tab | Manual | Planned |
+| T-WEB-0803b | WEB-0806 | Auto-refresh timer cleared on environment switch | Manual | Planned |
+| T-WEB-0803c | WEB-0806 | `CONFIG` fields updated from selected environment | Manual | Planned |
+| T-WEB-0803d | WEB-0806 | MSAL instance discarded on environment switch | Manual | Planned |
+| T-WEB-0803d2 | WEB-0806 | New MSAL instance initialized with new environment credentials | Manual | Planned |
+| T-WEB-0803e | WEB-0806 | Active MSAL account cleared on switch | Manual | Planned |
+| T-WEB-0803f | WEB-0806 | Only MSAL-related `sessionStorage` keys cleared (other session data preserved) | Manual | Planned |
+| T-WEB-0803g | WEB-0806 | Active tab re-rendered after switch | Manual | Planned |
 | T-WEB-0804 | WEB-0805 | Active environment name displayed in header bar | Manual | Planned |
+| T-WEB-0804b | WEB-0805 | Environment indicator updates when environment is switched | Manual | Planned |
 | T-WEB-0805 | WEB-0804 | Edit and delete operations on environments work correctly | Manual | Planned |
+| T-WEB-0805b | WEB-0804 | Deleting active environment switches to next available or shows setup modal | Manual | Planned |
 | T-WEB-0806 | WEB-0802 | Environment fields validated (all required, duplicate name rejected) | Manual | Planned |
 
 ### 5.9  Deployment
@@ -212,16 +257,23 @@ and verifies one or more acceptance criteria.
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
 | T-WEB-0901 | WEB-0901 | GitHub Actions workflow deploys `deploy/web-ui/` to GitHub Pages on push to main | Infrastructure | Planned |
+| T-WEB-0901b | WEB-0901 | Workflow uses `actions/upload-pages-artifact` and `actions/deploy-pages` | Infrastructure | Planned |
+| T-WEB-0901c | WEB-0901 | Manual trigger (`workflow_dispatch`) is supported | Infrastructure | Planned |
 | T-WEB-0902 | WEB-0902 | Bicep includes GitHub Pages and `sondeplatform.com` in CORS origins and SPA redirect URIs | Infrastructure | Planned |
+| T-WEB-0902b | WEB-0902 | CORS origins parameterized via Bicep parameters | Infrastructure | Planned |
 
 ### 5.10  Cross-Cutting
 
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
 | T-WEB-CC-01 | WEB-CC-01 | `deploy/web-ui/` contains only `.html`, `.js`, `.css`, `.json` — no build tools or `node_modules` | Inspection | Planned |
+| T-WEB-CC-01b | WEB-CC-01 | External libraries (MSAL.js, Chart.js) loaded via CDN `<script>` tags | Inspection | Planned |
 | T-WEB-CC-02 | WEB-CC-02 | All dynamic values in rendered HTML pass through `escapeHtml()` — no raw insertion of user/server data | Code review | Planned |
+| T-WEB-CC-02b | WEB-CC-02 | `escapeHtml()` escapes all five characters: `escapeHtml('&<>"\'')` returns `'&amp;&lt;&gt;&quot;&#39;'` with no double-encoding (e.g., no `&amp;lt;`) | Unit (JS) | Planned |
 | T-WEB-CC-03 | WEB-CC-03 | Non-auth hashes temporarily cleared before MSAL init; restored after | Manual | Planned |
+| T-WEB-CC-03b | WEB-CC-03 | Auth hashes (containing `code=`, `error=`, `access_token=`) preserved for MSAL | Manual | Planned |
 | T-WEB-CC-04 | WEB-CC-04 | SPA loaded inside MSAL popup does not call `init()` | Code review | Planned |
+| T-WEB-CC-04b | WEB-CC-04 | Popup detection uses `window.opener && window.opener !== window` check | Code review | Planned |
 
 ### 5.11  Divergence Edge Cases
 
@@ -280,3 +332,4 @@ and verifies one or more acceptance criteria.
 | Date | Author | Description |
 |------|--------|-------------|
 | 2026-05-19 | Spec extraction (automated) | Restructured with sections, traceability matrix, risk prioritization. Added references to web-ui-requirements.md. |
+| 2026-05-19 | Trifecta remediation (#1012) | Added ~35 fine-grained test cases to cover all acceptance criteria individually. Updated traceability matrix. |


### PR DESCRIPTION
## Summary

Closes #1012 — remediates all 35 trifecta audit findings across the Web UI specification stack.

### Design changes (\web-ui-design.md\)

| Finding | Category | Change |
|---------|----------|--------|
| F-WEB-001 (WEB-CC-02) | D1 | Added §12.1: HTML output escaping contract — 5-char entity map, replacement order, \innerHTML\ prohibition |
| WEB-CC-03 | D1 | Added §12.2: MSAL hash routing compatibility — 3-step hash save/clear/restore |
| WEB-CC-04 | D1 | Added §12.3: Popup window detection — \window.opener\ check, \init()\ skip |
| F-WEB-008 (WEB-0701) | D6 | Fixed §10.2: tightened downsample from \displayable density\ to hard 500-point-per-series cap |

### Validation changes (\web-ui-validation.md\)

Added ~38 fine-grained test cases so every acceptance criterion has individual coverage:

- **WEB-0606** (EasyAuth): split into 5 individual setting assertions (T-WEB-0606 through 0606e)
- **WEB-0806** (env switch): split into 8 individual re-init step tests (T-WEB-0803 through 0803g + 0803d2)
- **WEB-0310** (DESIRED_STATE keys): split into 4 per-key tests (T-WEB-0310 through 0310d)
- **WEB-CC-02**: added \scapeHtml()\ unit test with double-encoding guard
- **WEB-0309**: added gateway re-verification integration test
- **WEB-0501/0502/0504**: added per-AC auth flow tests
- 25 medium/low-severity D7 findings: added individual tests for sort order, empty states, truncation, defaults, parameterized origins, auth hash preservation, CDN tags, UTF-8 encoding

Updated traceability matrix (§4) with all new test IDs.

### Not changed

- \web-ui-requirements.md\ — requirements are correct; all 35 findings were downstream gaps in design/validation