### PR TITLE
fix: resolve azure-handler design-vs-implementation drift

### DIFF
--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -60,9 +60,6 @@ pub struct RuntimeConfig {
     pub desired_state_table: String,
     pub programs_table: String,
     pub sensor_data_table: String,
-    /// Azure Table for gateway escrow metadata (pubkey, salt, state).
-    /// Defaults to `"gatewayescrow"` if not set.
-    pub escrow_table: String,
 }
 
 impl RuntimeConfig {
@@ -78,10 +75,6 @@ impl RuntimeConfig {
             desired_state_table: required_env("SONDE_AZURE_HANDLER_DESIRED_STATE_TABLE")?,
             programs_table: required_env("SONDE_AZURE_HANDLER_PROGRAMS_TABLE")?,
             sensor_data_table: required_env("SONDE_AZURE_HANDLER_SENSOR_DATA_TABLE")?,
-            escrow_table: std::env::var("SONDE_AZURE_HANDLER_ESCROW_TABLE")
-                .ok()
-                .filter(|v| !v.trim().is_empty())
-                .unwrap_or_else(|| "gatewayescrow".to_string()),
         })
     }
 }
@@ -96,7 +89,7 @@ fn required_env(name: &str) -> Result<String, HandlerError> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActualStateRow {
     pub row_key: String,
-    /// Entity kind: `"node"` or `"phone"`.
+    /// Entity kind (e.g. `"node"`).
     pub entity_kind: String,
     pub node_id: String,
     pub observed_current_program_hash: Option<Vec<u8>>,
@@ -106,24 +99,10 @@ pub struct ActualStateRow {
     pub firmware_abi_version: Option<u32>,
     pub firmware_version: Option<String>,
     pub timestamp_ms: u64,
-    /// Encrypted PSK escrow blob (AZH-0600).
-    pub encrypted_psk_escrow: Option<Vec<u8>>,
-    /// Key hint for escrow recovery lookup (AZH-0601).
-    pub escrow_key_hint: Option<u16>,
-    /// Master key version for escrow blob versioning.
-    pub escrow_key_version: Option<u64>,
 }
 
 impl ActualStateRow {
     fn from_message(message: &ActualStateMessage) -> Result<Self, HandlerError> {
-        if message.encrypted_psk_escrow.is_some()
-            && (message.escrow_key_hint.is_none() || message.escrow_key_version.is_none())
-        {
-            return Err(HandlerError::Decode(
-                "ACTUAL_STATE with encrypted_psk_escrow must include escrow_key_hint and escrow_key_version"
-                    .into(),
-            ));
-        }
         Ok(Self {
             row_key: next_history_row_key(message.timestamp_ms)?,
             entity_kind: message.entity_kind.clone(),
@@ -135,9 +114,6 @@ impl ActualStateRow {
             firmware_abi_version: message.firmware_abi_version,
             firmware_version: message.firmware_version.clone(),
             timestamp_ms: message.timestamp_ms,
-            encrypted_psk_escrow: message.encrypted_psk_escrow.clone(),
-            escrow_key_hint: message.escrow_key_hint,
-            escrow_key_version: message.escrow_key_version,
         })
     }
 }
@@ -187,36 +163,6 @@ pub struct ActualStateMessage {
     pub firmware_version: Option<String>,
     pub timestamp_ms: u64,
     pub schedule_interval_s: Option<u32>,
-    /// Encrypted PSK escrow blob (CBOR key 12, GW-2003).
-    pub encrypted_psk_escrow: Option<Vec<u8>>,
-    /// Key hint from escrow blob metadata (CBOR key 13, GW-2003).
-    pub escrow_key_hint: Option<u16>,
-    /// Master key version from escrow blob metadata (CBOR key 14, GW-2003).
-    pub escrow_key_version: Option<u64>,
-    /// Gateway-scoped status_details (CBOR key 10, AZH-0605).
-    pub status_details: Option<GatewayStatusDetails>,
-}
-
-/// Parsed gateway-scoped status_details from ACTUAL_STATE (CBOR key 10).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GatewayStatusDetails {
-    /// Escrow lifecycle state (disabled, bootstrapping, ready, etc.).
-    pub escrow_state: Option<String>,
-    /// Current master key version.
-    pub escrow_key_version: Option<u64>,
-    /// KDF salt bytes.
-    pub escrow_salt: Option<Vec<u8>>,
-    /// KDF parameters (Argon2id).
-    pub escrow_kdf_params: Option<KdfParams>,
-}
-
-/// KDF parameters for Argon2id (mirroring the gateway-side definition).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KdfParams {
-    pub m_cost: u32,
-    pub t_cost: u32,
-    pub p_cost: u32,
-    pub kdf_version: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -234,29 +180,7 @@ pub struct AppDataMessage {
 pub enum ConnectorMessage {
     ActualState(ActualStateMessage),
     AppData(AppDataMessage),
-    /// KEY_ESCROW_PUBKEY (msg_type 0x10, GW-2001).
-    KeyEscrowPubkey(KeyEscrowPubkeyMessage),
-    /// KEY_ESCROW_REQUEST (msg_type 0x11, GW-2009).
-    KeyEscrowRequest(KeyEscrowRequestMessage),
-    /// MASTER_KEY_INSTALL (msg_type 0x13, AZH-0604) — opaque relay.
-    MasterKeyInstall(Vec<u8>),
     Unsupported(u64),
-}
-
-/// Gateway recovery public key publication (AZH-0602).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KeyEscrowPubkeyMessage {
-    pub public_key: Vec<u8>,
-    pub key_epoch: u64,
-    pub created_at: u64,
-    pub fingerprint_words: Vec<String>,
-}
-
-/// Request for escrowed PSK(s) matching a key_hint (AZH-0601).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct KeyEscrowRequestMessage {
-    pub key_hint: u16,
-    pub request_id: Vec<u8>,
 }
 
 #[async_trait]
@@ -277,67 +201,6 @@ pub trait HandlerStore: Send + Sync {
     async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), HandlerError>;
     /// Append a row to the `SensorData` table for a `GW-0813` message (AZH-0500).
     async fn append_sensor_data(&self, row: &SensorDataRow) -> Result<(), HandlerError>;
-
-    // ── PSK key escrow (AZH-0600–AZH-0605) ────────────────────
-
-    /// Store or update the gateway's recovery public key (AZH-0602).
-    /// Only updates if `key_epoch` >= stored epoch (monotonic guard).
-    async fn store_gateway_escrow_pubkey(
-        &self,
-        public_key: &[u8],
-        key_epoch: u64,
-        created_at: u64,
-    ) -> Result<(), HandlerError> {
-        let _ = (public_key, key_epoch, created_at);
-        Err(HandlerError::Store(
-            "store_gateway_escrow_pubkey not implemented for this store backend".into(),
-        ))
-    }
-
-    /// Load escrowed PSK blobs matching a key_hint (AZH-0601).
-    /// Returns at most `max_candidates` blobs.
-    async fn load_escrow_blobs_by_key_hint(
-        &self,
-        key_hint: u16,
-        max_candidates: usize,
-    ) -> Result<Vec<Vec<u8>>, HandlerError> {
-        let _ = (key_hint, max_candidates);
-        Err(HandlerError::Store(
-            "load_escrow_blobs_by_key_hint not implemented for this store backend".into(),
-        ))
-    }
-
-    /// Store the gateway's escrow lifecycle state (AZH-0605).
-    ///
-    /// `timestamp_ms` is the ACTUAL_STATE message timestamp; implementations
-    /// should only update if the incoming timestamp is >= the stored one.
-    async fn store_gateway_escrow_state(
-        &self,
-        details: &GatewayStatusDetails,
-        timestamp_ms: u64,
-    ) -> Result<(), HandlerError> {
-        let _ = (details, timestamp_ms);
-        Err(HandlerError::Store(
-            "store_gateway_escrow_state not implemented for this store backend".into(),
-        ))
-    }
-
-    /// Store the KDF salt with first-writer-wins semantics (AZH-0603).
-    ///
-    /// If no salt has been stored yet, persists the given salt and returns
-    /// `Ok(true)`. If a salt already exists, leaves it untouched and returns
-    /// `Ok(false)`.
-    async fn store_escrow_salt_if_absent(
-        &self,
-        salt: &[u8],
-        kdf_params: Option<&KdfParams>,
-        created_at: u64,
-    ) -> Result<bool, HandlerError> {
-        let _ = (salt, kdf_params, created_at);
-        Err(HandlerError::Store(
-            "store_escrow_salt_if_absent not implemented for this store backend".into(),
-        ))
-    }
 }
 
 #[async_trait]
@@ -369,44 +232,6 @@ where
             ConnectorMessage::ActualState(actual_state) => {
                 match actual_state.entity_kind.as_str() {
                     "node" => self.handle_actual_state(actual_state).await?,
-                    "phone" => {
-                        // Phone escrow ACTUAL_STATE (AZH-0600): store escrow blob
-                        // with phone-scoped partition key ("p:" prefix).
-                        if actual_state.entity_id.is_empty() {
-                            return Err(HandlerError::Decode(
-                                "phone ACTUAL_STATE has empty entity_id".into(),
-                            ));
-                        }
-                        if actual_state.encrypted_psk_escrow.is_some() {
-                            let row = ActualStateRow::from_message(&actual_state)?;
-                            self.store.append_actual_state(&row).await?;
-                        }
-                    }
-                    "gateway" => {
-                        // Gateway-scoped ACTUAL_STATE (AZH-0605): persist escrow state.
-                        if let Some(ref details) = actual_state.status_details {
-                            self.store
-                                .store_gateway_escrow_state(details, actual_state.timestamp_ms)
-                                .await?;
-
-                            // AZH-0603: first-writer-wins salt storage.
-                            if let Some(ref salt) = details.escrow_salt {
-                                let stored = self
-                                    .store
-                                    .store_escrow_salt_if_absent(
-                                        salt,
-                                        details.escrow_kdf_params.as_ref(),
-                                        actual_state.timestamp_ms,
-                                    )
-                                    .await?;
-                                if !stored {
-                                    tracing::debug!(
-                                        "escrow salt already exists, ignoring incoming salt (first-writer-wins)"
-                                    );
-                                }
-                            }
-                        }
-                    }
                     other => {
                         warn!(
                             entity_kind = %other,
@@ -418,17 +243,6 @@ where
                 Ok(())
             }
             ConnectorMessage::AppData(app_data) => self.handle_app_data(app_data).await,
-            ConnectorMessage::KeyEscrowPubkey(msg) => {
-                self.store
-                    .store_gateway_escrow_pubkey(&msg.public_key, msg.key_epoch, msg.created_at)
-                    .await
-            }
-            ConnectorMessage::KeyEscrowRequest(msg) => self.handle_key_escrow_request(msg).await,
-            ConnectorMessage::MasterKeyInstall(raw_bytes) => {
-                self.publisher
-                    .publish(&self.downstream_queue, raw_bytes)
-                    .await
-            }
             ConnectorMessage::Unsupported(msg_type) => {
                 warn!(msg_type, "ignoring unsupported connector message");
                 Ok(())
@@ -528,24 +342,6 @@ where
         let desired = encode_desired_state(&desired_row, program_row.as_ref())?;
         self.publisher
             .publish(&self.downstream_queue, desired)
-            .await
-    }
-
-    /// Handle KEY_ESCROW_REQUEST: look up escrow blobs by key_hint and
-    /// respond with KEY_ESCROW_RESPONSE (AZH-0601).
-    async fn handle_key_escrow_request(
-        &self,
-        msg: KeyEscrowRequestMessage,
-    ) -> Result<(), HandlerError> {
-        let mut candidates = self
-            .store
-            .load_escrow_blobs_by_key_hint(msg.key_hint, 16)
-            .await?;
-        candidates.truncate(16);
-
-        let response = encode_key_escrow_response(&msg.request_id, msg.key_hint, &candidates)?;
-        self.publisher
-            .publish(&self.downstream_queue, response)
             .await
     }
 
@@ -852,7 +648,6 @@ pub struct AzureTablesStore {
     desired_state_table: azure_data_tables::clients::TableClient,
     programs_table: azure_data_tables::clients::TableClient,
     sensor_data_table: azure_data_tables::clients::TableClient,
-    escrow_table: azure_data_tables::clients::TableClient,
 }
 
 impl AzureTablesStore {
@@ -869,7 +664,6 @@ impl AzureTablesStore {
             desired_state_table: service.table_client(config.desired_state_table.clone()),
             programs_table: service.table_client(config.programs_table.clone()),
             sensor_data_table: service.table_client(config.sensor_data_table.clone()),
-            escrow_table: service.table_client(config.escrow_table.clone()),
         })
     }
 }
@@ -879,16 +673,6 @@ fn is_legacy_not_found(e: &LegacyAzureError) -> bool {
         e.kind(),
         LegacyAzureErrorKind::HttpResponse {
             status: LegacyStatusCode::NotFound,
-            ..
-        }
-    )
-}
-
-fn is_legacy_conflict(e: &LegacyAzureError) -> bool {
-    matches!(
-        e.kind(),
-        LegacyAzureErrorKind::HttpResponse {
-            status: LegacyStatusCode::Conflict,
             ..
         }
     )
@@ -1028,231 +812,6 @@ impl HandlerStore for AzureTablesStore {
             .map_err(|e| HandlerError::Store(format!("append sensor-data row failed: {e}")))?;
         Ok(())
     }
-
-    async fn store_gateway_escrow_pubkey(
-        &self,
-        public_key: &[u8],
-        key_epoch: u64,
-        created_at: u64,
-    ) -> Result<(), HandlerError> {
-        let key_epoch_i64 = i64::try_from(key_epoch)
-            .map_err(|_| HandlerError::Store(format!("key_epoch {key_epoch} exceeds i64::MAX")))?;
-        let created_at_i64 = i64::try_from(created_at).map_err(|_| {
-            HandlerError::Store(format!("created_at {created_at} exceeds i64::MAX"))
-        })?;
-
-        // Monotonic guard: only update if incoming epoch >= stored.
-        // Note: this is a non-atomic read-check-write. Concurrent racing
-        // messages can bypass the guard, but KEY_ESCROW_PUBKEY is only
-        // emitted once per gateway startup with a monotonically increasing
-        // epoch, so concurrent different-epoch messages are not possible
-        // in normal operation.
-        let existing = self
-            .escrow_table
-            .partition_key_client(ESCROW_PARTITION_KEY)
-            .entity_client("pubkey")
-            .get::<GatewayEscrowPubkeyEntity>()
-            .await;
-
-        match existing {
-            Ok(response) => {
-                if response.entity.key_epoch > key_epoch_i64 {
-                    // Stale message — stored epoch is higher, ignore.
-                    return Ok(());
-                }
-            }
-            Err(e) if is_legacy_not_found(&e) => {
-                // No existing pubkey — proceed with upsert.
-            }
-            Err(e) => {
-                return Err(HandlerError::Store(format!(
-                    "query existing escrow pubkey failed: {e}"
-                )));
-            }
-        }
-
-        let entity = GatewayEscrowPubkeyEntity {
-            partition_key: ESCROW_PARTITION_KEY.to_string(),
-            row_key: "pubkey".to_string(),
-            public_key: base64::prelude::BASE64_STANDARD.encode(public_key),
-            key_epoch: key_epoch_i64,
-            created_at: created_at_i64,
-        };
-        self.escrow_table
-            .partition_key_client(ESCROW_PARTITION_KEY)
-            .entity_client("pubkey")
-            .insert_or_replace(entity)
-            .map_err(|e| HandlerError::Store(format!("prepare escrow pubkey upsert failed: {e}")))?
-            .await
-            .map_err(|e| HandlerError::Store(format!("upsert escrow pubkey failed: {e}")))?;
-        Ok(())
-    }
-
-    async fn load_escrow_blobs_by_key_hint(
-        &self,
-        key_hint: u16,
-        max_candidates: usize,
-    ) -> Result<Vec<Vec<u8>>, HandlerError> {
-        // Query actual_state table for rows with matching escrow_key_hint.
-        // Azure Tables stores key_hint as u32, so filter on that.
-        let filter = format!("escrow_key_hint eq {}", key_hint as u32);
-        // Fetch more than needed to deduplicate by partition (latest per subject).
-        let fetch_limit = (max_candidates + 1) * 3;
-        let mut stream = self
-            .actual_state_table
-            .query()
-            .filter(filter)
-            .top(fetch_limit as u32)
-            .into_stream::<ActualStateEntity>();
-
-        // Collect results, dedup by partition_key (keep first = latest per reverse-tick row_key).
-        let mut seen_partitions = std::collections::HashSet::new();
-        let mut blobs = Vec::new();
-        while let Some(result) = stream.next().await {
-            let response = result.map_err(|e| {
-                HandlerError::Store(format!("query escrow blobs by key_hint failed: {e}"))
-            })?;
-            for entity in response.entities {
-                if seen_partitions.contains(&entity.partition_key) {
-                    continue;
-                }
-                if let Some(b64_blob) = &entity.encrypted_psk_escrow {
-                    let blob = base64::prelude::BASE64_STANDARD
-                        .decode(b64_blob)
-                        .map_err(|e| {
-                            HandlerError::Store(format!(
-                                "invalid base64 in encrypted_psk_escrow: {e}"
-                            ))
-                        })?;
-                    seen_partitions.insert(entity.partition_key.clone());
-                    blobs.push(blob);
-                }
-            }
-        }
-
-        if blobs.len() > max_candidates {
-            warn!(
-                key_hint,
-                total = blobs.len(),
-                max_candidates,
-                "escrow recovery candidates exceed max, truncating"
-            );
-            blobs.truncate(max_candidates);
-        }
-        Ok(blobs)
-    }
-
-    async fn store_gateway_escrow_state(
-        &self,
-        details: &GatewayStatusDetails,
-        timestamp_ms: u64,
-    ) -> Result<(), HandlerError> {
-        let timestamp_ms_i64 = i64::try_from(timestamp_ms).map_err(|_| {
-            HandlerError::Store(format!("timestamp_ms {timestamp_ms} exceeds i64::MAX"))
-        })?;
-
-        // Out-of-order guard: only update if incoming timestamp >= stored.
-        let existing = self
-            .escrow_table
-            .partition_key_client(ESCROW_PARTITION_KEY)
-            .entity_client("state")
-            .get::<GatewayEscrowStateEntity>()
-            .await;
-        match existing {
-            Ok(response) => {
-                if response.entity.timestamp_ms > timestamp_ms_i64 {
-                    return Ok(());
-                }
-            }
-            Err(e) if is_legacy_not_found(&e) => {}
-            Err(e) => {
-                return Err(HandlerError::Store(format!(
-                    "query existing escrow state failed: {e}"
-                )));
-            }
-        }
-
-        let escrow_key_version = details
-            .escrow_key_version
-            .map(|v| {
-                i64::try_from(v).map_err(|_| {
-                    HandlerError::Store(format!("escrow_key_version {v} exceeds i64::MAX"))
-                })
-            })
-            .transpose()?;
-
-        let kdf_params_json = details.escrow_kdf_params.as_ref().map(|kdf| {
-            serde_json::json!({
-                "m_cost": kdf.m_cost,
-                "t_cost": kdf.t_cost,
-                "p_cost": kdf.p_cost,
-                "version": kdf.kdf_version,
-            })
-            .to_string()
-        });
-
-        let entity = GatewayEscrowStateEntity {
-            partition_key: ESCROW_PARTITION_KEY.to_string(),
-            row_key: "state".to_string(),
-            escrow_state: details.escrow_state.clone(),
-            escrow_key_version,
-            // Salt is stored exclusively in the dedicated "salt" row
-            // (first-writer-wins via store_escrow_salt_if_absent).
-            // Omit from the mutable state row to avoid inconsistency.
-            escrow_salt: None,
-            kdf_params_json,
-            timestamp_ms: timestamp_ms_i64,
-        };
-        self.escrow_table
-            .partition_key_client(ESCROW_PARTITION_KEY)
-            .entity_client("state")
-            .insert_or_replace(entity)
-            .map_err(|e| HandlerError::Store(format!("prepare escrow state upsert failed: {e}")))?
-            .await
-            .map_err(|e| HandlerError::Store(format!("upsert escrow state failed: {e}")))?;
-        Ok(())
-    }
-
-    async fn store_escrow_salt_if_absent(
-        &self,
-        salt: &[u8],
-        kdf_params: Option<&KdfParams>,
-        created_at: u64,
-    ) -> Result<bool, HandlerError> {
-        let created_at_i64 = i64::try_from(created_at).map_err(|_| {
-            HandlerError::Store(format!("salt created_at {created_at} exceeds i64::MAX"))
-        })?;
-        let kdf_params_json = kdf_params.map(|kdf| {
-            serde_json::json!({
-                "m_cost": kdf.m_cost,
-                "t_cost": kdf.t_cost,
-                "p_cost": kdf.p_cost,
-                "version": kdf.kdf_version,
-            })
-            .to_string()
-        });
-        let entity = GatewayEscrowSaltEntity {
-            partition_key: ESCROW_PARTITION_KEY.to_string(),
-            row_key: "salt".to_string(),
-            salt: base64::prelude::BASE64_STANDARD.encode(salt),
-            kdf_params_json,
-            created_at: created_at_i64,
-        };
-        // First-writer-wins: use insert (not upsert). 409 Conflict means
-        // a salt row already exists, which is the expected steady-state.
-        match self
-            .escrow_table
-            .insert::<_, GatewayEscrowSaltEntity>(&entity)
-            .map_err(|e| HandlerError::Store(format!("prepare escrow salt insert failed: {e}")))?
-            .await
-        {
-            Ok(_) => Ok(true),
-            Err(e) if is_legacy_conflict(&e) => Ok(false),
-            Err(e) => Err(HandlerError::Store(format!(
-                "insert escrow salt failed: {e}"
-            ))),
-        }
-    }
 }
 
 const STORAGE_QUEUE_API_VERSION: &str = "2024-11-04";
@@ -1339,15 +898,6 @@ struct ActualStateEntity {
     firmware_version: Option<String>,
     #[serde(deserialize_with = "deserialize_u64_flexible")]
     timestamp_ms: u64,
-    /// Base64-encoded encrypted PSK escrow blob (AZH-0600).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    encrypted_psk_escrow: Option<String>,
-    /// Key hint for escrow recovery lookup (AZH-0601).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    escrow_key_hint: Option<u32>,
-    /// Master key version for escrow blob versioning.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    escrow_key_version: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -1424,14 +974,9 @@ impl TryFrom<ActualStateEntity> for ActualStateRow {
     type Error = HandlerError;
 
     fn try_from(value: ActualStateEntity) -> Result<Self, Self::Error> {
-        let entity_kind = if value.partition_key.starts_with("p:") {
-            "phone".to_string()
-        } else {
-            "node".to_string()
-        };
         Ok(Self {
             row_key: value.row_key,
-            entity_kind,
+            entity_kind: "node".to_string(),
             node_id: value.node_id,
             observed_current_program_hash: decode_optional_program_hash(
                 value.observed_current_program_hash,
@@ -1446,21 +991,6 @@ impl TryFrom<ActualStateEntity> for ActualStateRow {
             firmware_abi_version: value.firmware_abi_version,
             firmware_version: value.firmware_version,
             timestamp_ms: value.timestamp_ms,
-            encrypted_psk_escrow: value
-                .encrypted_psk_escrow
-                .map(|b64| {
-                    base64::prelude::BASE64_STANDARD.decode(&b64).map_err(|e| {
-                        HandlerError::Decode(format!("invalid base64 in encrypted_psk_escrow: {e}"))
-                    })
-                })
-                .transpose()?,
-            escrow_key_hint: match value.escrow_key_hint {
-                Some(h) => Some(u16::try_from(h).map_err(|_| {
-                    HandlerError::Decode(format!("escrow_key_hint {} out of u16 range", h))
-                })?),
-                None => None,
-            },
-            escrow_key_version: value.escrow_key_version,
         })
     }
 }
@@ -1469,15 +999,7 @@ impl TryFrom<ActualStateRow> for ActualStateEntity {
     type Error = HandlerError;
 
     fn try_from(value: ActualStateRow) -> Result<Self, Self::Error> {
-        let partition_key = match value.entity_kind.as_str() {
-            "node" => encode_node_partition_key(&value.node_id),
-            "phone" => encode_phone_partition_key(&value.node_id),
-            other => {
-                return Err(HandlerError::Decode(format!(
-                    "unsupported entity_kind for partition key: {other}"
-                )));
-            }
-        };
+        let partition_key = encode_node_partition_key(&value.node_id);
         Ok(Self {
             partition_key,
             row_key: value.row_key,
@@ -1491,11 +1013,6 @@ impl TryFrom<ActualStateRow> for ActualStateEntity {
             firmware_abi_version: value.firmware_abi_version,
             firmware_version: value.firmware_version,
             timestamp_ms: value.timestamp_ms,
-            encrypted_psk_escrow: value
-                .encrypted_psk_escrow
-                .map(|b| base64::prelude::BASE64_STANDARD.encode(&b)),
-            escrow_key_hint: value.escrow_key_hint.map(|h| h as u32),
-            escrow_key_version: value.escrow_key_version,
         })
     }
 }
@@ -1610,10 +1127,6 @@ fn decode_connector_message(bytes: &[u8]) -> Result<ConnectorMessage, HandlerErr
             firmware_version: optional_text_field(&map, 8, "firmware_version")?,
             timestamp_ms: required_u64(&map, 9, "timestamp_ms")?,
             schedule_interval_s: optional_u32_field(&map, 11, "schedule_interval_s")?,
-            encrypted_psk_escrow: optional_bytes_field(&map, 12, "encrypted_psk_escrow")?,
-            escrow_key_hint: optional_u16_field(&map, 13, "escrow_key_hint")?,
-            escrow_key_version: optional_u64_field(&map, 14, "escrow_key_version")?,
-            status_details: decode_optional_status_details(&map, 10)?,
         })),
         MSG_TYPE_APP_DATA => Ok(ConnectorMessage::AppData(AppDataMessage {
             node_id: required_text(&map, 2, "node_id")?,
@@ -1622,43 +1135,6 @@ fn decode_connector_message(bytes: &[u8]) -> Result<ConnectorMessage, HandlerErr
             timestamp_ms: required_u64(&map, 5, "timestamp_ms")?,
             readings: decode_optional_readings(&map, 16)?,
         })),
-        sonde_protocol::CONNECTOR_MSG_TYPE_KEY_ESCROW_PUBKEY => {
-            let public_key = required_bytes(&map, 2, "public_key")?;
-            if public_key.len() != 32 {
-                return Err(HandlerError::Decode(format!(
-                    "public_key has invalid length: expected 32 bytes, got {}",
-                    public_key.len()
-                )));
-            }
-            Ok(ConnectorMessage::KeyEscrowPubkey(KeyEscrowPubkeyMessage {
-                public_key,
-                key_epoch: required_u64(&map, 3, "key_epoch")?,
-                created_at: required_u64(&map, 4, "created_at")?,
-                fingerprint_words: optional_text_array_field(&map, 5)?,
-            }))
-        }
-        sonde_protocol::CONNECTOR_MSG_TYPE_KEY_ESCROW_REQUEST => {
-            let key_hint_raw = required_u64(&map, 2, "key_hint")?;
-            let key_hint = u16::try_from(key_hint_raw).map_err(|_| {
-                HandlerError::Decode(format!("key_hint {} exceeds u16::MAX", key_hint_raw))
-            })?;
-            let request_id = required_bytes(&map, 3, "request_id")?;
-            if request_id.len() != 16 {
-                return Err(HandlerError::Decode(format!(
-                    "request_id has invalid length: expected 16 bytes, got {}",
-                    request_id.len()
-                )));
-            }
-            Ok(ConnectorMessage::KeyEscrowRequest(
-                KeyEscrowRequestMessage {
-                    key_hint,
-                    request_id,
-                },
-            ))
-        }
-        sonde_protocol::CONNECTOR_MSG_TYPE_MASTER_KEY_INSTALL => {
-            Ok(ConnectorMessage::MasterKeyInstall(bytes.to_vec()))
-        }
         other => Ok(ConnectorMessage::Unsupported(other)),
     }
 }
@@ -1702,28 +1178,6 @@ pub(crate) fn encode_desired_state(
 
 fn encode_optional_hex(value: Option<Vec<u8>>) -> Option<String> {
     value.map(hex::encode)
-}
-
-/// Encode a KEY_ESCROW_RESPONSE message (msg_type 0x12, AZH-0601).
-fn encode_key_escrow_response(
-    request_id: &[u8],
-    key_hint: u16,
-    candidates: &[Vec<u8>],
-) -> Result<Vec<u8>, HandlerError> {
-    let candidate_values: Vec<Value> = candidates.iter().map(|c| Value::Bytes(c.clone())).collect();
-    let value = Value::Map(vec![
-        map_entry(
-            1,
-            Value::Integer(sonde_protocol::CONNECTOR_MSG_TYPE_KEY_ESCROW_RESPONSE.into()),
-        ),
-        map_entry(2, Value::Bytes(request_id.to_vec())),
-        map_entry(3, Value::Array(candidate_values)),
-        map_entry(4, Value::Integer((key_hint as u64).into())),
-    ]);
-    let mut bytes = Vec::new();
-    ciborium::into_writer(&value, &mut bytes)
-        .map_err(|e| HandlerError::Decode(format!("encode KEY_ESCROW_RESPONSE failed: {e}")))?;
-    Ok(bytes)
 }
 
 /// JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 - 1).
@@ -1789,69 +1243,6 @@ impl TryFrom<SensorDataRow> for SensorDataEntity {
 fn encode_node_partition_key(node_id: &str) -> String {
     let digest = Sha256::digest(node_id.as_bytes());
     format!("n:{}", hex::encode(digest))
-}
-
-fn encode_phone_partition_key(phone_id: &str) -> String {
-    let digest = Sha256::digest(phone_id.as_bytes());
-    format!("p:{}", hex::encode(digest))
-}
-
-/// Azure Table entity for gateway escrow public key (AZH-0602).
-#[derive(Debug, Deserialize, Serialize, Clone)]
-struct GatewayEscrowPubkeyEntity {
-    #[serde(rename = "PartitionKey")]
-    partition_key: String,
-    #[serde(rename = "RowKey")]
-    row_key: String,
-    /// Base64-encoded X25519 public key (32 bytes).
-    public_key: String,
-    /// Monotonic key epoch.
-    key_epoch: i64,
-    /// Creation timestamp (Unix milliseconds).
-    created_at: i64,
-}
-
-/// Gateway escrow metadata partition key (fixed).
-const ESCROW_PARTITION_KEY: &str = "gateway";
-
-/// Azure Table entity for gateway escrow state (AZH-0605).
-#[derive(Debug, Deserialize, Serialize, Clone)]
-struct GatewayEscrowStateEntity {
-    #[serde(rename = "PartitionKey")]
-    partition_key: String,
-    #[serde(rename = "RowKey")]
-    row_key: String,
-    /// Escrow lifecycle state (disabled, bootstrapping, ready, etc.).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    escrow_state: Option<String>,
-    /// Current master key version.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    escrow_key_version: Option<i64>,
-    /// Base64-encoded KDF salt bytes.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    escrow_salt: Option<String>,
-    /// JSON-encoded KDF parameters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    kdf_params_json: Option<String>,
-    /// ACTUAL_STATE message timestamp (Unix milliseconds) for out-of-order guard.
-    #[serde(default)]
-    timestamp_ms: i64,
-}
-
-/// Azure Table entity for KDF salt (AZH-0603).
-#[derive(Debug, Deserialize, Serialize, Clone)]
-struct GatewayEscrowSaltEntity {
-    #[serde(rename = "PartitionKey")]
-    partition_key: String,
-    #[serde(rename = "RowKey")]
-    row_key: String,
-    /// Base64-encoded KDF salt bytes.
-    salt: String,
-    /// JSON-encoded KDF parameters.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    kdf_params_json: Option<String>,
-    /// Creation timestamp (Unix milliseconds).
-    created_at: i64,
 }
 
 // Equal-timestamp ordering is only guaranteed within one handler process
@@ -2019,205 +1410,10 @@ fn optional_text_field(
     }
 }
 
-fn optional_u16_field(
-    map: &[(Value, Value)],
-    key: u64,
-    field: &str,
-) -> Result<Option<u16>, HandlerError> {
-    match map_get(map, key) {
-        Some(Value::Null) | None => Ok(None),
-        Some(value) => value
-            .as_integer()
-            .and_then(|i| u64::try_from(i).ok())
-            .and_then(|v| u16::try_from(v).ok())
-            .map(Some)
-            .ok_or_else(|| HandlerError::Decode(format!("`{field}` must be uint or null"))),
-    }
-}
-
-fn optional_u64_field(
-    map: &[(Value, Value)],
-    key: u64,
-    field: &str,
-) -> Result<Option<u64>, HandlerError> {
-    match map_get(map, key) {
-        Some(Value::Null) | None => Ok(None),
-        Some(value) => value
-            .as_integer()
-            .and_then(|i| u64::try_from(i).ok())
-            .map(Some)
-            .ok_or_else(|| HandlerError::Decode(format!("`{field}` must be uint or null"))),
-    }
-}
-
-fn optional_text_array_field(
-    map: &[(Value, Value)],
-    key: u64,
-) -> Result<Vec<String>, HandlerError> {
-    match map_get(map, key) {
-        Some(Value::Array(arr)) => {
-            let mut result = Vec::with_capacity(arr.len());
-            for v in arr {
-                match v {
-                    Value::Text(s) => result.push(s.clone()),
-                    _ => {
-                        return Err(HandlerError::Decode(
-                            "fingerprint_words array contains non-text entry".into(),
-                        ));
-                    }
-                }
-            }
-            Ok(result)
-        }
-        Some(Value::Null) | None => Ok(Vec::new()),
-        Some(other) => Err(HandlerError::Decode(format!(
-            "fingerprint_words must be an array, got {:?}",
-            other
-        ))),
-    }
-}
-
 fn opt_bytes_value(value: Option<&[u8]>) -> Value {
     match value {
         Some(bytes) => Value::Bytes(bytes.to_vec()),
         None => Value::Null,
-    }
-}
-
-fn decode_optional_status_details(
-    map: &[(Value, Value)],
-    key: u64,
-) -> Result<Option<GatewayStatusDetails>, HandlerError> {
-    match map_get(map, key) {
-        Some(Value::Map(sd_pairs)) => {
-            let mut escrow_state = None;
-            let mut escrow_key_version = None;
-            let mut escrow_salt = None;
-            let mut escrow_kdf_params = None;
-
-            for (k, v) in sd_pairs {
-                let sd_key = match k {
-                    Value::Integer(i) => {
-                        let val: i128 = (*i).into();
-                        u64::try_from(val).ok()
-                    }
-                    _ => None,
-                };
-                match sd_key {
-                    Some(1) => {
-                        if let Value::Text(s) = v {
-                            escrow_state = Some(s.clone());
-                        } else {
-                            return Err(HandlerError::Decode(
-                                "status_details escrow_state must be text".into(),
-                            ));
-                        }
-                    }
-                    Some(2) => {
-                        if let Value::Integer(i) = v {
-                            let val: i128 = (*i).into();
-                            escrow_key_version = Some(u64::try_from(val).map_err(|_| {
-                                HandlerError::Decode(format!(
-                                    "status_details escrow_key_version {val} out of u64 range"
-                                ))
-                            })?);
-                        } else {
-                            return Err(HandlerError::Decode(
-                                "status_details escrow_key_version must be an integer".into(),
-                            ));
-                        }
-                    }
-                    Some(3) => {
-                        if let Value::Bytes(b) = v {
-                            if b.len() != 16 {
-                                return Err(HandlerError::Decode(format!(
-                                    "escrow_salt must be 16 bytes, got {}",
-                                    b.len()
-                                )));
-                            }
-                            escrow_salt = Some(b.clone());
-                        } else if !matches!(v, Value::Null) {
-                            return Err(HandlerError::Decode(
-                                "status_details escrow_salt must be bytes".into(),
-                            ));
-                        }
-                    }
-                    Some(4) => {
-                        if let Value::Map(kdf_pairs) = v {
-                            let mut m_cost: Option<u32> = None;
-                            let mut t_cost: Option<u32> = None;
-                            let mut p_cost: Option<u32> = None;
-                            let mut kdf_version: Option<u32> = None;
-                            for (kk, kv) in kdf_pairs {
-                                let kdf_key = match kk {
-                                    Value::Integer(i) => {
-                                        let val: i128 = (*i).into();
-                                        u64::try_from(val).ok()
-                                    }
-                                    _ => None,
-                                };
-                                if let Value::Integer(iv) = kv {
-                                    let val: i128 = (*iv).into();
-                                    let val32 = u32::try_from(val).map_err(|_| {
-                                        HandlerError::Decode(format!(
-                                            "KDF parameter value {val} out of u32 range"
-                                        ))
-                                    })?;
-                                    match kdf_key {
-                                        Some(1) => m_cost = Some(val32),
-                                        Some(2) => t_cost = Some(val32),
-                                        Some(3) => p_cost = Some(val32),
-                                        Some(4) => kdf_version = Some(val32),
-                                        _ => {}
-                                    }
-                                }
-                            }
-                            match (m_cost, t_cost, p_cost, kdf_version) {
-                                (Some(m), Some(t), Some(p), Some(v)) => {
-                                    escrow_kdf_params = Some(KdfParams {
-                                        m_cost: m,
-                                        t_cost: t,
-                                        p_cost: p,
-                                        kdf_version: v,
-                                    });
-                                }
-                                _ => {
-                                    return Err(HandlerError::Decode(
-                                        "escrow_kdf_params map is missing required subkeys (m_cost, t_cost, p_cost, version)".into(),
-                                    ));
-                                }
-                            }
-                        } else if !matches!(v, Value::Null) {
-                            return Err(HandlerError::Decode(
-                                "status_details escrow_kdf_params must be a map".into(),
-                            ));
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            // Only return Some if at least one field was populated.
-            if escrow_state.is_some()
-                || escrow_key_version.is_some()
-                || escrow_salt.is_some()
-                || escrow_kdf_params.is_some()
-            {
-                Ok(Some(GatewayStatusDetails {
-                    escrow_state,
-                    escrow_key_version,
-                    escrow_salt,
-                    escrow_kdf_params,
-                }))
-            } else {
-                Ok(None)
-            }
-        }
-        Some(Value::Null) | None => Ok(None),
-        Some(other) => Err(HandlerError::Decode(format!(
-            "status_details (key 10) must be a map, got {:?}",
-            other
-        ))),
     }
 }
 
@@ -2310,10 +1506,6 @@ mod tests {
         program_images: Mutex<HashMap<String, ProgramImageRow>>,
         stored_program_rows: Mutex<Vec<ProgramImageRow>>,
         sensor_data_rows: Mutex<Vec<SensorDataRow>>,
-        escrow_blobs_by_hint: Mutex<HashMap<u16, Vec<Vec<u8>>>>,
-        stored_gateway_pubkeys: Mutex<Vec<(Vec<u8>, u64, u64)>>,
-        stored_escrow_state: Mutex<Option<GatewayStatusDetails>>,
-        stored_salt: Mutex<Option<Vec<u8>>>,
     }
 
     impl MemoryStore {
@@ -2359,13 +1551,6 @@ mod tests {
                 .lock()
                 .await
                 .insert(hex::encode(program_hash), row);
-        }
-
-        async fn set_escrow_blobs(&self, key_hint: u16, blobs: Vec<Vec<u8>>) {
-            self.escrow_blobs_by_hint
-                .lock()
-                .await
-                .insert(key_hint, blobs);
         }
     }
 
@@ -2432,59 +1617,6 @@ mod tests {
         async fn append_sensor_data(&self, row: &SensorDataRow) -> Result<(), HandlerError> {
             self.sensor_data_rows.lock().await.push(row.clone());
             Ok(())
-        }
-
-        async fn store_gateway_escrow_pubkey(
-            &self,
-            public_key: &[u8],
-            key_epoch: u64,
-            created_at: u64,
-        ) -> Result<(), HandlerError> {
-            self.stored_gateway_pubkeys.lock().await.push((
-                public_key.to_vec(),
-                key_epoch,
-                created_at,
-            ));
-            Ok(())
-        }
-
-        async fn load_escrow_blobs_by_key_hint(
-            &self,
-            key_hint: u16,
-            max_candidates: usize,
-        ) -> Result<Vec<Vec<u8>>, HandlerError> {
-            let blobs = self
-                .escrow_blobs_by_hint
-                .lock()
-                .await
-                .get(&key_hint)
-                .cloned()
-                .unwrap_or_default();
-            Ok(blobs.into_iter().take(max_candidates).collect())
-        }
-
-        async fn store_gateway_escrow_state(
-            &self,
-            details: &GatewayStatusDetails,
-            _timestamp_ms: u64,
-        ) -> Result<(), HandlerError> {
-            *self.stored_escrow_state.lock().await = Some(details.clone());
-            Ok(())
-        }
-
-        async fn store_escrow_salt_if_absent(
-            &self,
-            salt: &[u8],
-            _kdf_params: Option<&KdfParams>,
-            _created_at: u64,
-        ) -> Result<bool, HandlerError> {
-            let mut stored = self.stored_salt.lock().await;
-            if stored.is_some() {
-                Ok(false)
-            } else {
-                *stored = Some(salt.to_vec());
-                Ok(true)
-            }
         }
     }
 
@@ -2773,34 +1905,6 @@ mod tests {
         bytes
     }
 
-    fn sample_key_escrow_request(key_hint: u16, request_id: [u8; 16]) -> Vec<u8> {
-        let value = Value::Map(vec![
-            map_entry(
-                1,
-                Value::Integer(sonde_protocol::CONNECTOR_MSG_TYPE_KEY_ESCROW_REQUEST.into()),
-            ),
-            map_entry(2, Value::Integer((key_hint as u64).into())),
-            map_entry(3, Value::Bytes(request_id.to_vec())),
-        ]);
-        let mut bytes = Vec::new();
-        ciborium::into_writer(&value, &mut bytes).unwrap();
-        bytes
-    }
-
-    fn sample_master_key_install() -> Vec<u8> {
-        let value = Value::Map(vec![
-            map_entry(
-                1,
-                Value::Integer(sonde_protocol::CONNECTOR_MSG_TYPE_MASTER_KEY_INSTALL.into()),
-            ),
-            map_entry(2, Value::Bytes(vec![0xAA; 32])),
-            map_entry(3, Value::Bytes(vec![0xBB; 16])),
-        ]);
-        let mut bytes = Vec::new();
-        ciborium::into_writer(&value, &mut bytes).unwrap();
-        bytes
-    }
-
     #[tokio::test]
     async fn first_actual_state_appends_row_without_publish_when_desired_is_absent() {
         let store = Arc::new(MemoryStore::default());
@@ -2942,9 +2046,6 @@ mod tests {
                 firmware_abi_version: Some(2),
                 firmware_version: Some("2.0.0".to_string()),
                 timestamp_ms: 5000,
-                encrypted_psk_escrow: None,
-                escrow_key_hint: None,
-                escrow_key_version: None,
             })
             .await
             .unwrap();
@@ -3053,9 +2154,6 @@ mod tests {
                 firmware_abi_version: Some(1),
                 firmware_version: Some("1.2.3".to_string()),
                 timestamp_ms: 1234,
-                encrypted_psk_escrow: None,
-                escrow_key_hint: None,
-                escrow_key_version: None,
             },
             desired: desired_row("node-1", Some(vec![0xCC; 32]), Some(60), 100),
             appended_rows: Mutex::new(Vec::new()),
@@ -3111,64 +2209,6 @@ mod tests {
         ));
         assert_eq!(store.appended_rows.lock().await.len(), 1);
         assert!(publisher.sends.lock().await.is_empty());
-    }
-
-    #[tokio::test]
-    async fn key_escrow_request_publishes_response_candidates() {
-        let store = Arc::new(MemoryStore::default());
-        store
-            .set_escrow_blobs(0x1234, vec![vec![0xA1; 12], vec![0xB2; 24]])
-            .await;
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
-        let request_id = [0xAB; 16];
-
-        handler
-            .handle_payload(&sample_key_escrow_request(0x1234, request_id))
-            .await
-            .unwrap();
-
-        let sends = publisher.sends.lock().await;
-        assert_eq!(sends.len(), 1);
-        assert_eq!(sends[0].0, "downstream");
-        let response = decode_map(&sends[0].1).unwrap();
-        assert_eq!(
-            required_u64(&response, 1, "msg_type").unwrap(),
-            sonde_protocol::CONNECTOR_MSG_TYPE_KEY_ESCROW_RESPONSE
-        );
-        assert_eq!(
-            required_bytes(&response, 2, "request_id").unwrap(),
-            request_id.to_vec()
-        );
-        assert_eq!(required_u64(&response, 4, "key_hint").unwrap(), 0x1234);
-        let candidates = match map_get(&response, 3) {
-            Some(Value::Array(values)) => values,
-            other => panic!("expected candidates array, got {other:?}"),
-        };
-        assert_eq!(candidates.len(), 2);
-        match &candidates[0] {
-            Value::Bytes(bytes) => assert_eq!(bytes, &vec![0xA1; 12]),
-            other => panic!("expected first candidate bytes, got {other:?}"),
-        }
-        match &candidates[1] {
-            Value::Bytes(bytes) => assert_eq!(bytes, &vec![0xB2; 24]),
-            other => panic!("expected second candidate bytes, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn master_key_install_is_relayed_verbatim() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
-        let payload = sample_master_key_install();
-
-        handler.handle_payload(&payload).await.unwrap();
-
-        let sends = publisher.sends.lock().await;
-        assert_eq!(sends.len(), 1);
-        assert_eq!(sends[0].0, "downstream");
-        assert_eq!(sends[0].1, payload);
     }
 
     #[tokio::test]
@@ -3299,9 +2339,6 @@ mod tests {
             firmware_abi_version: Some(1),
             firmware_version: Some("1.2.3".to_string()),
             timestamp_ms: 1234,
-            encrypted_psk_escrow: None,
-            escrow_key_hint: None,
-            escrow_key_version: None,
         };
 
         let entity = ActualStateEntity::try_from(row.clone()).unwrap();
@@ -4269,34 +3306,6 @@ mod tests {
     // ── decode_optional_readings error path tests ──────────────────────
 
     #[test]
-    fn decode_key_escrow_pubkey_rejects_non_text_fingerprint_words() {
-        let value = Value::Map(vec![
-            map_entry(
-                1,
-                Value::Integer(sonde_protocol::CONNECTOR_MSG_TYPE_KEY_ESCROW_PUBKEY.into()),
-            ),
-            map_entry(2, Value::Bytes(vec![0x42u8; 32])),
-            map_entry(3, Value::Integer(1u64.into())),
-            map_entry(4, Value::Integer(2u64.into())),
-            map_entry(
-                5,
-                Value::Array(vec![
-                    Value::Text("abandon".to_string()),
-                    Value::Integer(7u64.into()),
-                ]),
-            ),
-        ]);
-        let mut bytes = Vec::new();
-        ciborium::into_writer(&value, &mut bytes).unwrap();
-        let err = decode_connector_message(&bytes).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("fingerprint_words array contains non-text entry"),
-            "expected fingerprint_words error, got: {err}"
-        );
-    }
-
-    #[test]
     fn decode_readings_rejects_non_map_value() {
         let value = Value::Map(vec![
             map_entry(1, Value::Integer(MSG_TYPE_APP_DATA.into())),
@@ -4362,59 +3371,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_escrow_store_methods_return_errors() {
-        struct DefaultEscrowStore;
-
-        #[async_trait]
-        impl HandlerStore for DefaultEscrowStore {
-            async fn append_actual_state(&self, _: &ActualStateRow) -> Result<(), HandlerError> {
-                Ok(())
-            }
-            async fn load_latest_actual_state(
-                &self,
-                _: &str,
-            ) -> Result<Option<ActualStateRow>, HandlerError> {
-                Ok(None)
-            }
-            async fn load_latest_desired_state(
-                &self,
-                _: &str,
-            ) -> Result<Option<DesiredStateRow>, HandlerError> {
-                Ok(None)
-            }
-            async fn load_program_image(
-                &self,
-                _: &[u8],
-            ) -> Result<Option<ProgramImageRow>, HandlerError> {
-                Ok(None)
-            }
-            async fn store_program_image(&self, _: &ProgramImageRow) -> Result<(), HandlerError> {
-                Ok(())
-            }
-            async fn append_sensor_data(&self, _: &SensorDataRow) -> Result<(), HandlerError> {
-                Ok(())
-            }
-        }
-
-        let store = DefaultEscrowStore;
-        let err = store
-            .store_gateway_escrow_pubkey(&[0x42u8; 32], 1, 2)
-            .await
-            .unwrap_err();
-        assert!(
-            matches!(err, HandlerError::Store(message) if message.contains("store_gateway_escrow_pubkey not implemented"))
-        );
-
-        let err = store
-            .load_escrow_blobs_by_key_hint(0x1234, 4)
-            .await
-            .unwrap_err();
-        assert!(
-            matches!(err, HandlerError::Store(message) if message.contains("load_escrow_blobs_by_key_hint not implemented"))
-        );
-    }
-
-    #[tokio::test]
     async fn gateway_actual_state_is_informational_only() {
         let store = Arc::new(MemoryStore::default());
         let publisher = Arc::new(RecordingPublisher::default());
@@ -4434,76 +3390,6 @@ mod tests {
         assert!(publisher.sends.lock().await.is_empty());
     }
 
-    #[tokio::test]
-    async fn gateway_actual_state_persists_escrow_status_details() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
-
-        // Build status_details map: key 10 in the ACTUAL_STATE
-        let status_details = Value::Map(vec![
-            map_entry(1, Value::Text("ready".to_string())),
-            map_entry(2, Value::Integer(3u64.into())),
-            map_entry(3, Value::Bytes(vec![0xAA; 16])),
-            map_entry(
-                4,
-                Value::Map(vec![
-                    map_entry(1, Value::Integer(65536u64.into())),
-                    map_entry(2, Value::Integer(3u64.into())),
-                    map_entry(3, Value::Integer(1u64.into())),
-                    map_entry(4, Value::Integer(1u64.into())),
-                ]),
-            ),
-        ]);
-
-        let value = Value::Map(vec![
-            map_entry(1, Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
-            map_entry(2, Value::Text("gateway".to_string())),
-            map_entry(3, Value::Text("gateway-1".to_string())),
-            map_entry(9, Value::Integer(1234u64.into())),
-            map_entry(10, status_details),
-        ]);
-        let mut payload = Vec::new();
-        ciborium::into_writer(&value, &mut payload).unwrap();
-
-        handler.handle_payload(&payload).await.unwrap();
-        let state = store.stored_escrow_state.lock().await;
-        let details = state.as_ref().unwrap();
-        assert_eq!(details.escrow_state, Some("ready".to_string()));
-        assert_eq!(details.escrow_key_version, Some(3));
-        assert_eq!(details.escrow_salt, Some(vec![0xAA; 16]));
-        let kdf = details.escrow_kdf_params.as_ref().unwrap();
-        assert_eq!(kdf.m_cost, 65536);
-        assert_eq!(kdf.t_cost, 3);
-        assert_eq!(kdf.p_cost, 1);
-        assert_eq!(kdf.kdf_version, 1);
-    }
-
-    #[test]
-    fn phone_actual_state_uses_phone_partition_key() {
-        let row = ActualStateRow {
-            row_key: next_history_row_key(1234).unwrap(),
-            entity_kind: "phone".to_string(),
-            node_id: "phone-42".to_string(),
-            observed_current_program_hash: None,
-            observed_assigned_program_hash: None,
-            observed_schedule_interval_s: None,
-            battery_mv: None,
-            firmware_abi_version: None,
-            firmware_version: None,
-            timestamp_ms: 1234,
-            encrypted_psk_escrow: Some(vec![0xBB; 48]),
-            escrow_key_hint: Some(0x1234),
-            escrow_key_version: Some(1),
-        };
-        let entity = ActualStateEntity::try_from(row).unwrap();
-        assert!(
-            entity.partition_key.starts_with("p:"),
-            "phone entity should use 'p:' partition prefix, got: {}",
-            entity.partition_key
-        );
-    }
-
     #[test]
     fn node_actual_state_uses_node_partition_key() {
         let row = ActualStateRow {
@@ -4517,76 +3403,12 @@ mod tests {
             firmware_abi_version: None,
             firmware_version: None,
             timestamp_ms: 1234,
-            encrypted_psk_escrow: None,
-            escrow_key_hint: None,
-            escrow_key_version: None,
         };
         let entity = ActualStateEntity::try_from(row).unwrap();
         assert!(
             entity.partition_key.starts_with("n:"),
             "node entity should use 'n:' partition prefix, got: {}",
             entity.partition_key
-        );
-    }
-
-    #[tokio::test]
-    async fn gateway_actual_state_stores_salt_first_writer_wins() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
-
-        let status_details = Value::Map(vec![
-            map_entry(1, Value::Text("bootstrapping".to_string())),
-            map_entry(3, Value::Bytes(vec![0xBB; 16])),
-            map_entry(
-                4,
-                Value::Map(vec![
-                    map_entry(1, Value::Integer(65536u64.into())),
-                    map_entry(2, Value::Integer(3u64.into())),
-                    map_entry(3, Value::Integer(1u64.into())),
-                    map_entry(4, Value::Integer(1u64.into())),
-                ]),
-            ),
-        ]);
-
-        let value = Value::Map(vec![
-            map_entry(1, Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
-            map_entry(2, Value::Text("gateway".to_string())),
-            map_entry(3, Value::Text("gateway-1".to_string())),
-            map_entry(9, Value::Integer(1000u64.into())),
-            map_entry(10, status_details),
-        ]);
-        let mut payload = Vec::new();
-        ciborium::into_writer(&value, &mut payload).unwrap();
-
-        // First write should succeed.
-        handler.handle_payload(&payload).await.unwrap();
-        assert_eq!(
-            store.stored_salt.lock().await.as_deref(),
-            Some([0xBBu8; 16].as_slice())
-        );
-
-        // Second write with different salt should be ignored (first-writer-wins).
-        let status_details2 = Value::Map(vec![
-            map_entry(1, Value::Text("ready".to_string())),
-            map_entry(3, Value::Bytes(vec![0xCC; 16])),
-        ]);
-        let value2 = Value::Map(vec![
-            map_entry(1, Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
-            map_entry(2, Value::Text("gateway".to_string())),
-            map_entry(3, Value::Text("gateway-1".to_string())),
-            map_entry(9, Value::Integer(2000u64.into())),
-            map_entry(10, status_details2),
-        ]);
-        let mut payload2 = Vec::new();
-        ciborium::into_writer(&value2, &mut payload2).unwrap();
-
-        handler.handle_payload(&payload2).await.unwrap();
-        // Salt should still be the original.
-        assert_eq!(
-            store.stored_salt.lock().await.as_deref(),
-            Some([0xBBu8; 16].as_slice()),
-            "salt should not be overwritten (first-writer-wins)"
         );
     }
 }

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -169,7 +169,7 @@ The row contains the following logical columns:
 
 | Column | Purpose |
 |--------|---------|
-| `entity_kind` | Entity kind string (e.g. `"node"`). Routes the partition key prefix (`"n:"` for nodes). |
+| `entity_kind` | Entity kind string (e.g. `"node"`). In-memory only — not persisted as an Azure Table property. Derived from the `PartitionKey` prefix on read (`"n:"` → `"node"`). Present in the handler's row model for dispatch routing. |
 | `node_id` | Original opaque node identifier used by gateway and handlers. |
 | `observed_current_program_hash` | Node-reported current resident program hash, nullable. |
 | `observed_assigned_program_hash` | Gateway-reported assigned resident program hash, nullable. |

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -169,7 +169,7 @@ The row contains the following logical columns:
 
 | Column | Purpose |
 |--------|---------|
-| `entity_kind` | Entity kind string (e.g. `"node"`). In-memory only — not persisted as an Azure Table property. Derived from the `PartitionKey` prefix on read (`"n:"` → `"node"`). Present in the handler's row model for dispatch routing. |
+| `entity_kind` | Entity kind string. In-memory only — not persisted as an Azure Table property. Currently hard-coded to `"node"` on deserialization since the handler only processes node-scoped rows. Present in the handler's row model for dispatch routing. |
 | `node_id` | Original opaque node identifier used by gateway and handlers. |
 | `observed_current_program_hash` | Node-reported current resident program hash, nullable. |
 | `observed_assigned_program_hash` | Gateway-reported assigned resident program hash, nullable. |

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -5,8 +5,8 @@
 > **Document status:** Draft
 > **Scope:** Internal design for the Azure cloud-side handler hosted in the
 > Azure Function App. Covers upstream connector message intake, Azure Table
-> schemas, node-state reconciliation, downstream `GW-0811` publication, and
-> `GW-0813` sensor data storage.
+> schemas, node-state reconciliation, downstream `GW-0811` publication,
+> `GW-0813` sensor data storage, and BPF program ingestion.
 > **Audience:** Implementers building the Azure Function App and reviewers
 > auditing traceability to the gateway connector contract.
 > **Related:** [azure-handler-requirements.md](azure-handler-requirements.md),
@@ -26,8 +26,10 @@ Azure handler owns the first Sonde-aware cloud logic:
 1. consume upstream connector messages from the upstream queue,
 2. append node-scoped `GW-0812` actual-state messages to actual-state history,
 3. compare the latest eligible actual-state row against the latest desired-state
-   row and publish a complete node-scoped `GW-0811` when they diverge, and
-4. store `GW-0813` application-data messages in the `SensorData` table.
+   row and publish a complete node-scoped `GW-0811` when they diverge,
+4. store `GW-0813` application-data messages in the `SensorData` table, and
+5. accept BPF program ELF uploads via an HTTP trigger, verify and store them in
+   the `Programs` table for downstream embedding.
 
 The handler does not replace the gateway's reconciler model. It expresses cloud
 intent only by publishing `GW-0811` desired-state messages.
@@ -42,18 +44,60 @@ The Azure handler runs inside the Azure Function App provisioned by the Bicep
 stack. The Function App uses a system-assigned managed identity with:
 
 1. receive permission on the upstream queue,
-2. send permission on the downstream queue, and
+2. send permission on the downstream queue,
 3. append permission on `ActualNodeState`, read permission on
-   `DesiredNodeState`, and read/write permission on `SensorData`.
+   `DesiredNodeState`, and read/write permission on `SensorData`, and
+4. read/write permission on `Programs` (read for ELF embedding in `GW-0811`,
+   write for program ingestion via the `ProgramIngest` HTTP trigger).
 
 The final permission set covers the handler's own tables. No external handler
 queue permissions are required.
 
 ### 2.1  Trigger model
 
-The Function App uses a Storage Queue-triggered entrypoint for upstream connector
-messages. Each invocation receives one raw connector payload from the upstream
-queue and performs the following dispatch:
+The Azure handler is deployed as an Azure Functions **Custom Handler**. Instead
+of running in-process, the Functions host forwards trigger invocations as HTTP
+requests to an Axum HTTP server listening on the port specified by the
+`FUNCTIONS_CUSTOMHANDLER_PORT` environment variable (default `3000`).
+
+The server exposes three routes:
+
+| Route | Trigger type | Purpose |
+|-------|-------------|---------|
+| `POST /` | Storage Queue | Upstream connector message dispatch |
+| `POST /{*path}` | Storage Queue (fallback) | Same as above — catches any function name path |
+| `POST /ProgramIngest` | HTTP (`/api/programs/ingest`) | Program ingestion (§8) |
+
+#### Queue trigger envelope
+
+For Storage Queue-triggered invocations the Functions host wraps the queue
+message in a JSON envelope. The handler extracts the raw connector payload by
+probing the following paths in order:
+
+1. `data.message`
+2. `Data.message`
+3. `Data` (top-level)
+4. `Body` or `body` (top-level)
+5. If `data` is an object with exactly one key, use that key's value.
+
+The extracted value is then decoded as:
+
+- a JSON **string** — stripped of surrounding double-quotes if present, then
+  base64-decoded (falling back to raw UTF-8 bytes if base64 fails),
+- a JSON **array** — interpreted as a byte array of `u8` values, or
+- a JSON **object** — re-serialized as JSON bytes.
+
+#### HTTP trigger envelope
+
+For the `ProgramIngest` HTTP trigger the Functions host wraps the HTTP request
+body in an envelope at `Data.req.Body` (case-insensitive: `data`/`Data`,
+`req`/`Req`, `Body`/`body`). The handler extracts and JSON-parses the body
+string.
+
+#### Dispatch rules
+
+After extracting the connector payload from a queue trigger, the handler
+performs the following dispatch:
 
 1. decode the top-level connector `msg_type`,
 2. if `msg_type = ACTUAL_STATE` and `entity_kind = "node"`, invoke node-state
@@ -86,8 +130,9 @@ node reconciliation it consumes:
 7. `timestamp_ms` as last check-in time, and
 8. `schedule_interval_s`.
 
-Gateway-scoped `ACTUAL_STATE` messages are outside the node-table ownership of
-this document and are therefore logged and ignored by the reconciliation path.
+Gateway-scoped and phone-scoped `ACTUAL_STATE` messages (`entity_kind` values
+other than `"node"`) are outside the node-table ownership of this document and
+are therefore logged and ignored by the handler.
 
 ### 3.2  `GW-0813` fields consumed by the handler
 
@@ -104,24 +149,27 @@ Fields beyond `program_hash` were previously opaque to the handler; the
 
 ## 4  Azure Table schemas
 
-> **Requirements:** AZH-0200, AZH-0205, AZH-0206
+> **Requirements:** AZH-0200, AZH-0205, AZH-0206, AZH-0500, WEB-0304
 
-The design uses two Azure Tables:
+The design uses four Azure Tables:
 
 1. **`ActualNodeState`** — append-only actual-state history keyed for latest-per-node queries.
 2. **`DesiredNodeState`** — append-only desired-state history keyed for latest-per-node queries.
+3. **`SensorData`** — append-only sensor data history (§6.1).
+4. **`Programs`** — BPF program image store, upserted by `ProgramIngest` (§8).
 
 ### 4.1  `ActualNodeState` schema
 
 Each row uses:
 
 - `PartitionKey = "n:" + lowercase hex-encoded SHA-256(node_id UTF-8 bytes)`
-- `RowKey = <reverse_tick_ms as fixed-width lowercase hex> + ":" + <implementation-defined suffix that preserves append uniqueness and orders later appends first within the same timestamp for one handler process lifetime>`
+- `RowKey = <reverse_tick_hex>:<reverse_sequence_hex>:<process_nonce_hex>` (see [History RowKey format](#history-rowkey-format) below)
 
 The row contains the following logical columns:
 
 | Column | Purpose |
 |--------|---------|
+| `entity_kind` | Entity kind string (e.g. `"node"`). Routes the partition key prefix (`"n:"` for nodes). |
 | `node_id` | Original opaque node identifier used by gateway and handlers. |
 | `observed_current_program_hash` | Node-reported current resident program hash, nullable. |
 | `observed_assigned_program_hash` | Gateway-reported assigned resident program hash, nullable. |
@@ -133,19 +181,15 @@ The row contains the following logical columns:
 
 The node-scoped `PartitionKey` keeps each node's history in one queryable
 partition. The reverse-tick `RowKey` prefix makes newer timestamps sort first.
-The suffix preserves append-only behavior when multiple deliveries share the
-same `timestamp_ms`, and it orders later appends before earlier appends only
-within one handler process lifetime. Across restarts or concurrent handler
-instances, equal-timestamp row ordering is intentionally unspecified, so the
-reconciliation path must not depend on `Top(1)` returning the most recently
-appended equal-timestamp row.
+See [History RowKey format](#history-rowkey-format) for the complete three-part
+scheme.
 
 ### 4.2  `DesiredNodeState` schema
 
 Each row uses:
 
 - `PartitionKey = "n:" + lowercase hex-encoded SHA-256(node_id UTF-8 bytes)`
-- `RowKey = <reverse_tick_ms as fixed-width lowercase hex> + ":" + <implementation-defined suffix that preserves append uniqueness and orders later appends first within the same timestamp for one handler process lifetime>`
+- `RowKey = <reverse_tick_hex>:<reverse_sequence_hex>:<process_nonce_hex>` (see [History RowKey format](#history-rowkey-format))
 
 The row contains:
 
@@ -158,6 +202,53 @@ The row contains:
 
 The Azure handler reads this table but does not write it. Admin/control-plane
 surfaces append desired-state rows when requested state changes.
+
+### 4.3  History RowKey format
+
+All history tables (`ActualNodeState`, `DesiredNodeState`, and `SensorData`)
+use the same three-part `RowKey` format:
+
+```
+{reverse_tick_hex}:{reverse_sequence_hex}:{process_nonce_hex}
+```
+
+Each component is a 16-character, zero-padded, lowercase hexadecimal `u64`:
+
+| Component | Value | Purpose |
+|-----------|-------|---------|
+| `reverse_tick_hex` | `u64::MAX - timestamp_ms` | Newest timestamps sort first for `Top(1)` queries. |
+| `reverse_sequence_hex` | `u64::MAX - sequence` | Monotonically incrementing per-process counter (reversed). Within one handler process lifetime, later appends sort before earlier appends when timestamps are equal. |
+| `process_nonce_hex` | Random `u64` generated once at process startup | Provides probabilistic uniqueness across concurrent handler instances and restarts; collisions are negligibly unlikely. |
+
+The `":"` separators ensure that each component is compared independently during
+lexicographic ordering. Across restarts or concurrent handler instances,
+equal-timestamp row ordering is intentionally unspecified, so the reconciliation
+path must not depend on `Top(1)` returning the most recently appended
+equal-timestamp row.
+
+### 4.4  `Programs` table schema
+
+The `Programs` table stores ingested BPF program images. It is written by the
+`ProgramIngest` HTTP trigger (§8) and read by the reconciliation path when
+embedding ELF images in downstream `GW-0811` payloads (§5 step 11).
+
+Each row uses:
+
+- `PartitionKey = "program"` (single partition for all programs)
+- `RowKey = lowercase hex-encoded program_hash`
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `cbor_image` | `String` (base64) | CBOR-encoded BPF program image extracted from ELF. |
+| `elf_image` | `String` (base64) | Original uploaded ELF binary, max 1 MB. Used for inline embedding in `GW-0811`. |
+| `source_filename` | `String` | Normalized source filename (basename only), nullable. |
+| `abi_version` | `Edm.Int32` | Firmware ABI version the program targets, nullable. |
+| `size_bytes` | `Edm.Int32` | CBOR image size in bytes. |
+| `verification_profile` | `String` | `"resident"` or `"ephemeral"`. |
+| `created_at` | `String` | ISO 8601 UTC timestamp of ingestion. |
+
+Programs are upserted (insert-or-replace) keyed by `program_hash`. Re-ingesting
+the same ELF overwrites the existing row.
 
 ---
 
@@ -263,8 +354,8 @@ exceeding that threshold are encoded as JSON strings to preserve precision
 (AZH-0501 AC-5). Otherwise `decoded_readings` is `""`.
 
 The `PartitionKey` and `RowKey` follow the same patterns as `ActualNodeState`
-(§4.1) — hashed partition key for safe table keys, reverse-tick plus uniqueness
-suffix for chronological ordering and append uniqueness.
+— hashed partition key for safe table keys, three-part history RowKey (§4.3)
+for chronological ordering and append uniqueness.
 
 `SensorData` writes complete the `GW-0813` handling path — no further routing
 or delivery is performed.
@@ -316,3 +407,77 @@ operations that determine externally visible control-plane behavior:
 This failure model preserves at-least-once retry behavior from the Azure
 Function runtime instead of silently pretending that state was reconciled or
 sensor data was stored.
+
+---
+
+## 8  Program ingestion
+
+> **Requirements:** WEB-0300, WEB-0301, WEB-0302, WEB-0303, WEB-0304,
+> WEB-0305, WEB-0306, WEB-0307, WEB-0308
+> (defined in [web-ui-requirements.md](web-ui-requirements.md))
+
+The Azure handler hosts the `ProgramIngest` HTTP trigger endpoint used by the
+SPA (and any authorized client) to upload BPF ELF binaries for verification
+and storage.
+
+### 8.1  Endpoint
+
+| Property | Value |
+|----------|-------|
+| External route | `POST /api/programs/ingest` |
+| Auth level | `anonymous` (authentication enforced by Function App EasyAuth; see WEB-0503, WEB-0606, WEB-0607 in [web-ui-requirements.md](web-ui-requirements.md) and [azure-provisioning-design.md](azure-provisioning-design.md)) |
+| Custom Handler route | `POST /ProgramIngest` |
+| Binding | `ProgramIngest/function.json` — HTTP trigger in, HTTP out (`res`) |
+
+### 8.2  Request schema
+
+The request body is JSON:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `elf` | `String` (base64) | Yes | Base64-encoded ELF binary. |
+| `source_filename` | `String` | No | Original filename. Normalized to basename only (path components stripped). |
+| `abi_version` | `Integer` | No | Firmware ABI version the program targets. Must be non-negative and ≤ `i32::MAX` (2,147,483,647). |
+| `verification_profile` | `String` | No | `"resident"` (default) or `"ephemeral"`. Controls BPF verification profile and CBOR image size limits. |
+
+### 8.3  Validation rules
+
+1. `elf` must be present, non-empty, and valid base64.
+2. Decoded ELF size must not exceed 1 MB (1,048,576 bytes). A pre-decode
+   length check on the base64 string rejects obviously oversized payloads
+   before allocating the decoded buffer.
+3. `verification_profile`, if present, must be exactly `"resident"` or
+   `"ephemeral"`.
+4. `abi_version`, if present, must be a non-negative integer within
+   `Edm.Int32` range.
+5. The ELF binary is passed through `ProgramLibrary::ingest_elf()` for BPF
+   bytecode extraction and Prevail verification. Verification failure is
+   rejected with HTTP 422.
+
+### 8.4  Response schema
+
+On success (HTTP 200):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `program_hash` | `String` | Lowercase hex SHA-256 of the CBOR program image. |
+| `size` | `Integer` | CBOR image size in bytes. |
+| `abi_version` | `Integer` | Echo of the supplied ABI version, if any. |
+| `source_filename` | `String` | Normalized filename, if any. |
+
+On error, the response body is `{"error": "<message>"}` with an HTTP status
+code embedded in the Azure Functions output binding envelope:
+
+| Status | Condition |
+|--------|-----------|
+| 400 | Missing or malformed fields, invalid base64, empty ELF. |
+| 413 | ELF exceeds 1 MB size limit. |
+| 422 | BPF verification/ingestion failed (invalid bytecode, size limit exceeded by verification profile). |
+| 500 | Internal error (store write failure). |
+
+### 8.5  Storage
+
+On successful verification the handler upserts one row in the `Programs` table
+(§4.4) containing both the CBOR-encoded program image and the original ELF
+binary. The ELF is retained so the reconciliation path (§5 step 11) can embed
+it in downstream `GW-0811` messages without requiring a separate ELF store.


### PR DESCRIPTION
## Summary

Resolves #1029 — closes all 10 design-vs-implementation drift findings for the Azure handler.

### Specification changes (\docs/azure-handler-design.md\)

**6 findings documented as-is:**

| Finding | Section | Change |
|---------|---------|--------|
| B1: ProgramIngest endpoint | New §8 | Full endpoint spec: route, request/response schemas, validation rules, error codes, storage |
| B5: HTTP runtime | §2.1 | Rewrote trigger model to describe Azure Functions Custom Handler (Axum HTTP server, 3 routes) |
| B6: Programs table | New §4.4 | Table schema (\PartitionKey=\"program\"\, \RowKey=hex(program_hash)\) |
| B7: \ntity_kind\ column | §4.1 | Added column to \ActualNodeState\ schema |
| B9: HTTP envelope parsing | §2.1 | Documented queue and HTTP trigger envelope extraction with fallback paths |
| B10: RowKey suffix | New §4.3 | Documented 3-part scheme (\everse_tick:reverse_sequence:process_nonce\) |

Also updated: §1 scope/overview, §2 permissions (+Programs), §3.1 entity_kind dispatch, §4 table count, §4.2 RowKey reference, §6.1 SensorData RowKey cross-reference. Added WEB-0300–0308 requirement traceability and EasyAuth cross-references.

### Implementation changes (\crates/sonde-azure-handler/src/lib.rs\)

**4 findings resolved by dead code removal (~1000 lines):**

| Finding | Action |
|---------|--------|
| B2: PSK key escrow subsystem | Removed (being replaced by new model) |
| B3: Phone-scoped \ACTUAL_STATE\ | Removed (escrow-only) |
| B4: Gateway-scoped \status_details\ | Removed (escrow-only) |
| B8: \scrow_table\ config | Removed (escrow-only) |

Removed: 4 structs, 3 enum variants, 4 store trait methods + impls, 3 Azure Table entity types, CBOR parsing for keys 10/12/13/14, phone partition logic, 6 tests + 2 test helpers.

### Verification

- \cargo build -p sonde-azure-handler\ ✅
- \cargo test -p sonde-azure-handler\ ✅ (82 passed)
- \cargo clippy -p sonde-azure-handler -- -D warnings\ ✅
- Zero escrow references remain in the handler crate

### Out-of-scope follow-ups

1. SensorData RowKey idempotency claim in §6 (design says queue message ID, impl uses process nonce)
2. \ntity_kind\ is in-memory only — not persisted to Azure Tables (reconstructed from partition prefix)
3. No AZH-series requirements for ProgramIngest or HTTP runtime (traced to WEB-0300+ instead)
