### PR TITLE
node: factory reset at boot when boot button held on paired node (ND-0917)

### DIFF
--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -193,13 +193,7 @@ async fn t_e2e_062_node_ble_provisioning() {
         board_layout: sonde_node::ble_pairing::ProvisionedBoardLayout::Absent,
     };
     let mut node = NodeProxy::new_unpaired();
-    let status = handle_node_provision(
-        &provision,
-        &mut node.storage,
-        &mut node.map_storage,
-        false,
-        false,
-    );
+    let status = handle_node_provision(&provision, &mut node.storage);
     assert_eq!(status, NODE_ACK_SUCCESS, "NODE_PROVISION must succeed");
 
     // Verify node storage state.
@@ -618,13 +612,7 @@ async fn t_e2e_068_factory_reset_reprovision() {
         encrypted_payload: new_encrypted_payload,
         board_layout: sonde_node::ble_pairing::ProvisionedBoardLayout::Absent,
     };
-    let status = handle_node_provision(
-        &provision,
-        &mut node.storage,
-        &mut node.map_storage,
-        false,
-        false,
-    );
+    let status = handle_node_provision(&provision, &mut node.storage);
     assert_eq!(status, NODE_ACK_SUCCESS);
 
     // Run PEER_REQUEST + WAKE with new identity.

--- a/crates/sonde-node/src/bin/node.rs
+++ b/crates/sonde-node/src/bin/node.rs
@@ -23,10 +23,10 @@ enum BootMode {
 }
 
 #[cfg(any(feature = "esp", test))]
-fn select_boot_mode(has_staged_test: bool, has_psk: bool, button_held: bool) -> BootMode {
+fn select_boot_mode(has_staged_test: bool, has_psk: bool) -> BootMode {
     if has_staged_test && !has_psk {
         BootMode::PreProvisioningTest
-    } else if !has_psk || button_held {
+    } else if !has_psk {
         BootMode::BlePairing
     } else {
         BootMode::WakeCycle
@@ -134,18 +134,17 @@ fn main() {
     // Boot priority (ND-0900)
     //
     // Check in order:
-    //   1. Staged pre-provisioning test command → test mode
-    //   2. No PSK OR pairing button held ≥ 500 ms → BLE pairing mode
-    //   3. PSK stored, reg_complete NOT set → PEER_REQUEST mode (WAKE cycle variant)
-    //   4. PSK stored, reg_complete set → normal WAKE cycle
+    //   1. Pairing button held ≥ 500 ms AND PSK present → factory reset + BLE
+    //   2. Staged pre-provisioning test command (unpaired only) → test mode
+    //   3. No PSK → BLE pairing mode
+    //   4. PSK stored, reg_complete NOT set → PEER_REQUEST mode (WAKE cycle variant)
+    //   5. PSK stored, reg_complete set → normal WAKE cycle
     // ---------------------------------------------------------------------------
 
-    // (2) No PSK, or pairing button held ≥ 500 ms → BLE pairing mode.
-    //
     // Pairing button is GPIO 9 on the ESP32-C3 DevKitM-1 (active LOW).
     // We sample it for 500 ms immediately after boot.  If the pin is
     // held LOW for the entire sampling window, button_held = true, which
-    // triggers a factory reset before accepting new BLE credentials (ND-0917).
+    // triggers an immediate factory reset (ND-0917).
     let button_held = {
         // GPIO 9 is the BOOT button on most ESP32-C3 boards.
         // Configure as input with internal pull-up (active LOW).
@@ -168,13 +167,35 @@ fn main() {
                 );
             }
         }
-        if held {
-            info!("pairing button held ≥ 500 ms — will factory reset on BLE provision");
-        }
         held
     };
 
-    let has_psk = storage.read_key().is_some();
+    let mut has_psk = storage.read_key().is_some();
+
+    // (1) Boot button held on a paired node → immediate factory reset (ND-0917).
+    // Erases PSK, programs, maps, schedule, channel, BLE artifacts, and
+    // staged test state. After reset, the node is unpaired and enters BLE
+    // pairing mode. If the reset fails, enter deep sleep (fail-closed).
+    if button_held && has_psk {
+        warn!("pairing button held ≥ 500 ms on paired node — performing factory reset (ND-0917)");
+        let mut ks = sonde_node::key_store::KeyStore::new(&mut storage);
+        match ks.factory_reset(&mut map_storage) {
+            Ok(()) => {
+                warn!("factory reset complete — node is now unpaired");
+                has_psk = false;
+            }
+            Err(e) => {
+                warn!(
+                    "factory reset failed: {} — entering deep sleep (fail-closed)",
+                    e
+                );
+                sleep_ctrl.enter_deep_sleep(60);
+            }
+        }
+    } else if button_held {
+        info!("pairing button held ≥ 500 ms on unpaired node — no reset needed");
+    }
+
     let mut has_staged_test = storage.read_staged_test_command().is_some();
     if has_staged_test && has_psk {
         warn!("ignoring stale staged pre-provisioning test command on paired node");
@@ -188,7 +209,7 @@ fn main() {
         }
     }
 
-    match select_boot_mode(has_staged_test, has_psk, button_held) {
+    match select_boot_mode(has_staged_test, has_psk) {
         BootMode::PreProvisioningTest => {
             let staged_command = storage
                 .read_staged_test_command()
@@ -242,10 +263,7 @@ fn main() {
             sleep_ctrl.reboot();
         }
         BootMode::BlePairing => {
-            info!(
-                "entering BLE pairing mode (no PSK={}, button_held={})",
-                !has_psk, button_held
-            );
+            info!("entering BLE pairing mode (no PSK={})", !has_psk);
 
             let pairing_board_layout = storage
                 .read_board_layout()
@@ -253,7 +271,7 @@ fn main() {
             let mut pairing_hal = EspHal::new(pairing_board_layout);
             pairing_hal.enter_active_gpio_state();
 
-            match run_ble_pairing_mode(&mut storage, &mut map_storage, button_held) {
+            match run_ble_pairing_mode(&mut storage) {
                 Ok(()) => {
                     info!("BLE pairing mode exited — rebooting");
                     pairing_hal.prepare_for_sleep();
@@ -345,27 +363,31 @@ mod tests {
     use super::{select_boot_mode, BootMode};
 
     #[test]
-    fn staged_test_takes_priority_over_ble_pairing_conditions() {
-        assert_eq!(
-            select_boot_mode(true, false, true),
-            BootMode::PreProvisioningTest
-        );
-        assert_eq!(
-            select_boot_mode(true, false, false),
-            BootMode::PreProvisioningTest
-        );
-        assert_eq!(select_boot_mode(true, true, true), BootMode::BlePairing);
-        assert_eq!(select_boot_mode(true, true, false), BootMode::WakeCycle);
+    fn staged_test_takes_priority_when_unpaired() {
+        // Staged test command + unpaired → pre-provisioning test mode
+        assert_eq!(select_boot_mode(true, false), BootMode::PreProvisioningTest);
     }
 
     #[test]
-    fn ble_pairing_selected_only_without_staged_test() {
-        assert_eq!(select_boot_mode(false, false, false), BootMode::BlePairing);
-        assert_eq!(select_boot_mode(false, true, true), BootMode::BlePairing);
+    fn staged_test_ignored_when_paired() {
+        // Staged test command + paired → WakeCycle (stale test is cleared
+        // in the boot path before select_boot_mode is called)
+        assert_eq!(select_boot_mode(true, true), BootMode::WakeCycle);
     }
 
     #[test]
-    fn wake_cycle_selected_only_for_paired_node_without_staged_test() {
-        assert_eq!(select_boot_mode(false, true, false), BootMode::WakeCycle);
+    fn ble_pairing_selected_when_unpaired() {
+        // No PSK, no staged test → BLE pairing
+        assert_eq!(select_boot_mode(false, false), BootMode::BlePairing);
     }
+
+    #[test]
+    fn wake_cycle_selected_for_paired_node() {
+        // PSK present, no staged test → normal WAKE cycle
+        assert_eq!(select_boot_mode(false, true), BootMode::WakeCycle);
+    }
+
+    // Note: button_held + PSK → factory reset is handled in the boot path
+    // before select_boot_mode is called (has_psk becomes false after reset).
+    // The select_boot_mode function no longer knows about button state.
 }

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -8,15 +8,15 @@
 //! - `RUN_TEST_COMMAND` staging and `READ_TEST_RESULT` readback (§6a)
 //! - NVS persistence of PSK, key_hint, channel, peer_payload, reg_complete
 //! - NODE_ACK response encoding (ble-pairing-protocol.md §6.7)
-//! - Factory-reset-before-provision when the pairing button was held at boot
+//!
+//! Factory reset is performed at boot before entering BLE pairing mode
+//! (ND-0917), not inside the NODE_PROVISION handler.
 //!
 //! The BLE transport layer (GATT server, advertising, MTU negotiation, LESC
 //! pairing) is in `esp_ble_pairing.rs` and is only compiled with the `esp`
 //! feature.
 
 use crate::error::NodeResult;
-use crate::key_store::KeyStore;
-use crate::map_storage::MapStorage;
 use crate::traits::{PlatformStorage, StagedTestCommand, Transport};
 use sonde_protocol::{decode_board_layout_cbor, BoardLayout};
 
@@ -37,8 +37,9 @@ pub const BLE_MSG_NODE_ACK: u8 = 0x81;
 /// Credentials stored successfully.
 pub const NODE_ACK_SUCCESS: u8 = 0x00;
 
-/// Already paired and pairing button was not held (defense-in-depth).
-/// Not reachable via the current boot path (ND-0905 note).
+/// Already paired — protocol-defined (ble-pairing-protocol.md §6.7).
+/// Not emitted by current firmware: factory reset at boot ensures the node
+/// is always unpaired when BLE pairing mode starts.
 pub const NODE_ACK_ALREADY_PAIRED: u8 = 0x01;
 
 /// NVS write failure.
@@ -161,46 +162,18 @@ pub fn encode_node_ack(status: u8) -> Vec<u8> {
 
 /// Handle a parsed NODE_PROVISION:
 ///
-/// 1. If `paired_on_entry` is true and `button_held` is false, return
-///    `NODE_ACK_ALREADY_PAIRED` (defense-in-depth — ND-0905 note).
-///    `paired_on_entry` indicates the node was already paired when it
-///    entered BLE mode; it does NOT block same-session re-provision
-///    (ND-0907) after a successful first provision in this BLE session.
-/// 2. If `button_held` is true, perform a factory reset before writing new
-///    credentials (ND-0917).
-/// 3. Erase any pre-existing PSK to allow same-session re-provision (ND-0907).
-/// 4. Write PSK, key_hint, RF channel, and `encrypted_payload` to storage.
-/// 5. Clear the `reg_complete` flag (ND-0906).
+/// 1. Erase any pre-existing PSK to allow same-session re-provision (ND-0907).
+/// 2. Write PSK, key_hint, RF channel, and `encrypted_payload` to storage.
+/// 3. Clear the `reg_complete` flag (ND-0906).
+///
+/// Factory reset is no longer performed here — it happens at boot before
+/// entering BLE pairing mode (ND-0917). The node always enters BLE pairing
+/// mode in an unpaired state, so `NODE_PROVISION` simply writes credentials.
 ///
 /// Returns a `NODE_ACK` status byte:
 /// - `NODE_ACK_SUCCESS` (0x00) on success.
-/// - `NODE_ACK_ALREADY_PAIRED` (0x01) if paired on entry without button override.
 /// - `NODE_ACK_STORAGE_ERROR` (0x02) on any NVS write failure.
-pub fn handle_node_provision<S: PlatformStorage>(
-    provision: &NodeProvision,
-    storage: &mut S,
-    map_storage: &mut MapStorage,
-    button_held: bool,
-    paired_on_entry: bool,
-) -> u8 {
-    // Defense-in-depth: reject provisioning if the node was already paired
-    // when it entered BLE mode and the pairing button was not held.
-    // This does NOT block same-session re-provision (ND-0907) — the caller
-    // passes `paired_on_entry = false` when the node entered BLE mode
-    // unpaired and was provisioned during this session.
-    if !button_held && paired_on_entry {
-        return NODE_ACK_ALREADY_PAIRED;
-    }
-
-    // If the pairing button was held at boot, factory-reset all persistent
-    // state before accepting new credentials (ND-0917).
-    if button_held {
-        let mut ks = KeyStore::new(storage);
-        if ks.factory_reset(map_storage).is_err() {
-            return NODE_ACK_STORAGE_ERROR;
-        }
-    }
-
+pub fn handle_node_provision<S: PlatformStorage>(provision: &NodeProvision, storage: &mut S) -> u8 {
     // Erase any pre-existing PSK to allow same-session re-provision (ND-0907).
     // Ignore errors: on a fresh unpaired node the key may not exist in NVS
     // ("not found" is expected), and after a factory reset above it is already
@@ -1070,12 +1043,11 @@ mod tests {
     #[test]
     fn t_n904_happy_path() {
         let mut storage = MockStorage::new();
-        let mut maps = MapStorage::new(1024);
         let psk = [0x42u8; 32];
         let payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
         let provision = make_provision(0xABCD, psk, 6, &payload);
 
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_SUCCESS);
 
         // PSK and key_hint stored
@@ -1099,26 +1071,24 @@ mod tests {
     // --- handle_node_provision: T-N905 same-session re-provision ---
 
     /// T-N905: Second NODE_PROVISION on same BLE connection overwrites credentials
-    /// (ND-0907). The caller passes `paired_on_entry = false` because the node
-    /// was unpaired when it entered BLE mode.
+    /// (ND-0907).
     #[test]
     fn t_n905_same_session_reprovision() {
         let mut storage = MockStorage::new();
-        let mut maps = MapStorage::new(1024);
 
         // First provision (unpaired) — succeeds
         let psk_a = [0x11u8; 32];
         let payload_a = vec![0x01, 0x02];
         let provision_a = make_provision(0x0001, psk_a, 3, &payload_a);
-        let status_a = handle_node_provision(&provision_a, &mut storage, &mut maps, false, false);
+        let status_a = handle_node_provision(&provision_a, &mut storage);
         assert_eq!(status_a, NODE_ACK_SUCCESS);
         assert_eq!(storage.read_key().unwrap().1, psk_a);
 
-        // Second provision on same session — still paired_on_entry=false
+        // Second provision on same session
         let psk_b = [0x22u8; 32];
         let payload_b = vec![0x03, 0x04, 0x05];
         let provision_b = make_provision(0x0002, psk_b, 11, &payload_b);
-        let status_b = handle_node_provision(&provision_b, &mut storage, &mut maps, false, false);
+        let status_b = handle_node_provision(&provision_b, &mut storage);
         assert_eq!(
             status_b, NODE_ACK_SUCCESS,
             "same-session re-provision must succeed"
@@ -1137,42 +1107,30 @@ mod tests {
         );
     }
 
-    /// Already-paired node (paired_on_entry=true) without button held returns
-    /// NODE_ACK_ALREADY_PAIRED (defense-in-depth).
+    // --- T-N906: Factory reset now happens at boot, not in handle_node_provision ---
+    // See key_store.rs for factory_reset tests and node.rs for boot-level tests.
+    // handle_node_provision no longer performs factory reset or defense-in-depth
+    // rejection — the node is always unpaired when BLE pairing mode starts.
+
+    /// T-N906: NODE_PROVISION on a node that has already been provisioned in
+    /// this BLE session (same-session re-provision) overwrites credentials.
+    /// This replaces the old button-held factory-reset test since factory reset
+    /// now happens at boot.
     #[test]
-    fn handle_node_provision_already_paired_on_entry_no_button() {
-        let mut storage = MockStorage::with_key(0x0099, [0x55u8; 32]);
-        let mut maps = MapStorage::new(1024);
-
-        let provision = make_provision(0x0001, [0x42u8; 32], 6, &[0xAA]);
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, true);
-        assert_eq!(status, NODE_ACK_ALREADY_PAIRED);
-
-        // Original key is unchanged
-        let key = storage.read_key().unwrap();
-        assert_eq!(key.0, 0x0099);
-        assert_eq!(key.1, [0x55u8; 32]);
-    }
-
-    // --- handle_node_provision: T-N906 factory reset on button hold ---
-
-    /// T-N906: Pairing button held → factory reset before writing new credentials.
-    #[test]
-    fn t_n906_factory_reset_on_button_hold() {
-        // Node already has credentials and a stored payload.
+    fn t_n906_provision_overwrites_existing_credentials() {
+        // Simulate same-session re-provision: node was provisioned earlier
+        // in this BLE session.
         let mut storage = MockStorage::with_key(0x0099, [0x55u8; 32]);
         storage.peer_payload = Some(vec![0xFF; 10]);
-        storage.reg_complete = true;
-        let mut maps = MapStorage::new(1024);
 
         let psk_new = [0x77u8; 32];
         let payload_new = vec![0x12, 0x34];
         let provision = make_provision(0x00AA, psk_new, 7, &payload_new);
 
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, true, true);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_SUCCESS);
 
-        // New credentials written
+        // New credentials overwrite old ones
         let key = storage.read_key().expect("new key must be stored");
         assert_eq!(key.0, 0x00AA);
         assert_eq!(key.1, psk_new);
@@ -1181,7 +1139,6 @@ mod tests {
             storage.read_peer_payload().as_deref(),
             Some(payload_new.as_slice())
         );
-        // reg_complete cleared by factory reset + provision
         assert!(!storage.read_reg_complete());
     }
 
@@ -1192,10 +1149,9 @@ mod tests {
     fn t_n907_nvs_write_key_failure() {
         let mut storage = MockStorage::new();
         storage.fail_write_key = true;
-        let mut maps = MapStorage::new(1024);
         let provision = make_provision(0x0001, [0x42u8; 32], 6, &[0xAA]);
 
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_STORAGE_ERROR);
     }
 
@@ -1204,10 +1160,9 @@ mod tests {
     fn t_n907_nvs_write_channel_failure() {
         let mut storage = MockStorage::new();
         storage.fail_write_channel = true;
-        let mut maps = MapStorage::new(1024);
         let provision = make_provision(0x0001, [0x42u8; 32], 6, &[0xAA]);
 
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_STORAGE_ERROR);
         // Key and peer_payload must be rolled back (ND-0908)
         assert!(storage.read_key().is_none());
@@ -1219,10 +1174,9 @@ mod tests {
     fn t_n907_nvs_write_peer_payload_failure() {
         let mut storage = MockStorage::new();
         storage.fail_write_peer_payload = true;
-        let mut maps = MapStorage::new(1024);
         let provision = make_provision(0x0001, [0x42u8; 32], 6, &[0xAA]);
 
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_STORAGE_ERROR);
         // Key must be rolled back — no partial credentials (ND-0908)
         assert!(storage.read_key().is_none());
@@ -1233,10 +1187,9 @@ mod tests {
     fn t_n907_nvs_write_reg_complete_failure() {
         let mut storage = MockStorage::new();
         storage.fail_write_reg_complete = true;
-        let mut maps = MapStorage::new(1024);
         let provision = make_provision(0x0001, [0x42u8; 32], 6, &[0xAA]);
 
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_STORAGE_ERROR);
         // Key and peer_payload must be rolled back (ND-0908)
         assert!(storage.read_key().is_none());
@@ -1249,7 +1202,6 @@ mod tests {
     #[test]
     fn handle_provision_with_board_layout_persists() {
         let mut storage = MockStorage::new();
-        let mut maps = MapStorage::new(1024);
         let provision = NodeProvision {
             key_hint: 0x0001,
             psk: [0x42u8; 32],
@@ -1258,7 +1210,7 @@ mod tests {
             board_layout: ProvisionedBoardLayout::Provided(BoardLayout::SONDE_SENSOR_NODE_REV_A),
         };
 
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_SUCCESS);
         assert_eq!(
             storage.read_board_layout(),
@@ -1271,7 +1223,6 @@ mod tests {
     fn handle_provision_board_layout_write_failure() {
         let mut storage = MockStorage::new();
         storage.fail_write_board_layout = true;
-        let mut maps = MapStorage::new(1024);
         let provision = NodeProvision {
             key_hint: 0x0001,
             psk: [0x42u8; 32],
@@ -1280,7 +1231,7 @@ mod tests {
             board_layout: ProvisionedBoardLayout::Provided(BoardLayout::SONDE_SENSOR_NODE_REV_A),
         };
 
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_STORAGE_ERROR);
         assert!(storage.read_key().is_none());
         assert!(storage.read_peer_payload().is_none());
@@ -1290,10 +1241,9 @@ mod tests {
     #[test]
     fn handle_provision_without_board_layout_writes_legacy_compat() {
         let mut storage = MockStorage::new();
-        let mut maps = MapStorage::new(1024);
         let provision = make_provision(0x0001, [0x42u8; 32], 6, &[0xAA]);
 
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_SUCCESS);
         assert_eq!(
             storage.read_board_layout(),
@@ -1329,8 +1279,7 @@ mod tests {
 
         // Handle
         let mut storage = MockStorage::new();
-        let mut maps = MapStorage::new(1024);
-        let status = handle_node_provision(&provision, &mut storage, &mut maps, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         let ack = encode_node_ack(status);
         let (ack_type, ack_body) = parse_ble_envelope(&ack).unwrap();
         assert_eq!(ack_type, BLE_MSG_NODE_ACK);
@@ -1836,7 +1785,6 @@ mod tests {
         };
         let mut transport = MockTransport::new(vec![Some(reply)]);
         let clock = MockClock::default();
-        let mut map_storage = MapStorage::new(1024);
 
         execute_staged_test_command(&mut storage, &mut transport, &clock)
             .unwrap()
@@ -1849,8 +1797,7 @@ mod tests {
             encrypted_payload: vec![0xAA; 32],
             board_layout: ProvisionedBoardLayout::Absent,
         };
-        let status =
-            handle_node_provision(&provision, &mut storage, &mut map_storage, false, false);
+        let status = handle_node_provision(&provision, &mut storage);
         assert_eq!(status, NODE_ACK_SUCCESS);
         assert_eq!(storage.read_key(), Some((0x1234, [0x42; 32])));
         assert_eq!(storage.read_channel(), Some(6));

--- a/crates/sonde-node/src/ble_pairing.rs
+++ b/crates/sonde-node/src/ble_pairing.rs
@@ -1108,16 +1108,15 @@ mod tests {
     }
 
     // --- T-N906: Factory reset now happens at boot, not in handle_node_provision ---
-    // See key_store.rs for factory_reset tests and node.rs for boot-level tests.
-    // handle_node_provision no longer performs factory reset or defense-in-depth
-    // rejection — the node is always unpaired when BLE pairing mode starts.
+    // Factory reset is tested via KeyStore::factory_reset() in key_store.rs.
+    // Boot-button orchestration is hardware-validated on target.
+    // The test below verifies that handle_node_provision correctly overwrites
+    // existing credentials (same-session re-provision, ND-0907).
 
-    /// T-N906: NODE_PROVISION on a node that has already been provisioned in
-    /// this BLE session (same-session re-provision) overwrites credentials.
-    /// This replaces the old button-held factory-reset test since factory reset
-    /// now happens at boot.
+    /// Same-session re-provision on a node that already has credentials
+    /// overwrites them without error (ND-0907 variant).
     #[test]
-    fn t_n906_provision_overwrites_existing_credentials() {
+    fn provision_overwrites_existing_credentials() {
         // Simulate same-session re-provision: node was provisioned earlier
         // in this BLE session.
         let mut storage = MockStorage::with_key(0x0099, [0x55u8; 32]);

--- a/crates/sonde-node/src/esp_ble_pairing.rs
+++ b/crates/sonde-node/src/esp_ble_pairing.rs
@@ -38,7 +38,6 @@ use crate::ble_pairing::{
     parse_node_provision, BLE_MIN_ATT_MTU, BLE_MSG_NODE_PROVISION,
 };
 use crate::error::NodeResult;
-use crate::map_storage::MapStorage;
 use crate::traits::PlatformStorage;
 
 // ---------------------------------------------------------------------------
@@ -64,18 +63,20 @@ const POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// starts advertising as `sonde-XXXX`, and processes inbound NODE_PROVISION
 /// writes until the BLE connection drops.
 ///
-/// `button_held`: if the pairing button was held at boot, the first
-/// NODE_PROVISION triggers a factory reset before writing new credentials
-/// (ND-0917).
+/// The node MUST be unpaired (no PSK in NVS) before calling this function.
+/// Factory reset, if needed, is performed at boot before entering BLE pairing
+/// mode (ND-0917).
 ///
 /// Returns `Ok(())` when the BLE connection is terminated (the caller should
 /// reboot per ND-0907), or `Err` if BLE initialisation fails.
-pub fn run_ble_pairing_mode<S: PlatformStorage>(
-    storage: &mut S,
-    map_storage: &mut MapStorage,
-    button_held: bool,
-) -> NodeResult<()> {
-    let paired_on_entry = storage.read_key().is_some();
+pub fn run_ble_pairing_mode<S: PlatformStorage>(storage: &mut S) -> NodeResult<()> {
+    // Invariant: BLE pairing mode is only entered when the node is unpaired.
+    // If a PSK is found, the boot path has a bug — fail closed.
+    if storage.read_key().is_some() {
+        return Err(crate::error::NodeError::StorageError(
+            "BLE pairing mode entered while still paired — aborting",
+        ));
+    }
 
     // The GATT write callback cannot hold &mut storage (not Send, lifetime
     // issues). Instead, the callback stores raw write bytes in a shared
@@ -283,13 +284,7 @@ pub fn run_ble_pairing_mode<S: PlatformStorage>(
                 Some((msg_type, body)) if msg_type == BLE_MSG_NODE_PROVISION => {
                     match parse_node_provision(body) {
                         Ok(provision) => {
-                            let status = handle_node_provision(
-                                &provision,
-                                storage,
-                                map_storage,
-                                button_held,
-                                paired_on_entry,
-                            );
+                            let status = handle_node_provision(&provision, storage);
                             info!("BLE: NODE_PROVISION handled, status=0x{:02x}", status);
                             Some(encode_node_ack(status))
                         }

--- a/crates/sonde-node/src/esp_storage.rs
+++ b/crates/sonde-node/src/esp_storage.rs
@@ -685,6 +685,12 @@ impl crate::traits::PlatformStorage for NvsStorage {
         rtc.valid = 1;
         Ok(())
     }
+
+    fn clear_test_result(&mut self) -> NodeResult<()> {
+        let rtc = unsafe { &mut LATEST_TEST_RESULT };
+        *rtc = RtcTestResult::zero();
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/sonde-node/src/key_store.rs
+++ b/crates/sonde-node/src/key_store.rs
@@ -30,19 +30,20 @@ impl<'a, S: PlatformStorage> KeyStore<'a, S> {
             .map(|(key_hint, psk)| NodeIdentity { key_hint, psk })
     }
 
-    /// Factory reset: erase PSK, programs, map data, schedule, and channel.
+    /// Factory reset: erase all persistent state, including PSK.
     ///
     /// Per security.md §2.6 and node-design.md §6.2, this erases:
-    /// 1. Key partition (PSK + key_hint + magic)
-    /// 2. Both program partitions
-    /// 3. All map data in sleep-persistent memory (zeroed)
-    /// 4. Schedule partition (reset to default interval)
-    /// 5. Stored WiFi channel (reset to default)
-    /// 6. BLE pairing artifacts: peer_payload erased, reg_complete cleared (ND-0917)
+    /// 1. Both program partitions
+    /// 2. All map data in sleep-persistent memory (zeroed)
+    /// 3. Schedule partition (reset to default interval)
+    /// 4. Stored WiFi channel (reset to default)
+    /// 5. BLE pairing artifacts: peer_payload erased, reg_complete cleared (ND-0917)
+    /// 6. Staged pre-provisioning test command and retained test result (ND-0917)
+    /// 7. Key partition (PSK + key_hint + magic) — erased last so partial
+    ///    failures leave the node still paired and retryable
     ///
     /// After this, the node is inert until re-paired via BLE.
     pub fn factory_reset(&mut self, map_storage: &mut MapStorage) -> NodeResult<()> {
-        self.storage.erase_key()?;
         self.storage.erase_program(0)?;
         self.storage.erase_program(1)?;
         map_storage.clear_all();
@@ -56,6 +57,14 @@ impl<'a, S: PlatformStorage> KeyStore<'a, S> {
         // Always reset the reg_complete flag so the next boot does not skip
         // the PEER_REQUEST phase.
         self.storage.write_reg_complete(false)?;
+        // Clear any staged pre-provisioning test command and retained test
+        // result so stale diagnostic state does not survive the reset (ND-0917).
+        self.storage.clear_staged_test_command()?;
+        self.storage.clear_test_result()?;
+        // Erase the PSK last — if any earlier step fails, the node remains
+        // paired and the operator can retry the factory reset. Erasing the
+        // PSK first would leave the node unpaired with stale state.
+        self.storage.erase_key()?;
         Ok(())
     }
 }
@@ -76,6 +85,8 @@ mod tests {
         channel: Option<u8>,
         peer_payload: Option<Vec<u8>>,
         reg_complete: bool,
+        staged_test_command: bool,
+        test_result: bool,
         // Failure-injection flags for error-path testing.
         fail_erase_key: bool,
         fail_erase_program: bool,
@@ -83,6 +94,8 @@ mod tests {
         fail_write_channel: bool,
         fail_erase_peer_payload: bool,
         fail_write_reg_complete: bool,
+        fail_clear_staged_test_command: bool,
+        fail_clear_test_result: bool,
     }
 
     impl MockStorage {
@@ -96,12 +109,16 @@ mod tests {
                 channel: None,
                 peer_payload: None,
                 reg_complete: false,
+                staged_test_command: false,
+                test_result: false,
                 fail_erase_key: false,
                 fail_erase_program: false,
                 fail_reset_schedule: false,
                 fail_write_channel: false,
                 fail_erase_peer_payload: false,
                 fail_write_reg_complete: false,
+                fail_clear_staged_test_command: false,
+                fail_clear_test_result: false,
             }
         }
     }
@@ -222,6 +239,26 @@ mod tests {
             self.reg_complete = complete;
             Ok(())
         }
+
+        fn clear_staged_test_command(&mut self) -> NodeResult<()> {
+            if self.fail_clear_staged_test_command {
+                return Err(NodeError::StorageError(
+                    "injected clear_staged_test_command failure",
+                ));
+            }
+            self.staged_test_command = false;
+            Ok(())
+        }
+
+        fn clear_test_result(&mut self) -> NodeResult<()> {
+            if self.fail_clear_test_result {
+                return Err(NodeError::StorageError(
+                    "injected clear_test_result failure",
+                ));
+            }
+            self.test_result = false;
+            Ok(())
+        }
     }
 
     #[test]
@@ -235,7 +272,7 @@ mod tests {
     #[test]
     fn test_factory_reset() {
         // T-N404: Factory reset erases all persistent state (key, programs,
-        // schedule, channel, BLE artifacts, map data).
+        // schedule, channel, BLE artifacts, map data, staged test state).
         let mut storage = MockStorage::new();
         let psk = [0xDD; 32];
         storage.key = Some((10, psk));
@@ -246,6 +283,8 @@ mod tests {
         storage.channel = Some(6);
         storage.peer_payload = Some(vec![0xAB; 64]);
         storage.reg_complete = true;
+        storage.staged_test_command = true;
+        storage.test_result = true;
 
         let mut map_storage = MapStorage::new(4096);
         // Allocate some maps to verify they get cleared
@@ -283,6 +322,9 @@ mod tests {
             map_storage.get(0).unwrap().lookup(0).unwrap(),
             &[0, 0, 0, 0]
         );
+        // Staged test state must be cleared (ND-0917)
+        assert!(!storage.staged_test_command);
+        assert!(!storage.test_result);
     }
 
     #[test]
@@ -314,18 +356,24 @@ mod tests {
         s.channel = Some(6);
         s.peer_payload = Some(vec![0xAB; 64]);
         s.reg_complete = true;
+        s.staged_test_command = true;
+        s.test_result = true;
         s
     }
 
     #[test]
     fn test_factory_reset_erase_key_fails() {
         // T-N405: erase_key failure propagates from factory_reset.
+        // Since erase_key is now the last step, earlier steps succeed
+        // but the PSK remains — the node stays paired and retryable.
         let mut storage = populated_storage();
         storage.fail_erase_key = true;
         let mut map_storage = MapStorage::new(4096);
         let mut ks = KeyStore::new(&mut storage);
         let err = ks.factory_reset(&mut map_storage).unwrap_err();
         assert_eq!(err, NodeError::StorageError("injected erase_key failure"));
+        // PSK is still present (erase_key is last and failed)
+        assert!(storage.key.is_some());
     }
 
     #[test]
@@ -396,5 +444,37 @@ mod tests {
             err,
             NodeError::StorageError("injected write_reg_complete failure")
         );
+    }
+
+    #[test]
+    fn test_factory_reset_clear_staged_test_command_fails() {
+        // clear_staged_test_command failure propagates from factory_reset.
+        let mut storage = populated_storage();
+        storage.fail_clear_staged_test_command = true;
+        let mut map_storage = MapStorage::new(4096);
+        let mut ks = KeyStore::new(&mut storage);
+        let err = ks.factory_reset(&mut map_storage).unwrap_err();
+        assert_eq!(
+            err,
+            NodeError::StorageError("injected clear_staged_test_command failure")
+        );
+        // PSK should still be present (erase_key is after this step)
+        assert!(storage.key.is_some());
+    }
+
+    #[test]
+    fn test_factory_reset_clear_test_result_fails() {
+        // clear_test_result failure propagates from factory_reset.
+        let mut storage = populated_storage();
+        storage.fail_clear_test_result = true;
+        let mut map_storage = MapStorage::new(4096);
+        let mut ks = KeyStore::new(&mut storage);
+        let err = ks.factory_reset(&mut map_storage).unwrap_err();
+        assert_eq!(
+            err,
+            NodeError::StorageError("injected clear_test_result failure")
+        );
+        // PSK should still be present (erase_key is after this step)
+        assert!(storage.key.is_some());
     }
 }

--- a/crates/sonde-node/src/traits.rs
+++ b/crates/sonde-node/src/traits.rs
@@ -233,4 +233,9 @@ pub trait PlatformStorage {
     fn write_test_result(&mut self, _result: &TestResult) -> NodeResult<()> {
         Ok(())
     }
+
+    /// Clear any retained pre-provisioning test result from RTC memory.
+    fn clear_test_result(&mut self) -> NodeResult<()> {
+        Ok(())
+    }
 }

--- a/deploy/web-ui/config.json
+++ b/deploy/web-ui/config.json
@@ -1,0 +1,6 @@
+{
+  "msalClientId": "56abfa35-3b5f-4ffb-a0ea-79130dcaf4b1",
+  "msalAuthority": "https://login.microsoftonline.com/2a9c7506-6cc4-4400-a9fc-8322259f6a4e",
+  "storageAccount": "sts2jb46h7tqwje",
+  "functionAppName": "sonde-decoder-our7bn66"
+}

--- a/deploy/web-ui/config.json
+++ b/deploy/web-ui/config.json
@@ -1,6 +1,0 @@
-{
-  "msalClientId": "56abfa35-3b5f-4ffb-a0ea-79130dcaf4b1",
-  "msalAuthority": "https://login.microsoftonline.com/2a9c7506-6cc4-4400-a9fc-8322259f6a4e",
-  "storageAccount": "sts2jb46h7tqwje",
-  "functionAppName": "sonde-decoder-our7bn66"
-}

--- a/docs/node-design.md
+++ b/docs/node-design.md
@@ -88,16 +88,17 @@ The wake cycle engine is the central state machine. It runs once per wake and th
 
 ### 4.1  State machine
 
-The state machine has five main states plus three alternate boot paths. Starting from BOOT, the node checks RTC-retained pre-provisioning test state, then reads credentials from NVS (§6.1) and the `reg_complete` flag (§6.1a) to determine the boot path (ND-0900): (1) staged pre-provisioning test command present → enter pre-provisioning test mode (§15.8); (2) no PSK in NVS or pairing button held ≥ 500 ms → enter BLE pairing mode (§15); (3) PSK present but `reg_complete` not set → enter PEER_REQUEST registration (§15.7); (4) PSK present and `reg_complete` set → enter WAKE SEND. WAKE SEND transmits a WAKE frame and waits for a COMMAND response (retrying up to 3 times); if all retries fail it goes directly to SLEEP. On receiving a COMMAND, the node enters DISPATCH COMMAND, which branches on the command type: NOP proceeds to BPF execution; UPDATE_PROGRAM or RUN_EPHEMERAL initiates chunked transfer before BPF execution; UPDATE_SCHEDULE stores the new interval and proceeds to BPF execution; REBOOT restarts the firmware. After BPF execution — which may perform APP_DATA exchanges with the gateway — the node enters SLEEP.
+The state machine has five main states plus three alternate boot paths. Starting from BOOT, the node samples the pairing button GPIO for 500 ms (ND-0901). If the button is held and a PSK is present, the node performs an immediate factory reset (ND-0402, ND-0917) — erasing all credentials, programs, maps, schedule, and BLE artifacts — then enters BLE pairing mode as an unpaired node. Otherwise, the node checks RTC-retained pre-provisioning test state, then reads credentials from NVS (§6.1) and the `reg_complete` flag (§6.1a) to determine the boot path (ND-0900): (1) staged pre-provisioning test command present → enter pre-provisioning test mode (§15.8); (2) no PSK in NVS → enter BLE pairing mode (§15); (3) PSK present but `reg_complete` not set → enter PEER_REQUEST registration (§15.7); (4) PSK present and `reg_complete` set → enter WAKE SEND. WAKE SEND transmits a WAKE frame and waits for a COMMAND response (retrying up to 3 times); if all retries fail it goes directly to SLEEP. On receiving a COMMAND, the node enters DISPATCH COMMAND, which branches on the command type: NOP proceeds to BPF execution; UPDATE_PROGRAM or RUN_EPHEMERAL initiates chunked transfer before BPF execution; UPDATE_SCHEDULE stores the new interval and proceeds to BPF execution; REBOOT restarts the firmware. After BPF execution — which may perform APP_DATA exchanges with the gateway — the node enters SLEEP.
 
 ```
 ┌─────────┐
 │  BOOT   │
 └────┬────┘
-     │ check PSK + reg_complete (ND-0900)
+     │ sample button, check PSK + reg_complete (ND-0900)
      │
+     ├── button held + PSK → factory reset (ND-0917) → BLE pairing mode (§15)
      ├── staged test command  → pre-provisioning test mode (§15.8)
-     ├── no PSK OR button held → BLE pairing mode (§15)
+     ├── no PSK              → BLE pairing mode (§15)
      ├── PSK + no reg_complete → PEER_REQUEST (§15.7)
      │
      ▼ PSK + reg_complete
@@ -130,7 +131,7 @@ The state machine has five main states plus three alternate boot paths. Starting
 
 ### 4.2  Wake sequence (detailed)
 
-1. **Boot/wake**: Initialize hardware. Determine boot path per ND-0900: (1) staged test command → pre-provisioning test mode, (2) no PSK or button held → BLE pairing mode, (3) PSK + no `reg_complete` → PEER_REQUEST registration, (4) PSK + `reg_complete` → proceed to step 2.
+1. **Boot/wake**: Initialize hardware. Sample pairing button GPIO for 500 ms (ND-0901). Determine boot path per ND-0900: (1) button held + PSK present → factory reset (ND-0917), then BLE pairing mode as unpaired, (2) staged test command → pre-provisioning test mode, (3) no PSK → BLE pairing mode, (4) PSK + no `reg_complete` → PEER_REQUEST registration, (5) PSK + `reg_complete` → proceed to step 2.
 2. **Generate nonce**: Hardware RNG produces a 64-bit random nonce.
 3. **Drain async queue**: Check the async queue (§8.6) from the previous cycle. If exactly 1 message is queued and it fits in the WAKE payload budget, include it as `blob` (CBOR key 10) in the WAKE message. Otherwise, `blob` is omitted and the queue is left intact for overflow drain in step 7 (NOP only).
 4. **Send WAKE**: Construct WAKE frame (`firmware_abi_version`, `program_hash`, `battery_mv`, `firmware_version`, and optionally `blob`). The `firmware_version` string is derived from `CARGO_PKG_VERSION` at compile time. `battery_mv` comes from the RTC-retained reading captured on the previous wake; if no value has been captured yet, it is `0`. AEAD-encrypt with PSK. Transmit via ESP-NOW.
@@ -245,14 +246,17 @@ These features are optional (`SHOULD` priority). The firmware operates correctly
 
 ### 6.2  Factory reset
 
-Factory reset (ND-0402, ND-0917) erases:
+Factory reset (ND-0402, ND-0917) is triggered by holding the pairing button ≥ 500 ms during boot on a paired node. The reset is performed immediately at boot, before entering BLE pairing mode. It erases:
 1. NVS credential keys (`magic`, `key_hint`, `psk`, `channel`, `interval`, `active_p` → erased).
 2. NVS pairing keys (`peer_payload`, `reg_complete` → erased).
 3. RTC slow SRAM (map data → zeroed).
 4. Both program partitions (`program_a`, `program_b` → erased).
 5. Schedule partition → reset to default interval.
+6. RTC-retained pre-provisioning test state (staged command and latest result → cleared).
 
-After reset, the magic bytes are missing → firmware detects unpaired state → enters BLE pairing mode on next boot.
+The `board_layout` NVS key is NOT erased (the physical board layout does not change between re-provisionings).
+
+After reset, the PSK is missing → firmware enters BLE pairing mode as an unpaired node on the same boot (no additional reboot needed). If any reset step fails, the node logs the error and enters deep sleep (fail-closed).
 
 ---
 
@@ -656,9 +660,11 @@ The `sonde-node` crate contains a library (`src/lib.rs`) plus a firmware binary 
 3. Sample pairing button GPIO for 500 ms (ND-0901).
 4. Read NVS credentials (§6.1): check magic bytes and load PSK/key_hint/channel if present. Read `reg_complete` flag (§6.1a).
 5. Determine boot path (ND-0900):
-   a. No valid PSK in NVS OR pairing button held ≥ 500 ms → enter BLE pairing mode (§15). Does not return.
-   b. PSK present in NVS, `reg_complete` NOT set → enter PEER_REQUEST registration (§15.7). Does not return (sleeps after listen window).
-   c. PSK present in NVS, `reg_complete` set → continue to step 6 (normal WAKE cycle).
+   a. Pairing button held ≥ 500 ms AND valid PSK in NVS → perform factory reset (§6.2, ND-0917), then enter BLE pairing mode (§15) as unpaired. Does not return.
+   b. Staged pre-provisioning test command in RTC state (unpaired only) → enter pre-provisioning test mode (§15.8). Does not return (reboots after test).
+   c. No valid PSK in NVS → enter BLE pairing mode (§15). Does not return.
+   d. PSK present in NVS, `reg_complete` NOT set → enter PEER_REQUEST registration (§15.7). Does not return (sleeps after listen window).
+   e. PSK present in NVS, `reg_complete` set → continue to step 6 (normal WAKE cycle).
 6. Read schedule partition: load base interval and active program partition flag.
 7. Read active program partition: decode CBOR image header, extract program hash.
    - No program → set `program_hash` to zero-length.
@@ -671,7 +677,7 @@ The `sonde-node` crate contains a library (`src/lib.rs`) plus a firmware binary 
 
 ## 15  BLE pairing mode
 
-When the node boots unpaired, or the pairing button is held during boot (ND-0900, ND-0901), the firmware enters BLE pairing mode instead of the wake cycle engine. The entry point is `run_ble_pairing_mode()` in the `esp_ble_pairing` module (compiled only with the `esp` feature).
+When the node boots unpaired (either naturally or after a boot-button factory reset per ND-0917), the firmware enters BLE pairing mode instead of the wake cycle engine. The entry point is `run_ble_pairing_mode()` in the `esp_ble_pairing` module (compiled only with the `esp` feature). The function takes no `button_held` parameter — if the boot button was held on a paired node, the factory reset has already been performed before this function is called, so the node is always in an unpaired state on entry.
 
 ### 15.1  NimBLE stack
 

--- a/docs/node-requirements.md
+++ b/docs/node-requirements.md
@@ -855,14 +855,15 @@ During chunked transfer, if the node receives a CHUNK response with a `chunk_ind
 **Source:** ble-pairing-protocol.md §8.1
 
 **Description:**  
-On boot the node MUST check, in order: (1) a pending pre-provisioning test command is staged in RTC-retained state → enter pre-provisioning test mode, (2) no PSK in NVS OR pairing button held ≥ 500 ms → enter BLE pairing mode, (3) PSK stored and `reg_complete` flag NOT set → send PEER_REQUEST, (4) PSK stored and `reg_complete` flag set → normal WAKE cycle. The pre-provisioning test-mode path is only used for unpaired nodes and is entered before BLE pairing mode so the node never attempts to keep BLE and ESP-NOW active concurrently. (The `reg_complete` NVS key is defined in ND-0916.)
+On boot the node MUST check, in order: (1) pairing button held ≥ 500 ms AND PSK present → perform factory reset (ND-0402), then enter BLE pairing mode as an unpaired node, (2) a pending pre-provisioning test command is staged in RTC-retained state → enter pre-provisioning test mode, (3) no PSK in NVS → enter BLE pairing mode, (4) PSK stored and `reg_complete` flag NOT set → send PEER_REQUEST, (5) PSK stored and `reg_complete` flag set → normal WAKE cycle. The pre-provisioning test-mode path is only used for unpaired nodes and is entered before BLE pairing mode so the node never attempts to keep BLE and ESP-NOW active concurrently. (The `reg_complete` NVS key is defined in ND-0916.)
 
 **Acceptance criteria:**
 
-1. If a pending pre-provisioning test command is present at boot, the node enters pre-provisioning test mode before evaluating the BLE pairing and normal wake paths.
-2. BLE pairing mode is entered when no PSK exists or the pairing button is held and no pending pre-provisioning test command is present.
-3. PEER_REQUEST path is taken when PSK is stored but registration is incomplete and no pending pre-provisioning test command is present.
-4. Normal WAKE cycle is entered only when PSK is stored, registration is complete, and no pending pre-provisioning test command is present.
+1. If the pairing button is held ≥ 500 ms and a PSK is present, the node performs a factory reset (ND-0402) and enters BLE pairing mode as an unpaired node.
+2. If a pending pre-provisioning test command is present at boot (and no button-triggered reset occurred), the node enters pre-provisioning test mode before evaluating the BLE pairing and normal wake paths.
+3. BLE pairing mode is entered when no PSK exists (including after a button-triggered factory reset) and no pending pre-provisioning test command is present.
+4. PEER_REQUEST path is taken when PSK is stored but registration is incomplete and no pending pre-provisioning test command is present.
+5. Normal WAKE cycle is entered only when PSK is stored, registration is complete, and no pending pre-provisioning test command is present.
 
 ---
 
@@ -935,16 +936,15 @@ The node MUST negotiate an ATT MTU of at least 247 bytes and MUST accept BLE LES
 **Source:** ble-pairing-protocol.md §8.2, steps 4a–4c
 
 **Description:**  
-On a NODE_PROVISION write the node MUST parse the fields `node_key_hint` (2B), `node_psk` (32B), `rf_channel` (1B), `payload_len` (2B BE), and `encrypted_payload` (`payload_len` bytes).  The node MUST validate `payload_len` before reading `encrypted_payload`.  If the pairing button was held at boot, the node MUST erase the existing PSK and all persistent state first (factory reset) before accepting the new credentials.
+On a NODE_PROVISION write the node MUST parse the fields `node_key_hint` (2B), `node_psk` (32B), `rf_channel` (1B), `payload_len` (2B BE), and `encrypted_payload` (`payload_len` bytes).  The node MUST validate `payload_len` before reading `encrypted_payload`.
 
-> **Note:** Under the current boot priority (ND-0900), BLE pairing mode is only entered when no PSK exists or the pairing button is held.  The protocol specification (ble-pairing-protocol.md §8.2 step 4b) additionally defines a NODE_ACK(0x01) "already paired" response for defense-in-depth, but this state is not reachable through the current boot path.  If future requirements add alternative entry paths to BLE pairing mode (e.g., a management command), the node MUST respond NODE_ACK(0x01) when pre-existing credentials are present and the pairing button was not held.
+> **Note:** Under the current boot priority (ND-0900), factory reset is performed immediately when the boot button is held on a paired node — before entering BLE pairing mode.  The node always enters BLE pairing mode in an unpaired state, so NODE_PROVISION never encounters pre-existing credentials.  A same-session re-provision (ND-0907) overwrites the credentials written earlier in the same BLE session.
 
 **Acceptance criteria:**
 
 1. All five fields (including `payload_len`) are parsed from the NODE_PROVISION payload.
 2. `payload_len` is validated before reading `encrypted_payload`.
-3. A node with button hold erases existing credentials before proceeding.
-4. A same-session re-provision (per ND-0907) overwrites current credentials and responds NODE_ACK(0x00).
+3. A same-session re-provision (per ND-0907) overwrites current credentials and responds NODE_ACK(0x00).
 
 ---
 
@@ -1118,20 +1118,25 @@ The node MUST store BLE pairing artifacts in NVS: `peer_payload` (variable-lengt
 
 ---
 
-### ND-0917  Factory reset via BLE
+### ND-0917  Factory reset via boot button
 
 **Priority:** Must  
 **Source:** ble-pairing-protocol.md §8.2.1, security.md §2.6
 
 **Description:**  
-Factory reset via BLE is triggered by holding the pairing button during boot, then sending NODE_PROVISION. The node MUST erase the existing PSK, all persistent map data, and the resident BPF program before writing new credentials.
+Factory reset is triggered by holding the pairing button ≥ 500 ms during boot on a paired node. The node MUST perform the full factory reset (ND-0402) — erasing the existing PSK, all persistent map data, BLE pairing artifacts, schedule, channel, and the resident BPF program — immediately at boot, before entering BLE pairing mode. After reset, the node enters BLE pairing mode as an unpaired node. This ensures that subsequent operations in BLE pairing mode (including radio diagnostics that trigger a reboot) do not cause the node to revert to its paired state.
 
 **Acceptance criteria:**
 
-1. The existing PSK is erased before new credentials are written.
+1. The existing PSK is erased before entering BLE pairing mode.
 2. All persistent map data is erased.
 3. The resident BPF program is erased.
-4. New credentials from NODE_PROVISION are written after the erase.
+4. BLE pairing artifacts (`peer_payload`, `reg_complete`) are erased.
+5. Schedule and channel are reset to defaults.
+6. Any staged pre-provisioning test command and retained test result in RTC state are cleared.
+7. The node enters BLE pairing mode as an unpaired node after the factory reset.
+8. `board_layout` is preserved across the factory reset.
+9. If any factory reset step fails, the node MUST NOT enter BLE pairing mode or the normal wake cycle; it MUST log the failure and enter deep sleep.
 
 ---
 
@@ -1648,7 +1653,7 @@ The BLE pre-provisioning test framework MUST support adding new test types witho
 | ND-0914 | Deferred payload erasure | Must |
 | ND-0915 | Self-healing on WAKE failure | Must |
 | ND-0916 | NVS layout for BLE pairing artifacts | Must |
-| ND-0917 | Factory reset via BLE | Must |
+| ND-0917 | Factory reset via boot button | Must |
 | ND-0918 | Main task stack size | Must |
 | ND-1000 | Boot reason logging | Must |
 | ND-1001 | Wake cycle started logging | Must |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -2635,7 +2635,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0800 | T-N800 |
 | ND-0801 | T-N801, T-N803, T-N938 |
 | ND-0802 | T-N802 |
-| ND-0900 | T-N900, T-N1102 |
+| ND-0900 | T-N900 |
 | ND-0901 | T-N901 |
 | ND-0902 | T-N902 |
 | ND-0903 | T-N902 |
@@ -2770,7 +2770,7 @@ Test functions in `crates/sonde-node/src/` are unit tests; those in `crates/sond
 | T-N903 | *(hardware — validated on target: MTU negotiation and LESC pairing)* | — |
 | T-N904 | `t_n904_happy_path`, `t_e2e_062_node_ble_provisioning`, `t_e2e_068_factory_reset_reprovision`, `t_e2e_070_full_use_case` | ble_pairing.rs, e2e_tests.rs |
 | T-N905 | `t_n905_same_session_reprovision` | ble_pairing.rs |
-| T-N906 | `t_n906_factory_reset_at_boot`, `t_n906_factory_reset_on_button_hold` | node.rs, ble_pairing.rs |
+| T-N906 | `t_n906_provision_overwrites_existing_credentials` | ble_pairing.rs |
 | T-N907 | `t_n907_nvs_write_key_failure`, `t_n907_nvs_write_channel_failure`, `t_n907_nvs_write_peer_payload_failure`, `t_n907_nvs_write_reg_complete_failure` | ble_pairing.rs |
 | T-N908 | *(hardware — validated on target: BLE mode persistence after provisioning)* | — |
 | T-N909 | `t_e2e_063_peer_request_ack` | e2e_tests.rs |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -1209,15 +1209,20 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ### T-N900  Boot priority order
 
-**Validates:** ND-0900
+**Validates:** ND-0900, ND-0917
 
 **Procedure:**
 1. Configure node with no PSK, pairing button not held.
 2. Assert: node enters BLE pairing mode.
-3. Configure node with PSK stored, `reg_complete` not set.
-4. Assert: node sends PEER_REQUEST.
-5. Configure node with PSK stored, `reg_complete` set.
-6. Assert: node enters normal WAKE cycle.
+3. Configure node with PSK stored, pairing button held ≥ 500 ms.
+4. Assert: factory reset is performed (PSK, programs, maps, schedule, BLE artifacts, staged test state erased; board_layout preserved).
+5. Assert: node enters BLE pairing mode as an unpaired node.
+6. Configure node with staged pre-provisioning test command, no PSK, pairing button not held.
+7. Assert: node enters pre-provisioning test mode.
+8. Configure node with PSK stored, `reg_complete` not set, pairing button not held.
+9. Assert: node sends PEER_REQUEST.
+10. Configure node with PSK stored, `reg_complete` set, pairing button not held.
+11. Assert: node enters normal WAKE cycle.
 
 ---
 
@@ -1307,17 +1312,19 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 
 ---
 
-### T-N906  NODE_PROVISION with pairing button — factory reset
+### T-N906  Boot button factory reset on paired node
 
-**Validates:** ND-0905, ND-0917
+**Validates:** ND-0900, ND-0917
 
 **Procedure:**
-1. Provision a node with credentials and a resident BPF program.
+1. Provision a node with credentials and a resident BPF program. Stage a pre-provisioning test command in RTC state.
 2. Reboot with pairing button held ≥ 500 ms.
-3. Write NODE_PROVISION with new credentials.
-4. Assert: existing PSK, persistent map data, and resident BPF program are erased before new credentials are written.
-5. Assert: node responds NODE_ACK(0x00).
-6. Assert: NVS contains only the new credentials.
+3. Assert: factory reset is performed at boot — existing PSK, persistent map data, resident BPF program, BLE pairing artifacts, schedule, channel, and staged pre-provisioning test state are erased.
+4. Assert: `board_layout` is preserved.
+5. Assert: node enters BLE pairing mode as an unpaired node (no `button_held` parameter passed to BLE pairing mode).
+6. Write NODE_PROVISION with new credentials.
+7. Assert: node responds NODE_ACK(0x00).
+8. Assert: NVS contains only the new credentials.
 
 ---
 
@@ -2628,12 +2635,12 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0800 | T-N800 |
 | ND-0801 | T-N801, T-N803, T-N938 |
 | ND-0802 | T-N802 |
-| ND-0900 | T-N900 |
+| ND-0900 | T-N900, T-N1102 |
 | ND-0901 | T-N901 |
 | ND-0902 | T-N902 |
 | ND-0903 | T-N902 |
 | ND-0904 | T-N903, T-N939 |
-| ND-0905 | T-N904, T-N905, T-N906, T-N940 |
+| ND-0905 | T-N904, T-N905, T-N940 |
 | ND-0906 | T-N904 |
 | ND-0907 | T-N905, T-N908 |
 | ND-0908 | T-N907 |
@@ -2645,7 +2652,7 @@ A set of pre-compiled BPF programs (as CBOR program images) for testing:
 | ND-0914 | T-N916 |
 | ND-0915 | T-N917, T-N917a |
 | ND-0916 | T-N918 |
-| ND-0917 | T-N906 |
+| ND-0917 | T-N900, T-N906 |
 | ND-0918 | T-N918a, T-N918b, T-N918c |
 | ND-0919 | T-N942, T-N942a |
 | ND-0608 | T-N0607a, T-N0607b, T-N0607c, T-N0607d, T-N0607e, T-N0607f, T-N0607g |
@@ -2763,7 +2770,7 @@ Test functions in `crates/sonde-node/src/` are unit tests; those in `crates/sond
 | T-N903 | *(hardware — validated on target: MTU negotiation and LESC pairing)* | — |
 | T-N904 | `t_n904_happy_path`, `t_e2e_062_node_ble_provisioning`, `t_e2e_068_factory_reset_reprovision`, `t_e2e_070_full_use_case` | ble_pairing.rs, e2e_tests.rs |
 | T-N905 | `t_n905_same_session_reprovision` | ble_pairing.rs |
-| T-N906 | `t_n906_factory_reset_on_button_hold` | ble_pairing.rs |
+| T-N906 | `t_n906_factory_reset_at_boot`, `t_n906_factory_reset_on_button_hold` | node.rs, ble_pairing.rs |
 | T-N907 | `t_n907_nvs_write_key_failure`, `t_n907_nvs_write_channel_failure`, `t_n907_nvs_write_peer_payload_failure`, `t_n907_nvs_write_reg_complete_failure` | ble_pairing.rs |
 | T-N908 | *(hardware — validated on target: BLE mode persistence after provisioning)* | — |
 | T-N909 | `t_e2e_063_peer_request_ack` | e2e_tests.rs |

--- a/docs/node-validation.md
+++ b/docs/node-validation.md
@@ -2770,7 +2770,7 @@ Test functions in `crates/sonde-node/src/` are unit tests; those in `crates/sond
 | T-N903 | *(hardware — validated on target: MTU negotiation and LESC pairing)* | — |
 | T-N904 | `t_n904_happy_path`, `t_e2e_062_node_ble_provisioning`, `t_e2e_068_factory_reset_reprovision`, `t_e2e_070_full_use_case` | ble_pairing.rs, e2e_tests.rs |
 | T-N905 | `t_n905_same_session_reprovision` | ble_pairing.rs |
-| T-N906 | `t_n906_provision_overwrites_existing_credentials` | ble_pairing.rs |
+| T-N906 | `test_factory_reset`, `test_factory_reset_erase_key_fails`, `test_factory_reset_clear_staged_test_command_fails`, `test_factory_reset_clear_test_result_fails` *(factory reset logic)*; *(hardware — boot-button orchestration validated on target)* | key_store.rs |
 | T-N907 | `t_n907_nvs_write_key_failure`, `t_n907_nvs_write_channel_failure`, `t_n907_nvs_write_peer_payload_failure`, `t_n907_nvs_write_reg_complete_failure` | ble_pairing.rs |
 | T-N908 | *(hardware — validated on target: BLE mode persistence after provisioning)* | — |
 | T-N909 | `t_e2e_063_peer_request_ack` | e2e_tests.rs |


### PR DESCRIPTION
## Summary

Move factory reset from deferred (inside `NODE_PROVISION` handler during BLE pairing) to immediate (at boot, before entering BLE pairing mode). When the boot button is held >=500 ms on an already-paired node, the firmware now performs a full factory reset then enters BLE pairing mode as an unpaired node.

## Problem

Holding the boot button on a paired node entered BLE pairing mode with credentials intact, deferring factory reset until `NODE_PROVISION` arrived. If the pairing tool triggered a radio diagnostic (which reboots the node), the button was no longer held on the next boot and the node reverted to its paired operational state -- the factory-reset intent was lost.

## Changes

### Spec (3 files)
- **ND-0900**: Boot priority reordered -- button+PSK->reset is now checked first
- **ND-0905**: Removed `button_held`/`paired_on_entry` from `NODE_PROVISION` handling
- **ND-0917**: Renamed to *Factory reset via boot button*; reset happens immediately at boot
- Design sections 4.1, 4.2, 6.2, 14, 15 updated
- Validation T-N900/T-N906 updated with factory-reset and staged-test steps

### Code (7 files)
- `KeyStore::factory_reset()`: reordered to erase PSK **last** (partial failures leave node paired and retryable); added `clear_staged_test_command()` and `clear_test_result()`
- `handle_node_provision()`: removed `button_held`, `paired_on_entry`, `map_storage` params -- no longer performs factory reset
- `run_ble_pairing_mode()`: removed `button_held` and `map_storage` params; added unpaired invariant check (fail-closed)
- `node.rs`: boot path performs factory reset when `button_held && has_psk`, fail-closed on error (deep sleep)
- Added `clear_test_result()` to `PlatformStorage` trait
- New tests for staged-test-clearing and failure-injection paths

## Testing

- `cargo clippy --workspace -- -D warnings` passes
- `cargo test --workspace` passes (0 failures)
