### PR TITLE
node: suppress INFO-level ESP-IDF boot logs in default firmware

### DIFF
--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -44,6 +44,7 @@ jobs:
             features: esp,verbose
             no_default_features: --no-default-features
             artifact: node-firmware-verbose
+            sdkconfig_extra: ;crates/sonde-node/sdkconfig.verbose
 
     container:
       image: ghcr.io/alan-jowett/sonde-esp-dev:latest
@@ -60,7 +61,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           workspaces: ". -> target"
-          key: esp32c3-riscv-${{ hashFiles('crates/sonde-node/sdkconfig.defaults', '.github/docker/Dockerfile.esp-dev') }}
+          key: esp32c3-riscv-${{ matrix.variant }}-${{ hashFiles('crates/sonde-node/sdkconfig.defaults', 'crates/sonde-node/sdkconfig.verbose', '.github/docker/Dockerfile.esp-dev') }}
 
       # ------------------------------------------------------------------ #
       # Build
@@ -80,7 +81,7 @@ jobs:
         # ESP-IDF defaults. We also delete any cached sdkconfig and CMake
         # cache so a stale rust-cache restore cannot override our settings.
         env:
-          ESP_IDF_SDKCONFIG_DEFAULTS: crates/sonde-node/sdkconfig.defaults
+          ESP_IDF_SDKCONFIG_DEFAULTS: crates/sonde-node/sdkconfig.defaults${{ matrix.sdkconfig_extra || '' }}
           ESP_IDF_COMPONENT_MANAGER: "off"
           SONDE_GIT_COMMIT: ${{ github.sha }}
         run: |
@@ -174,6 +175,12 @@ jobs:
       # ------------------------------------------------------------------ #
 
       - name: Run QEMU smoke test
+        # Only run on the verbose variant — the default (quiet) build sets
+        # CONFIG_LOG_DEFAULT_LEVEL_WARN which suppresses the INFO-level
+        # ESP-IDF boot markers this test asserts on.  The verbose build
+        # still validates the same thing: correct cross-compilation,
+        # flash-image assembly, bootloader chain, and CPU init.
+        if: matrix.variant == 'verbose'
         # Source IDF export.sh so qemu-system-riscv32 is on PATH.
         #
         # NOTE: The smoke test checks for ESP-IDF boot markers instead of

--- a/crates/sonde-node/sdkconfig.defaults
+++ b/crates/sonde-node/sdkconfig.defaults
@@ -24,8 +24,9 @@ CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED=n
 
 # Log level: WARN suppresses the verbose ESP-IDF component chatter
 # (heap_init, wifi_init, phy_init, etc.) that adds ~200 ms to boot.
-# The verbose firmware variant overrides this via sdkconfig — the QEMU
-# smoke test runs against the verbose build where INFO markers are present.
+# The verbose firmware variant overrides this via sdkconfig.verbose
+# (applied with ESP_IDF_SDKCONFIG_DEFAULTS); the QEMU smoke test runs
+# against the verbose build where INFO markers are present.
 CONFIG_LOG_DEFAULT_LEVEL_WARN=y
 
 # Bootloader log level: suppress the 2nd-stage bootloader's partition

--- a/crates/sonde-node/sdkconfig.defaults
+++ b/crates/sonde-node/sdkconfig.defaults
@@ -22,8 +22,15 @@ CONFIG_ESP_CONSOLE_UART_NUM=0
 CONFIG_ESP_CONSOLE_UART_BAUDRATE=115200
 CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG_ENABLED=n
 
-# Log level: INFO captures the boot-marker lines the smoke test asserts on.
-CONFIG_LOG_DEFAULT_LEVEL_INFO=y
+# Log level: WARN suppresses the verbose ESP-IDF component chatter
+# (heap_init, wifi_init, phy_init, etc.) that adds ~200 ms to boot.
+# The verbose firmware variant overrides this via sdkconfig — the QEMU
+# smoke test runs against the verbose build where INFO markers are present.
+CONFIG_LOG_DEFAULT_LEVEL_WARN=y
+
+# Bootloader log level: suppress the 2nd-stage bootloader's partition
+# table dump, segment loading, and flash detection messages.
+CONFIG_BOOTLOADER_LOG_LEVEL_WARN=y
 
 # Size optimizations — reduce firmware binary size.
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y

--- a/crates/sonde-node/sdkconfig.verbose
+++ b/crates/sonde-node/sdkconfig.verbose
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 sonde contributors
+#
+# Verbose-build overrides — applied AFTER sdkconfig.defaults to restore
+# INFO-level ESP-IDF component logging for the verbose firmware variant.
+# The QEMU smoke test depends on these INFO-level boot markers.
+
+CONFIG_LOG_DEFAULT_LEVEL_INFO=y
+CONFIG_BOOTLOADER_LOG_LEVEL_INFO=y


### PR DESCRIPTION
The default (quiet) firmware still emitted ~60 lines of INFO-level ESP-IDF component logs (bootloader partition dump, \heap_init\, \wifi_init\, \phy_init\, etc.) on every boot, adding unnecessary UART time.

## Changes

- Set \CONFIG_LOG_DEFAULT_LEVEL_WARN\ and \CONFIG_BOOTLOADER_LOG_LEVEL_WARN\ in \sdkconfig.defaults\ so only WARN+ messages appear on the quiet firmware.
- Add \sdkconfig.verbose\ overlay that restores INFO level for the verbose firmware variant.
- Gate the QEMU smoke test on \matrix.variant == 'verbose'\ since the quiet build no longer emits the INFO markers it asserts on.
- Include \matrix.variant\ and \sdkconfig.verbose\ in the CI cache key.