### PR TITLE
feat: add wake-packet RSSI to Azure, admin, display, and web UI

### DIFF
--- a/crates/sonde-admin/src/main.rs
+++ b/crates/sonde-admin/src/main.rs
@@ -566,6 +566,7 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
                     "node_id": status.node_id,
                     "current_program_hash": hex::encode(&status.current_program_hash),
                     "battery_mv": status.battery_mv,
+                    "wake_rssi_dbm": status.last_wake_rssi_dbm,
                     "firmware_abi_version": status.firmware_abi_version,
                     "last_seen_ms": status.last_seen_ms,
                     "has_active_session": status.has_active_session,
@@ -583,6 +584,9 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
                 );
                 if let Some(mv) = status.battery_mv {
                     println!("Battery:  {mv} mV");
+                }
+                if let Some(rssi) = status.last_wake_rssi_dbm {
+                    println!("RSSI:     {rssi} dBm");
                 }
                 if let Some(abi) = status.firmware_abi_version {
                     println!("ABI:      {abi}");
@@ -957,6 +961,9 @@ fn print_node(n: &pb::NodeInfo, program_names: &HashMap<Vec<u8>, String>, verbos
     if let Some(mv) = n.last_battery_mv {
         println!("    battery:  {mv} mV");
     }
+    if let Some(rssi) = n.last_wake_rssi_dbm {
+        println!("    RSSI:     {rssi} dBm");
+    }
     if let Some(ms) = n.last_seen_ms {
         println!("    last seen: {}", format_epoch_ms(ms));
     }
@@ -972,6 +979,7 @@ fn node_to_json(n: &pb::NodeInfo) -> serde_json::Value {
         "assigned_program_hash": hex::encode(&n.assigned_program_hash),
         "current_program_hash": hex::encode(&n.current_program_hash),
         "last_battery_mv": n.last_battery_mv,
+        "last_wake_rssi_dbm": n.last_wake_rssi_dbm,
         "last_firmware_abi_version": n.last_firmware_abi_version,
         "last_seen_ms": n.last_seen_ms,
         "schedule_interval_s": n.schedule_interval_s,

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -993,7 +993,12 @@ impl TryFrom<ActualStateEntity> for ActualStateRow {
             )?,
             observed_schedule_interval_s: value.observed_schedule_interval_s,
             battery_mv: value.battery_mv,
-            wake_rssi_dbm: value.wake_rssi_dbm.and_then(|v| i8::try_from(v).ok()),
+            wake_rssi_dbm: match value.wake_rssi_dbm {
+                None => None,
+                Some(v) => Some(i8::try_from(v).map_err(|_| {
+                    HandlerError::Store(format!("`wake_rssi_dbm` value {v} is out of i8 range"))
+                })?),
+            },
             firmware_abi_version: value.firmware_abi_version,
             firmware_version: value.firmware_version,
             timestamp_ms: value.timestamp_ms,
@@ -3440,5 +3445,80 @@ mod tests {
             "node entity should use 'n:' partition prefix, got: {}",
             entity.partition_key
         );
+    }
+
+    #[tokio::test]
+    async fn actual_state_with_rssi_decodes_negative_value() {
+        let value = Value::Map(vec![
+            map_entry(1, Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
+            map_entry(2, Value::Text("node".to_string())),
+            map_entry(3, Value::Text("node-rssi".to_string())),
+            map_entry(4, Value::Null),
+            map_entry(5, Value::Null),
+            map_entry(6, Value::Integer(3300u64.into())),
+            map_entry(7, Value::Integer(1u64.into())),
+            map_entry(8, Value::Text("1.0.0".to_string())),
+            map_entry(9, Value::Integer(9999u64.into())),
+            map_entry(10, Value::Map(Vec::new())),
+            map_entry(11, Value::Null),
+            map_entry(28, Value::Integer((-65i64).into())),
+        ]);
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&value, &mut bytes).unwrap();
+
+        let store = Arc::new(MemoryStore::default());
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler =
+            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
+
+        handler.handle_payload(&bytes).await.unwrap();
+
+        let rows = store.actual_rows_for("node-rssi").await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].wake_rssi_dbm, Some(-65));
+    }
+
+    #[tokio::test]
+    async fn actual_state_without_rssi_key_decodes_as_none() {
+        // sample_actual_state does not include key 28 — backward compatibility
+        let store = Arc::new(MemoryStore::default());
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler =
+            AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "desired-state");
+
+        handler
+            .handle_payload(&sample_actual_state(
+                "node-no-rssi",
+                Some(&[0xAA; 32]),
+                None,
+                Some(60),
+            ))
+            .await
+            .unwrap();
+
+        let rows = store.actual_rows_for("node-no-rssi").await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].wake_rssi_dbm, None);
+    }
+
+    #[test]
+    fn actual_state_rssi_rejects_wrong_type() {
+        let value = Value::Map(vec![
+            map_entry(1, Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
+            map_entry(2, Value::Text("node".to_string())),
+            map_entry(3, Value::Text("node-bad".to_string())),
+            map_entry(4, Value::Null),
+            map_entry(5, Value::Null),
+            map_entry(6, Value::Null),
+            map_entry(7, Value::Null),
+            map_entry(8, Value::Null),
+            map_entry(9, Value::Integer(1234u64.into())),
+            map_entry(28, Value::Text("not-an-int".to_string())),
+        ]);
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&value, &mut bytes).unwrap();
+
+        let result = decode_connector_message(&bytes);
+        assert!(result.is_err(), "string value at key 28 should fail decode");
     }
 }

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -96,6 +96,7 @@ pub struct ActualStateRow {
     pub observed_assigned_program_hash: Option<Vec<u8>>,
     pub observed_schedule_interval_s: Option<u32>,
     pub battery_mv: Option<u32>,
+    pub wake_rssi_dbm: Option<i8>,
     pub firmware_abi_version: Option<u32>,
     pub firmware_version: Option<String>,
     pub timestamp_ms: u64,
@@ -111,6 +112,7 @@ impl ActualStateRow {
             observed_assigned_program_hash: message.assigned_program_hash.clone(),
             observed_schedule_interval_s: message.schedule_interval_s,
             battery_mv: message.battery_mv,
+            wake_rssi_dbm: message.wake_rssi_dbm,
             firmware_abi_version: message.firmware_abi_version,
             firmware_version: message.firmware_version.clone(),
             timestamp_ms: message.timestamp_ms,
@@ -159,6 +161,7 @@ pub struct ActualStateMessage {
     pub current_program_hash: Option<Vec<u8>>,
     pub assigned_program_hash: Option<Vec<u8>>,
     pub battery_mv: Option<u32>,
+    pub wake_rssi_dbm: Option<i8>,
     pub firmware_abi_version: Option<u32>,
     pub firmware_version: Option<String>,
     pub timestamp_ms: u64,
@@ -894,6 +897,8 @@ struct ActualStateEntity {
     observed_assigned_program_hash: Option<String>,
     observed_schedule_interval_s: Option<u32>,
     battery_mv: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    wake_rssi_dbm: Option<i32>,
     firmware_abi_version: Option<u32>,
     firmware_version: Option<String>,
     #[serde(deserialize_with = "deserialize_u64_flexible")]
@@ -988,6 +993,7 @@ impl TryFrom<ActualStateEntity> for ActualStateRow {
             )?,
             observed_schedule_interval_s: value.observed_schedule_interval_s,
             battery_mv: value.battery_mv,
+            wake_rssi_dbm: value.wake_rssi_dbm.and_then(|v| i8::try_from(v).ok()),
             firmware_abi_version: value.firmware_abi_version,
             firmware_version: value.firmware_version,
             timestamp_ms: value.timestamp_ms,
@@ -1010,6 +1016,7 @@ impl TryFrom<ActualStateRow> for ActualStateEntity {
             ),
             observed_schedule_interval_s: value.observed_schedule_interval_s,
             battery_mv: value.battery_mv,
+            wake_rssi_dbm: value.wake_rssi_dbm.map(|v| v as i32),
             firmware_abi_version: value.firmware_abi_version,
             firmware_version: value.firmware_version,
             timestamp_ms: value.timestamp_ms,
@@ -1123,6 +1130,7 @@ fn decode_connector_message(bytes: &[u8]) -> Result<ConnectorMessage, HandlerErr
             current_program_hash: optional_program_hash_field(&map, 4, "current_program_hash")?,
             assigned_program_hash: optional_program_hash_field(&map, 5, "assigned_program_hash")?,
             battery_mv: optional_u32_field(&map, 6, "battery_mv")?,
+            wake_rssi_dbm: optional_i8_field(&map, 28, "wake_rssi_dbm")?,
             firmware_abi_version: optional_u32_field(&map, 7, "firmware_abi_version")?,
             firmware_version: optional_text_field(&map, 8, "firmware_version")?,
             timestamp_ms: required_u64(&map, 9, "timestamp_ms")?,
@@ -1393,6 +1401,24 @@ fn optional_u32_field(
             .and_then(|v| u32::try_from(v).ok())
             .map(Some)
             .ok_or_else(|| HandlerError::Decode(format!("`{field}` must be uint or null"))),
+    }
+}
+
+fn optional_i8_field(
+    map: &[(Value, Value)],
+    key: u64,
+    field: &str,
+) -> Result<Option<i8>, HandlerError> {
+    match map_get(map, key) {
+        Some(Value::Null) | None => Ok(None),
+        Some(value) => value
+            .as_integer()
+            .and_then(|i| i64::try_from(i).ok())
+            .and_then(|v| i8::try_from(v).ok())
+            .map(Some)
+            .ok_or_else(|| {
+                HandlerError::Decode(format!("`{field}` must be int (-128..127) or null"))
+            }),
     }
 }
 
@@ -2043,6 +2069,7 @@ mod tests {
                 observed_assigned_program_hash: Some(vec![0xAA; 32]),
                 observed_schedule_interval_s: Some(60),
                 battery_mv: Some(3200),
+                wake_rssi_dbm: None,
                 firmware_abi_version: Some(2),
                 firmware_version: Some("2.0.0".to_string()),
                 timestamp_ms: 5000,
@@ -2151,6 +2178,7 @@ mod tests {
                 observed_assigned_program_hash: Some(vec![0xBB; 32]),
                 observed_schedule_interval_s: Some(60),
                 battery_mv: Some(3200),
+                wake_rssi_dbm: None,
                 firmware_abi_version: Some(1),
                 firmware_version: Some("1.2.3".to_string()),
                 timestamp_ms: 1234,
@@ -2336,6 +2364,7 @@ mod tests {
             observed_assigned_program_hash: Some(vec![0x33; 32]),
             observed_schedule_interval_s: Some(30),
             battery_mv: Some(3300),
+            wake_rssi_dbm: None,
             firmware_abi_version: Some(1),
             firmware_version: Some("1.2.3".to_string()),
             timestamp_ms: 1234,
@@ -3400,6 +3429,7 @@ mod tests {
             observed_assigned_program_hash: None,
             observed_schedule_interval_s: None,
             battery_mv: None,
+            wake_rssi_dbm: None,
             firmware_abi_version: None,
             firmware_version: None,
             timestamp_ms: 1234,

--- a/crates/sonde-gateway/proto/admin.proto
+++ b/crates/sonde-gateway/proto/admin.proto
@@ -54,6 +54,7 @@ message NodeInfo {
     optional uint32 last_firmware_abi_version = 6;
     optional uint64 last_seen_ms = 7;
     optional uint32 schedule_interval_s = 8;
+    optional int32 last_wake_rssi_dbm = 9;
 }
 
 message ListNodesResponse { repeated NodeInfo nodes = 1; }
@@ -104,6 +105,7 @@ message NodeStatus {
     optional uint32 firmware_abi_version = 4;
     optional uint64 last_seen_ms = 5;
     bool has_active_session = 6;
+    optional int32 last_wake_rssi_dbm = 7;
 }
 message ExportStateRequest { string passphrase = 1; }
 message ExportStateResponse { bytes data = 1; }

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -185,6 +185,7 @@ fn node_to_info(
     n: &NodeRecord,
     last_seen: Option<std::time::SystemTime>,
     last_battery_mv: Option<u32>,
+    last_wake_rssi_dbm: Option<i8>,
 ) -> NodeInfo {
     let last_seen_ms = last_seen.and_then(system_time_to_millis);
     NodeInfo {
@@ -196,6 +197,7 @@ fn node_to_info(
         last_firmware_abi_version: n.firmware_abi_version,
         last_seen_ms,
         schedule_interval_s: Some(n.schedule_interval_s),
+        last_wake_rssi_dbm: last_wake_rssi_dbm.map(|v| v as i32),
     }
 }
 
@@ -204,6 +206,7 @@ pub(crate) struct NodeStatusSnapshot {
     pub(crate) node_id: String,
     pub(crate) current_program_hash: Vec<u8>,
     pub(crate) battery_mv: Option<u32>,
+    pub(crate) wake_rssi_dbm: Option<i8>,
     pub(crate) firmware_abi_version: Option<u32>,
     pub(crate) last_seen_ms: Option<u64>,
     pub(crate) has_active_session: bool,
@@ -420,10 +423,12 @@ pub(crate) async fn get_node_status_impl(
         .await
         .and_then(system_time_to_millis);
     let battery_mv = session_manager.get_battery_mv(node_id).await;
+    let wake_rssi_dbm = session_manager.get_wake_rssi_dbm(node_id).await;
     Ok(NodeStatusSnapshot {
         node_id: node.node_id,
         current_program_hash: node.current_program_hash.unwrap_or_default(),
         battery_mv,
+        wake_rssi_dbm,
         firmware_abi_version: node.firmware_abi_version,
         last_seen_ms,
         has_active_session,
@@ -513,6 +518,7 @@ impl GatewayAdmin for AdminService {
         let nodes = list_nodes_impl(&self.storage).await?;
         let last_seen = self.session_manager.snapshot_last_seen().await;
         let battery_mv = self.session_manager.snapshot_battery_mv().await;
+        let wake_rssi_dbm = self.session_manager.snapshot_wake_rssi_dbm().await;
         let mut nodes: Vec<_> = nodes
             .iter()
             .map(|node| {
@@ -520,6 +526,7 @@ impl GatewayAdmin for AdminService {
                     node,
                     last_seen.get(&node.node_id).copied(),
                     battery_mv.get(&node.node_id).copied(),
+                    wake_rssi_dbm.get(&node.node_id).copied(),
                 )
             })
             .collect();
@@ -535,7 +542,13 @@ impl GatewayAdmin for AdminService {
         let node = get_node_impl(&self.storage, node_id).await?;
         let last_seen = self.session_manager.get_last_seen(node_id).await;
         let battery_mv = self.session_manager.get_battery_mv(node_id).await;
-        Ok(Response::new(node_to_info(&node, last_seen, battery_mv)))
+        let wake_rssi_dbm = self.session_manager.get_wake_rssi_dbm(node_id).await;
+        Ok(Response::new(node_to_info(
+            &node,
+            last_seen,
+            battery_mv,
+            wake_rssi_dbm,
+        )))
     }
 
     async fn register_node(
@@ -617,6 +630,7 @@ impl GatewayAdmin for AdminService {
         self.session_manager.remove_session(node_id).await;
         self.session_manager.clear_last_seen(node_id).await;
         self.session_manager.clear_battery_mv(node_id).await;
+        self.session_manager.clear_wake_rssi_dbm(node_id).await;
 
         Ok(Response::new(Empty {}))
     }
@@ -661,6 +675,7 @@ impl GatewayAdmin for AdminService {
         self.session_manager.remove_session(node_id).await;
         self.session_manager.clear_last_seen(node_id).await;
         self.session_manager.clear_battery_mv(node_id).await;
+        self.session_manager.clear_wake_rssi_dbm(node_id).await;
 
         // Clear any pending commands for the removed node.
         self.pending_commands.write().await.remove(node_id);
@@ -898,6 +913,7 @@ impl GatewayAdmin for AdminService {
             firmware_abi_version: status.firmware_abi_version,
             last_seen_ms: status.last_seen_ms,
             has_active_session: status.has_active_session,
+            last_wake_rssi_dbm: status.wake_rssi_dbm.map(|v| v as i32),
         }))
     }
 
@@ -1113,6 +1129,7 @@ impl GatewayAdmin for AdminService {
         self.pending_commands.write().await.clear();
         self.session_manager.clear_all_last_seen().await;
         self.session_manager.clear_all_battery_mv().await;
+        self.session_manager.clear_all_wake_rssi_dbm().await;
 
         Ok(Response::new(Empty {}))
     }

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -211,7 +211,7 @@ fn build_node_status_lines(
             push_wrapped_property_value(&mut lines, "battery", &format!("{mv} mV"));
         }
         if let Some(rssi) = wake_rssi_dbm_by_node.get(&node.node_id).copied() {
-            push_wrapped_property_value(&mut lines, "RSSI", &format!("{rssi} dBm"));
+            push_wrapped_property_value(&mut lines, "rssi", &format!("{rssi} dBm"));
         }
         if let Some(last_seen) = last_seen_by_node.get(&node.node_id).copied() {
             push_wrapped_property_value(
@@ -2201,6 +2201,35 @@ mod tests {
                 &HashMap::new(),
             ),
             vec!["No nodes registered.".to_string()]
+        );
+    }
+
+    #[test]
+    fn node_status_lines_render_rssi_when_present_and_omit_when_absent() {
+        let node_a = make_rich_node("alpha", 1, 0x11, 1_700_000_000);
+        let node_b = make_rich_node("bravo", 2, 0x22, 1_700_000_060);
+
+        let mut rssi_by_node: HashMap<String, i8> = HashMap::new();
+        rssi_by_node.insert(node_a.node_id.clone(), -65);
+        // node_b intentionally has no RSSI
+
+        let lines = build_node_status_lines(
+            &[node_a, node_b],
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &rssi_by_node,
+        );
+
+        // RSSI property and value lines should appear once (for node_a only)
+        assert_eq!(
+            lines.iter().filter(|line| *line == "rssi").count(),
+            1,
+            "rssi should appear once (only for node with RSSI data)"
+        );
+        assert!(
+            lines.iter().any(|line| line.contains("-65 dBm")),
+            "rssi value should render as '-65 dBm'"
         );
     }
 

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -178,6 +178,7 @@ fn build_node_status_lines(
     program_names: &HashMap<Vec<u8>, String>,
     last_seen_by_node: &HashMap<String, SystemTime>,
     battery_mv_by_node: &HashMap<String, u32>,
+    wake_rssi_dbm_by_node: &HashMap<String, i8>,
 ) -> Vec<String> {
     if nodes.is_empty() {
         return vec!["No nodes registered.".to_string()];
@@ -209,6 +210,9 @@ fn build_node_status_lines(
         if let Some(mv) = battery_mv_by_node.get(&node.node_id).copied() {
             push_wrapped_property_value(&mut lines, "battery", &format!("{mv} mV"));
         }
+        if let Some(rssi) = wake_rssi_dbm_by_node.get(&node.node_id).copied() {
+            push_wrapped_property_value(&mut lines, "RSSI", &format!("{rssi} dBm"));
+        }
         if let Some(last_seen) = last_seen_by_node.get(&node.node_id).copied() {
             push_wrapped_property_value(
                 &mut lines,
@@ -234,19 +238,21 @@ async fn node_status_nodes(
         Vec<NodeRecord>,
         HashMap<String, SystemTime>,
         HashMap<String, u32>,
+        HashMap<String, i8>,
     ),
     sonde_gateway::storage::StorageError,
 > {
     let nodes = storage.list_nodes().await?;
-    let (last_seen, battery_mv) = if let Some(session_manager) = session_manager {
+    let (last_seen, battery_mv, wake_rssi_dbm) = if let Some(session_manager) = session_manager {
         (
             session_manager.snapshot_last_seen().await,
             session_manager.snapshot_battery_mv().await,
+            session_manager.snapshot_wake_rssi_dbm().await,
         )
     } else {
-        (HashMap::new(), HashMap::new())
+        (HashMap::new(), HashMap::new(), HashMap::new())
     };
-    Ok((nodes, last_seen, battery_mv))
+    Ok((nodes, last_seen, battery_mv, wake_rssi_dbm))
 }
 
 async fn render_status_page(
@@ -269,7 +275,7 @@ async fn render_status_page(
             RenderedStatusPage::Static(Box::new(render_display_message(&line_refs)))
         }
         StatusPage::Nodes => match node_status_nodes(storage, session_manager).await {
-            Ok((nodes, last_seen_by_node, battery_mv_by_node)) => {
+            Ok((nodes, last_seen_by_node, battery_mv_by_node, wake_rssi_dbm_by_node)) => {
                 if nodes.is_empty() {
                     return RenderedStatusPage::Scrollable(render_status_text_page(
                         &build_node_status_lines(
@@ -277,6 +283,7 @@ async fn render_status_page(
                             &HashMap::new(),
                             &last_seen_by_node,
                             &battery_mv_by_node,
+                            &wake_rssi_dbm_by_node,
                         ),
                     ));
                 }
@@ -293,6 +300,7 @@ async fn render_status_page(
                     &program_names,
                     &last_seen_by_node,
                     &battery_mv_by_node,
+                    &wake_rssi_dbm_by_node,
                 )))
             }
             Err(e) => {
@@ -2118,6 +2126,7 @@ mod tests {
             &HashMap::new(),
             &last_seen_by_node,
             &battery_mv_by_node,
+            &HashMap::new(),
         );
         let a_index = lines
             .iter()
@@ -2189,6 +2198,7 @@ mod tests {
                 &HashMap::new(),
                 &HashMap::new(),
                 &HashMap::new(),
+                &HashMap::new(),
             ),
             vec!["No nodes registered.".to_string()]
         );
@@ -2226,6 +2236,7 @@ mod tests {
             &program_names,
             &last_seen_by_node,
             &battery_mv_by_node,
+            &HashMap::new(),
         );
 
         assert!(
@@ -2282,6 +2293,7 @@ mod tests {
             ]),
             &last_seen_by_node,
             &battery_mv_by_node,
+            &HashMap::new(),
         ));
 
         match rendered {
@@ -2318,6 +2330,7 @@ mod tests {
             &HashMap::new(),
             &last_seen_by_node,
             &battery_mv_by_node,
+            &HashMap::new(),
         ));
 
         match rendered {
@@ -2815,6 +2828,7 @@ mod tests {
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
+            &HashMap::new(),
         ));
         assert_eq!(framebuffer, expected_nodes_page.visible_window(0));
         assert!(second_press.await.unwrap());
@@ -2880,6 +2894,7 @@ mod tests {
             &HashMap::new(),
             &last_seen_by_node,
             &battery_mv_by_node,
+            &HashMap::new(),
         ));
         assert!(expected_page.is_scrollable(), "rich node page must scroll");
 
@@ -2974,6 +2989,7 @@ mod tests {
             &HashMap::new(),
             &last_seen_by_node,
             &battery_mv_by_node,
+            &HashMap::new(),
         ));
 
         tokio::time::pause();
@@ -3059,6 +3075,7 @@ mod tests {
 
         let expected_page = render_status_text_page(&build_node_status_lines(
             &[] as &[NodeRecord],
+            &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),
             &HashMap::new(),

--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -1403,6 +1403,38 @@ mod tests {
             optional_u32_field(&decoded, 11, "schedule_interval_s").unwrap(),
             Some(60)
         );
+        // WAKE RSSI at key 28 (signed integer)
+        match map_get(&decoded, 28) {
+            Some(Value::Integer(i)) => {
+                let val: i128 = (*i).into();
+                assert_eq!(val, -42);
+            }
+            other => panic!("expected signed integer at key 28, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn actual_state_encoding_emits_null_rssi_when_absent() {
+        let message = ConnectorOutboundMessage::ActualState {
+            entity_kind: "node",
+            entity_id: "node-1".to_string(),
+            current_program_hash: Some(vec![0x11; 32]),
+            assigned_program_hash: None,
+            schedule_interval_s: None,
+            battery_mv: Some(3300),
+            firmware_abi_version: Some(1),
+            firmware_version: None,
+            timestamp_ms: 1234,
+            encrypted_psk_escrow: None,
+            escrow_key_hint: None,
+            master_key_id: None,
+            wake_rssi_dbm: None,
+        };
+
+        let encoded = message.encode().unwrap();
+        let decoded = decode_map(&encoded).unwrap();
+
+        assert!(matches!(map_get(&decoded, 28), Some(Value::Null)));
     }
 
     #[test]

--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -116,6 +116,8 @@ enum ConnectorOutboundMessage {
         escrow_key_hint: Option<u16>,
         /// Opaque master key ID (16 bytes) that encrypted this PSK, CBOR key 14.
         master_key_id: Option<Vec<u8>>,
+        /// Modem-measured RSSI (dBm) of the node's WAKE frame, CBOR key 28.
+        wake_rssi_dbm: Option<i8>,
     },
     AppData {
         node_id: String,
@@ -197,6 +199,7 @@ impl ConnectorOutboundMessage {
                 encrypted_psk_escrow,
                 escrow_key_hint,
                 master_key_id,
+                wake_rssi_dbm,
             } => {
                 let mut pairs = vec![
                     map_entry(1, Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
@@ -234,6 +237,15 @@ impl ConnectorOutboundMessage {
                     14,
                     match master_key_id {
                         Some(ref id) => Value::Bytes(id.clone()),
+                        None => Value::Null,
+                    },
+                ));
+
+                // WAKE RSSI (key 28) — node-scoped only
+                pairs.push(map_entry(
+                    28,
+                    match wake_rssi_dbm {
+                        Some(rssi) => Value::Integer((*rssi as i64).into()),
                         None => Value::Null,
                     },
                 ));
@@ -434,6 +446,7 @@ impl ConnectorEventHub {
         firmware_abi_version: u32,
         firmware_version: String,
         timestamp_ms: u64,
+        wake_rssi_dbm: Option<i8>,
     ) {
         let _ = self.tx.send(ConnectorOutboundMessage::ActualState {
             entity_kind: "node",
@@ -448,6 +461,7 @@ impl ConnectorEventHub {
             encrypted_psk_escrow: None,
             escrow_key_hint: None,
             master_key_id: None,
+            wake_rssi_dbm,
         });
     }
 
@@ -466,6 +480,7 @@ impl ConnectorEventHub {
         encrypted_psk_escrow: Option<Vec<u8>>,
         escrow_key_hint: Option<u16>,
         master_key_id: Option<Vec<u8>>,
+        wake_rssi_dbm: Option<i8>,
     ) {
         let escrow_fields = match encrypted_psk_escrow {
             Some(blob) => {
@@ -510,6 +525,7 @@ impl ConnectorEventHub {
             encrypted_psk_escrow: escrow_fields.0,
             escrow_key_hint: escrow_fields.1,
             master_key_id: escrow_fields.2,
+            wake_rssi_dbm,
         });
     }
 
@@ -1373,6 +1389,7 @@ mod tests {
             encrypted_psk_escrow: None,
             escrow_key_hint: None,
             master_key_id: None,
+            wake_rssi_dbm: Some(-42),
         };
 
         let encoded = message.encode().unwrap();
@@ -1458,6 +1475,7 @@ mod tests {
             Some(vec![0xAA; 8]),
             None,
             Some(vec![0x42; 16]),
+            Some(-65),
         );
 
         let message = rx.try_recv().unwrap();

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -382,7 +382,7 @@ impl Gateway {
 
         match decoded.header.msg_type {
             MSG_WAKE => {
-                self.handle_wake(&node, &decoded.header, &payload, peer)
+                self.handle_wake(&node, &decoded.header, &payload, peer, rssi)
                     .await
             }
             MSG_GET_CHUNK | MSG_PROGRAM_ACK | MSG_APP_DATA => {
@@ -677,6 +677,7 @@ impl Gateway {
         header: &FrameHeader,
         payload: &[u8],
         peer: PeerAddress,
+        rssi: Option<i8>,
     ) -> Option<(FrameHeader, Vec<u8>, bool)> {
         // 1. Decode NodeMessage::Wake from payload
         let (firmware_abi_version, program_hash, battery_mv, firmware_version, wake_blob) =
@@ -750,6 +751,7 @@ impl Gateway {
             node_id = %node.node_id,
             seq = starting_seq,
             battery_mv,
+            wake_rssi_dbm = ?rssi,
             "WAKE received"
         );
 
@@ -855,6 +857,9 @@ impl Gateway {
                 );
                 self.session_manager.clear_last_seen(&node.node_id).await;
                 self.session_manager.clear_battery_mv(&node.node_id).await;
+                self.session_manager
+                    .clear_wake_rssi_dbm(&node.node_id)
+                    .await;
                 false
             }
             Err(e) => {
@@ -876,6 +881,11 @@ impl Gateway {
             self.session_manager
                 .record_battery_mv(&node.node_id, battery_mv)
                 .await;
+            if let Some(rssi_val) = rssi {
+                self.session_manager
+                    .record_wake_rssi_dbm(&node.node_id, rssi_val)
+                    .await;
+            }
         }
 
         self.connector_event_hub.emit_actual_state_for_node(
@@ -887,6 +897,7 @@ impl Gateway {
             firmware_abi_version,
             updated_node.firmware_version.clone().unwrap_or_default(),
             timestamp_ms,
+            rssi,
         );
 
         // 4a. Emit node_online EVENT to handlers (GW-0507)
@@ -1176,9 +1187,11 @@ impl Gateway {
         header: &FrameHeader,
         payload: &[u8],
         peer: PeerAddress,
+        rssi: Option<i8>,
     ) -> Option<Vec<u8>> {
-        let (response_header, response_cbor, deferred_delivered) =
-            self.handle_wake_core(node, header, payload, peer).await?;
+        let (response_header, response_cbor, deferred_delivered) = self
+            .handle_wake_core(node, header, payload, peer, rssi)
+            .await?;
         let frame = self.encode_response(&response_header, &response_cbor, &node.psk)?;
         // Only remove deferred reply if it was actually included in this NOP COMMAND.
         if deferred_delivered {

--- a/crates/sonde-gateway/src/session.rs
+++ b/crates/sonde-gateway/src/session.rs
@@ -73,6 +73,7 @@ pub struct SessionManager {
     sessions: RwLock<HashMap<String, Session>>,
     last_seen: RwLock<HashMap<String, SystemTime>>,
     last_battery_mv: RwLock<HashMap<String, u32>>,
+    last_wake_rssi_dbm: RwLock<HashMap<String, i8>>,
     timeout: Duration,
     /// Held as a write-lock during state import to prevent new sessions
     /// from being created while the storage is being replaced.  Normal
@@ -87,6 +88,7 @@ impl SessionManager {
             sessions: RwLock::new(HashMap::new()),
             last_seen: RwLock::new(HashMap::new()),
             last_battery_mv: RwLock::new(HashMap::new()),
+            last_wake_rssi_dbm: RwLock::new(HashMap::new()),
             timeout,
             import_lock: RwLock::new(()),
         }
@@ -189,6 +191,19 @@ impl SessionManager {
         self.last_battery_mv.read().await.get(node_id).copied()
     }
 
+    /// Record the modem-measured RSSI of the most recent WAKE frame.
+    pub async fn record_wake_rssi_dbm(&self, node_id: &str, rssi_dbm: i8) {
+        self.last_wake_rssi_dbm
+            .write()
+            .await
+            .insert(node_id.to_string(), rssi_dbm);
+    }
+
+    /// Get the runtime WAKE RSSI for a node, if any.
+    pub async fn get_wake_rssi_dbm(&self, node_id: &str) -> Option<i8> {
+        self.last_wake_rssi_dbm.read().await.get(node_id).copied()
+    }
+
     /// Return a snapshot of runtime last-seen timestamps keyed by node ID.
     pub async fn snapshot_last_seen(&self) -> HashMap<String, SystemTime> {
         self.last_seen.read().await.clone()
@@ -197,6 +212,11 @@ impl SessionManager {
     /// Return a snapshot of runtime battery readings keyed by node ID.
     pub async fn snapshot_battery_mv(&self) -> HashMap<String, u32> {
         self.last_battery_mv.read().await.clone()
+    }
+
+    /// Return a snapshot of runtime WAKE RSSI readings keyed by node ID.
+    pub async fn snapshot_wake_rssi_dbm(&self) -> HashMap<String, i8> {
+        self.last_wake_rssi_dbm.read().await.clone()
     }
 
     /// Remove the runtime last-seen timestamp for a node.
@@ -209,6 +229,11 @@ impl SessionManager {
         self.last_battery_mv.write().await.remove(node_id);
     }
 
+    /// Remove the runtime WAKE RSSI reading for a node.
+    pub async fn clear_wake_rssi_dbm(&self, node_id: &str) {
+        self.last_wake_rssi_dbm.write().await.remove(node_id);
+    }
+
     /// Remove all runtime last-seen timestamps.
     pub async fn clear_all_last_seen(&self) {
         self.last_seen.write().await.clear();
@@ -217,6 +242,11 @@ impl SessionManager {
     /// Remove all runtime battery readings.
     pub async fn clear_all_battery_mv(&self) {
         self.last_battery_mv.write().await.clear();
+    }
+
+    /// Remove all runtime WAKE RSSI readings.
+    pub async fn clear_all_wake_rssi_dbm(&self) {
+        self.last_wake_rssi_dbm.write().await.clear();
     }
 
     /// Remove all sessions that have exceeded the configured timeout.

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -552,6 +552,7 @@ async function renderDashboard() {
         <tr>
           <td>${escapeHtml(actual.node_id || '—')}</td>
           <td>${escapeHtml(actual.battery_mv ?? '—')}</td>
+          <td>${escapeHtml(actual.wake_rssi_dbm != null ? actual.wake_rssi_dbm + ' dBm' : '—')}</td>
           <td>${escapeHtml(actual.firmware_version || '—')}</td>
           <td>${escapeHtml(actual.firmware_abi_version ?? '—')}</td>
           <td title="${escapeHtml(scheduleTitle)}">${escapeHtml(scheduleDisplay)}</td>
@@ -570,6 +571,7 @@ async function renderDashboard() {
             <tr>
               <th>Node ID</th>
               <th>Battery (mV)</th>
+              <th>RSSI</th>
               <th>Firmware</th>
               <th>ABI</th>
               <th>Schedule (s)</th>

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -125,10 +125,11 @@ node reconciliation it consumes:
 2. `current_program_hash`,
 3. `assigned_program_hash`,
 4. `battery_mv`,
-5. `firmware_abi_version`,
-6. `firmware_version`,
-7. `timestamp_ms` as last check-in time, and
-8. `schedule_interval_s`.
+5. `wake_rssi_dbm`,
+6. `firmware_abi_version`,
+7. `firmware_version`,
+8. `timestamp_ms` as last check-in time, and
+9. `schedule_interval_s`.
 
 Gateway-scoped and phone-scoped `ACTUAL_STATE` messages (`entity_kind` values
 other than `"node"`) are outside the node-table ownership of this document and
@@ -175,6 +176,7 @@ The row contains the following logical columns:
 | `observed_assigned_program_hash` | Gateway-reported assigned resident program hash, nullable. |
 | `observed_schedule_interval_s` | Gateway-reported node schedule interval, nullable. |
 | `battery_mv` | Latest battery reading from `GW-0812`, nullable. |
+| `wake_rssi_dbm` | Modem-measured receive RSSI (dBm) of the WAKE frame, nullable. |
 | `firmware_abi_version` | Latest firmware ABI version, nullable. |
 | `firmware_version` | Latest firmware version, nullable. |
 | `timestamp_ms` | Check-in time carried by the source `GW-0812`. |

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -109,7 +109,7 @@ are `assigned_program_hash` and `schedule_interval_s`.
 
 1. `ActualNodeState` stores append-only actual-state rows for each `node_id`.
 2. `DesiredNodeState` stores append-only desired-state rows for each `node_id`.
-3. Actual-state rows contain observed `current_program_hash`, observed gateway-assigned program hash, observed `schedule_interval_s`, `battery_mv`, firmware ABI/version fields, and `timestamp_ms`.
+3. Actual-state rows contain observed `current_program_hash`, observed gateway-assigned program hash, observed `schedule_interval_s`, `battery_mv`, `wake_rssi_dbm`, firmware ABI/version fields, and `timestamp_ms`.
 4. Desired-state rows contain desired `assigned_program_hash` and desired `schedule_interval_s`.
 5. The schema distinguishes actual-state history from desired-state history rather than collapsing them into one mutable row shape.
 
@@ -152,7 +152,7 @@ rather than overwriting or discarding them at write time.
 **Acceptance criteria:**
 
 1. Each node-scoped `GW-0812` appends exactly one new actual-state row.
-2. The appended row's `timestamp_ms`, `battery_mv`, firmware ABI/version fields, current program, assigned program, and schedule fields match the message.
+2. The appended row's `timestamp_ms`, `battery_mv`, `wake_rssi_dbm`, firmware ABI/version fields, current program, assigned program, and schedule fields match the message.
 3. Repeated delivery of the same logical check-in results in multiple history rows rather than in-place replacement.
 4. Older deliveries may still be appended for diagnostics and audit history.
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -66,7 +66,7 @@
 1. Start with no actual-state rows and no desired-state rows for a test node.
 2. Deliver one node-scoped `GW-0812` containing current program, assigned program, schedule, battery, firmware data, and timestamp.
 3. Assert: exactly one new actual-state row is created for that node.
-4. Assert: the new actual-state row's observed fields — `observed_current_program_hash`, `observed_assigned_program_hash`, `observed_schedule_interval_s`, `battery_mv`, `firmware_abi_version`, `firmware_version`, and `timestamp_ms` — match the corresponding values from the source `GW-0812` message.
+4. Assert: the new actual-state row's observed fields — `observed_current_program_hash`, `observed_assigned_program_hash`, `observed_schedule_interval_s`, `battery_mv`, `wake_rssi_dbm`, `firmware_abi_version`, `firmware_version`, and `timestamp_ms` — match the corresponding values from the source `GW-0812` message.
 5. Assert: no desired-state row is created for that node.
 6. Assert: no downstream `GW-0811` message is published.
 

--- a/docs/gateway-companion-api.md
+++ b/docs/gateway-companion-api.md
@@ -232,8 +232,9 @@ state.
 | `modem_firmware_version` | 25 | tstr/null | Modem firmware semver. Gateway-scoped only. |
 | `modem_firmware_commit` | 26 | tstr/null | Modem firmware git commit. Gateway-scoped only. |
 | `rotation_in_progress` | 27 | bool/null | `true` if rotation is in progress. Gateway-scoped only. |
+| `wake_rssi_dbm` | 28 | int/null | Modem-measured receive RSSI (dBm) of the node's WAKE frame. Node-scoped only; null when the transport does not supply RSSI metadata. |
 
-**Key scoping:** Keys 4–8, 10–11 are node-specific and MUST be omitted for
+**Key scoping:** Keys 4–8, 10–11, 28 are node-specific and MUST be omitted for
 `entity_kind = "gateway"`. Keys 12–14 are node escrow fields. Keys 15–27
 are gateway-specific and MUST be omitted for `entity_kind = "node"`. Key 9
 (`timestamp_ms`) is shared and required for all entity kinds. Decoders

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -383,6 +383,7 @@ The gateway maintains a separate in-memory map for per-node runtime observations
 pub struct RuntimeNodeState {
     pub last_seen: Option<SystemTime>,
     pub last_battery_mv: Option<u32>,
+    pub last_wake_rssi_dbm: Option<i8>,
 }
 ```
 
@@ -889,7 +890,7 @@ The `Gateway::process_frame` / `handle_wake` / `handle_peer_request` methods emi
 
 - **PEER_REQUEST processed** — `node_id`, `key_hint`, `result` (`"registered"` or `"duplicate"`)
 - **PEER_ACK frame encoded** — `node_id`
-- **WAKE received** — `node_id`, `seq`, `battery_mv`
+- **WAKE received** — `node_id`, `seq`, `battery_mv`, `wake_rssi_dbm`
 - **COMMAND selected** — `node_id`, `command_type`
 - **Session created** — `node_id` (emitted in `handle_wake` after `create_session`)
 - **Session expired** — `node_id` (emitted in `SessionManager::reap_expired`)
@@ -1210,6 +1211,8 @@ node `send_recv()` responses.
 The node actual-state payload continues to include `battery_mv` from the just-
 processed WAKE even though battery telemetry is runtime-only locally and is not
 written to durable gateway storage.
+The payload also includes `wake_rssi_dbm` (CBOR key 28) when the modem supplies
+RSSI metadata; the field is null when the transport does not provide RSSI.
 
 ### 13A.4  External transport boundary and loss signaling
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -1072,12 +1072,12 @@ The gateway MUST emit upstream control-plane messages that describe actual
 gateway and node state changes relevant to reconciliation. For nodes, this
 includes the state learned when the gateway accepts and processes an
 authenticated `WAKE`, such as `node_id`, current and assigned program hashes
-when known, `schedule_interval_s`, `battery_mv`, firmware ABI/version data, and
+when known, `schedule_interval_s`, `battery_mv`, `wake_rssi_dbm`, firmware ABI/version data, and
 a reception timestamp encoded as Unix time in milliseconds. For node-scoped
 actual-state updates, that timestamp is the node's last check-in time as
 observed by the gateway. `battery_mv` remains part of the emitted actual-state
 record even though battery telemetry is runtime-only locally and is not durably
-persisted under GW-0702. These upstream messages are produced only after the
+persisted under GW-0702. `wake_rssi_dbm` carries the modem-measured receive RSSI (dBm) of the node's WAKE frame, or null when the transport does not supply RSSI metadata. These upstream messages are produced only after the
 gateway has updated its latest-known actual state for the affected entity.
 
 **Acceptance criteria:**
@@ -1303,8 +1303,8 @@ framebuffer rendering; the modem continues to render only the received
 framebuffer bytes. The default status-page sequence consists of a `Channel`
 page and a `Nodes` page. The `Nodes` page text output MUST show the key
 operational node details in `node_id` order: `node_id`, assigned/current
-program identifiers, battery, last seen, and schedule, with optional fields
-omitted when absent. Battery and last seen are runtime-only observation fields:
+program identifiers, battery, RSSI, last seen, and schedule, with optional fields
+omitted when absent. Battery, RSSI, and last seen are runtime-only observation fields:
 they are absent until the node completes a `WAKE` in the current gateway
 process and disappear again after gateway restart until the next `WAKE`. For
 assigned/current programs, the default display identifier is the stored
@@ -1320,7 +1320,7 @@ registered.`
 
 1. A `BUTTON_SHORT` event received while no BLE pairing session is active causes the gateway to send a new reliable display transfer for the next status page.
 2. Consecutive short presses advance through the configured status-page sequence in order; the default sequence remains `Channel` followed by `Nodes`.
-3. The `Nodes` page renders `node_id`, assigned/current program identifiers, battery, last seen, and schedule in `node_id` order, omits absent optional fields, excludes `key_hint`, and uses a left-aligned property line followed by a `- value` line for each displayed field.
+3. The `Nodes` page renders `node_id`, assigned/current program identifiers, battery, RSSI, last seen, and schedule in `node_id` order, omits absent optional fields, excludes `key_hint`, and uses a left-aligned property line followed by a `- value` line for each displayed field.
 4. When a program record has `source_filename`, the `Nodes` page uses that basename as the program identifier and never renders a full path; otherwise it renders the hash.
 5. When the node registry is empty, the `Nodes` page displays `No nodes registered.`
 6. Status-page framebuffer generation remains gateway-owned; the modem receives only opaque framebuffer data.

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -2076,10 +2076,10 @@ A configurable stub handler process (or in-process mock) that:
 
 **Procedure:**
 1. Start a gateway instance with a mock modem and complete the startup handshake.
-2. Populate storage with at least two nodes whose metadata exercises optional fields: assigned/current program identifiers, battery, last seen, and schedule on one node, and at least one omitted optional field on another. At least one displayed program must have `source_filename` metadata and at least one displayed program must exercise hash fallback.
+2. Populate storage with at least two nodes whose metadata exercises optional fields: assigned/current program identifiers, battery, RSSI, last seen, and schedule on one node, and at least one omitted optional field on another. At least one displayed program must have `source_filename` metadata and at least one displayed program must exercise hash fallback.
 3. Inject `EVENT_BUTTON(BUTTON_SHORT)` twice while no BLE pairing session is active so the second page shown is `Nodes`.
 4. Reassemble the first visible `Nodes` page framebuffer.
-5. Assert: the rendered text uses `node_id`, assigned/current program identifiers, battery, last seen, and schedule in `node_id` order; omits absent optional fields; excludes `key_hint`; formats `last seen` in local time with locale-style date/time output; and renders each displayed field as a left-aligned property line followed by a left-aligned `- value` line.
+5. Assert: the rendered text uses `node_id`, assigned/current program identifiers, battery, RSSI, last seen, and schedule in `node_id` order; omits absent optional fields; excludes `key_hint`; formats `last seen` in local time with locale-style date/time output; and renders each displayed field as a left-aligned property line followed by a left-aligned `- value` line.
 6. Assert: when a displayed program has `source_filename`, the rendered identifier is that basename and never a full path; when `source_filename` is absent, the rendered identifier is the hash.
 
 ---


### PR DESCRIPTION
## Summary

Thread modem-measured RSSI (i8 dBm) from the ESP-NOW WAKE packet through all reporting surfaces, mirroring the existing \attery_mv\ pattern. This provides a long-term RF health diagnostic tool for monitoring signal quality across deployed nodes.

## What changed

### Protocol
- New CBOR key 28 (\wake_rssi_dbm\, int/null) in ACTUAL_STATE — node-scoped only

### Gateway
- Thread \ssi: Option<i8>\ from \process_frame_with_rssi\ → \handle_wake\ → \handle_wake_core\
- Cache in \SessionManager.last_wake_rssi_dbm\ (runtime-only, **not** persisted to SQLite)
- Emit in connector ACTUAL_STATE at CBOR key 28
- Clear alongside \attery_mv\ on node removal, factory reset, and state import
- Add to structured WAKE log entry
- Add to modem display Nodes status page (after battery, before last seen)

### Admin
- \last_wake_rssi_dbm\ added to \NodeInfo\ and \NodeStatus\ proto messages
- Displayed in CLI \status\ and \list\ text and JSON output

### Azure handler
- Decode CBOR key 28 via new \optional_i8_field\ helper
- \wake_rssi_dbm\ added to \ActualStateRow\, \ActualStateMessage\, and \ActualStateEntity\

### Web UI
- RSSI column added to dashboard node status table

### Specifications updated
- GW-0812, GW-1101b, AZH-0200, AZH-0202 requirements amended
- gateway-companion-api.md, gateway-design.md, gateway-validation.md, azure-handler-design.md, azure-handler-validation.md updated

## Design notes

- RSSI is **transient** data — cached in \SessionManager\ in-memory maps only, identical lifecycle to \attery_mv\ (absent until first WAKE, cleared on restart)
- RSSI is recorded **only after** authenticated WAKE acceptance (post-AEAD decrypt), preventing spoofed injection
- When the transport does not supply RSSI (e.g., direct ESP-NOW without modem), all surfaces show null/omit
- Backward compatible: old ACTUAL_STATE messages without key 28 decode with \wake_rssi_dbm: None\

## Verification

- \cargo build --workspace\ ✅
- \cargo test --workspace\ ✅
- \cargo clippy --workspace -- -D warnings\ ✅
- \cargo fmt --all --check\ ✅