### PR TITLE
feat(gateway): implement rotation execution engine (GW-2006, GW-2007, GW-2013)

### DIFF
--- a/crates/sonde-gateway/src/lib.rs
+++ b/crates/sonde-gateway/src/lib.rs
@@ -19,6 +19,7 @@ pub mod phone_trust;
 pub mod program;
 pub mod registry;
 pub mod rotation;
+pub mod rotation_engine;
 pub mod session;
 pub mod sonde_platform;
 pub mod sqlite_storage;
@@ -40,6 +41,7 @@ pub use handler::{
 pub use phone_trust::{PhonePskRecord, PhonePskStatus};
 pub use program::{ProgramLibrary, ProgramRecord, VerificationProfile};
 pub use registry::{NodeRecord, SensorDescriptor};
+pub use rotation_engine::RotationEngine;
 pub use session::{Session, SessionManager, SessionState};
 pub use sqlite_storage::SqliteStorage;
 pub use storage::{InMemoryStorage, Storage, StorageError};

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -29,11 +29,30 @@ pub type RotationSubmitChannel =
 type RotationSubmitReceiver =
     mpsc::UnboundedReceiver<(Vec<u8>, oneshot::Sender<Result<(), String>>)>;
 
+/// Notification sent when a rotation completes, carrying the new key state
+/// so the gateway can emit a full gateway ACTUAL_STATE.
+#[derive(Debug, Clone)]
+pub struct RotationCompleteNotification {
+    pub new_master_key_id: [u8; 16],
+    pub new_epoch: u64,
+}
+
 /// Rotation execution engine.
 ///
 /// Receives rotation payloads from two channels (gRPC and DESIRED_STATE),
 /// validates them, and executes the 8-step rotation pipeline. At most one
 /// rotation can be active at a time; concurrent requests are rejected.
+///
+/// ## Startup wiring
+///
+/// The gateway binary (or test harness) must:
+/// 1. Call [`RotationEngine::resume_pending_rotation`] before starting the
+///    connector or admin service (step 2a per gateway-design.md §23.11).
+/// 2. Create channels, pass senders to [`AdminService::with_rotation_tx`]
+///    and [`ConnectorService::set_gateway_desired_state_tx`].
+/// 3. Spawn [`RotationEngine::run`] as a tokio task.
+/// 4. Optionally subscribe to `rotation_complete_tx` to trigger gateway
+///    ACTUAL_STATE re-emission on rotation completion.
 pub struct RotationEngine {
     storage: Arc<SqliteStorage>,
     identity: GatewayIdentity,
@@ -45,6 +64,10 @@ pub struct RotationEngine {
     desired_state_rx: mpsc::UnboundedReceiver<GatewayDesiredState>,
     /// Set to `true` while a rotation is executing to reject concurrent requests.
     rotation_active: Arc<AtomicBool>,
+    /// Optional notification channel for rotation completion. The gateway
+    /// binary subscribes to trigger a full gateway ACTUAL_STATE re-emission
+    /// (which requires runtime state not available to this engine).
+    rotation_complete_tx: Option<mpsc::UnboundedSender<RotationCompleteNotification>>,
 }
 
 impl RotationEngine {
@@ -63,7 +86,21 @@ impl RotationEngine {
             grpc_rx,
             desired_state_rx,
             rotation_active: Arc::new(AtomicBool::new(false)),
+            rotation_complete_tx: None,
         }
+    }
+
+    /// Set the notification channel for rotation completion events.
+    ///
+    /// When a rotation completes, the engine sends a [`RotationCompleteNotification`]
+    /// so the gateway can emit a full gateway ACTUAL_STATE with all runtime fields
+    /// (channel, version, fingerprint, etc.).
+    pub fn with_rotation_complete_tx(
+        mut self,
+        tx: mpsc::UnboundedSender<RotationCompleteNotification>,
+    ) -> Self {
+        self.rotation_complete_tx = Some(tx);
+        self
     }
 
     /// Run the rotation engine event loop.
@@ -92,9 +129,8 @@ impl RotationEngine {
     /// Handle a full DESIRED_STATE message — process rotation_payload if present.
     async fn handle_desired_state(&mut self, state: GatewayDesiredState) {
         if let Some(payload) = state.rotation_payload {
-            if let Err(e) = self.handle_rotation_payload(&payload, false).await {
-                warn!(error = %e, "DESIRED_STATE rotation payload rejected");
-            }
+            // Errors from DESIRED_STATE rotation are silently discarded per spec.
+            let _ = self.handle_rotation_payload(&payload, false).await;
         }
         // Future: handle recovered_psks, salt, kdf_params, channel changes here.
     }
@@ -142,9 +178,11 @@ impl RotationEngine {
 
         // Rate limit check.
         if !self.rate_limiter.check(current_epoch) {
-            let msg = "rotation attempt rate-limited";
-            warn!("{msg}");
-            return Err(msg.into());
+            if is_grpc {
+                return Err("rotation attempt rate-limited".into());
+            }
+            // DESIRED_STATE: silently discard per evolve-962 §2.6.1 rule 8.
+            return Err("rate-limited".into());
         }
 
         // Decrypt the rotation payload.
@@ -215,6 +253,8 @@ impl RotationEngine {
                 &decrypted.new_master_key,
                 &decrypted.new_master_key_id,
                 new_epoch,
+                decrypted.salt.as_deref(),
+                decrypted.kdf_params.as_ref(),
             )
             .await
             .map_err(|e| format!("prepare failed: {e}"))?;
@@ -366,7 +406,20 @@ impl RotationEngine {
     }
 
     /// Emit updated ACTUAL_STATE after rotation completes (step 8).
-    async fn emit_post_rotation_state(&self, _new_epoch: u64, _new_key_id: &[u8; 16]) {
+    ///
+    /// Emits per-node ACTUAL_STATE with updated escrow fields. For gateway-level
+    /// ACTUAL_STATE (which requires runtime state like channel, version, fingerprint),
+    /// sends a [`RotationCompleteNotification`] via the optional callback channel
+    /// so the gateway binary can emit a full gateway ACTUAL_STATE.
+    async fn emit_post_rotation_state(&self, new_epoch: u64, new_key_id: &[u8; 16]) {
+        // Notify the gateway binary to emit a full gateway ACTUAL_STATE.
+        if let Some(ref tx) = self.rotation_complete_tx {
+            let _ = tx.send(RotationCompleteNotification {
+                new_master_key_id: *new_key_id,
+                new_epoch,
+            });
+        }
+
         // Re-emit node ACTUAL_STATE with updated escrow fields.
         match self.storage.list_node_escrow_state().await {
             Ok(nodes) => {
@@ -443,7 +496,19 @@ impl RotationEngine {
             grpc_rx: mpsc::unbounded_channel().1,
             desired_state_rx: mpsc::unbounded_channel().1,
             rotation_active: Arc::new(AtomicBool::new(true)),
+            rotation_complete_tx: None,
         };
+
+        // Parse salt/kdf_params from the pending_rotation record for crash recovery.
+        let kdf_params = pending.kdf_params_json.as_deref().and_then(|json| {
+            let v: serde_json::Value = serde_json::from_str(json).ok()?;
+            Some(crate::rotation::KdfParamsPayload {
+                m_cost: v["m_cost"].as_u64()? as u32,
+                t_cost: v["t_cost"].as_u64()? as u32,
+                p_cost: v["p_cost"].as_u64()? as u32,
+                kdf_version: v["kdf_version"].as_u64()? as u32,
+            })
+        });
 
         let result = engine
             .execute_rotation_phases(
@@ -451,8 +516,8 @@ impl RotationEngine {
                 &new_key,
                 &pending.new_master_key_id,
                 pending.new_epoch,
-                None, // salt/kdf_params are stored in the rotation payload, not pending_rotation
-                None,
+                pending.salt.as_deref(),
+                kdf_params.as_ref(),
             )
             .await;
 
@@ -498,7 +563,7 @@ mod tests {
 
         // After writing a pending_rotation, it should report in progress.
         store
-            .write_pending_rotation(&[0xAAu8; 32], &[0xBBu8; 16], 2)
+            .write_pending_rotation(&[0xAAu8; 32], &[0xBBu8; 16], 2, None, None)
             .await
             .unwrap();
         let in_progress = store.is_rotation_in_progress().await.unwrap();

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -16,9 +16,7 @@ use zeroize::Zeroizing;
 
 use crate::connector::{ConnectorEventHub, GatewayDesiredState};
 use crate::gateway_identity::GatewayIdentity;
-use crate::rotation::{
-    decrypt_rotation_payload, DecryptedRotation, RotationError, RotationRateLimiter,
-};
+use crate::rotation::{decrypt_rotation_payload, DecryptedRotation, RotationRateLimiter};
 use crate::sqlite_storage::SqliteStorage;
 
 /// Channel type matching the admin service's rotation submission channel.
@@ -195,13 +193,6 @@ impl RotationEngine {
         let decrypted =
             match decrypt_rotation_payload(payload, &x25519_secret, gateway_id, current_epoch) {
                 Ok(d) => d,
-                Err(RotationError::WrongRotationCode) => {
-                    self.rate_limiter.record_failure(current_epoch);
-                    return Err("rotation code does not match".into());
-                }
-                Err(RotationError::RateLimited) => {
-                    return Err("rotation attempt rate-limited".into());
-                }
                 Err(e) => {
                     self.rate_limiter.record_failure(current_epoch);
                     return Err(format!("rotation payload error: {e}"));
@@ -509,10 +500,10 @@ impl RotationEngine {
         let kdf_params = pending.kdf_params_json.as_deref().and_then(|json| {
             let v: serde_json::Value = serde_json::from_str(json).ok()?;
             Some(crate::rotation::KdfParamsPayload {
-                m_cost: v["m_cost"].as_u64()? as u32,
-                t_cost: v["t_cost"].as_u64()? as u32,
-                p_cost: v["p_cost"].as_u64()? as u32,
-                kdf_version: v["kdf_version"].as_u64()? as u32,
+                m_cost: u32::try_from(v["m_cost"].as_u64()?).ok()?,
+                t_cost: u32::try_from(v["t_cost"].as_u64()?).ok()?,
+                p_cost: u32::try_from(v["p_cost"].as_u64()?).ok()?,
+                kdf_version: u32::try_from(v["kdf_version"].as_u64()?).ok()?,
             })
         });
 

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -421,7 +421,7 @@ impl RotationEngine {
                         node.current_program_hash.clone(),
                         node.assigned_program_hash.clone(),
                         node.schedule_interval_s,
-                        0, // battery_mv not stored in DB
+                        node.last_battery_mv,
                         node.firmware_abi_version,
                         node.firmware_version.clone(),
                         current_time_ms(),

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Master key rotation execution engine (GW-2006, GW-2007, GW-2013).
+//!
+//! Coordinates the 8-step rotation pipeline and crash recovery, receiving
+//! rotation payloads from both gRPC (`SubmitRotation`) and DESIRED_STATE
+//! ingress channels.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::{mpsc, oneshot};
+use tracing::{error, info, warn};
+use zeroize::Zeroizing;
+
+use crate::connector::{ConnectorEventHub, GatewayDesiredState};
+use crate::gateway_identity::GatewayIdentity;
+use crate::rotation::{
+    decrypt_rotation_payload, DecryptedRotation, RotationError, RotationRateLimiter,
+};
+use crate::sqlite_storage::SqliteStorage;
+
+/// Channel type matching the admin service's rotation submission channel.
+pub type RotationSubmitChannel =
+    mpsc::UnboundedSender<(Vec<u8>, oneshot::Sender<Result<(), String>>)>;
+
+/// Receiver side of the rotation submission channel.
+type RotationSubmitReceiver =
+    mpsc::UnboundedReceiver<(Vec<u8>, oneshot::Sender<Result<(), String>>)>;
+
+/// Rotation execution engine.
+///
+/// Receives rotation payloads from two channels (gRPC and DESIRED_STATE),
+/// validates them, and executes the 8-step rotation pipeline. At most one
+/// rotation can be active at a time; concurrent requests are rejected.
+pub struct RotationEngine {
+    storage: Arc<SqliteStorage>,
+    identity: GatewayIdentity,
+    event_hub: Arc<ConnectorEventHub>,
+    rate_limiter: RotationRateLimiter,
+    /// Receives rotation payloads from the gRPC `SubmitRotation` RPC.
+    grpc_rx: RotationSubmitReceiver,
+    /// Receives parsed DESIRED_STATE from the connector.
+    desired_state_rx: mpsc::UnboundedReceiver<GatewayDesiredState>,
+    /// Set to `true` while a rotation is executing to reject concurrent requests.
+    rotation_active: Arc<AtomicBool>,
+}
+
+impl RotationEngine {
+    pub fn new(
+        storage: Arc<SqliteStorage>,
+        identity: GatewayIdentity,
+        event_hub: Arc<ConnectorEventHub>,
+        grpc_rx: RotationSubmitReceiver,
+        desired_state_rx: mpsc::UnboundedReceiver<GatewayDesiredState>,
+    ) -> Self {
+        Self {
+            storage,
+            identity,
+            event_hub,
+            rate_limiter: RotationRateLimiter::default(),
+            grpc_rx,
+            desired_state_rx,
+            rotation_active: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Run the rotation engine event loop.
+    ///
+    /// This should be spawned as a tokio task. It runs until both channels
+    /// are closed.
+    pub async fn run(mut self) {
+        info!("rotation engine started");
+        loop {
+            tokio::select! {
+                Some((payload, reply_tx)) = self.grpc_rx.recv() => {
+                    let result = self.handle_rotation_payload(&payload, true).await;
+                    let _ = reply_tx.send(result);
+                }
+                Some(desired_state) = self.desired_state_rx.recv() => {
+                    self.handle_desired_state(desired_state).await;
+                }
+                else => {
+                    info!("rotation engine channels closed, shutting down");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Handle a full DESIRED_STATE message — process rotation_payload if present.
+    async fn handle_desired_state(&mut self, state: GatewayDesiredState) {
+        if let Some(payload) = state.rotation_payload {
+            if let Err(e) = self.handle_rotation_payload(&payload, false).await {
+                warn!(error = %e, "DESIRED_STATE rotation payload rejected");
+            }
+        }
+        // Future: handle recovered_psks, salt, kdf_params, channel changes here.
+    }
+
+    /// Process a raw rotation payload from either gRPC or DESIRED_STATE.
+    ///
+    /// `is_grpc` controls the error response style — gRPC gets error messages,
+    /// DESIRED_STATE silently discards.
+    pub async fn handle_rotation_payload(
+        &mut self,
+        payload: &[u8],
+        is_grpc: bool,
+    ) -> Result<(), String> {
+        // Check for concurrent rotation — reject before any crypto work.
+        if self.rotation_active.load(Ordering::SeqCst) {
+            let msg = "rotation already in progress";
+            if is_grpc {
+                return Err(msg.into());
+            }
+            warn!("{msg} — discarding incoming rotation payload");
+            return Err(msg.into());
+        }
+
+        // Also check the DB for pending_rotation (crash recovery may have set it).
+        let db_in_progress = self
+            .storage
+            .is_rotation_in_progress()
+            .await
+            .map_err(|e| format!("storage error: {e}"))?;
+        if db_in_progress {
+            let msg = "rotation already in progress (pending_rotation exists)";
+            if is_grpc {
+                return Err(msg.into());
+            }
+            warn!("{msg} — discarding incoming rotation payload");
+            return Err(msg.into());
+        }
+
+        // Load current epoch and rotation code for validation.
+        let (_, current_epoch) = self
+            .storage
+            .init_master_key_id()
+            .await
+            .map_err(|e| format!("failed to load master_key_epoch: {e}"))?;
+
+        // Rate limit check.
+        if !self.rate_limiter.check(current_epoch) {
+            let msg = "rotation attempt rate-limited";
+            warn!("{msg}");
+            return Err(msg.into());
+        }
+
+        // Decrypt the rotation payload.
+        let (x25519_secret, _) = self
+            .identity
+            .to_x25519()
+            .map_err(|e| format!("X25519 conversion failed: {e}"))?;
+        let gateway_id = self.identity.gateway_id();
+
+        let decrypted =
+            match decrypt_rotation_payload(payload, &x25519_secret, gateway_id, current_epoch) {
+                Ok(d) => d,
+                Err(RotationError::WrongRotationCode) => {
+                    self.rate_limiter.record_failure(current_epoch);
+                    return Err("rotation code does not match".into());
+                }
+                Err(RotationError::RateLimited) => {
+                    return Err("rotation attempt rate-limited".into());
+                }
+                Err(e) => {
+                    self.rate_limiter.record_failure(current_epoch);
+                    return Err(format!("rotation payload error: {e}"));
+                }
+            };
+
+        // Verify rotation code against stored code.
+        let stored_code = self
+            .storage
+            .init_rotation_code()
+            .await
+            .map_err(|e| format!("failed to load rotation_code: {e}"))?;
+
+        if decrypted.rotation_code != stored_code {
+            self.rate_limiter.record_failure(current_epoch);
+            return Err("rotation code does not match".into());
+        }
+
+        // Verify epoch (step 3): new_epoch must be current_epoch + 1.
+        let new_epoch = current_epoch.checked_add(1).ok_or("epoch overflow")?;
+
+        // Execute the rotation pipeline.
+        self.rotation_active.store(true, Ordering::SeqCst);
+        let result = self
+            .execute_rotation(decrypted, new_epoch, current_epoch)
+            .await;
+        self.rotation_active.store(false, Ordering::SeqCst);
+
+        result
+    }
+
+    /// Execute the full rotation pipeline (steps 4–8).
+    async fn execute_rotation(
+        &self,
+        decrypted: DecryptedRotation,
+        new_epoch: u64,
+        current_epoch: u64,
+    ) -> Result<(), String> {
+        let old_key = {
+            let mk = self.storage.master_key();
+            Zeroizing::new(**mk)
+        };
+
+        info!(new_epoch, current_epoch, "starting master key rotation");
+
+        // Step 4: Prepare — write pending_rotation + purge pending_recovery.
+        self.storage
+            .write_pending_rotation(
+                &decrypted.new_master_key,
+                &decrypted.new_master_key_id,
+                new_epoch,
+            )
+            .await
+            .map_err(|e| format!("prepare failed: {e}"))?;
+
+        // Set dual-key state for frame processing during migration.
+        self.storage
+            .set_rotation_new_key(Zeroizing::new(*decrypted.new_master_key), new_epoch);
+
+        // Execute steps 5–7 (resume-safe).
+        let result = self
+            .execute_rotation_phases(
+                &old_key,
+                &decrypted.new_master_key,
+                &decrypted.new_master_key_id,
+                new_epoch,
+                decrypted.salt.as_deref(),
+                decrypted.kdf_params.as_ref(),
+            )
+            .await;
+
+        if let Err(ref e) = result {
+            error!(error = %e, "rotation failed during execution");
+            // Leave pending_rotation in place for crash recovery.
+            self.storage.clear_rotation_new_key();
+            return result;
+        }
+
+        // Step 7 post: swap in-memory master key.
+        self.storage
+            .swap_master_key(Zeroizing::new(*decrypted.new_master_key));
+        self.storage.clear_rotation_new_key();
+
+        info!(new_epoch, "master key rotation committed successfully");
+
+        // Step 8: Emit updated ACTUAL_STATE.
+        self.emit_post_rotation_state(new_epoch, &decrypted.new_master_key_id)
+            .await;
+
+        Ok(())
+    }
+
+    /// Execute rotation steps 5–7. This is the resume-safe portion — can be
+    /// called from both fresh rotation and crash recovery.
+    async fn execute_rotation_phases(
+        &self,
+        old_key: &[u8; 32],
+        new_key: &[u8; 32],
+        new_key_id: &[u8; 16],
+        new_epoch: u64,
+        salt: Option<&[u8]>,
+        kdf_params: Option<&crate::rotation::KdfParamsPayload>,
+    ) -> Result<(), String> {
+        // Read current phase to support resume.
+        let pending = self
+            .storage
+            .read_pending_rotation()
+            .await
+            .map_err(|e| format!("read pending_rotation: {e}"))?
+            .ok_or("pending_rotation disappeared during execution")?;
+
+        let phase = pending.phase.as_str();
+
+        // Step 5: Migrate PSKs.
+        if phase == "migrating_psks" {
+            self.migrate_all_psks(old_key, new_key, new_key_id, new_epoch)
+                .await?;
+            self.storage
+                .update_rotation_phase("rewrapping_identity")
+                .await
+                .map_err(|e| format!("update phase to rewrapping_identity: {e}"))?;
+        }
+
+        // Step 6: Rewrap identity seed.
+        let pending = self
+            .storage
+            .read_pending_rotation()
+            .await
+            .map_err(|e| format!("read pending_rotation: {e}"))?
+            .ok_or("pending_rotation disappeared")?;
+
+        if pending.phase == "rewrapping_identity" {
+            self.storage
+                .rewrap_identity_seed(old_key, new_key)
+                .await
+                .map_err(|e| format!("rewrap identity seed: {e}"))?;
+            self.storage
+                .update_rotation_phase("committing")
+                .await
+                .map_err(|e| format!("update phase to committing: {e}"))?;
+        }
+
+        // Step 7: Atomic commit.
+        let pending = self
+            .storage
+            .read_pending_rotation()
+            .await
+            .map_err(|e| format!("read pending_rotation: {e}"))?
+            .ok_or("pending_rotation disappeared")?;
+
+        if pending.phase == "committing" {
+            self.storage
+                .commit_rotation(new_key_id, new_epoch, salt, kdf_params)
+                .await
+                .map_err(|e| format!("commit rotation: {e}"))?;
+        }
+
+        Ok(())
+    }
+
+    /// Migrate all PSKs (nodes and phone_psks) from old key to new key.
+    async fn migrate_all_psks(
+        &self,
+        old_key: &[u8; 32],
+        new_key: &[u8; 32],
+        new_key_id: &[u8; 16],
+        new_epoch: u64,
+    ) -> Result<(), String> {
+        // Migrate node PSKs.
+        let node_ids = self
+            .storage
+            .list_unmigrated_node_ids(new_epoch)
+            .await
+            .map_err(|e| format!("list unmigrated nodes: {e}"))?;
+
+        info!(count = node_ids.len(), "migrating node PSKs");
+        for node_id in &node_ids {
+            self.storage
+                .migrate_node_psk(node_id, old_key, new_key, new_key_id, new_epoch)
+                .await
+                .map_err(|e| format!("migrate node `{node_id}`: {e}"))?;
+        }
+
+        // Migrate phone PSKs.
+        let phone_ids = self
+            .storage
+            .list_unmigrated_phone_ids(new_epoch)
+            .await
+            .map_err(|e| format!("list unmigrated phones: {e}"))?;
+
+        info!(count = phone_ids.len(), "migrating phone PSKs");
+        for phone_id in &phone_ids {
+            self.storage
+                .migrate_phone_psk(*phone_id, old_key, new_key, new_key_id, new_epoch)
+                .await
+                .map_err(|e| format!("migrate phone {phone_id}: {e}"))?;
+        }
+
+        Ok(())
+    }
+
+    /// Emit updated ACTUAL_STATE after rotation completes (step 8).
+    async fn emit_post_rotation_state(&self, _new_epoch: u64, _new_key_id: &[u8; 16]) {
+        // Re-emit node ACTUAL_STATE with updated escrow fields.
+        match self.storage.list_node_escrow_state().await {
+            Ok(nodes) => {
+                for node in &nodes {
+                    self.event_hub.emit_actual_state_for_node_with_escrow(
+                        node.node_id.clone(),
+                        node.current_program_hash.clone(),
+                        node.assigned_program_hash.clone(),
+                        node.schedule_interval_s,
+                        0, // battery_mv not stored in DB
+                        node.firmware_abi_version,
+                        node.firmware_version.clone(),
+                        current_time_ms(),
+                        Some(node.encrypted_psk.clone()),
+                        Some(node.key_hint),
+                        Some(node.master_key_id.clone()),
+                        None, // rssi
+                    );
+                }
+                info!(
+                    count = nodes.len(),
+                    "re-emitted node ACTUAL_STATE after rotation"
+                );
+            }
+            Err(e) => {
+                error!(error = %e, "failed to list nodes for post-rotation ACTUAL_STATE");
+            }
+        }
+    }
+
+    /// Resume a pending rotation from crash recovery (GW-2007).
+    ///
+    /// Called at startup before the main event loop. If `pending_rotation`
+    /// exists in the database, decrypts the new key and resumes from the
+    /// recorded phase.
+    pub async fn resume_pending_rotation(
+        storage: &Arc<SqliteStorage>,
+        identity: &GatewayIdentity,
+    ) -> Result<bool, String> {
+        let pending = storage
+            .read_pending_rotation()
+            .await
+            .map_err(|e| format!("read pending_rotation at startup: {e}"))?;
+
+        let pending = match pending {
+            Some(p) => p,
+            None => return Ok(false),
+        };
+
+        info!(
+            phase = %pending.phase,
+            new_epoch = pending.new_epoch,
+            "detected pending rotation — resuming crash recovery"
+        );
+
+        // Decrypt the pending new key using the current (old) master key.
+        let old_key = {
+            let mk = storage.master_key();
+            Zeroizing::new(**mk)
+        };
+
+        let new_key = SqliteStorage::decrypt_pending_new_key(&old_key, &pending.new_master_key_enc)
+            .map_err(|e| format!("decrypt pending new key: {e}"))?;
+
+        // Set dual-key state for frame processing during recovery.
+        storage.set_rotation_new_key(Zeroizing::new(*new_key), pending.new_epoch);
+
+        // Create a temporary engine for executing the phases.
+        let engine = RotationEngine {
+            storage: Arc::clone(storage),
+            identity: identity.clone(),
+            event_hub: Arc::new(ConnectorEventHub::default()),
+            rate_limiter: RotationRateLimiter::default(),
+            grpc_rx: mpsc::unbounded_channel().1,
+            desired_state_rx: mpsc::unbounded_channel().1,
+            rotation_active: Arc::new(AtomicBool::new(true)),
+        };
+
+        let result = engine
+            .execute_rotation_phases(
+                &old_key,
+                &new_key,
+                &pending.new_master_key_id,
+                pending.new_epoch,
+                None, // salt/kdf_params are stored in the rotation payload, not pending_rotation
+                None,
+            )
+            .await;
+
+        if let Err(ref e) = result {
+            error!(error = %e, "crash recovery rotation failed");
+            storage.clear_rotation_new_key();
+            return Err(format!("crash recovery failed: {e}"));
+        }
+
+        // Swap in-memory master key.
+        storage.swap_master_key(Zeroizing::new(*new_key));
+        storage.clear_rotation_new_key();
+
+        info!(
+            new_epoch = pending.new_epoch,
+            "crash recovery rotation completed"
+        );
+        Ok(true)
+    }
+}
+
+/// Helper to get current time in milliseconds.
+fn current_time_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sqlite_storage::SqliteStorage;
+
+    #[tokio::test]
+    async fn test_rotation_engine_concurrent_check() {
+        let master_key = Zeroizing::new([0x42u8; 32]);
+        let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
+
+        // The is_rotation_in_progress check works via DB.
+        let in_progress = store.is_rotation_in_progress().await.unwrap();
+        assert!(!in_progress); // No DB record yet.
+
+        // After writing a pending_rotation, it should report in progress.
+        store
+            .write_pending_rotation(&[0xAAu8; 32], &[0xBBu8; 16], 2)
+            .await
+            .unwrap();
+        let in_progress = store.is_rotation_in_progress().await.unwrap();
+        assert!(in_progress);
+    }
+}

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -277,8 +277,9 @@ impl RotationEngine {
 
         if let Err(ref e) = result {
             error!(error = %e, "rotation failed during execution");
-            // Leave pending_rotation in place for crash recovery.
-            self.storage.clear_rotation_new_key();
+            // Leave pending_rotation AND rotation_key_state in place: some PSKs
+            // may already be migrated to new_epoch, so dual-key decryption must
+            // remain active until the next restart resolves the situation.
             return result;
         }
 
@@ -455,10 +456,15 @@ impl RotationEngine {
     /// Called at startup before the main event loop. If `pending_rotation`
     /// exists in the database, decrypts the new key and resumes from the
     /// recorded phase.
+    ///
+    /// Returns `Ok(Some(notification))` if a rotation was resumed and committed,
+    /// `Ok(None)` if no pending rotation existed. The caller should use the
+    /// returned notification to trigger gateway ACTUAL_STATE re-emission
+    /// and node escrow re-emission once the connector is ready.
     pub async fn resume_pending_rotation(
         storage: &Arc<SqliteStorage>,
         identity: &GatewayIdentity,
-    ) -> Result<bool, String> {
+    ) -> Result<Option<RotationCompleteNotification>, String> {
         let pending = storage
             .read_pending_rotation()
             .await
@@ -466,7 +472,7 @@ impl RotationEngine {
 
         let pending = match pending {
             Some(p) => p,
-            None => return Ok(false),
+            None => return Ok(None),
         };
 
         info!(
@@ -523,7 +529,7 @@ impl RotationEngine {
 
         if let Err(ref e) = result {
             error!(error = %e, "crash recovery rotation failed");
-            storage.clear_rotation_new_key();
+            // Keep dual-key state — some PSKs may be partially migrated.
             return Err(format!("crash recovery failed: {e}"));
         }
 
@@ -535,7 +541,10 @@ impl RotationEngine {
             new_epoch = pending.new_epoch,
             "crash recovery rotation completed"
         );
-        Ok(true)
+        Ok(Some(RotationCompleteNotification {
+            new_master_key_id: pending.new_master_key_id,
+            new_epoch: pending.new_epoch,
+        }))
     }
 }
 

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -605,6 +605,10 @@ pub struct PendingRotationRecord {
     pub new_epoch: u64,
     /// Current rotation phase.
     pub phase: String,
+    /// KDF salt from the rotation payload (persisted for crash recovery).
+    pub salt: Option<Vec<u8>>,
+    /// KDF params from the rotation payload, serialized as JSON.
+    pub kdf_params_json: Option<String>,
 }
 
 /// Node escrow metadata for ACTUAL_STATE re-emission after rotation.
@@ -951,7 +955,9 @@ impl SqliteStorage {
                     new_master_key_id  BLOB    NOT NULL,
                     new_epoch          INTEGER NOT NULL,
                     started_at         INTEGER NOT NULL,
-                    phase              TEXT    NOT NULL DEFAULT 'migrating_psks'
+                    phase              TEXT    NOT NULL DEFAULT 'migrating_psks',
+                    salt               BLOB,
+                    kdf_params_json    TEXT
                 )",
             )
             .map_err(|e| {
@@ -1005,9 +1011,12 @@ impl SqliteStorage {
                 )
                 .optional()
                 .map_err(map_err)?;
-            pending.map(|(_, epoch_raw)| RotationKeyState {
-                new_key: Arc::new(Zeroizing::new(**new_key)),
-                new_epoch: epoch_raw as u64,
+            pending.and_then(|(_, epoch_raw): (Vec<u8>, i64)| {
+                let new_epoch = u64::try_from(epoch_raw).ok()?;
+                Some(RotationKeyState {
+                    new_key: Arc::new(Zeroizing::new(**new_key)),
+                    new_epoch,
+                })
             })
         } else {
             None
@@ -1191,6 +1200,7 @@ impl SqliteStorage {
     /// Write a pending_rotation record and purge pending_recovery (§2.6.2 step 4).
     ///
     /// The new master key is encrypted with the OLD master key for crash safety.
+    /// Salt and KDF params are persisted so crash recovery can apply them.
     /// This must be called within a single logical operation — the DB transaction
     /// ensures atomicity of both the insert and the purge.
     pub async fn write_pending_rotation(
@@ -1198,9 +1208,11 @@ impl SqliteStorage {
         new_master_key: &[u8; 32],
         new_master_key_id: &[u8; 16],
         new_epoch: u64,
+        salt: Option<&[u8]>,
+        kdf_params: Option<&crate::rotation::KdfParamsPayload>,
     ) -> Result<(), StorageError> {
         let mk = self.master_key();
-        let new_key = *new_master_key;
+        let new_key = Zeroizing::new(*new_master_key);
         let new_id = *new_master_key_id;
 
         // Encrypt the new master key with the old key (AAD = "sonde-pending-rotation").
@@ -1225,6 +1237,17 @@ impl SqliteStorage {
             StorageError::Internal(format!("new_epoch {new_epoch} exceeds i64::MAX"))
         })?;
 
+        let salt_blob = salt.map(|s| s.to_vec());
+        let kdf_json = kdf_params.map(|p| {
+            serde_json::json!({
+                "m_cost": p.m_cost,
+                "t_cost": p.t_cost,
+                "p_cost": p.p_cost,
+                "kdf_version": p.kdf_version,
+            })
+            .to_string()
+        });
+
         self.with_conn(move |conn| {
             let tx = conn.unchecked_transaction().map_err(map_err)?;
 
@@ -1235,9 +1258,15 @@ impl SqliteStorage {
             // Insert pending_rotation record.
             tx.execute(
                 "INSERT INTO pending_rotation \
-                 (id, new_master_key_enc, new_master_key_id, new_epoch, started_at, phase) \
-                 VALUES (1, ?1, ?2, ?3, strftime('%s', 'now'), 'migrating_psks')",
-                params![enc_blob, new_id.as_slice(), epoch_i64],
+                 (id, new_master_key_enc, new_master_key_id, new_epoch, started_at, phase, salt, kdf_params_json) \
+                 VALUES (1, ?1, ?2, ?3, strftime('%s', 'now'), 'migrating_psks', ?4, ?5)",
+                params![
+                    enc_blob,
+                    new_id.as_slice(),
+                    epoch_i64,
+                    salt_blob,
+                    kdf_json,
+                ],
             )
             .map_err(map_err)?;
 
@@ -1248,35 +1277,59 @@ impl SqliteStorage {
     }
 
     /// Read the pending_rotation record, if one exists.
+    #[allow(clippy::type_complexity)]
     pub async fn read_pending_rotation(
         &self,
     ) -> Result<Option<PendingRotationRecord>, StorageError> {
         self.with_conn(|conn| {
-            let row: Option<(Vec<u8>, Vec<u8>, i64, String)> = conn
+            let row: Option<(
+                Vec<u8>,
+                Vec<u8>,
+                i64,
+                String,
+                Option<Vec<u8>>,
+                Option<String>,
+            )> = conn
                 .query_row(
-                    "SELECT new_master_key_enc, new_master_key_id, new_epoch, phase \
-                     FROM pending_rotation WHERE id = 1",
+                    "SELECT new_master_key_enc, new_master_key_id, new_epoch, phase, \
+                     salt, kdf_params_json FROM pending_rotation WHERE id = 1",
                     [],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                            row.get(5)?,
+                        ))
+                    },
                 )
                 .optional()
                 .map_err(map_err)?;
             match row {
                 None => Ok(None),
-                Some((enc, id_vec, epoch_raw, phase)) => {
+                Some((enc, id_vec, epoch_raw, phase, salt, kdf_params_json)) => {
                     if id_vec.len() != 16 {
                         return Err(StorageError::Internal(format!(
                             "pending_rotation.new_master_key_id has wrong length: {} (expected 16)",
                             id_vec.len()
                         )));
                     }
+                    let new_epoch = u64::try_from(epoch_raw).map_err(|_| {
+                        StorageError::Internal(format!(
+                            "pending_rotation.new_epoch is negative: {epoch_raw}"
+                        ))
+                    })?;
                     let mut new_master_key_id = [0u8; 16];
                     new_master_key_id.copy_from_slice(&id_vec);
                     Ok(Some(PendingRotationRecord {
                         new_master_key_enc: enc,
                         new_master_key_id,
-                        new_epoch: epoch_raw as u64,
+                        new_epoch,
                         phase,
+                        salt,
+                        kdf_params_json,
                     }))
                 }
             }
@@ -1309,7 +1362,9 @@ impl SqliteStorage {
         &self,
         new_epoch: u64,
     ) -> Result<Vec<String>, StorageError> {
-        let epoch_i64 = new_epoch as i64;
+        let epoch_i64 = i64::try_from(new_epoch).map_err(|_| {
+            StorageError::Internal(format!("new_epoch {new_epoch} exceeds i64::MAX"))
+        })?;
         self.with_conn(move |conn| {
             let mut stmt = conn
                 .prepare("SELECT node_id FROM nodes WHERE master_key_epoch < ?1")
@@ -1332,8 +1387,8 @@ impl SqliteStorage {
         new_epoch: u64,
     ) -> Result<(), StorageError> {
         let node_id = node_id.to_owned();
-        let old_key = *old_key;
-        let new_key = *new_key;
+        let old_key = Zeroizing::new(*old_key);
+        let new_key = Zeroizing::new(*new_key);
         let new_key_id = *new_key_id;
         let epoch_i64 = i64::try_from(new_epoch).map_err(|_| {
             StorageError::Internal(format!("new_epoch {new_epoch} exceeds i64::MAX"))
@@ -1376,7 +1431,9 @@ impl SqliteStorage {
         &self,
         new_epoch: u64,
     ) -> Result<Vec<u32>, StorageError> {
-        let epoch_i64 = new_epoch as i64;
+        let epoch_i64 = i64::try_from(new_epoch).map_err(|_| {
+            StorageError::Internal(format!("new_epoch {new_epoch} exceeds i64::MAX"))
+        })?;
         self.with_conn(move |conn| {
             let mut stmt = conn
                 .prepare("SELECT phone_id FROM phone_psks WHERE master_key_epoch < ?1")
@@ -1398,8 +1455,8 @@ impl SqliteStorage {
         new_key_id: &[u8; 16],
         new_epoch: u64,
     ) -> Result<(), StorageError> {
-        let old_key = *old_key;
-        let new_key = *new_key;
+        let old_key = Zeroizing::new(*old_key);
+        let new_key = Zeroizing::new(*new_key);
         let new_key_id = *new_key_id;
         let epoch_i64 = i64::try_from(new_epoch).map_err(|_| {
             StorageError::Internal(format!("new_epoch {new_epoch} exceeds i64::MAX"))
@@ -1939,7 +1996,13 @@ fn row_to_node(
     // During rotation, migrated records have the new epoch; unmigrated records
     // have the old epoch.
     let epoch_raw: i64 = row.get(13)?;
-    let record_epoch = epoch_raw as u64;
+    let record_epoch = u64::try_from(epoch_raw).map_err(|_| {
+        rusqlite::Error::FromSqlConversionFailure(
+            13,
+            rusqlite::types::Type::Integer,
+            format!("negative master_key_epoch: {epoch_raw}").into(),
+        )
+    })?;
 
     let decrypt_key = match rotation_key {
         Some((new_key, new_epoch)) if record_epoch >= new_epoch => new_key,
@@ -2643,7 +2706,11 @@ impl Storage for SqliteStorage {
             for row in rows {
                 let (phone_id, key_hint, psk_blob, label, issued_at, status_str, key_version_raw, epoch_raw) =
                     row.map_err(map_err)?;
-                let record_epoch = epoch_raw as u64;
+                let record_epoch = u64::try_from(epoch_raw).map_err(|_| {
+                    StorageError::Internal(format!(
+                        "negative master_key_epoch: {epoch_raw}"
+                    ))
+                })?;
                 let decrypt_key: &[u8; 32] = match rk.as_ref() {
                     Some(s) if record_epoch >= s.new_epoch => &s.new_key,
                     _ => &mk,
@@ -2706,7 +2773,11 @@ impl Storage for SqliteStorage {
             for row in rows {
                 let (phone_id, kh, psk_blob, label, issued_at, status_str, key_version_raw, epoch_raw) =
                     row.map_err(map_err)?;
-                let record_epoch = epoch_raw as u64;
+                let record_epoch = u64::try_from(epoch_raw).map_err(|_| {
+                    StorageError::Internal(format!(
+                        "negative master_key_epoch: {epoch_raw}"
+                    ))
+                })?;
                 let decrypt_key: &[u8; 32] = match rk.as_ref() {
                     Some(s) if record_epoch >= s.new_epoch => &s.new_key,
                     _ => &mk,

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -431,8 +431,8 @@ fn validate_master_key(
         .map_err(map_err)?;
 
     if let Some((node_id, psk_blob)) = psk_row {
-        let current_ok = decrypt_psk(master_key, &node_id, &psk_blob).is_ok();
-        if !current_ok {
+        let current_err = decrypt_psk(master_key, &node_id, &psk_blob).err();
+        if let Some(decrypt_err) = current_err {
             // If we have a pending new key (interrupted rotation), try that.
             if let Some(new_key) = pending_new_key {
                 let _decrypted = Zeroizing::new(
@@ -447,7 +447,7 @@ fn validate_master_key(
             } else {
                 return Err(StorageError::Internal(format!(
                     "master key validation failed — cannot decrypt PSK for node \
-                     `{node_id}`; this may indicate a wrong master key or \
+                     `{node_id}`: {decrypt_err}; this may indicate a wrong master key or \
                      corrupt/tampered database data",
                 )));
             }
@@ -1556,12 +1556,24 @@ impl SqliteStorage {
             let tx = conn.unchecked_transaction().map_err(map_err)?;
 
             // Promote encrypted_seed_new → encrypted_seed.
-            tx.execute(
-                "UPDATE gateway_identity SET encrypted_seed = encrypted_seed_new, \
-                 encrypted_seed_new = NULL WHERE id = 1",
-                [],
-            )
-            .map_err(map_err)?;
+            // Guard: only update if encrypted_seed_new is non-NULL to prevent
+            // overwriting the seed with NULL on out-of-order calls.
+            let updated = tx
+                .execute(
+                    "UPDATE gateway_identity SET encrypted_seed = encrypted_seed_new, \
+                     encrypted_seed_new = NULL \
+                     WHERE id = 1 AND encrypted_seed_new IS NOT NULL",
+                    [],
+                )
+                .map_err(map_err)?;
+            if updated == 0 {
+                let _ = tx.execute("ROLLBACK", []);
+                return Err(StorageError::Internal(
+                    "commit_rotation: encrypted_seed_new is NULL — \
+                     cannot promote; identity rewrap may not have completed"
+                        .into(),
+                ));
+            }
 
             // Update master_key_id in gateway_config.
             tx.execute(

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1567,7 +1567,6 @@ impl SqliteStorage {
                 )
                 .map_err(map_err)?;
             if updated == 0 {
-                let _ = tx.execute("ROLLBACK", []);
                 return Err(StorageError::Internal(
                     "commit_rotation: encrypted_seed_new is NULL — \
                      cannot promote; identity rewrap may not have completed"

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -397,7 +397,11 @@ fn migrate_legacy_psks(conn: &mut Connection, master_key: &[u8; 32]) -> Result<(
 ///
 /// If no PSK rows exist yet (new or empty database) the function returns
 /// `Ok(())` since there is nothing to validate against.
-fn validate_master_key(conn: &Connection, master_key: &[u8; 32]) -> Result<(), StorageError> {
+fn validate_master_key(
+    conn: &Connection,
+    master_key: &[u8; 32],
+    pending_new_key: Option<&[u8; 32]>,
+) -> Result<(), StorageError> {
     // Reject any PSK blobs with unexpected lengths.
     let bad_count: i64 = conn
         .query_row(
@@ -415,6 +419,8 @@ fn validate_master_key(conn: &Connection, master_key: &[u8; 32]) -> Result<(), S
     }
 
     // Try to decrypt one encrypted row to verify the master key.
+    // During interrupted rotation, some PSKs may be encrypted with the new
+    // key. We try the current key first, then the pending new key if available.
     let psk_row: Option<(String, Vec<u8>)> = conn
         .query_row(
             "SELECT node_id, psk FROM nodes WHERE LENGTH(psk) = ?1 LIMIT 1",
@@ -425,16 +431,88 @@ fn validate_master_key(conn: &Connection, master_key: &[u8; 32]) -> Result<(), S
         .map_err(map_err)?;
 
     if let Some((node_id, psk_blob)) = psk_row {
-        let _decrypted =
-            Zeroizing::new(decrypt_psk(master_key, &node_id, &psk_blob).map_err(|e| {
-                StorageError::Internal(format!(
+        let current_ok = decrypt_psk(master_key, &node_id, &psk_blob).is_ok();
+        if !current_ok {
+            // If we have a pending new key (interrupted rotation), try that.
+            if let Some(new_key) = pending_new_key {
+                let _decrypted = Zeroizing::new(
+                    decrypt_psk(new_key, &node_id, &psk_blob).map_err(|e| {
+                        StorageError::Internal(format!(
+                            "master key validation failed — cannot decrypt PSK for node \
+                             `{node_id}` with either current or pending rotation key: {e}; \
+                             this may indicate a wrong master key or corrupt/tampered database data",
+                        ))
+                    })?,
+                );
+            } else {
+                return Err(StorageError::Internal(format!(
                     "master key validation failed — cannot decrypt PSK for node \
-                     `{node_id}`: {e}; this may indicate a wrong master key or \
+                     `{node_id}`; this may indicate a wrong master key or \
                      corrupt/tampered database data",
-                ))
-            })?);
+                )));
+            }
+        }
     }
     Ok(())
+}
+
+/// Decrypt the pending new master key from the `pending_rotation` table,
+/// if one exists. Returns `None` if no rotation is pending.
+///
+/// Called during `open()` before `validate_master_key` to support crash
+/// recovery (GW-2007): some PSKs may already be re-encrypted with the
+/// new key.
+fn load_pending_rotation_key(
+    conn: &Connection,
+    current_key: &[u8; 32],
+) -> Result<Option<Zeroizing<[u8; 32]>>, StorageError> {
+    let pending: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT new_master_key_enc FROM pending_rotation WHERE id = 1",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_err)?;
+
+    let enc_blob = match pending {
+        Some(blob) => blob,
+        None => return Ok(None),
+    };
+
+    if enc_blob.len() != ENCRYPTED_PSK_LEN {
+        return Err(StorageError::Internal(format!(
+            "pending_rotation.new_master_key_enc has wrong length: {} (expected {ENCRYPTED_PSK_LEN})",
+            enc_blob.len()
+        )));
+    }
+
+    let key = Key::<Aes256Gcm>::from_slice(current_key);
+    let cipher = Aes256Gcm::new(key);
+    let nonce = Nonce::from_slice(&enc_blob[..12]);
+    let payload = Payload {
+        msg: &enc_blob[12..],
+        aad: PENDING_ROTATION_AAD,
+    };
+
+    let plaintext = Zeroizing::new(cipher.decrypt(nonce, payload).map_err(|_| {
+        StorageError::Internal(
+            "cannot decrypt pending_rotation.new_master_key_enc — wrong master key \
+             or data corruption"
+                .into(),
+        )
+    })?);
+
+    if plaintext.len() != 32 {
+        return Err(StorageError::Internal(format!(
+            "decrypted pending new master key is {} bytes, expected 32",
+            plaintext.len()
+        )));
+    }
+
+    let mut arr = Zeroizing::new([0u8; 32]);
+    arr.copy_from_slice(&plaintext);
+    Ok(Some(arr))
 }
 
 const SCHEMA: &str = "
@@ -504,6 +582,48 @@ CREATE TABLE IF NOT EXISTS handlers (
 );
 ";
 
+/// State for dual-key PSK decryption during master key rotation (GW-2006).
+///
+/// Set via [`SqliteStorage::set_rotation_new_key`] when a rotation begins.
+/// Cleared via [`SqliteStorage::clear_rotation_new_key`] after commit.
+#[derive(Clone)]
+struct RotationKeyState {
+    /// The new master key being rotated to.
+    new_key: Arc<Zeroizing<[u8; 32]>>,
+    /// The epoch assigned to the new key.
+    new_epoch: u64,
+}
+
+/// A pending rotation record from the `pending_rotation` table (GW-2007).
+#[derive(Clone, Debug)]
+pub struct PendingRotationRecord {
+    /// New master key encrypted with the old key (60 bytes: nonce + ciphertext + tag).
+    pub new_master_key_enc: Vec<u8>,
+    /// Random 16-byte ID for the new key.
+    pub new_master_key_id: [u8; 16],
+    /// Epoch for the new key (current_epoch + 1).
+    pub new_epoch: u64,
+    /// Current rotation phase.
+    pub phase: String,
+}
+
+/// Node escrow metadata for ACTUAL_STATE re-emission after rotation.
+#[derive(Clone, Debug)]
+pub struct NodeEscrowRecord {
+    pub node_id: String,
+    pub key_hint: u16,
+    pub encrypted_psk: Vec<u8>,
+    pub master_key_id: Vec<u8>,
+    pub schedule_interval_s: u32,
+    pub firmware_abi_version: u32,
+    pub firmware_version: String,
+    pub current_program_hash: Vec<u8>,
+    pub assigned_program_hash: Option<Vec<u8>>,
+}
+
+/// AAD for encrypting the new master key in the `pending_rotation` table.
+const PENDING_ROTATION_AAD: &[u8] = b"sonde-pending-rotation";
+
 /// SQLite-backed persistent storage for the gateway.
 ///
 /// Uses `Arc<Mutex<Connection>>` so storage operations can be offloaded
@@ -513,10 +633,28 @@ CREATE TABLE IF NOT EXISTS handlers (
 /// (GW-0601a). The master key is never written to the database.
 pub struct SqliteStorage {
     conn: Arc<Mutex<Connection>>,
-    master_key: Arc<Zeroizing<[u8; 32]>>,
+    /// Current master key, wrapped in RwLock to support in-memory swap after
+    /// rotation commit (GW-2006 step 7). Readers clone the inner Arc (cheap)
+    /// and drop the lock immediately.
+    master_key: Arc<std::sync::RwLock<Arc<Zeroizing<[u8; 32]>>>>,
+    /// During rotation, holds the new master key and its epoch for dual-key
+    /// PSK decryption (GW-2006 §2.6.2 step 5).
+    rotation_key_state: Arc<std::sync::RwLock<Option<RotationKeyState>>>,
 }
 
 impl SqliteStorage {
+    /// Return a cloned Arc to the current master key.
+    ///
+    /// The RwLock is held only long enough to clone the inner Arc (not the key
+    /// material itself), so contention is negligible.
+    pub(crate) fn master_key(&self) -> Arc<Zeroizing<[u8; 32]>> {
+        self.master_key.read().unwrap().clone()
+    }
+
+    /// Return the rotation key state if a rotation is in progress.
+    fn rotation_key(&self) -> Option<RotationKeyState> {
+        self.rotation_key_state.read().unwrap().clone()
+    }
     /// Open (or create) a SQLite database at the given path.
     ///
     /// `master_key` is a 32-byte AES-256 key used to encrypt PSK material at
@@ -728,9 +866,7 @@ impl SqliteStorage {
             })?;
         }
         // Migration: evolve-962 — master_key_id, master_key_epoch, pending_recovery,
-        // and encrypted_seed_new columns. The pending_rotation table migration
-        // (from evolve-887 schema to evolve-962 schema) is deferred to the
-        // rotation execution wiring PR.
+        // encrypted_seed_new, and pending_rotation (GW-2006, GW-2007).
         {
             // Add master_key_id and master_key_epoch columns to nodes (GW-2001).
             // Check each column independently to handle partially migrated DBs.
@@ -807,6 +943,23 @@ impl SqliteStorage {
                 ))
             })?;
 
+            // Create pending_rotation table (GW-2007, evolve-962 §2.6.2 step 4).
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS pending_rotation (
+                    id                 INTEGER PRIMARY KEY CHECK (id = 1),
+                    new_master_key_enc BLOB    NOT NULL,
+                    new_master_key_id  BLOB    NOT NULL,
+                    new_epoch          INTEGER NOT NULL,
+                    started_at         INTEGER NOT NULL,
+                    phase              TEXT    NOT NULL DEFAULT 'migrating_psks'
+                )",
+            )
+            .map_err(|e| {
+                StorageError::Internal(format!(
+                    "migration failed: CREATE TABLE pending_rotation: {e}"
+                ))
+            })?;
+
             // Add encrypted_seed_new column to gateway_identity for crash-safe
             // rotation (GW-2007). Permanent column, reused on each rotation.
             let gi_cols: Vec<String> = conn
@@ -831,12 +984,39 @@ impl SqliteStorage {
         // form. This must run before `validate_master_key` since validation only
         // checks encrypted blobs.
         migrate_legacy_psks(&mut conn, &master_key)?;
+
+        // If a rotation was interrupted, decrypt the pending new key so that
+        // validate_master_key can handle PSKs encrypted with either key.
+        let pending_new_key = load_pending_rotation_key(&conn, &master_key)?;
+
         // Verify that the master key can actually decrypt existing PSK data.
         // Catches a wrong key at startup rather than at first node read.
-        validate_master_key(&conn, &master_key)?;
+        // During interrupted rotation, some PSKs may be encrypted with the
+        // new key — we pass it so validation can try both.
+        validate_master_key(&conn, &master_key, pending_new_key.as_deref())?;
+
+        // Build the initial rotation key state if a rotation is in progress.
+        let rotation_key_state = if let Some(ref new_key) = pending_new_key {
+            let pending: Option<(Vec<u8>, i64)> = conn
+                .query_row(
+                    "SELECT new_master_key_id, new_epoch FROM pending_rotation WHERE id = 1",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()
+                .map_err(map_err)?;
+            pending.map(|(_, epoch_raw)| RotationKeyState {
+                new_key: Arc::new(Zeroizing::new(**new_key)),
+                new_epoch: epoch_raw as u64,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
-            master_key: Arc::new(master_key),
+            master_key: Arc::new(std::sync::RwLock::new(Arc::new(master_key))),
+            rotation_key_state: Arc::new(std::sync::RwLock::new(rotation_key_state)),
         })
     }
 
@@ -1002,6 +1182,493 @@ impl SqliteStorage {
             .map_err(map_err)?;
 
             Ok(code)
+        })
+        .await
+    }
+
+    // ── Master key rotation (GW-2006, GW-2007, GW-2013) ───────
+
+    /// Write a pending_rotation record and purge pending_recovery (§2.6.2 step 4).
+    ///
+    /// The new master key is encrypted with the OLD master key for crash safety.
+    /// This must be called within a single logical operation — the DB transaction
+    /// ensures atomicity of both the insert and the purge.
+    pub async fn write_pending_rotation(
+        &self,
+        new_master_key: &[u8; 32],
+        new_master_key_id: &[u8; 16],
+        new_epoch: u64,
+    ) -> Result<(), StorageError> {
+        let mk = self.master_key();
+        let new_key = *new_master_key;
+        let new_id = *new_master_key_id;
+
+        // Encrypt the new master key with the old key (AAD = "sonde-pending-rotation").
+        let key = Key::<Aes256Gcm>::from_slice(mk.as_slice());
+        let cipher = Aes256Gcm::new(key);
+        let mut nonce_bytes = [0u8; 12];
+        getrandom::fill(&mut nonce_bytes)
+            .map_err(|e| StorageError::Internal(format!("pending_rotation nonce rng: {e}")))?;
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let payload = Payload {
+            msg: new_key.as_slice(),
+            aad: PENDING_ROTATION_AAD,
+        };
+        let ciphertext = cipher
+            .encrypt(nonce, payload)
+            .map_err(|e| StorageError::Internal(format!("pending_rotation encrypt: {e}")))?;
+        let mut enc_blob = Vec::with_capacity(ENCRYPTED_PSK_LEN);
+        enc_blob.extend_from_slice(&nonce_bytes);
+        enc_blob.extend_from_slice(&ciphertext);
+
+        let epoch_i64 = i64::try_from(new_epoch).map_err(|_| {
+            StorageError::Internal(format!("new_epoch {new_epoch} exceeds i64::MAX"))
+        })?;
+
+        self.with_conn(move |conn| {
+            let tx = conn.unchecked_transaction().map_err(map_err)?;
+
+            // Purge pending_recovery — old records encrypted with pre-rotation key (GW-2013).
+            tx.execute("DELETE FROM pending_recovery", [])
+                .map_err(map_err)?;
+
+            // Insert pending_rotation record.
+            tx.execute(
+                "INSERT INTO pending_rotation \
+                 (id, new_master_key_enc, new_master_key_id, new_epoch, started_at, phase) \
+                 VALUES (1, ?1, ?2, ?3, strftime('%s', 'now'), 'migrating_psks')",
+                params![enc_blob, new_id.as_slice(), epoch_i64],
+            )
+            .map_err(map_err)?;
+
+            tx.commit().map_err(map_err)?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Read the pending_rotation record, if one exists.
+    pub async fn read_pending_rotation(
+        &self,
+    ) -> Result<Option<PendingRotationRecord>, StorageError> {
+        self.with_conn(|conn| {
+            let row: Option<(Vec<u8>, Vec<u8>, i64, String)> = conn
+                .query_row(
+                    "SELECT new_master_key_enc, new_master_key_id, new_epoch, phase \
+                     FROM pending_rotation WHERE id = 1",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .optional()
+                .map_err(map_err)?;
+            match row {
+                None => Ok(None),
+                Some((enc, id_vec, epoch_raw, phase)) => {
+                    if id_vec.len() != 16 {
+                        return Err(StorageError::Internal(format!(
+                            "pending_rotation.new_master_key_id has wrong length: {} (expected 16)",
+                            id_vec.len()
+                        )));
+                    }
+                    let mut new_master_key_id = [0u8; 16];
+                    new_master_key_id.copy_from_slice(&id_vec);
+                    Ok(Some(PendingRotationRecord {
+                        new_master_key_enc: enc,
+                        new_master_key_id,
+                        new_epoch: epoch_raw as u64,
+                        phase,
+                    }))
+                }
+            }
+        })
+        .await
+    }
+
+    /// Update the rotation phase in the pending_rotation record.
+    pub async fn update_rotation_phase(&self, phase: &str) -> Result<(), StorageError> {
+        let phase = phase.to_owned();
+        self.with_conn(move |conn| {
+            let updated = conn
+                .execute(
+                    "UPDATE pending_rotation SET phase = ?1 WHERE id = 1",
+                    params![phase],
+                )
+                .map_err(map_err)?;
+            if updated == 0 {
+                return Err(StorageError::Internal(
+                    "no pending_rotation record to update".into(),
+                ));
+            }
+            Ok(())
+        })
+        .await
+    }
+
+    /// List node IDs that have not been migrated to the new epoch.
+    pub async fn list_unmigrated_node_ids(
+        &self,
+        new_epoch: u64,
+    ) -> Result<Vec<String>, StorageError> {
+        let epoch_i64 = new_epoch as i64;
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT node_id FROM nodes WHERE master_key_epoch < ?1")
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(params![epoch_i64], |row| row.get(0))
+                .map_err(map_err)?;
+            rows.collect::<Result<Vec<String>, _>>().map_err(map_err)
+        })
+        .await
+    }
+
+    /// Re-encrypt a single node's PSK from old_key to new_key (§2.6.2 step 5).
+    pub async fn migrate_node_psk(
+        &self,
+        node_id: &str,
+        old_key: &[u8; 32],
+        new_key: &[u8; 32],
+        new_key_id: &[u8; 16],
+        new_epoch: u64,
+    ) -> Result<(), StorageError> {
+        let node_id = node_id.to_owned();
+        let old_key = *old_key;
+        let new_key = *new_key;
+        let new_key_id = *new_key_id;
+        let epoch_i64 = i64::try_from(new_epoch).map_err(|_| {
+            StorageError::Internal(format!("new_epoch {new_epoch} exceeds i64::MAX"))
+        })?;
+
+        self.with_conn(move |conn| {
+            // Read the current encrypted PSK.
+            let psk_blob: Vec<u8> = conn
+                .query_row(
+                    "SELECT psk FROM nodes WHERE node_id = ?1",
+                    params![node_id],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?;
+
+            // Decrypt with old key.
+            let psk = Zeroizing::new(decrypt_psk(&old_key, &node_id, &psk_blob).map_err(|e| {
+                StorageError::Internal(format!(
+                    "rotate: cannot decrypt PSK for node `{node_id}`: {e}"
+                ))
+            })?);
+
+            // Re-encrypt with new key.
+            let encrypted = encrypt_psk(&new_key, &node_id, &psk)?;
+
+            // Update the record.
+            conn.execute(
+                "UPDATE nodes SET psk = ?1, master_key_id = ?2, master_key_epoch = ?3 \
+                 WHERE node_id = ?4",
+                params![encrypted, new_key_id.as_slice(), epoch_i64, node_id],
+            )
+            .map_err(map_err)?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// List phone IDs that have not been migrated to the new epoch.
+    pub async fn list_unmigrated_phone_ids(
+        &self,
+        new_epoch: u64,
+    ) -> Result<Vec<u32>, StorageError> {
+        let epoch_i64 = new_epoch as i64;
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare("SELECT phone_id FROM phone_psks WHERE master_key_epoch < ?1")
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(params![epoch_i64], |row| row.get(0))
+                .map_err(map_err)?;
+            rows.collect::<Result<Vec<u32>, _>>().map_err(map_err)
+        })
+        .await
+    }
+
+    /// Re-encrypt a single phone PSK from old_key to new_key (§2.6.2 step 5).
+    pub async fn migrate_phone_psk(
+        &self,
+        phone_id: u32,
+        old_key: &[u8; 32],
+        new_key: &[u8; 32],
+        new_key_id: &[u8; 16],
+        new_epoch: u64,
+    ) -> Result<(), StorageError> {
+        let old_key = *old_key;
+        let new_key = *new_key;
+        let new_key_id = *new_key_id;
+        let epoch_i64 = i64::try_from(new_epoch).map_err(|_| {
+            StorageError::Internal(format!("new_epoch {new_epoch} exceeds i64::MAX"))
+        })?;
+
+        self.with_conn(move |conn| {
+            let psk_blob: Vec<u8> = conn
+                .query_row(
+                    "SELECT psk FROM phone_psks WHERE phone_id = ?1",
+                    params![phone_id],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?;
+
+            let psk = Zeroizing::new(decrypt_phone_psk(&old_key, phone_id, &psk_blob)?);
+            let encrypted = encrypt_phone_psk(&new_key, phone_id, &psk)?;
+
+            conn.execute(
+                "UPDATE phone_psks SET psk = ?1, master_key_id = ?2, master_key_epoch = ?3 \
+                 WHERE phone_id = ?4",
+                params![encrypted, new_key_id.as_slice(), epoch_i64, phone_id],
+            )
+            .map_err(map_err)?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Re-encrypt the gateway identity seed under the new key (§2.6.2 step 6).
+    ///
+    /// Writes to `encrypted_seed_new` column, preserving the original
+    /// `encrypted_seed` (encrypted with old key) for crash safety.
+    pub async fn rewrap_identity_seed(
+        &self,
+        old_key: &[u8; 32],
+        new_key: &[u8; 32],
+    ) -> Result<(), StorageError> {
+        let old_key = *old_key;
+        let new_key = *new_key;
+        self.with_conn(move |conn| {
+            let row: Option<(Vec<u8>, Vec<u8>)> = conn
+                .query_row(
+                    "SELECT encrypted_seed, gateway_id FROM gateway_identity WHERE id = 1",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()
+                .map_err(map_err)?;
+
+            let (encrypted_seed, gateway_id_vec) = row.ok_or_else(|| {
+                StorageError::Internal("no gateway_identity row to rewrap".into())
+            })?;
+
+            let gateway_id: [u8; 16] = gateway_id_vec
+                .as_slice()
+                .try_into()
+                .map_err(|_| StorageError::Internal("gateway_id is not 16 bytes".into()))?;
+
+            // Decrypt seed with old key.
+            let seed = Zeroizing::new(decrypt_seed(&old_key, &encrypted_seed, &gateway_id)?);
+
+            // Re-encrypt seed with new key.
+            let new_encrypted = encrypt_seed(&new_key, &seed, &gateway_id)?;
+
+            // Write to encrypted_seed_new column.
+            conn.execute(
+                "UPDATE gateway_identity SET encrypted_seed_new = ?1 WHERE id = 1",
+                params![new_encrypted],
+            )
+            .map_err(map_err)?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Atomic commit of the rotation (§2.6.2 step 7).
+    ///
+    /// In a single transaction:
+    /// - Promote `encrypted_seed_new` → `encrypted_seed`, clear `encrypted_seed_new`
+    /// - Update `master_key_id` and `master_key_epoch` in `gateway_config`
+    /// - Store salt and KDF params if non-null
+    /// - Generate new rotation code
+    /// - Delete `pending_rotation`
+    pub async fn commit_rotation(
+        &self,
+        new_key_id: &[u8; 16],
+        new_epoch: u64,
+        salt: Option<&[u8]>,
+        kdf_params: Option<&crate::rotation::KdfParamsPayload>,
+    ) -> Result<String, StorageError> {
+        let new_key_id = *new_key_id;
+        let salt = salt.map(|s| s.to_vec());
+        let kdf_params = kdf_params.cloned();
+        let hex_id = hex::encode(new_key_id);
+
+        self.with_conn(move |conn| {
+            let tx = conn.unchecked_transaction().map_err(map_err)?;
+
+            // Promote encrypted_seed_new → encrypted_seed.
+            tx.execute(
+                "UPDATE gateway_identity SET encrypted_seed = encrypted_seed_new, \
+                 encrypted_seed_new = NULL WHERE id = 1",
+                [],
+            )
+            .map_err(map_err)?;
+
+            // Update master_key_id in gateway_config.
+            tx.execute(
+                "INSERT INTO gateway_config (key, value) VALUES ('master_key_id', ?1) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![hex_id],
+            )
+            .map_err(map_err)?;
+
+            // Update master_key_epoch in gateway_config.
+            tx.execute(
+                "INSERT INTO gateway_config (key, value) VALUES ('master_key_epoch', ?1) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![new_epoch.to_string()],
+            )
+            .map_err(map_err)?;
+
+            // Store salt if provided.
+            if let Some(ref salt_bytes) = salt {
+                tx.execute(
+                    "INSERT INTO gateway_config (key, value) VALUES ('salt', ?1) \
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    params![hex::encode(salt_bytes)],
+                )
+                .map_err(map_err)?;
+            }
+
+            // Store KDF params if provided.
+            if let Some(ref params) = kdf_params {
+                let kdf_json = serde_json::json!({
+                    "m_cost": params.m_cost,
+                    "t_cost": params.t_cost,
+                    "p_cost": params.p_cost,
+                    "kdf_version": params.kdf_version,
+                });
+                tx.execute(
+                    "INSERT INTO gateway_config (key, value) VALUES ('kdf_params', ?1) \
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    params![kdf_json.to_string()],
+                )
+                .map_err(map_err)?;
+            }
+
+            // Generate new rotation code.
+            let new_code = generate_rotation_code()?;
+            tx.execute(
+                "INSERT INTO gateway_config (key, value) VALUES ('rotation_code', ?1) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![new_code],
+            )
+            .map_err(map_err)?;
+
+            // Delete pending_rotation.
+            tx.execute("DELETE FROM pending_rotation", [])
+                .map_err(map_err)?;
+
+            tx.commit().map_err(map_err)?;
+            Ok(new_code)
+        })
+        .await
+    }
+
+    /// Swap the in-memory master key to the new key after DB commit (§2.6.2 step 7).
+    ///
+    /// This is NOT part of the DB transaction — it only occurs after commit
+    /// succeeds. If the process crashes after DB commit but before this call,
+    /// the next startup will load the new key from gateway_config.
+    pub fn swap_master_key(&self, new_key: Zeroizing<[u8; 32]>) {
+        *self.master_key.write().unwrap() = Arc::new(new_key);
+    }
+
+    /// Set the rotation new key for dual-key PSK decryption during rotation.
+    pub fn set_rotation_new_key(&self, key: Zeroizing<[u8; 32]>, epoch: u64) {
+        *self.rotation_key_state.write().unwrap() = Some(RotationKeyState {
+            new_key: Arc::new(key),
+            new_epoch: epoch,
+        });
+    }
+
+    /// Clear the rotation new key after rotation completes.
+    pub fn clear_rotation_new_key(&self) {
+        *self.rotation_key_state.write().unwrap() = None;
+    }
+
+    /// Decrypt the pending new master key from the pending_rotation table.
+    ///
+    /// Uses the current in-memory master key. Returns `None` if no rotation
+    /// is pending.
+    pub fn decrypt_pending_new_key(
+        current_key: &[u8; 32],
+        enc_blob: &[u8],
+    ) -> Result<Zeroizing<[u8; 32]>, StorageError> {
+        if enc_blob.len() != ENCRYPTED_PSK_LEN {
+            return Err(StorageError::Internal(format!(
+                "new_master_key_enc has wrong length: {} (expected {ENCRYPTED_PSK_LEN})",
+                enc_blob.len()
+            )));
+        }
+        let key = Key::<Aes256Gcm>::from_slice(current_key);
+        let cipher = Aes256Gcm::new(key);
+        let nonce = Nonce::from_slice(&enc_blob[..12]);
+        let payload = Payload {
+            msg: &enc_blob[12..],
+            aad: PENDING_ROTATION_AAD,
+        };
+        let plaintext = Zeroizing::new(cipher.decrypt(nonce, payload).map_err(|_| {
+            StorageError::Internal(
+                "cannot decrypt new_master_key_enc — wrong key or data corruption".into(),
+            )
+        })?);
+        if plaintext.len() != 32 {
+            return Err(StorageError::Internal(format!(
+                "decrypted new master key is {} bytes, expected 32",
+                plaintext.len()
+            )));
+        }
+        let mut arr = Zeroizing::new([0u8; 32]);
+        arr.copy_from_slice(&plaintext);
+        Ok(arr)
+    }
+
+    /// List node escrow metadata for ACTUAL_STATE re-emission after rotation.
+    pub async fn list_node_escrow_state(&self) -> Result<Vec<NodeEscrowRecord>, StorageError> {
+        self.with_conn(|conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT node_id, key_hint, psk, master_key_id, \
+                     schedule_interval_s, firmware_abi_version, firmware_version, \
+                     current_program_hash, assigned_program_hash FROM nodes",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map([], |row| {
+                    let kh: u32 = row.get(1)?;
+                    Ok(NodeEscrowRecord {
+                        node_id: row.get(0)?,
+                        key_hint: u16::try_from(kh)
+                            .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(1, kh as i64))?,
+                        encrypted_psk: row.get(2)?,
+                        master_key_id: row.get::<_, Option<Vec<u8>>>(3)?.unwrap_or_default(),
+                        schedule_interval_s: row.get(4)?,
+                        firmware_abi_version: row.get::<_, Option<u32>>(5)?.unwrap_or(0),
+                        firmware_version: row.get::<_, Option<String>>(6)?.unwrap_or_default(),
+                        current_program_hash: row.get::<_, Option<Vec<u8>>>(7)?.unwrap_or_default(),
+                        assigned_program_hash: row.get(8)?,
+                    })
+                })
+                .map_err(map_err)?;
+            rows.collect::<Result<Vec<_>, _>>().map_err(map_err)
+        })
+        .await
+    }
+
+    /// Check whether a rotation is currently in progress (pending_rotation exists).
+    pub async fn is_rotation_in_progress(&self) -> Result<bool, StorageError> {
+        self.with_conn(|conn| {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM pending_rotation WHERE id = 1",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?;
+            Ok(count > 0)
         })
         .await
     }
@@ -1260,10 +1927,26 @@ fn sensors_from_json(json: &str) -> Vec<SensorDescriptor> {
 ///
 /// The `node_id` column (index 0) is used as AAD for the AES-GCM decryption
 /// so that swapping PSK blobs between rows is detected as an authentication failure.
-fn row_to_node(row: &rusqlite::Row<'_>, master_key: &[u8; 32]) -> rusqlite::Result<NodeRecord> {
+fn row_to_node(
+    row: &rusqlite::Row<'_>,
+    master_key: &[u8; 32],
+    rotation_key: Option<(&[u8; 32], u64)>,
+) -> rusqlite::Result<NodeRecord> {
     let node_id: String = row.get(0)?;
     let psk_blob: Vec<u8> = row.get(2)?;
-    let psk = decrypt_psk(master_key, &node_id, &psk_blob).map_err(|e| {
+
+    // Dual-key decryption: check master_key_epoch to select the correct key.
+    // During rotation, migrated records have the new epoch; unmigrated records
+    // have the old epoch.
+    let epoch_raw: i64 = row.get(13)?;
+    let record_epoch = epoch_raw as u64;
+
+    let decrypt_key = match rotation_key {
+        Some((new_key, new_epoch)) if record_epoch >= new_epoch => new_key,
+        _ => master_key,
+    };
+
+    let psk = decrypt_psk(decrypt_key, &node_id, &psk_blob).map_err(|e| {
         rusqlite::Error::FromSqlConversionFailure(
             2,
             rusqlite::types::Type::Blob,
@@ -1329,18 +2012,22 @@ impl Storage for SqliteStorage {
     // ── Node registry ──────────────────────────────────────────
 
     async fn list_nodes(&self) -> Result<Vec<NodeRecord>, StorageError> {
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
+        let rk = self.rotation_key();
         self.with_conn(move |conn| {
             let mut stmt = conn
                 .prepare(
                     "SELECT node_id, key_hint, psk, assigned_program_hash, \
                      current_program_hash, desired_schedule_interval_s, schedule_interval_s, \
                      firmware_abi_version, rf_channel, sensors_json, registered_by_phone_id, \
-                     firmware_version, key_version FROM nodes",
+                     firmware_version, key_version, master_key_epoch FROM nodes",
                 )
                 .map_err(map_err)?;
+            let rk_ref = rk
+                .as_ref()
+                .map(|s| (&**s.new_key as &[u8; 32], s.new_epoch));
             let rows = stmt
-                .query_map([], |row| row_to_node(row, &mk))
+                .query_map([], |row| row_to_node(row, &mk, rk_ref))
                 .map_err(map_err)?;
             let mut nodes = Vec::new();
             for row in rows {
@@ -1353,16 +2040,20 @@ impl Storage for SqliteStorage {
 
     async fn get_node(&self, node_id: &str) -> Result<Option<NodeRecord>, StorageError> {
         let node_id = node_id.to_string();
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
+        let rk = self.rotation_key();
         self.with_conn(move |conn| {
+            let rk_ref = rk
+                .as_ref()
+                .map(|s| (&**s.new_key as &[u8; 32], s.new_epoch));
             let maybe_node = conn
                 .query_row(
                     "SELECT node_id, key_hint, psk, assigned_program_hash, \
                      current_program_hash, desired_schedule_interval_s, schedule_interval_s, \
                      firmware_abi_version, rf_channel, sensors_json, registered_by_phone_id, \
-                     firmware_version, key_version FROM nodes WHERE node_id = ?1",
+                     firmware_version, key_version, master_key_epoch FROM nodes WHERE node_id = ?1",
                     params![node_id],
-                    |row| row_to_node(row, &mk),
+                    |row| row_to_node(row, &mk, rk_ref),
                 )
                 .optional()
                 .map_err(map_err)?;
@@ -1372,18 +2063,20 @@ impl Storage for SqliteStorage {
     }
 
     async fn get_nodes_by_key_hint(&self, key_hint: u16) -> Result<Vec<NodeRecord>, StorageError> {
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
+        let rk = self.rotation_key();
         self.with_conn(move |conn| {
             let mut stmt = conn
                 .prepare(
                     "SELECT node_id, key_hint, psk, assigned_program_hash, \
                      current_program_hash, desired_schedule_interval_s, schedule_interval_s, \
                      firmware_abi_version, rf_channel, sensors_json, registered_by_phone_id, \
-                     firmware_version, key_version FROM nodes WHERE key_hint = ?1",
+                     firmware_version, key_version, master_key_epoch FROM nodes WHERE key_hint = ?1",
                 )
                 .map_err(map_err)?;
+            let rk_ref = rk.as_ref().map(|s| (&**s.new_key as &[u8; 32], s.new_epoch));
             let rows = stmt
-                .query_map(params![key_hint as u32], |row| row_to_node(row, &mk))
+                .query_map(params![key_hint as u32], |row| row_to_node(row, &mk, rk_ref))
                 .map_err(map_err)?;
             let mut nodes = Vec::new();
             for row in rows {
@@ -1396,7 +2089,7 @@ impl Storage for SqliteStorage {
 
     async fn upsert_node(&self, record: &NodeRecord) -> Result<(), StorageError> {
         let record = record.clone();
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
         self.with_conn(move |conn| {
             let encrypted_psk = encrypt_psk(&mk, &record.node_id, &record.psk)?;
             let sensors_json = sensors_to_json(&record.sensors);
@@ -1494,7 +2187,7 @@ impl Storage for SqliteStorage {
 
     async fn insert_node_if_not_exists(&self, record: &NodeRecord) -> Result<bool, StorageError> {
         let record = record.clone();
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
         self.with_conn(move |conn| {
             let encrypted_psk = encrypt_psk(&mk, &record.node_id, &record.psk)?;
             let sensors_json = sensors_to_json(&record.sensors);
@@ -1772,7 +2465,7 @@ impl Storage for SqliteStorage {
     ) -> Result<(), StorageError> {
         let nodes = nodes.to_vec();
         let programs = programs.to_vec();
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
         self.with_conn(move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE").map_err(map_err)?;
 
@@ -1851,7 +2544,7 @@ impl Storage for SqliteStorage {
     // ── Gateway identity (GW-1200, GW-1201) ───────────────────
 
     async fn load_gateway_identity(&self) -> Result<Option<GatewayIdentity>, StorageError> {
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
         self.with_conn(move |conn| {
             let row: Option<(Vec<u8>, Vec<u8>, Vec<u8>)> = conn
                 .query_row(
@@ -1898,7 +2591,7 @@ impl Storage for SqliteStorage {
     }
 
     async fn store_gateway_identity(&self, identity: &GatewayIdentity) -> Result<(), StorageError> {
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
         let seed = Zeroizing::new(*identity.seed());
         let gateway_id_arr = *identity.gateway_id();
         let gateway_id = identity.gateway_id().to_vec();
@@ -1923,12 +2616,13 @@ impl Storage for SqliteStorage {
     // ── Phone trust store (GW-1210) ────────────────────────────
 
     async fn list_phone_psks(&self) -> Result<Vec<PhonePskRecord>, StorageError> {
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
+        let rk = self.rotation_key();
         self.with_conn(move |conn| {
             let mut stmt = conn
                 .prepare(
-                    "SELECT phone_id, phone_key_hint, psk, label, issued_at_epoch_s, status, key_version \
-                     FROM phone_psks",
+                    "SELECT phone_id, phone_key_hint, psk, label, issued_at_epoch_s, status, key_version, \
+                     master_key_epoch FROM phone_psks",
                 )
                 .map_err(map_err)?;
             let rows = stmt
@@ -1941,14 +2635,20 @@ impl Storage for SqliteStorage {
                         row.get::<_, i64>(4)?,
                         row.get::<_, String>(5)?,
                         row.get::<_, i64>(6)?,
+                        row.get::<_, i64>(7)?,
                     ))
                 })
                 .map_err(map_err)?;
             let mut records = Vec::new();
             for row in rows {
-                let (phone_id, key_hint, psk_blob, label, issued_at, status_str, key_version_raw) =
+                let (phone_id, key_hint, psk_blob, label, issued_at, status_str, key_version_raw, epoch_raw) =
                     row.map_err(map_err)?;
-                let psk = Zeroizing::new(decrypt_phone_psk(&mk, phone_id, &psk_blob)?);
+                let record_epoch = epoch_raw as u64;
+                let decrypt_key: &[u8; 32] = match rk.as_ref() {
+                    Some(s) if record_epoch >= s.new_epoch => &s.new_key,
+                    _ => &mk,
+                };
+                let psk = Zeroizing::new(decrypt_phone_psk(decrypt_key, phone_id, &psk_blob)?);
                 let status = PhonePskStatus::from_str_value(&status_str).ok_or_else(|| {
                     StorageError::Internal(format!("unknown phone psk status: {status_str}"))
                 })?;
@@ -1979,12 +2679,13 @@ impl Storage for SqliteStorage {
         &self,
         key_hint: u16,
     ) -> Result<Vec<PhonePskRecord>, StorageError> {
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
+        let rk = self.rotation_key();
         self.with_conn(move |conn| {
             let mut stmt = conn
                 .prepare(
-                    "SELECT phone_id, phone_key_hint, psk, label, issued_at_epoch_s, status, key_version \
-                     FROM phone_psks WHERE phone_key_hint = ?1",
+                    "SELECT phone_id, phone_key_hint, psk, label, issued_at_epoch_s, status, key_version, \
+                     master_key_epoch FROM phone_psks WHERE phone_key_hint = ?1",
                 )
                 .map_err(map_err)?;
             let rows = stmt
@@ -1997,14 +2698,20 @@ impl Storage for SqliteStorage {
                         row.get::<_, i64>(4)?,
                         row.get::<_, String>(5)?,
                         row.get::<_, i64>(6)?,
+                        row.get::<_, i64>(7)?,
                     ))
                 })
                 .map_err(map_err)?;
             let mut records = Vec::new();
             for row in rows {
-                let (phone_id, kh, psk_blob, label, issued_at, status_str, key_version_raw) =
+                let (phone_id, kh, psk_blob, label, issued_at, status_str, key_version_raw, epoch_raw) =
                     row.map_err(map_err)?;
-                let psk = Zeroizing::new(decrypt_phone_psk(&mk, phone_id, &psk_blob)?);
+                let record_epoch = epoch_raw as u64;
+                let decrypt_key: &[u8; 32] = match rk.as_ref() {
+                    Some(s) if record_epoch >= s.new_epoch => &s.new_key,
+                    _ => &mk,
+                };
+                let psk = Zeroizing::new(decrypt_phone_psk(decrypt_key, phone_id, &psk_blob)?);
                 let status = PhonePskStatus::from_str_value(&status_str).ok_or_else(|| {
                     StorageError::Internal(format!("unknown phone psk status: {status_str}"))
                 })?;
@@ -2041,7 +2748,7 @@ impl Storage for SqliteStorage {
             )));
         }
 
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
         let record = record.clone();
         self.with_conn(move |conn| {
             let issued_at = system_time_to_epoch_s(&record.issued_at);
@@ -2145,7 +2852,7 @@ impl Storage for SqliteStorage {
             }
         }
 
-        let mk = self.master_key.clone();
+        let mk = self.master_key();
         let records = records.to_vec();
         self.with_conn(move |conn| {
             conn.execute_batch("BEGIN IMMEDIATE").map_err(map_err)?;

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -431,25 +431,30 @@ fn validate_master_key(
         .map_err(map_err)?;
 
     if let Some((node_id, psk_blob)) = psk_row {
-        let current_err = decrypt_psk(master_key, &node_id, &psk_blob).err();
-        if let Some(decrypt_err) = current_err {
-            // If we have a pending new key (interrupted rotation), try that.
-            if let Some(new_key) = pending_new_key {
-                let _decrypted = Zeroizing::new(
-                    decrypt_psk(new_key, &node_id, &psk_blob).map_err(|e| {
-                        StorageError::Internal(format!(
-                            "master key validation failed — cannot decrypt PSK for node \
-                             `{node_id}` with either current or pending rotation key: {e}; \
-                             this may indicate a wrong master key or corrupt/tampered database data",
-                        ))
-                    })?,
-                );
-            } else {
-                return Err(StorageError::Internal(format!(
-                    "master key validation failed — cannot decrypt PSK for node \
-                     `{node_id}`: {decrypt_err}; this may indicate a wrong master key or \
-                     corrupt/tampered database data",
-                )));
+        match decrypt_psk(master_key, &node_id, &psk_blob) {
+            Ok(psk) => {
+                // Zeroize the validated PSK immediately.
+                let _z = Zeroizing::new(psk);
+            }
+            Err(decrypt_err) => {
+                // If we have a pending new key (interrupted rotation), try that.
+                if let Some(new_key) = pending_new_key {
+                    let _decrypted = Zeroizing::new(
+                        decrypt_psk(new_key, &node_id, &psk_blob).map_err(|e| {
+                            StorageError::Internal(format!(
+                                "master key validation failed — cannot decrypt PSK for node \
+                                 `{node_id}` with either current or pending rotation key: {e}; \
+                                 this may indicate a wrong master key or corrupt/tampered database data",
+                            ))
+                        })?,
+                    );
+                } else {
+                    return Err(StorageError::Internal(format!(
+                        "master key validation failed — cannot decrypt PSK for node \
+                         `{node_id}`: {decrypt_err}; this may indicate a wrong master key or \
+                         corrupt/tampered database data",
+                    )));
+                }
             }
         }
     }
@@ -623,6 +628,7 @@ pub struct NodeEscrowRecord {
     pub firmware_version: String,
     pub current_program_hash: Vec<u8>,
     pub assigned_program_hash: Option<Vec<u8>>,
+    pub last_battery_mv: u32,
 }
 
 /// AAD for encrypting the new master key in the `pending_rotation` table.
@@ -1713,7 +1719,7 @@ impl SqliteStorage {
                 .prepare(
                     "SELECT node_id, key_hint, psk, master_key_id, \
                      schedule_interval_s, firmware_abi_version, firmware_version, \
-                     current_program_hash, assigned_program_hash FROM nodes",
+                     current_program_hash, assigned_program_hash, last_battery_mv FROM nodes",
                 )
                 .map_err(map_err)?;
             let rows = stmt
@@ -1730,6 +1736,7 @@ impl SqliteStorage {
                         firmware_version: row.get::<_, Option<String>>(6)?.unwrap_or_default(),
                         current_program_hash: row.get::<_, Option<Vec<u8>>>(7)?.unwrap_or_default(),
                         assigned_program_hash: row.get(8)?,
+                        last_battery_mv: row.get::<_, Option<u32>>(9)?.unwrap_or(0),
                     })
                 })
                 .map_err(map_err)?;

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1011,13 +1011,25 @@ impl SqliteStorage {
                 )
                 .optional()
                 .map_err(map_err)?;
-            pending.and_then(|(_, epoch_raw): (Vec<u8>, i64)| {
-                let new_epoch = u64::try_from(epoch_raw).ok()?;
-                Some(RotationKeyState {
-                    new_key: Arc::new(Zeroizing::new(**new_key)),
-                    new_epoch,
+            pending
+                .map(|(id_vec, epoch_raw): (Vec<u8>, i64)| {
+                    let new_epoch = u64::try_from(epoch_raw).map_err(|_| {
+                        StorageError::Internal(format!(
+                            "pending_rotation.new_epoch is negative: {epoch_raw}"
+                        ))
+                    })?;
+                    if id_vec.len() != 16 {
+                        return Err(StorageError::Internal(format!(
+                            "pending_rotation.new_master_key_id has wrong length: {} (expected 16)",
+                            id_vec.len()
+                        )));
+                    }
+                    Ok(RotationKeyState {
+                        new_key: Arc::new(Zeroizing::new(**new_key)),
+                        new_epoch,
+                    })
                 })
-            })
+                .transpose()?
         } else {
             None
         };
@@ -1590,17 +1602,17 @@ impl SqliteStorage {
             )
             .map_err(map_err)?;
 
-            // Store salt if provided.
+            // Store salt if provided (key matches admin GetGatewayState reader).
             if let Some(ref salt_bytes) = salt {
                 tx.execute(
-                    "INSERT INTO gateway_config (key, value) VALUES ('salt', ?1) \
+                    "INSERT INTO gateway_config (key, value) VALUES ('kdf_salt', ?1) \
                      ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                     params![hex::encode(salt_bytes)],
                 )
                 .map_err(map_err)?;
             }
 
-            // Store KDF params if provided.
+            // Store KDF params if provided (key matches admin GetGatewayState reader).
             if let Some(ref params) = kdf_params {
                 let kdf_json = serde_json::json!({
                     "m_cost": params.m_cost,
@@ -1609,7 +1621,7 @@ impl SqliteStorage {
                     "kdf_version": params.kdf_version,
                 });
                 tx.execute(
-                    "INSERT INTO gateway_config (key, value) VALUES ('kdf_params', ?1) \
+                    "INSERT INTO gateway_config (key, value) VALUES ('kdf_params_json', ?1) \
                      ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                     params![kdf_json.to_string()],
                 )

--- a/crates/sonde-gateway/tests/rotation.rs
+++ b/crates/sonde-gateway/tests/rotation.rs
@@ -388,7 +388,7 @@ async fn test_t2004b_concurrent_rotation_discard() {
 
     // Manually create a pending_rotation to simulate an in-progress rotation.
     store
-        .write_pending_rotation(&new_key, &new_id, epoch + 1)
+        .write_pending_rotation(&new_key, &new_id, epoch + 1, None, None)
         .await
         .unwrap();
     assert!(store.is_rotation_in_progress().await.unwrap());
@@ -453,7 +453,7 @@ async fn test_t2005_crash_safe_rotation() {
 
     // Step 4: Prepare.
     store
-        .write_pending_rotation(&new_key, &new_id, new_epoch)
+        .write_pending_rotation(&new_key, &new_id, new_epoch, None, None)
         .await
         .unwrap();
 
@@ -580,7 +580,7 @@ async fn test_t2009_crash_recovery_all_phases() {
 
         // Prepare + migrate all PSKs + set phase to rewrapping_identity.
         store
-            .write_pending_rotation(&new_key, &new_id, new_epoch)
+            .write_pending_rotation(&new_key, &new_id, new_epoch, None, None)
             .await
             .unwrap();
         let nodes = store.list_unmigrated_node_ids(new_epoch).await.unwrap();
@@ -622,7 +622,7 @@ async fn test_t2009_crash_recovery_all_phases() {
 
         // Prepare + migrate + rewrap + set phase to committing.
         store
-            .write_pending_rotation(&new_key, &new_id, new_epoch)
+            .write_pending_rotation(&new_key, &new_id, new_epoch, None, None)
             .await
             .unwrap();
         let nodes = store.list_unmigrated_node_ids(new_epoch).await.unwrap();

--- a/crates/sonde-gateway/tests/rotation.rs
+++ b/crates/sonde-gateway/tests/rotation.rs
@@ -476,7 +476,7 @@ async fn test_t2005_crash_safe_rotation() {
         .await
         .unwrap();
     assert!(
-        recovered,
+        recovered.is_some(),
         "crash recovery should detect and resume rotation"
     );
 
@@ -599,7 +599,7 @@ async fn test_t2009_crash_recovery_all_phases() {
         let recovered = RotationEngine::resume_pending_rotation(&store, &identity)
             .await
             .unwrap();
-        assert!(recovered);
+        assert!(recovered.is_some());
 
         // Verify identity is loadable with the new key.
         let loaded = store.load_gateway_identity().await.unwrap();
@@ -642,7 +642,7 @@ async fn test_t2009_crash_recovery_all_phases() {
         let recovered = RotationEngine::resume_pending_rotation(&store, &identity)
             .await
             .unwrap();
-        assert!(recovered);
+        assert!(recovered.is_some());
         assert!(!store.is_rotation_in_progress().await.unwrap());
 
         // Verify identity is loadable.

--- a/crates/sonde-gateway/tests/rotation.rs
+++ b/crates/sonde-gateway/tests/rotation.rs
@@ -1,0 +1,704 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Integration tests for master key rotation (GW-2006, GW-2007, GW-2013).
+//!
+//! Test IDs: T-2003, T-2004, T-2004a, T-2004b, T-2005, T-2008, T-2009, T-2010.
+
+use std::sync::Arc;
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use hkdf::Hkdf;
+use sha2::Sha256;
+use tokio::sync::{mpsc, oneshot};
+use x25519_dalek::PublicKey as X25519PublicKey;
+use zeroize::Zeroizing;
+
+use sonde_gateway::connector::ConnectorEventHub;
+use sonde_gateway::gateway_identity::GatewayIdentity;
+use sonde_gateway::rotation_engine::RotationEngine;
+use sonde_gateway::sqlite_storage::SqliteStorage;
+use sonde_gateway::storage::Storage;
+
+/// Build a valid RotationPayloadV1 for testing.
+///
+/// Encrypts a rotation payload using X25519 + HKDF-SHA-256 + AES-256-GCM,
+/// matching the format specified in evolve-962 §2.6.1.
+fn build_rotation_payload(
+    gateway_identity: &GatewayIdentity,
+    current_epoch: u64,
+    new_master_key: &[u8; 32],
+    rotation_code: &str,
+    new_master_key_id: &[u8; 16],
+    salt: Option<&[u8; 16]>,
+) -> Vec<u8> {
+    // Generate ephemeral X25519 keypair.
+    let mut rng_bytes = [0u8; 32];
+    getrandom::fill(&mut rng_bytes).unwrap();
+    let ephemeral_secret = x25519_dalek::StaticSecret::from(rng_bytes);
+    let ephemeral_public = X25519PublicKey::from(&ephemeral_secret);
+
+    // Derive gateway's X25519 public key.
+    let (_, gw_x25519_public) = gateway_identity.to_x25519().unwrap();
+
+    // X25519 key agreement.
+    let shared_secret = ephemeral_secret.diffie_hellman(&gw_x25519_public);
+
+    // HKDF info: gateway_id_raw || current_epoch_be64.
+    let gateway_id = gateway_identity.gateway_id();
+    let mut info = Vec::with_capacity(24);
+    info.extend_from_slice(gateway_id);
+    info.extend_from_slice(&current_epoch.to_be_bytes());
+
+    // HKDF-SHA-256.
+    let hk = Hkdf::<Sha256>::new(Some(b"sonde-rotation-v1"), shared_secret.as_bytes());
+    let mut derived_key = [0u8; 32];
+    hk.expand(&info, &mut derived_key).unwrap();
+
+    // Build CBOR plaintext: {1: new_master_key, 2: rotation_code, 3: new_master_key_id, 4: salt, 5: null}
+    let mut cbor_pairs: Vec<(ciborium::Value, ciborium::Value)> = vec![
+        (
+            ciborium::Value::Integer(1.into()),
+            ciborium::Value::Bytes(new_master_key.to_vec()),
+        ),
+        (
+            ciborium::Value::Integer(2.into()),
+            ciborium::Value::Text(rotation_code.to_string()),
+        ),
+        (
+            ciborium::Value::Integer(3.into()),
+            ciborium::Value::Bytes(new_master_key_id.to_vec()),
+        ),
+    ];
+    if let Some(s) = salt {
+        cbor_pairs.push((
+            ciborium::Value::Integer(4.into()),
+            ciborium::Value::Bytes(s.to_vec()),
+        ));
+    } else {
+        cbor_pairs.push((ciborium::Value::Integer(4.into()), ciborium::Value::Null));
+    }
+    cbor_pairs.push((ciborium::Value::Integer(5.into()), ciborium::Value::Null));
+    let cbor_map = ciborium::Value::Map(cbor_pairs);
+    let mut plaintext = Vec::new();
+    ciborium::into_writer(&cbor_map, &mut plaintext).unwrap();
+
+    // AES-256-GCM encrypt.
+    let key = Key::<Aes256Gcm>::from_slice(&derived_key);
+    let cipher = Aes256Gcm::new(key);
+    let mut nonce_bytes = [0u8; 12];
+    getrandom::fill(&mut nonce_bytes).unwrap();
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let aad = info; // gateway_id || epoch_be64
+    let gcm_payload = Payload {
+        msg: &plaintext,
+        aad: &aad,
+    };
+    let ciphertext = cipher.encrypt(nonce, gcm_payload).unwrap();
+
+    // Assemble RotationPayloadV1.
+    let mut payload = Vec::with_capacity(1 + 32 + 12 + ciphertext.len());
+    payload.push(0x01); // version
+    payload.extend_from_slice(ephemeral_public.as_bytes());
+    payload.extend_from_slice(&nonce_bytes);
+    payload.extend_from_slice(&ciphertext);
+    payload
+}
+
+/// Helper to create a test gateway with identity, storage, and master key ID.
+async fn setup_test_gateway() -> (
+    Arc<SqliteStorage>,
+    GatewayIdentity,
+    [u8; 16], // master_key_id
+    u64,      // epoch
+    String,   // rotation_code
+) {
+    let master_key = Zeroizing::new([0x42u8; 32]);
+    let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
+
+    let identity = GatewayIdentity::generate().unwrap();
+    store.store_gateway_identity(&identity).await.unwrap();
+
+    let (key_id, epoch) = store.init_master_key_id().await.unwrap();
+    let code = store.init_rotation_code().await.unwrap();
+
+    (store, identity, key_id, epoch, code)
+}
+
+/// Helper to register a test node with the given PSK.
+async fn register_test_node(store: &Arc<SqliteStorage>, node_id: &str, key_hint: u16) {
+    use sonde_gateway::registry::NodeRecord;
+
+    let mut psk = [0u8; 32];
+    psk[0] = key_hint as u8;
+    psk[1] = (key_hint >> 8) as u8;
+
+    let record = NodeRecord {
+        node_id: node_id.to_string(),
+        key_hint,
+        psk,
+        assigned_program_hash: None,
+        current_program_hash: None,
+        desired_schedule_interval_s: Some(60),
+        schedule_interval_s: 60,
+        firmware_abi_version: Some(1),
+        firmware_version: Some("0.1.0".to_string()),
+        rf_channel: Some(1),
+        sensors: vec![],
+        registered_by_phone_id: None,
+        key_version: 0,
+    };
+    store.upsert_node(&record).await.unwrap();
+}
+
+/// T-2003: Rotation code authentication.
+#[tokio::test]
+async fn test_t2003_rotation_code_authentication() {
+    let (store, identity, _, epoch, code) = setup_test_gateway().await;
+
+    // Verify the rotation code was generated (6 chars, [A-Z0-9]).
+    assert_eq!(code.len(), 6);
+    assert!(code
+        .chars()
+        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()));
+
+    // Build a payload with the WRONG rotation code.
+    let new_key = [0xAAu8; 32];
+    let new_id = [0xBBu8; 16];
+    let wrong_code = "ZZZZZZ";
+    assert_ne!(wrong_code, code);
+
+    let payload = build_rotation_payload(&identity, epoch, &new_key, wrong_code, &new_id, None);
+
+    // Submit via the engine — should be rejected.
+    let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+
+    let result = engine.handle_rotation_payload(&payload, true).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("rotation code does not match"));
+
+    // Submit with the CORRECT rotation code — should succeed.
+    let payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+
+    let (_grpc_tx2, grpc_rx2) = mpsc::unbounded_channel();
+    let (_, desired_state_rx2) = mpsc::unbounded_channel();
+    let event_hub2 = Arc::new(ConnectorEventHub::default());
+    let mut engine2 = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub2,
+        grpc_rx2,
+        desired_state_rx2,
+    );
+
+    let result = engine2.handle_rotation_payload(&payload, true).await;
+    assert!(
+        result.is_ok(),
+        "valid rotation should succeed: {:?}",
+        result
+    );
+}
+
+/// T-2004: Master key rotation — happy path.
+#[tokio::test]
+async fn test_t2004_rotation_happy_path() {
+    let (store, identity, _old_key_id, old_epoch, code) = setup_test_gateway().await;
+
+    // Register 3 nodes and 1 phone PSK.
+    register_test_node(&store, "node-a", 100).await;
+    register_test_node(&store, "node-b", 200).await;
+    register_test_node(&store, "node-c", 300).await;
+
+    use sonde_gateway::phone_trust::PhonePskRecord;
+    let phone = PhonePskRecord {
+        phone_id: 0,
+        phone_key_hint: 400,
+        psk: Zeroizing::new([0xCCu8; 32]),
+        label: "test-phone".to_string(),
+        issued_at: std::time::SystemTime::now(),
+        status: sonde_gateway::phone_trust::PhonePskStatus::Active,
+        key_version: 0,
+    };
+    store.store_phone_psk(&phone).await.unwrap();
+
+    // Verify old PSKs are loadable.
+    let nodes = store.list_nodes().await.unwrap();
+    assert_eq!(nodes.len(), 3);
+    let phones = store.list_phone_psks().await.unwrap();
+    assert_eq!(phones.len(), 1);
+
+    // Build and submit rotation.
+    let new_key = [0xAAu8; 32];
+    let new_id = [0xBBu8; 16];
+    let payload = build_rotation_payload(&identity, old_epoch, &new_key, &code, &new_id, None);
+
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+
+    let result = engine.handle_rotation_payload(&payload, true).await;
+    assert!(result.is_ok(), "rotation should succeed: {:?}", result);
+
+    // Verify: all PSKs still loadable (now encrypted with new key).
+    let nodes = store.list_nodes().await.unwrap();
+    assert_eq!(nodes.len(), 3);
+    // Verify PSK values are preserved.
+    for node in &nodes {
+        assert_ne!(node.psk, [0u8; 32], "PSK should be non-zero");
+    }
+
+    let phones = store.list_phone_psks().await.unwrap();
+    assert_eq!(phones.len(), 1);
+
+    // Verify epoch incremented.
+    let (new_stored_id, new_stored_epoch) = store.init_master_key_id().await.unwrap();
+    assert_eq!(new_stored_epoch, old_epoch + 1);
+    assert_eq!(new_stored_id, new_id);
+
+    // Verify pending_rotation deleted.
+    assert!(!store.is_rotation_in_progress().await.unwrap());
+
+    // Verify rotation code changed.
+    let new_code = store.init_rotation_code().await.unwrap();
+    assert_ne!(new_code, code, "rotation code should change after rotation");
+}
+
+/// T-2004a: Rotation validation failures.
+#[tokio::test]
+async fn test_t2004a_rotation_validation_failures() {
+    let (store, identity, _, epoch, code) = setup_test_gateway().await;
+
+    let new_key = [0xAAu8; 32];
+    let new_id = [0xBBu8; 16];
+
+    // 1. Wrong epoch (build with epoch+1 — AAD won't match).
+    let wrong_epoch_payload =
+        build_rotation_payload(&identity, epoch + 1, &new_key, &code, &new_id, None);
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+    let result = engine
+        .handle_rotation_payload(&wrong_epoch_payload, true)
+        .await;
+    assert!(result.is_err(), "wrong epoch should be rejected");
+
+    // 2. Wrong rotation code.
+    let wrong_code_payload =
+        build_rotation_payload(&identity, epoch, &new_key, "BADCOD", &new_id, None);
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+    let result = engine
+        .handle_rotation_payload(&wrong_code_payload, true)
+        .await;
+    assert!(result.is_err(), "wrong code should be rejected");
+
+    // 3. Corrupted ciphertext.
+    let mut corrupted = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+    // Flip a byte in the ciphertext region.
+    let last = corrupted.len() - 1;
+    corrupted[last] ^= 0xFF;
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+    let result = engine.handle_rotation_payload(&corrupted, true).await;
+    assert!(result.is_err(), "corrupted ciphertext should be rejected");
+
+    // 4. Replay (submit valid, then replay — epoch already incremented).
+    let valid_payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+    let result = engine.handle_rotation_payload(&valid_payload, true).await;
+    assert!(result.is_ok(), "first submission should succeed");
+
+    // Replay same payload — epoch is now incremented, AAD won't match.
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+    let result = engine.handle_rotation_payload(&valid_payload, true).await;
+    assert!(
+        result.is_err(),
+        "replay should be rejected (epoch incremented)"
+    );
+}
+
+/// T-2004b: Concurrent rotation discard.
+#[tokio::test]
+async fn test_t2004b_concurrent_rotation_discard() {
+    let (store, identity, _, epoch, code) = setup_test_gateway().await;
+    register_test_node(&store, "node-a", 100).await;
+
+    let new_key = [0xAAu8; 32];
+    let new_id = [0xBBu8; 16];
+
+    // Manually create a pending_rotation to simulate an in-progress rotation.
+    store
+        .write_pending_rotation(&new_key, &new_id, epoch + 1)
+        .await
+        .unwrap();
+    assert!(store.is_rotation_in_progress().await.unwrap());
+
+    // Submit a second rotation payload — should be rejected.
+    let payload =
+        build_rotation_payload(&identity, epoch, &[0xCCu8; 32], &code, &[0xDDu8; 16], None);
+
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+    let result = engine.handle_rotation_payload(&payload, true).await;
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().contains("already in progress"),
+        "concurrent rotation should be rejected"
+    );
+
+    // DESIRED_STATE path should also silently discard.
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+    let result = engine.handle_rotation_payload(&payload, false).await;
+    assert!(result.is_err());
+}
+
+/// T-2005: Crash-safe key rotation.
+#[tokio::test]
+async fn test_t2005_crash_safe_rotation() {
+    let master_key = Zeroizing::new([0x42u8; 32]);
+    let store = Arc::new(SqliteStorage::in_memory(master_key.clone()).unwrap());
+
+    let identity = GatewayIdentity::generate().unwrap();
+    store.store_gateway_identity(&identity).await.unwrap();
+    let (_, epoch) = store.init_master_key_id().await.unwrap();
+    let _code = store.init_rotation_code().await.unwrap();
+
+    // Register 10 nodes.
+    for i in 0..10 {
+        register_test_node(&store, &format!("node-{i}"), (100 + i) as u16).await;
+    }
+
+    // Build and submit rotation — manually execute only partial migration to
+    // simulate a crash.
+    let new_key = [0xAAu8; 32];
+    let new_id = [0xBBu8; 16];
+    let new_epoch = epoch + 1;
+
+    // Step 4: Prepare.
+    store
+        .write_pending_rotation(&new_key, &new_id, new_epoch)
+        .await
+        .unwrap();
+
+    // Migrate only 5 of 10 nodes (simulating crash after partial migration).
+    let unmigrated = store.list_unmigrated_node_ids(new_epoch).await.unwrap();
+    assert_eq!(unmigrated.len(), 10);
+    for node_id in &unmigrated[..5] {
+        store
+            .migrate_node_psk(node_id, &master_key, &new_key, &new_id, new_epoch)
+            .await
+            .unwrap();
+    }
+
+    // Verify 5 migrated, 5 not.
+    let still_unmigrated = store.list_unmigrated_node_ids(new_epoch).await.unwrap();
+    assert_eq!(still_unmigrated.len(), 5);
+
+    // Simulate crash recovery.
+    let recovered = RotationEngine::resume_pending_rotation(&store, &identity)
+        .await
+        .unwrap();
+    assert!(
+        recovered,
+        "crash recovery should detect and resume rotation"
+    );
+
+    // Verify all 10 nodes are now migrated.
+    let remaining = store.list_unmigrated_node_ids(new_epoch).await.unwrap();
+    assert_eq!(
+        remaining.len(),
+        0,
+        "all nodes should be migrated after recovery"
+    );
+
+    // Verify pending_rotation deleted.
+    assert!(!store.is_rotation_in_progress().await.unwrap());
+
+    // Verify all nodes are loadable.
+    let nodes = store.list_nodes().await.unwrap();
+    assert_eq!(nodes.len(), 10);
+
+    // Verify epoch updated.
+    let (stored_id, stored_epoch) = store.init_master_key_id().await.unwrap();
+    assert_eq!(stored_epoch, new_epoch);
+    assert_eq!(stored_id, new_id);
+}
+
+/// T-2008: gRPC rotation path.
+#[tokio::test]
+async fn test_t2008_grpc_rotation_path() {
+    let (store, identity, _, epoch, code) = setup_test_gateway().await;
+    register_test_node(&store, "node-a", 100).await;
+
+    let new_key = [0xAAu8; 32];
+    let new_id = [0xBBu8; 16];
+    let payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+
+    // Submit via gRPC channel.
+    let (grpc_tx, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+
+    let engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+
+    // Spawn the engine and send a rotation.
+    let engine_handle = tokio::spawn(engine.run());
+
+    let (reply_tx, reply_rx) = oneshot::channel();
+    grpc_tx.send((payload.clone(), reply_tx)).unwrap();
+
+    let result: Result<Result<(), String>, _> =
+        tokio::time::timeout(std::time::Duration::from_secs(5), reply_rx)
+            .await
+            .expect("timeout waiting for rotation result");
+    let result = result.expect("channel closed");
+
+    assert!(result.is_ok(), "gRPC rotation should succeed: {:?}", result);
+
+    // Verify epoch incremented.
+    let (_, new_epoch) = store.init_master_key_id().await.unwrap();
+    assert_eq!(new_epoch, epoch + 1);
+
+    // Submit same payload again — should fail (epoch incremented).
+    let (reply_tx2, reply_rx2) = oneshot::channel();
+    grpc_tx.send((payload, reply_tx2)).unwrap();
+
+    let result2: Result<Result<(), String>, _> =
+        tokio::time::timeout(std::time::Duration::from_secs(5), reply_rx2)
+            .await
+            .expect("timeout");
+    let result2 = result2.expect("channel closed");
+
+    assert!(result2.is_err(), "replay should fail");
+
+    // Clean shutdown.
+    drop(grpc_tx);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), engine_handle).await;
+}
+
+/// T-2009: Crash recovery — all rotation phases.
+#[tokio::test]
+async fn test_t2009_crash_recovery_all_phases() {
+    let master_key = Zeroizing::new([0x42u8; 32]);
+    let new_key = [0xAAu8; 32];
+    let new_id = [0xBBu8; 16];
+
+    // Phase 1: Crash during migrating_psks (tested in T-2005).
+
+    // Phase 2: Crash during rewrapping_identity.
+    {
+        let store = Arc::new(SqliteStorage::in_memory(master_key.clone()).unwrap());
+        let identity = GatewayIdentity::generate().unwrap();
+        store.store_gateway_identity(&identity).await.unwrap();
+        let (_, epoch) = store.init_master_key_id().await.unwrap();
+        store.init_rotation_code().await.unwrap();
+        register_test_node(&store, "node-a", 100).await;
+        let new_epoch = epoch + 1;
+
+        // Prepare + migrate all PSKs + set phase to rewrapping_identity.
+        store
+            .write_pending_rotation(&new_key, &new_id, new_epoch)
+            .await
+            .unwrap();
+        let nodes = store.list_unmigrated_node_ids(new_epoch).await.unwrap();
+        for nid in &nodes {
+            store
+                .migrate_node_psk(nid, &master_key, &new_key, &new_id, new_epoch)
+                .await
+                .unwrap();
+        }
+        store
+            .update_rotation_phase("rewrapping_identity")
+            .await
+            .unwrap();
+
+        // Crash recovery.
+        let recovered = RotationEngine::resume_pending_rotation(&store, &identity)
+            .await
+            .unwrap();
+        assert!(recovered);
+
+        // Verify identity is loadable with the new key.
+        let loaded = store.load_gateway_identity().await.unwrap();
+        assert!(
+            loaded.is_some(),
+            "identity should be loadable after rewrap recovery"
+        );
+        assert!(!store.is_rotation_in_progress().await.unwrap());
+    }
+
+    // Phase 3: Crash during committing.
+    {
+        let store = Arc::new(SqliteStorage::in_memory(master_key.clone()).unwrap());
+        let identity = GatewayIdentity::generate().unwrap();
+        store.store_gateway_identity(&identity).await.unwrap();
+        let (_, epoch) = store.init_master_key_id().await.unwrap();
+        store.init_rotation_code().await.unwrap();
+        register_test_node(&store, "node-b", 200).await;
+        let new_epoch = epoch + 1;
+
+        // Prepare + migrate + rewrap + set phase to committing.
+        store
+            .write_pending_rotation(&new_key, &new_id, new_epoch)
+            .await
+            .unwrap();
+        let nodes = store.list_unmigrated_node_ids(new_epoch).await.unwrap();
+        for nid in &nodes {
+            store
+                .migrate_node_psk(nid, &master_key, &new_key, &new_id, new_epoch)
+                .await
+                .unwrap();
+        }
+        store
+            .rewrap_identity_seed(&master_key, &new_key)
+            .await
+            .unwrap();
+        store.update_rotation_phase("committing").await.unwrap();
+
+        // Crash recovery.
+        let recovered = RotationEngine::resume_pending_rotation(&store, &identity)
+            .await
+            .unwrap();
+        assert!(recovered);
+        assert!(!store.is_rotation_in_progress().await.unwrap());
+
+        // Verify identity is loadable.
+        let loaded = store.load_gateway_identity().await.unwrap();
+        assert!(loaded.is_some());
+        let (stored_id, stored_epoch) = store.init_master_key_id().await.unwrap();
+        assert_eq!(stored_epoch, new_epoch);
+        assert_eq!(stored_id, new_id);
+    }
+}
+
+/// T-2010: Pending recovery purge on rotation.
+#[tokio::test]
+async fn test_t2010_pending_recovery_purge() {
+    let (store, identity, _, epoch, code) = setup_test_gateway().await;
+    register_test_node(&store, "node-a", 100).await;
+
+    // Insert records into pending_recovery.
+    let fake_key_id = [0x11u8; 16];
+    store
+        .insert_pending_recovery(500, "recovered-node", &[0xEEu8; 60], &fake_key_id, epoch)
+        .await
+        .unwrap();
+
+    // Verify pending_recovery has a record.
+    let pending = store.lookup_pending_recovery(500).await.unwrap();
+    assert_eq!(pending.len(), 1);
+
+    // Initiate rotation.
+    let new_key = [0xAAu8; 32];
+    let new_id = [0xBBu8; 16];
+    let payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub,
+        grpc_rx,
+        desired_state_rx,
+    );
+
+    let result = engine.handle_rotation_payload(&payload, true).await;
+    assert!(result.is_ok(), "rotation should succeed: {:?}", result);
+
+    // Verify pending_recovery was purged.
+    let pending = store.lookup_pending_recovery(500).await.unwrap();
+    assert!(
+        pending.is_empty(),
+        "pending_recovery should be purged after rotation"
+    );
+
+    // Verify nodes are re-emitted (checked via list_node_escrow_state).
+    let escrow = store.list_node_escrow_state().await.unwrap();
+    assert_eq!(escrow.len(), 1);
+    assert_eq!(escrow[0].master_key_id, new_id.to_vec());
+}


### PR DESCRIPTION
## Summary

Implements the master key rotation execution engine specified in evolve-962 section 2.6 -- the critical-path component that makes `SubmitRotation` gRPC and DESIRED_STATE rotation operational.

**Requirements:** GW-2006 (master key rotation), GW-2007 (crash-safe rotation), GW-2013 (pending recovery purge)

## Changes

### New: `rotation_engine.rs`
- `RotationEngine` struct receiving rotation payloads from both gRPC (`rotation_tx` channel) and DESIRED_STATE (`gateway_desired_state_tx`)
- 8-step rotation pipeline: decrypt, verify code, verify epoch, prepare, migrate PSKs, rewrap identity, commit, emit
- Crash recovery via `resume_pending_rotation()` -- detects `pending_rotation` at startup and resumes from recorded phase
- `AtomicBool` flag for concurrent rotation rejection (check before any crypto work)
- ACTUAL_STATE re-emission via existing `ConnectorEventHub` API

### Modified: `sqlite_storage.rs`
- **`pending_rotation` table migration** -- previously deferred (line 731-733 comment), now created in `open()`
- **Dual-key PSK decryption** -- `rotation_key_state` field enables frame processing during migration when PSK records have mixed `master_key_epoch` values
- **Master key swap support** -- `master_key` changed to `RwLock<Arc<Zeroizing<...>>>` for in-memory key swap after rotation commit
- **Pending-rotation-aware startup** -- `validate_master_key` tries both old and new keys when an interrupted rotation is detected
- 12 new rotation storage methods: `write_pending_rotation`, `read_pending_rotation`, `update_rotation_phase`, `migrate_node_psk`, `migrate_phone_psk`, `rewrap_identity_seed`, `commit_rotation`, `swap_master_key`, `list_node_escrow_state`, `is_rotation_in_progress`, etc.

### New: `tests/rotation.rs`
| Test | Traces to | Description |
|------|-----------|-------------|
| T-2003 | GW-2006 AC-3 | Rotation code authentication (wrong code rejected, correct accepted) |
| T-2004 | GW-2006 AC-1,2 | Happy path -- 3 nodes + 1 phone PSK, full rotation cycle |
| T-2004a | GW-2006 AC-3,4,5 | Validation failures (wrong epoch, wrong code, corrupted ciphertext, replay) |
| T-2004b | GW-2006 AC-5 | Concurrent rotation discard (DB-level pending_rotation check) |
| T-2005 | GW-2007 AC-1,2,3,4 | Crash-safe rotation (partial migration, resume on restart) |
| T-2008 | GW-2012 AC-1,2,3 | gRPC rotation path via spawned engine task |
| T-2009 | GW-2007 AC-1,2 | Crash recovery -- all three phases (migrating_psks, rewrapping_identity, committing) |
| T-2010 | GW-2013 AC-1,2 | Pending recovery purge atomically with rotation start |

## Verification
- `cargo build --workspace` -- pass
- `cargo clippy --workspace -- -D warnings` -- zero warnings
- `cargo test --workspace` -- all existing + 8 new tests pass
- `cargo fmt --all` -- clean

Closes #1055