### PR TITLE
docs: resolve node design-vs-implementation drift

### DIFF
--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -33,7 +33,7 @@ The firmware is **uniform across all nodes** — application behavior is defined
 | BPF interpreter | `sonde-bpf` — custom RFC 9669 interpreter with tagged registers and zero heap allocation |
 | CBOR | Via `sonde-protocol` (`ciborium`) | serde-compatible; matches protocol crate implementation |
 | AES-256-GCM | RustCrypto `aes-gcm` crate (pure-Rust, `no_std`) (implements `sonde-protocol::AeadProvider` trait) | Pure-Rust AES-256-GCM; `no_std`-compatible, implements `AeadProvider` trait |
-| SHA-256 | ESP-IDF hardware SHA peripheral | Hardware-accelerated; used for program hash verification |
+| SHA-256 | `sha2` RustCrypto crate (software) | Pure-Rust SHA-256; used for program hash verification. Hardware acceleration via ESP-IDF peripheral is possible but not currently used — program updates are infrequent so software hashing is acceptable. |
 | RNG | ESP-IDF hardware TRNG | True random number generator; used for WAKE nonce |
 | Toolchain | Upstream Rust (C3) / `espup` (S3) | C3 is RISC-V (upstream); S3 is Xtensa (custom toolchain) |
 
@@ -355,6 +355,27 @@ pub enum BpfError {
 
 This trait is defined in the node firmware (not in `sonde-protocol`, since the gateway does not execute BPF). The `sonde-node` crate provides an adapter backed by `sonde-bpf`.
 
+The adapter internally wraps each registered helper as a `HelperDescriptor` (defined in `sonde-bpf`) which pairs the helper function with **return-type metadata**:
+
+```rust
+pub enum HelperReturn {
+    /// Helper returns a plain scalar (integer) value.
+    Scalar,
+    /// Helper returns a pointer into a map value (or null).
+    /// `map_arg` identifies which argument register carries the map pointer
+    /// (1-indexed), enabling the interpreter to derive pointer provenance.
+    MapValueOrNull { map_arg: u8 },
+}
+
+pub struct HelperDescriptor {
+    pub id: u32,
+    pub func: HelperFn,
+    pub ret: HelperReturn,
+}
+```
+
+This return-type tracking enables the `sonde-bpf` tagged register system to maintain pointer provenance across helper calls — when `map_lookup_elem` (helper 10) returns a non-null value, the interpreter tags the result register as a bounded map-value pointer, enabling safe bounds checking on subsequent memory accesses.
+
 The interpreter runs in bounded mode — an instruction counter enforces the instruction budget. If the budget is exceeded, execution is terminated and the program returns an error.
 
 ### 8.2  Helper registration
@@ -619,11 +640,13 @@ All inbound protocol errors result in **silent discard** — the node does not s
 | Flash (program) | 8 KB (2 × 4 KB) | — | 4 KB per program image |
 | BPF stack | 4 KB | — | 512 B × 8 frames |
 | Ephemeral program | — | — | Allocated from heap (≤ 2 KB) |
-| Main task stack (ND-0918) | 16 KB | — | `CONFIG_ESP_MAIN_TASK_STACK_SIZE=16384` |
+| Main task stack (ND-0918) | 24 KB | — | `CONFIG_ESP_MAIN_TASK_STACK_SIZE=24576`. ND-0918 requires at least 16 KB; 24 KB provides headroom for the BLE stack (NimBLE host + GATT server), PEER_REQUEST path, NVS, and BPF interpreter. |
 
 ---
 
 ## 14  Boot sequence
+
+The `sonde-node` crate contains a library (`src/lib.rs`) plus a firmware binary target at `src/bin/node.rs`. The Rust `fn main()` in that binary performs ESP-IDF setup, boot-mode selection, and the wake cycle launch. The `esp-idf-sys`/`esp-idf-svc` `binstart` feature provides the ESP-IDF startup bridge so the C `app_main()` entry invokes the Rust binary entry point. Build with `cargo +esp build -p sonde-node --bin node --features esp`.
 
 1. ESP-IDF initialization (clocks, peripherals, wifi/ESP-NOW).
 2. Task watchdog timer is configured and the main task is registered (ND-0919): `CONFIG_ESP_TASK_WDT_EN=y`, 20 s timeout, panic-on-expiry. The main task calls `esp_task_wdt_add()` at startup and `esp_task_wdt_delete()` after the wake cycle completes. If the wake cycle hangs, the watchdog triggers a hardware reset. For long-running modes (BLE pairing), the polling loop calls `esp_task_wdt_reset()` on each iteration to prevent spurious resets while still detecting hangs within a single 20 s polling window.

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -367,9 +367,12 @@ pub enum HelperReturn {
     MapValueOrNull { map_arg: u8 },
 }
 
+/// In `sonde-bpf`, the helper function type is:
+///   pub type Helper = fn(u64, u64, u64, u64, u64) -> u64;
+/// (same signature as the node firmware's `HelperFn` alias)
 pub struct HelperDescriptor {
     pub id: u32,
-    pub func: HelperFn,
+    pub func: Helper,
     pub ret: HelperReturn,
 }
 ```

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1880,10 +1880,10 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 **Validates:** ND-0918 (AC2)
 
 **Procedure:**
-1. Boot the node with `CONFIG_ESP_MAIN_TASK_STACK_SIZE=16384` (per sdkconfig.defaults).
+1. Boot the node with `CONFIG_ESP_MAIN_TASK_STACK_SIZE=24576` (per sdkconfig.defaults; ND-0918 requires at least 16 KB).
 2. Run a full wake cycle including WAKE, COMMAND, BPF execution, and deep-sleep entry.
 3. Assert: the wake cycle completes without a stack overflow panic.
-4. Assert: high-water-mark stack usage is logged or observable (remains below 16384).
+4. Assert: high-water-mark stack usage is logged or observable (remains below 24576).
 
 > **Note:** This test requires target hardware. Host-based tests use stack configurations that differ from ESP-IDF.
 
@@ -1908,7 +1908,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 **Procedure:**
 1. Open `crates/sonde-node/sdkconfig.defaults`.
-2. Assert: the file contains `CONFIG_ESP_MAIN_TASK_STACK_SIZE=16384` (or a value ≥ 16384).
+2. Assert: the file contains `CONFIG_ESP_MAIN_TASK_STACK_SIZE=24576` (or a value ≥ 16384, per ND-0918).
 
 > **Note:** This is a static inspection test, not a runtime test. It verifies the build configuration prerequisite for T-N918a and T-N918b.
 

--- a/docs/protocol-crate-design.md
+++ b/docs/protocol-crate-design.md
@@ -470,7 +470,7 @@ pub fn program_hash(image_cbor: &[u8], sha: &impl Sha256Provider) -> [u8; 32] {
 }
 ```
 
-Gateway uses RustCrypto `sha2`; node uses ESP-IDF hardware SHA.
+Gateway and node both use RustCrypto `sha2` (software SHA-256). The `Sha256Provider` trait allows platform-specific backends (e.g., ESP-IDF hardware SHA) to be substituted without changing protocol logic.
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves all four findings from the periodic maintenance audit in #1027 by updating design and validation docs to match the current implementation. **No code changes.**

### Findings Resolved

| Finding | Section | Change |
|---------|---------|--------|
| A1 | §2 Technology | SHA-256: \\ESP-IDF hardware SHA\\ → \\sha2 RustCrypto (software)\\ |
| A2 | §13 Memory budget | Main task stack: 16 KB → 24 KB (matches \\sdkconfig.defaults\\) |
| A3 | §14 Boot sequence | Added preamble documenting \\src/bin/node.rs\\ + \\instart\\ entry point |
| B1 | §8.1a BPF trait | Documented \\HelperDescriptor\\ and \\HelperReturn\\ for pointer provenance |

### Cross-reference fixes

- \\protocol-crate-design.md\\: corrected stale claim that node uses hardware SHA
- \\
ode-validation.md\\: updated stack size test procedures (16384 → 24576)

### Files Changed

- \\docs/node-design.md\\
- \\docs/node-validation.md\\
- \\docs/protocol-crate-design.md\\

Closes #1027