### PR TITLE
docs: resolve azure-companion design-vs-implementation drift

### DIFF
--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -194,6 +194,12 @@ The companion binary mirrors the gateway's Windows service-management fallback:
 3. These commands manage only the service registration; they preserve the
    companion state directory and provisioning artifacts.
 
+When the Windows service fails to start or encounters SCM registration errors,
+the companion writes diagnostic messages to `<state_dir>/service.log` in append
+mode. This file aids post-mortem debugging in headless environments where
+stderr may not be captured. The companion creates the state directory if it
+does not already exist before writing the diagnostic log.
+
 ---
 
 ### 3.6  Live Azure CI runtime topology
@@ -232,7 +238,7 @@ transport and the runtime bridge semantics already defined in section 5.
 ## 4  Bootstrap flow
 
 > **Requirements:** AZC-0200, AZC-0201, AZC-0202, AZC-0203, AZC-0204, AZC-0205, AZC-0300,
-> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0407, AZC-0408, AZC-0409, AZC-0411
+> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0407, AZC-0408, AZC-0409, AZC-0411, AZC-0412
 
 ### 4.1  Bootstrap trigger
 
@@ -292,18 +298,17 @@ When bootstrap is required, the Azure companion performs this sequence:
     `ShowModemDisplayMessage` RPC with a short prompt plus the exact device
     code and `persistent = true` so the code remains visible until the next
     phase replaces it.
-12. Wait for the container to finish. On success, `az deployment sub create`
-    produces JSON deployment outputs on stdout.
-13. Display "Deploying Azure…" on the modem display (transitions from auth to
-    deployment phase may overlap in the single container session).
-14. Capture and parse the JSON outputs to extract `tenantId`, `clientId`,
-    Storage Queue endpoint, queue names, Function App name, and deployment
-    container values from the `companionBootstrapValues` output object.
-15. Use the bundled prebuilt `sonde-azure-handler` package from the bootstrap
-    image to populate the provisioned Function App deployment target.
-16. Poll Azure for Function App activation until the uploaded package is active
-    and at least one function is reported as loaded.
-17. The bootstrap script then deploys the Web UI SPA content and configures the
+12. While the container runs, the Rust companion monitors the stderr stream
+    for structured phase markers emitted by the bootstrap script
+    (`__SONDE_AZURE_DEPLOYMENT_START__`, `__SONDE_AZURE_DEPLOYING_HANDLER__`,
+    `__SONDE_AZURE_CONFIGURING_ENTRA__`) and updates the modem display
+    accordingly ("Deploying Azure…", "Deploying handler…",
+    "Configuring Entra…").
+13. Inside the container, after Bicep deployment, the bootstrap script deploys
+    the bundled prebuilt `sonde-azure-handler` package into the provisioned
+    Function App and polls Azure until at least one function is reported as
+    loaded (see §8.3 steps 4–5 for the container-side sequence).
+14. The bootstrap script then deploys the Web UI SPA content and configures the
     Entra app registration. This phase runs inside the bootstrap container
     where the Azure CLI session is still authenticated. The script:
     a. Extracts `staticWebAppName`, `staticWebAppHostname`, `companionClientId`,
@@ -322,16 +327,21 @@ When bootstrap is required, the Azure companion performs this sequence:
        Function App). If the scope already exists, this step is a no-op.
     If any sub-step fails, the bootstrap script exits non-zero and the
     bootstrap container reports failure.
-18. Write `service-principal.json` and `storage-queues.json` to the staging
+15. Wait for the container to finish. On success, the bootstrap script produces
+    JSON deployment outputs on stdout. The Rust companion captures and parses
+    the JSON outputs to extract `tenantId`, `clientId`, Storage Queue endpoint,
+    queue names, Function App name, and deployment container values from the
+    `companionBootstrapValues` output object.
+16. Write `service-principal.json` and `storage-queues.json` to the staging
     directory with the extracted values and relative paths to the certificate
     and private-key PEM files.
-19. Rename the staging directory into a new generation directory under the state
+17. Rename the staging directory into a new generation directory under the state
     volume, then atomically update the `.current-state` marker to point at that
     generation, leaving the previous generation untouched until the new one is
     fully committed.
-20. Remove the bootstrap container.
-21. Display "Bootstrap complete" on the modem display.
-22. The bootstrap wrapper/entrypoint reports overall success only after
+18. Remove the bootstrap container.
+19. Display "Bootstrap complete" on the modem display.
+20. The bootstrap wrapper/entrypoint reports overall success only after
     bootstrap-complete state has been established.
 
 If any step fails, the staging directory is cleaned up, the bootstrap
@@ -349,7 +359,7 @@ non-zero status. It does not continue to a console-only fallback.
 ## 5  Rust binary interface
 
 > **Requirements:** AZC-0100, AZC-0102, AZC-0103, AZC-0104, AZC-0105, AZC-0201, AZC-0202, AZC-0205, AZC-0300, AZC-0301, AZC-0302, AZC-0304, AZC-0305,
-> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0410, AZC-0411
+> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0410, AZC-0411, AZC-0412
 
 The `sonde-azure-companion` binary exposes three cross-platform runtime modes
 plus Windows service-management entrypoints:
@@ -374,7 +384,10 @@ plus Windows service-management entrypoints:
    without deleting persisted companion state.
 6. **service runtime entrypoint** *(Windows)* — the SCM-launched execution path
    that performs the runtime-ready check and either starts `run` or fails closed
-   per AZC-0205.
+   per AZC-0205. The service control handler responds to `ServiceControl::Stop`
+   and `ServiceControl::Shutdown` events by setting `StopPending` status and
+   signaling the async runtime via a oneshot channel, enabling graceful
+   shutdown of the connector bridge and in-flight Storage Queue operations.
 
 The companion receives explicit runtime configuration for the Storage Queue
 namespace and queue names rather than inferring deployment-specific defaults.
@@ -446,6 +459,20 @@ from the bootstrap-complete state and authenticate to Azure as an Entra
 application / service principal. Interactive device auth is bootstrap-only and
 is not part of normal runtime operation.
 
+Before constructing the client-assertion credential, the runtime validates that
+the certificate and private key form a matching keypair by extracting the
+subject public key info (SPKI) from both the certificate PEM and the private
+key PEM and comparing them. If the public keys do not match, startup fails
+with a configuration error. This guards against misconfigured state directories
+where certificate and key files originate from different generation cycles.
+
+The runtime loads the private key by attempting RSA, EC, and EdDSA PEM parsing
+in order. EC keys are further validated to be on the P-256 curve by requiring
+successful P-256 private-key parsing; non-P-256 EC keys are rejected. This
+allows operators who provision credentials outside the bootstrap flow to use
+RSA or EdDSA keys, while bootstrap-generated credentials remain ECDSA P-256
+(see §8.1).
+
 The OAuth token endpoint URL is constructed from the `login_endpoint` field
 persisted in `service-principal.json`, with any trailing slash stripped before
 appending `/{tenant_id}/oauth2/v2.0/token`. When the field is absent (pre-existing
@@ -485,7 +512,7 @@ a detected bridge failure.
 ## 8  Provisioning orchestration internals
 
 > **Requirements:** AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405,
-> AZC-0406, AZC-0407, AZC-0408, AZC-0409
+> AZC-0406, AZC-0407, AZC-0408, AZC-0409, AZC-0412
 
 ### 8.1  Certificate generation
 
@@ -525,7 +552,11 @@ Engine API. It does not shell out to the `docker` CLI. The integration flow:
    or host-side Bicep paths.
 6. Start the container and stream its output (stdout/stderr).
 7. Monitor the output for the device-code pattern from `az login --use-device-code`.
-   When detected, extract the code and display it on the modem via the admin API.
+   The primary regex matches the standard `enter the code <CODE> to authenticate`
+   pattern. If the primary pattern does not match, a fallback regex attempts to
+   extract the code from `microsoft.com/devicelogin` output lines, handling
+   variations in Azure CLI output format across versions. When detected, extract
+   the code and display it on the modem via the admin API.
 8. Wait for the container to exit and capture the JSON deployment outputs.
 9. Remove the container after completion (regardless of success or failure).
 
@@ -609,6 +640,24 @@ persisted Storage Queue configuration file (`storage-queues.json`) as an alterna
 to environment variables, enabling a fully automated startup after bootstrap.
 Environment variables, if set, override the persisted file values.
 
+#### Path traversal protection
+
+The `certificate_path` and `private_key_path` values in `service-principal.json`
+are relative paths resolved against the state directory. Before resolving, the
+runtime applies two layers of validation:
+
+1. **Lexical rejection** — the path must be relative and must not contain
+   parent-directory components (`..`), root-directory components, or Windows
+   drive prefixes. Any of these cause an immediate configuration error.
+2. **Canonical containment** — after joining the relative path with the state
+   directory, the resolved path is canonicalized and verified to remain within
+   the canonical state directory. This prevents symlink-based escapes that
+   pass lexical checks but resolve outside the state directory.
+
+Together these checks ensure that an attacker who controls the contents of
+`service-principal.json` cannot cause the runtime to read arbitrary files
+outside the state directory.
+
 ### 8.5  Bootstrap-image contents
 
 The bootstrap Dockerfile includes:
@@ -667,3 +716,25 @@ container via structured stderr markers (`__SONDE_AZURE_DEPLOYING_HANDLER__`
 and `__SONDE_AZURE_CONFIGURING_ENTRA__`). The companion watches for these
 markers alongside the existing `__SONDE_AZURE_DEPLOYMENT_START__` marker and
 updates the modem display accordingly.
+
+### 8.8  Custom domain support
+
+> **Requirements:** AZC-0412
+
+The `bootstrap` subcommand accepts three optional parameters for configuring a
+custom domain on the Static Web App:
+
+| CLI flag | Environment variable | Description |
+|----------|---------------------|-------------|
+| `--custom-domain-name` | `SONDE_AZURE_CUSTOM_DOMAIN_NAME` | Custom domain FQDN (e.g., `sondeplatform.com`) |
+| `--custom-domain-dns-resource-group` | `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP` | Resource group containing the Azure DNS zone |
+| `--custom-domain-dns-zone-name` | `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME` | DNS zone name (defaults to custom domain name for apex domains) |
+
+When provided, the Rust companion passes these values to the bootstrap
+container as environment variables. The bootstrap script is responsible for
+consuming them to create DNS records, register the custom domain on the Static
+Web App, and configure Entra redirect URIs as appropriate.
+
+All three parameters are optional. When `custom_domain_name` is absent, no
+custom domain environment variables are passed to the container and the
+bootstrap uses the default Azure-provided Static Web App hostname.

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -728,7 +728,7 @@ custom domain on the Static Web App:
 |----------|---------------------|-------------|
 | `--custom-domain-name` | `SONDE_AZURE_CUSTOM_DOMAIN_NAME` | Custom domain FQDN (e.g., `sondeplatform.com`) |
 | `--custom-domain-dns-resource-group` | `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP` | Resource group containing the Azure DNS zone |
-| `--custom-domain-dns-zone-name` | `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME` | DNS zone name (defaults to custom domain name for apex domains) |
+| `--custom-domain-dns-zone-name` | `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME` | DNS zone name (operators typically set this to the custom domain name for apex domains) |
 
 When provided, the Rust companion passes each value individually to the
 bootstrap container as an environment variable. Each parameter is forwarded

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -730,11 +730,13 @@ custom domain on the Static Web App:
 | `--custom-domain-dns-resource-group` | `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP` | Resource group containing the Azure DNS zone |
 | `--custom-domain-dns-zone-name` | `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME` | DNS zone name (defaults to custom domain name for apex domains) |
 
-When provided, the Rust companion passes these values to the bootstrap
-container as environment variables. The bootstrap script is responsible for
-consuming them to create DNS records, register the custom domain on the Static
-Web App, and configure Entra redirect URIs as appropriate.
+When provided, the Rust companion passes each value individually to the
+bootstrap container as an environment variable. Each parameter is forwarded
+independently — setting one does not require or imply setting the others.
+The bootstrap script does not currently consume these environment variables;
+they are passed through for future use. The existing
+`SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN` variable (consumed by the bootstrap script
+for CORS and Entra redirect URI configuration) remains a separate mechanism.
 
-All three parameters are optional. When `custom_domain_name` is absent, no
-custom domain environment variables are passed to the container and the
-bootstrap uses the default Azure-provided Static Web App hostname.
+All three parameters are optional and independent. When none are set, no
+custom domain environment variables are passed to the container.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -912,8 +912,9 @@ Three parameters are accepted:
   `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP`) — the resource group
   containing the Azure DNS zone for the custom domain.
 - `--custom-domain-dns-zone-name` (env:
-  `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME`) — the DNS zone name; defaults to
-  the custom domain name for apex domains.
+  `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME`) — the DNS zone name. For apex
+  domains, operators typically set this to the custom domain name; no automatic
+  defaulting is applied.
 
 Each parameter is forwarded independently to the bootstrap container as an
 environment variable when set. Setting one does not require or imply setting

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -902,7 +902,7 @@ when needed (e.g., credential rotation).
 **Source:** [issue #1031](https://github.com/Alan-Jowett/sonde/issues/1031)
 
 **Description:**
-The `bootstrap` subcommand MUST accept optional custom domain parameters that
+The `bootstrap` subcommand SHOULD accept optional custom domain parameters that
 allow the operator to pass custom DNS configuration to the bootstrap container.
 Three parameters are accepted:
 

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -893,3 +893,39 @@ when needed (e.g., credential rotation).
 3. When valid state exists and `--force` is not set, bootstrap prints a message to stderr indicating that state already exists and exits with status 0.
 4. When valid state exists and `--force` is set, bootstrap performs the full provisioning lifecycle.
 5. When no valid state exists, bootstrap performs the full provisioning lifecycle regardless of the `--force` flag.
+
+---
+
+### AZC-0412  Custom domain configuration parameters for Static Web App
+
+**Priority:** Should
+**Source:** [issue #1031](https://github.com/Alan-Jowett/sonde/issues/1031)
+
+**Description:**
+The `bootstrap` subcommand MUST accept optional custom domain parameters that
+allow the operator to pass custom DNS configuration to the bootstrap container.
+Three parameters are accepted:
+
+- `--custom-domain-name` (env: `SONDE_AZURE_CUSTOM_DOMAIN_NAME`) — the custom
+  domain FQDN (e.g., `sondeplatform.com`).
+- `--custom-domain-dns-resource-group` (env:
+  `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP`) — the resource group
+  containing the Azure DNS zone for the custom domain.
+- `--custom-domain-dns-zone-name` (env:
+  `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME`) — the DNS zone name; defaults to
+  the custom domain name for apex domains.
+
+When `--custom-domain-name` is provided, the Rust companion passes all three
+values to the bootstrap container as environment variables. The bootstrap
+script is responsible for consuming them to perform custom domain
+configuration.
+
+When `--custom-domain-name` is absent, no custom domain environment variables
+are passed to the container and no custom domain configuration is performed.
+
+**Acceptance criteria:**
+
+1. `BootstrapArgs` includes all three custom domain CLI flags with corresponding environment variable overrides.
+2. All three parameters are optional; omitting them does not affect the rest of the bootstrap sequence.
+3. When `--custom-domain-name` is provided, the bootstrap container receives all three values as environment variables.
+4. When `--custom-domain-name` is absent, none of the three custom domain environment variables are present in the container environment.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -915,17 +915,14 @@ Three parameters are accepted:
   `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME`) — the DNS zone name; defaults to
   the custom domain name for apex domains.
 
-When `--custom-domain-name` is provided, the Rust companion passes all three
-values to the bootstrap container as environment variables. The bootstrap
-script is responsible for consuming them to perform custom domain
-configuration.
-
-When `--custom-domain-name` is absent, no custom domain environment variables
-are passed to the container and no custom domain configuration is performed.
+Each parameter is forwarded independently to the bootstrap container as an
+environment variable when set. Setting one does not require or imply setting
+the others. The bootstrap script does not currently consume these environment
+variables; they are passed through for future use.
 
 **Acceptance criteria:**
 
 1. `BootstrapArgs` includes all three custom domain CLI flags with corresponding environment variable overrides.
 2. All three parameters are optional; omitting them does not affect the rest of the bootstrap sequence.
-3. When `--custom-domain-name` is provided, the bootstrap container receives all three values as environment variables.
-4. When `--custom-domain-name` is absent, none of the three custom domain environment variables are present in the container environment.
+3. Each custom domain parameter that is set is forwarded to the bootstrap container as its corresponding environment variable, independently of the others.
+4. When none of the three parameters are set, none of the three custom domain environment variables are present in the container environment.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -809,3 +809,26 @@
 5. Prepare a fresh state directory with no valid bootstrap-complete state (empty or containing only stale/incomplete artifacts).
 6. Run `sonde-azure-companion bootstrap` (without `--force`) from the fresh no-valid-state directory with the same stubbed services.
 7. Assert: bootstrap performs the same full provisioning lifecycle as in step 3 — the `--force` flag does not alter behavior when no valid state exists.
+
+---
+
+### T-AZC-0430  Bootstrap passes custom domain parameters to container
+
+**Validates:** AZC-0412
+
+**Procedure:**
+1. Run `sonde-azure-companion bootstrap` with `--custom-domain-name sondeplatform.com --custom-domain-dns-resource-group my-dns-rg --custom-domain-dns-zone-name sondeplatform.com` and stubbed Docker/admin services.
+2. Assert: the bootstrap container is created with environment variables `SONDE_AZURE_CUSTOM_DOMAIN_NAME=sondeplatform.com`, `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP=my-dns-rg`, and `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME=sondeplatform.com`.
+3. Run `sonde-azure-companion bootstrap` without any custom domain flags.
+4. Assert: none of the three custom domain environment variables are present in the container environment.
+
+---
+
+### T-AZC-0431  Custom domain parameters accepted via environment variables
+
+**Validates:** AZC-0412
+
+**Procedure:**
+1. Set `SONDE_AZURE_CUSTOM_DOMAIN_NAME=example.org`, `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP=dns-rg`, `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME=example.org` in the process environment.
+2. Run `sonde-azure-companion bootstrap` with no CLI custom domain flags but with stubbed Docker/admin services.
+3. Assert: the bootstrap container receives all three custom domain values via its environment variables.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -819,7 +819,7 @@
 **Procedure:**
 1. Run `sonde-azure-companion bootstrap` with `--custom-domain-name sondeplatform.com --custom-domain-dns-resource-group my-dns-rg --custom-domain-dns-zone-name sondeplatform.com` and stubbed Docker/admin services.
 2. Assert: the bootstrap container is created with environment variables `SONDE_AZURE_CUSTOM_DOMAIN_NAME=sondeplatform.com`, `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP=my-dns-rg`, and `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME=sondeplatform.com`.
-3. Run `sonde-azure-companion bootstrap` without any custom domain flags.
+3. Run `sonde-azure-companion bootstrap` without any custom domain flags and with `SONDE_AZURE_CUSTOM_DOMAIN_NAME`, `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP`, and `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME` unset in the process environment.
 4. Assert: none of the three custom domain environment variables are present in the container environment.
 
 ---

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -832,3 +832,17 @@
 1. Set `SONDE_AZURE_CUSTOM_DOMAIN_NAME=example.org`, `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP=dns-rg`, `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME=example.org` in the process environment.
 2. Run `sonde-azure-companion bootstrap` with no CLI custom domain flags but with stubbed Docker/admin services.
 3. Assert: the bootstrap container receives all three custom domain values via its environment variables.
+
+---
+
+### T-AZC-0432  Custom domain parameters forwarded independently
+
+**Validates:** AZC-0412
+
+**Procedure:**
+1. Run `sonde-azure-companion bootstrap` with only `--custom-domain-name sondeplatform.com` and with `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP` and `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME` unset in the process environment. Use stubbed Docker/admin services.
+2. Assert: the bootstrap container environment contains `SONDE_AZURE_CUSTOM_DOMAIN_NAME=sondeplatform.com` but does not contain `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP` or `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME`.
+3. Run `sonde-azure-companion bootstrap` with only `--custom-domain-dns-resource-group my-rg` and with `SONDE_AZURE_CUSTOM_DOMAIN_NAME` and `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME` unset. Use stubbed Docker/admin services.
+4. Assert: the bootstrap container environment contains `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP=my-rg` but does not contain `SONDE_AZURE_CUSTOM_DOMAIN_NAME` or `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME`.
+5. Run `sonde-azure-companion bootstrap` with only `--custom-domain-dns-zone-name myzone.com` and with `SONDE_AZURE_CUSTOM_DOMAIN_NAME` and `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP` unset. Use stubbed Docker/admin services.
+6. Assert: the bootstrap container environment contains `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME=myzone.com` but does not contain `SONDE_AZURE_CUSTOM_DOMAIN_NAME` or `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP`.


### PR DESCRIPTION
Closes #1031

## Summary

Resolves 8 of 10 drift items from the azure-companion design-vs-implementation compliance audit. All changes are documentation-only — no code changes. The implementation is correct; the design doc needed to catch up.

### Design doc changes (\zure-companion-design.md\)

| ID | Severity | Section | Change |
|----|----------|---------|--------|
| A1 | Major | §4.2 | Clarified bootstrap container ownership — handler deployment, activation polling, SPA deployment, and Entra configuration happen inside the container; Rust monitors stderr markers and updates modem display |
| B1 | Major | New §8.8 | Documented custom domain CLI parameters (\--custom-domain-name\, \--custom-domain-dns-resource-group\, \--custom-domain-dns-zone-name\) passed to bootstrap container as env vars |
| B2 | Minor | §8.4 | Documented path traversal protection — lexical rejection (\../\, absolute, drive prefix) + canonical containment (symlink escape prevention) |
| B3 | Minor | §7.3 | Documented cert/key SPKI matching validation before credential construction |
| B4 | Minor | §7.3 | Documented RSA/EC(P-256)/EdDSA key type support at runtime (distinct from P-256 generation in §8.1) |
| B5 | Minor | §8.2 | Documented fallback device-code regex for \z login\ output format variations |
| B6 | Minor | §3.5 | Documented \service.log\ diagnostic logging on Windows service failures |
| B7 | Minor | §5 | Documented graceful shutdown (\Stop\/\Shutdown\ → \StopPending\ + oneshot channel) |

### Requirements (\zure-companion-requirements.md\)

- New **AZC-0412**: Custom domain configuration parameters for Static Web App (4 acceptance criteria)

### Validation (\zure-companion-validation.md\)

- **T-AZC-0430**: Bootstrap passes custom domain parameters to container
- **T-AZC-0431**: Custom domain parameters accepted via environment variables

### Not changed

- **B8** (stderr buffer trimming) and **B9** (Bicep JSON unwrapping) — trivial implementation details, left as-is per audit assessment
- No code changes — all drift items resolved by updating specifications to match the correct implementation