### PR TITLE
feat: add GetGatewayState and SubmitRotation gRPC RPCs (GW-2012)

### DIFF
--- a/crates/sonde-gateway/proto/admin.proto
+++ b/crates/sonde-gateway/proto/admin.proto
@@ -39,6 +39,10 @@ service GatewayAdmin {
     rpc AddHandler(AddHandlerRequest) returns (Empty);
     rpc RemoveHandler(RemoveHandlerRequest) returns (Empty);
     rpc ListHandlers(Empty) returns (ListHandlersResponse);
+
+    // Key management (GW-2012, evolve-962 §5.1.1).
+    rpc GetGatewayState(Empty) returns (GatewayState);
+    rpc SubmitRotation(SubmitRotationRequest) returns (SubmitRotationResponse);
 }
 
 message Empty {}
@@ -193,3 +197,34 @@ message HandlerInfo {
     optional uint64 reply_timeout_ms = 5;
 }
 message ListHandlersResponse { repeated HandlerInfo handlers = 1; }
+
+// Key management messages (GW-2012, evolve-962 §5.1.1).
+message GatewayState {
+    bytes gateway_id = 1;
+    uint32 channel = 2;
+    bytes master_key_id = 3;          // 16 bytes, opaque
+    uint64 master_key_epoch = 4;
+    bytes x25519_public_key = 5;      // 32 bytes
+    repeated string fingerprint_words = 6; // 6 BIP-39 words
+    bool rotation_in_progress = 7;
+    optional bytes salt = 8;          // 16 bytes or absent
+    optional KdfParameters kdf_params = 9;
+    string gateway_version = 10;
+    string gateway_commit = 11;
+}
+
+message KdfParameters {
+    uint32 m_cost = 1;
+    uint32 t_cost = 2;
+    uint32 p_cost = 3;
+    uint32 kdf_version = 4;
+}
+
+message SubmitRotationRequest {
+    bytes rotation_payload = 1; // RotationPayloadV1 binary (evolve-962 §2.6.1)
+}
+
+message SubmitRotationResponse {
+    bool accepted = 1;
+    string error = 2; // Human-readable error if rejected
+}

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -30,6 +30,7 @@ struct KdfParamsJson {
     m_cost: u32,
     t_cost: u32,
     p_cost: u32,
+    #[serde(alias = "version")]
     kdf_version: u32,
 }
 
@@ -1292,7 +1293,6 @@ impl GatewayAdmin for AdminService {
         let sha = crate::crypto::RustCryptoSha256;
         let fp = sonde_protocol::fingerprint::compute_fingerprint(x25519_public.as_bytes(), &sha);
 
-        // Channel — default to 1 if absent, error if stored value is malformed.
         // Channel — default to 1 if absent, error on non-integer.
         // Range is NOT validated here: this is a read-only diagnostic RPC,
         // so reporting the stored value (even if out-of-range) helps operators
@@ -1403,6 +1403,17 @@ impl GatewayAdmin for AdminService {
                 error: "rotation_payload is empty".to_string(),
             }));
         }
+        // Fail fast on obviously-too-short payloads (shared constant with rotation.rs).
+        if payload.len() < crate::rotation::MIN_PAYLOAD_LEN {
+            return Ok(Response::new(SubmitRotationResponse {
+                accepted: false,
+                error: format!(
+                    "rotation_payload too short: {} bytes (min {})",
+                    payload.len(),
+                    crate::rotation::MIN_PAYLOAD_LEN,
+                ),
+            }));
+        }
         // Enforce max payload size (shared constant with rotation.rs).
         if payload.len() > crate::rotation::MAX_PAYLOAD_LEN {
             return Ok(Response::new(SubmitRotationResponse {
@@ -1419,16 +1430,17 @@ impl GatewayAdmin for AdminService {
         tx.send((payload, resp_tx))
             .map_err(|_| Status::internal("rotation channel closed"))?;
 
-        match resp_rx.await {
-            Ok(Ok(())) => Ok(Response::new(SubmitRotationResponse {
+        match tokio::time::timeout(std::time::Duration::from_secs(30), resp_rx).await {
+            Ok(Ok(Ok(()))) => Ok(Response::new(SubmitRotationResponse {
                 accepted: true,
                 error: String::new(),
             })),
-            Ok(Err(e)) => Ok(Response::new(SubmitRotationResponse {
+            Ok(Ok(Err(e))) => Ok(Response::new(SubmitRotationResponse {
                 accepted: false,
                 error: e,
             })),
-            Err(_) => Err(Status::internal("rotation handler dropped response")),
+            Ok(Err(_)) => Err(Status::internal("rotation handler dropped response")),
+            Err(_) => Err(Status::deadline_exceeded("rotation handler timed out")),
         }
     }
 

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -1293,6 +1293,10 @@ impl GatewayAdmin for AdminService {
         let fp = sonde_protocol::fingerprint::compute_fingerprint(x25519_public.as_bytes(), &sha);
 
         // Channel — default to 1 if absent, error if stored value is malformed.
+        // Channel — default to 1 if absent, error on non-integer.
+        // Range is NOT validated here: this is a read-only diagnostic RPC,
+        // so reporting the stored value (even if out-of-range) helps operators
+        // diagnose DB issues. SetModemChannel enforces 1..=14 on writes.
         let channel: u32 = match self
             .storage
             .get_config("espnow_channel")
@@ -1346,7 +1350,10 @@ impl GatewayAdmin for AdminService {
             None => None,
         };
 
-        // Check pending_rotation table for active rotation.
+        // Check for active rotation via the `pending_rotation_phase` config key.
+        // This key is set by the rotation engine when a rotation begins and
+        // cleared on commit. When the engine wiring lands, this will reflect
+        // the actual pending_rotation table state.
         let rotation_in_progress = self
             .storage
             .get_config("pending_rotation_phase")
@@ -1375,6 +1382,11 @@ impl GatewayAdmin for AdminService {
     ///
     /// Both this gRPC path and the DESIRED_STATE connector path converge
     /// on the same rotation handler in the gateway engine.
+    ///
+    /// The `rotation_tx` channel is wired at gateway startup via
+    /// `with_rotation_tx()`. Until the engine wiring PR lands, this RPC
+    /// returns `UNAVAILABLE` — the correct gRPC status for an
+    /// unconfigured backend.
     async fn submit_rotation(
         &self,
         request: Request<SubmitRotationRequest>,
@@ -1391,13 +1403,14 @@ impl GatewayAdmin for AdminService {
                 error: "rotation_payload is empty".to_string(),
             }));
         }
-        // Enforce max payload size consistent with rotation.rs MAX_PAYLOAD_LEN.
-        if payload.len() > 1024 {
+        // Enforce max payload size (shared constant with rotation.rs).
+        if payload.len() > crate::rotation::MAX_PAYLOAD_LEN {
             return Ok(Response::new(SubmitRotationResponse {
                 accepted: false,
                 error: format!(
-                    "rotation_payload too large: {} bytes (max 1024)",
-                    payload.len()
+                    "rotation_payload too large: {} bytes (max {})",
+                    payload.len(),
+                    crate::rotation::MAX_PAYLOAD_LEN,
                 ),
             }));
         }

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -1428,7 +1428,7 @@ impl GatewayAdmin for AdminService {
 
         let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
         tx.send((payload, resp_tx))
-            .map_err(|_| Status::internal("rotation channel closed"))?;
+            .map_err(|_| Status::unavailable("rotation channel closed"))?;
 
         match tokio::time::timeout(std::time::Duration::from_secs(30), resp_rx).await {
             Ok(Ok(Ok(()))) => Ok(Response::new(SubmitRotationResponse {

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -24,6 +24,19 @@ use crate::session::SessionManager;
 use crate::storage::{HandlerRecord, Storage};
 use crate::transient_display::{show_modem_display_message, ActiveDisplayState};
 
+/// JSON-serializable KDF parameters (stored in gateway_config).
+#[derive(serde::Deserialize)]
+struct KdfParamsJson {
+    m_cost: u32,
+    t_cost: u32,
+    p_cost: u32,
+    kdf_version: u32,
+}
+
+/// Channel type for rotation payload submission with oneshot response.
+pub type RotationSubmitChannel =
+    tokio::sync::mpsc::UnboundedSender<(Vec<u8>, tokio::sync::oneshot::Sender<Result<(), String>>)>;
+
 pub mod pb {
     tonic::include_proto!("sonde.admin");
 }
@@ -43,6 +56,8 @@ pub struct AdminService {
     handler_configs: RwLock<Vec<HandlerConfig>>,
     /// Shared handler router for live reload (GW-1404, GW-1407).
     handler_router: Option<Arc<tokio::sync::RwLock<HandlerRouter>>>,
+    /// Channel for submitting rotation payloads to the gateway engine (GW-2012).
+    rotation_tx: Option<RotationSubmitChannel>,
 }
 
 impl AdminService {
@@ -61,6 +76,7 @@ impl AdminService {
             display_state: None,
             handler_configs: RwLock::new(Vec::new()),
             handler_router: None,
+            rotation_tx: None,
         }
     }
 
@@ -109,6 +125,12 @@ impl AdminService {
     /// Set the shared handler router for live reload (GW-1404, GW-1407).
     pub fn with_handler_router(mut self, router: Arc<tokio::sync::RwLock<HandlerRouter>>) -> Self {
         self.handler_router = Some(router);
+        self
+    }
+
+    /// Set the channel for submitting rotation payloads to the gateway engine.
+    pub fn with_rotation_tx(mut self, tx: RotationSubmitChannel) -> Self {
+        self.rotation_tx = Some(tx);
         self
     }
 
@@ -1213,6 +1235,157 @@ impl GatewayAdmin for AdminService {
             })
             .collect();
         Ok(Response::new(ListHandlersResponse { handlers }))
+    }
+
+    // ── Key management RPCs (GW-2012) ──────────────────────────
+
+    /// Return the gateway's current state for key management operations.
+    ///
+    /// Provides the X25519 public key, BIP-39 fingerprint, master key
+    /// identification, salt, KDF params, and rotation status needed by
+    /// the admin CLI `key rotate`, `key fingerprint`, and `key status`
+    /// commands.
+    async fn get_gateway_state(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<GatewayState>, Status> {
+        let gateway_id = self
+            .storage
+            .get_config("gateway_id_hex")
+            .await
+            .map_err(storage_err)?
+            .ok_or_else(|| Status::not_found("gateway identity not initialized"))?;
+        let gateway_id_bytes = hex::decode(&gateway_id)
+            .map_err(|e| Status::internal(format!("invalid gateway_id hex: {e}")))?;
+
+        let master_key_id_hex = self
+            .storage
+            .get_config("master_key_id")
+            .await
+            .map_err(storage_err)?
+            .ok_or_else(|| Status::not_found("master key not initialized"))?;
+        let master_key_id = hex::decode(&master_key_id_hex)
+            .map_err(|e| Status::internal(format!("invalid master_key_id hex: {e}")))?;
+
+        let master_key_epoch: u64 = self
+            .storage
+            .get_config("master_key_epoch")
+            .await
+            .map_err(storage_err)?
+            .ok_or_else(|| Status::not_found("master key epoch not initialized"))?
+            .parse()
+            .map_err(|e| Status::internal(format!("invalid master_key_epoch: {e}")))?;
+
+        let identity = self
+            .storage
+            .load_gateway_identity()
+            .await
+            .map_err(storage_err)?
+            .ok_or_else(|| Status::not_found("gateway identity not found"))?;
+
+        let (_, x25519_public) = identity
+            .to_x25519()
+            .map_err(|e| Status::internal(format!("X25519 conversion failed: {e}")))?;
+
+        let sha = crate::crypto::RustCryptoSha256;
+        let fp = sonde_protocol::fingerprint::compute_fingerprint(x25519_public.as_bytes(), &sha);
+
+        let channel_str = self
+            .storage
+            .get_config("espnow_channel")
+            .await
+            .map_err(storage_err)?;
+        let channel: u32 = channel_str.as_deref().unwrap_or("1").parse().unwrap_or(1);
+
+        let salt = self
+            .storage
+            .get_config("kdf_salt")
+            .await
+            .map_err(storage_err)?
+            .and_then(|s| hex::decode(s).ok());
+
+        let kdf_params = match self
+            .storage
+            .get_config("kdf_params_json")
+            .await
+            .map_err(storage_err)?
+        {
+            Some(json) => {
+                serde_json::from_str::<KdfParamsJson>(&json)
+                    .ok()
+                    .map(|p| KdfParameters {
+                        m_cost: p.m_cost,
+                        t_cost: p.t_cost,
+                        p_cost: p.p_cost,
+                        kdf_version: p.kdf_version,
+                    })
+            }
+            None => None,
+        };
+
+        // Check if a rotation is in progress by looking for pending_rotation
+        // config key (set by the rotation engine).
+        let rotation_in_progress = self
+            .storage
+            .get_config("rotation_in_progress")
+            .await
+            .map_err(storage_err)?
+            .map(|v| v == "true")
+            .unwrap_or(false);
+
+        Ok(Response::new(GatewayState {
+            gateway_id: gateway_id_bytes,
+            channel,
+            master_key_id,
+            master_key_epoch,
+            x25519_public_key: x25519_public.as_bytes().to_vec(),
+            fingerprint_words: fp.iter().map(|w| w.to_string()).collect(),
+            rotation_in_progress,
+            salt,
+            kdf_params,
+            gateway_version: env!("CARGO_PKG_VERSION").to_string(),
+            gateway_commit: option_env!("SONDE_BUILD_COMMIT")
+                .unwrap_or("unknown")
+                .to_string(),
+        }))
+    }
+
+    /// Accept a RotationPayloadV1 and forward it to the rotation engine.
+    ///
+    /// Both this gRPC path and the DESIRED_STATE connector path converge
+    /// on the same rotation handler in the gateway engine.
+    async fn submit_rotation(
+        &self,
+        request: Request<SubmitRotationRequest>,
+    ) -> Result<Response<SubmitRotationResponse>, Status> {
+        let tx = self
+            .rotation_tx
+            .as_ref()
+            .ok_or_else(|| Status::unavailable("rotation handler not configured"))?;
+
+        let payload = request.into_inner().rotation_payload;
+        if payload.is_empty() {
+            return Ok(Response::new(SubmitRotationResponse {
+                accepted: false,
+                error: "rotation_payload is empty".to_string(),
+            }));
+        }
+
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+        tx.send((payload, resp_tx))
+            .map_err(|_| Status::internal("rotation channel closed"))?;
+
+        match resp_rx.await {
+            Ok(Ok(())) => Ok(Response::new(SubmitRotationResponse {
+                accepted: true,
+                error: String::new(),
+            })),
+            Ok(Err(e)) => Ok(Response::new(SubmitRotationResponse {
+                accepted: false,
+                error: e,
+            })),
+            Err(_) => Err(Status::internal("rotation handler dropped response")),
+        }
     }
 
     /// Get modem status (channel, counters, uptime).

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -24,7 +24,7 @@ use crate::session::SessionManager;
 use crate::storage::{HandlerRecord, Storage};
 use crate::transient_display::{show_modem_display_message, ActiveDisplayState};
 
-/// JSON-serializable KDF parameters (stored in gateway_config).
+/// JSON-deserializable KDF parameters (stored in gateway_config).
 #[derive(serde::Deserialize)]
 struct KdfParamsJson {
     m_cost: u32,
@@ -1249,15 +1249,17 @@ impl GatewayAdmin for AdminService {
         &self,
         _request: Request<Empty>,
     ) -> Result<Response<GatewayState>, Status> {
-        let gateway_id = self
+        // Load gateway identity (source of truth for gateway_id).
+        let identity = self
             .storage
-            .get_config("gateway_id_hex")
+            .load_gateway_identity()
             .await
             .map_err(storage_err)?
             .ok_or_else(|| Status::not_found("gateway identity not initialized"))?;
-        let gateway_id_bytes = hex::decode(&gateway_id)
-            .map_err(|e| Status::internal(format!("invalid gateway_id hex: {e}")))?;
 
+        let gateway_id_bytes = identity.gateway_id().to_vec();
+
+        // Master key identification.
         let master_key_id_hex = self
             .storage
             .get_config("master_key_id")
@@ -1266,6 +1268,12 @@ impl GatewayAdmin for AdminService {
             .ok_or_else(|| Status::not_found("master key not initialized"))?;
         let master_key_id = hex::decode(&master_key_id_hex)
             .map_err(|e| Status::internal(format!("invalid master_key_id hex: {e}")))?;
+        if master_key_id.len() != 16 {
+            return Err(Status::internal(format!(
+                "master_key_id has wrong length: {} (expected 16)",
+                master_key_id.len()
+            )));
+        }
 
         let master_key_epoch: u64 = self
             .storage
@@ -1276,13 +1284,7 @@ impl GatewayAdmin for AdminService {
             .parse()
             .map_err(|e| Status::internal(format!("invalid master_key_epoch: {e}")))?;
 
-        let identity = self
-            .storage
-            .load_gateway_identity()
-            .await
-            .map_err(storage_err)?
-            .ok_or_else(|| Status::not_found("gateway identity not found"))?;
-
+        // X25519 public key and fingerprint.
         let (_, x25519_public) = identity
             .to_x25519()
             .map_err(|e| Status::internal(format!("X25519 conversion failed: {e}")))?;
@@ -1290,20 +1292,41 @@ impl GatewayAdmin for AdminService {
         let sha = crate::crypto::RustCryptoSha256;
         let fp = sonde_protocol::fingerprint::compute_fingerprint(x25519_public.as_bytes(), &sha);
 
-        let channel_str = self
+        // Channel — default to 1 if absent, error if stored value is malformed.
+        let channel: u32 = match self
             .storage
             .get_config("espnow_channel")
             .await
-            .map_err(storage_err)?;
-        let channel: u32 = channel_str.as_deref().unwrap_or("1").parse().unwrap_or(1);
+            .map_err(storage_err)?
+        {
+            Some(s) => s
+                .parse()
+                .map_err(|e| Status::internal(format!("invalid espnow_channel: {e}")))?,
+            None => 1,
+        };
 
-        let salt = self
+        // Salt — error if stored but malformed, None if absent.
+        let salt = match self
             .storage
             .get_config("kdf_salt")
             .await
             .map_err(storage_err)?
-            .and_then(|s| hex::decode(s).ok());
+        {
+            Some(s) => {
+                let bytes = hex::decode(&s)
+                    .map_err(|e| Status::internal(format!("invalid kdf_salt hex: {e}")))?;
+                if bytes.len() != 16 {
+                    return Err(Status::internal(format!(
+                        "kdf_salt has wrong length: {} (expected 16)",
+                        bytes.len()
+                    )));
+                }
+                Some(bytes)
+            }
+            None => None,
+        };
 
+        // KDF params — error if stored but malformed, None if absent.
         let kdf_params = match self
             .storage
             .get_config("kdf_params_json")
@@ -1311,27 +1334,25 @@ impl GatewayAdmin for AdminService {
             .map_err(storage_err)?
         {
             Some(json) => {
-                serde_json::from_str::<KdfParamsJson>(&json)
-                    .ok()
-                    .map(|p| KdfParameters {
-                        m_cost: p.m_cost,
-                        t_cost: p.t_cost,
-                        p_cost: p.p_cost,
-                        kdf_version: p.kdf_version,
-                    })
+                let p: KdfParamsJson = serde_json::from_str(&json)
+                    .map_err(|e| Status::internal(format!("invalid kdf_params_json: {e}")))?;
+                Some(KdfParameters {
+                    m_cost: p.m_cost,
+                    t_cost: p.t_cost,
+                    p_cost: p.p_cost,
+                    kdf_version: p.kdf_version,
+                })
             }
             None => None,
         };
 
-        // Check if a rotation is in progress by looking for pending_rotation
-        // config key (set by the rotation engine).
+        // Check pending_rotation table for active rotation.
         let rotation_in_progress = self
             .storage
-            .get_config("rotation_in_progress")
+            .get_config("pending_rotation_phase")
             .await
             .map_err(storage_err)?
-            .map(|v| v == "true")
-            .unwrap_or(false);
+            .is_some();
 
         Ok(Response::new(GatewayState {
             gateway_id: gateway_id_bytes,
@@ -1344,7 +1365,7 @@ impl GatewayAdmin for AdminService {
             salt,
             kdf_params,
             gateway_version: env!("CARGO_PKG_VERSION").to_string(),
-            gateway_commit: option_env!("SONDE_BUILD_COMMIT")
+            gateway_commit: option_env!("SONDE_GIT_COMMIT")
                 .unwrap_or("unknown")
                 .to_string(),
         }))
@@ -1368,6 +1389,16 @@ impl GatewayAdmin for AdminService {
             return Ok(Response::new(SubmitRotationResponse {
                 accepted: false,
                 error: "rotation_payload is empty".to_string(),
+            }));
+        }
+        // Enforce max payload size consistent with rotation.rs MAX_PAYLOAD_LEN.
+        if payload.len() > 1024 {
+            return Ok(Response::new(SubmitRotationResponse {
+                accepted: false,
+                error: format!(
+                    "rotation_payload too large: {} bytes (max 1024)",
+                    payload.len()
+                ),
             }));
         }
 

--- a/crates/sonde-gateway/src/rotation.rs
+++ b/crates/sonde-gateway/src/rotation.rs
@@ -14,7 +14,7 @@ use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret as X25519StaticSec
 use zeroize::Zeroizing;
 
 /// Minimum total payload length: version(1) + ephemeral_public(32) + nonce(12) + tag(16) = 61.
-const MIN_PAYLOAD_LEN: usize = 1 + 32 + 12 + 16;
+pub(crate) const MIN_PAYLOAD_LEN: usize = 1 + 32 + 12 + 16;
 
 /// Maximum total payload length. The plaintext is a small CBOR map (~100 bytes),
 /// so the encrypted payload should be well under 1 KiB. Reject larger payloads

--- a/crates/sonde-gateway/src/rotation.rs
+++ b/crates/sonde-gateway/src/rotation.rs
@@ -19,7 +19,7 @@ const MIN_PAYLOAD_LEN: usize = 1 + 32 + 12 + 16;
 /// Maximum total payload length. The plaintext is a small CBOR map (~100 bytes),
 /// so the encrypted payload should be well under 1 KiB. Reject larger payloads
 /// to prevent expensive AEAD work on oversized inputs.
-const MAX_PAYLOAD_LEN: usize = 1024;
+pub(crate) const MAX_PAYLOAD_LEN: usize = 1024;
 
 /// HKDF salt constant (17 bytes, ASCII "sonde-rotation-v1").
 const HKDF_SALT: &[u8; 17] = b"sonde-rotation-v1";


### PR DESCRIPTION
## Summary

Add `GetGatewayState` and `SubmitRotation` gRPC RPCs to the gateway admin service (GW-2012, evolve-962 §5.1.1).

### Proto changes (`admin.proto`)
- `GetGatewayState` RPC — returns `GatewayState` with all key management fields
- `SubmitRotation` RPC — accepts `RotationPayloadV1` binary, returns `{accepted, error}`
- New messages: `GatewayState`, `KdfParameters`, `SubmitRotationRequest`, `SubmitRotationResponse`

### Implementation (`admin.rs`)
- `get_gateway_state()` — reads gateway identity, master key ID/epoch, X25519 public key, computes BIP-39 fingerprint, reads salt/KDF params/channel/rotation status from storage
- `submit_rotation()` — validates payload is non-empty, forwards to engine via async channel with oneshot response
- `RotationSubmitChannel` type alias for the `mpsc::UnboundedSender<(Vec<u8>, oneshot::Sender<Result<(), String>>)>` channel
- `with_rotation_tx()` builder method for wiring at startup

### Usage by admin CLI (follow-up PR)
```
sonde-admin key fingerprint  → calls GetGatewayState, displays fingerprint_words
sonde-admin key status       → calls GetGatewayState, displays epoch/id/salt/rotation
sonde-admin key rotate       → calls GetGatewayState for public key + epoch,
                                constructs RotationPayloadV1, calls SubmitRotation
```

### Verification
- `cargo build --workspace` ✅
- `cargo clippy -p sonde-gateway -- -D warnings` ✅
- `cargo test -p sonde-gateway` ✅ (all tests pass)
- `cargo fmt --all` ✅
