### PR TITLE
feat(gateway): implement declarative node recovery engine (GW-2009, GW-2013)

### DIFF
--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1019,7 +1019,7 @@ async fn run_gateway(
         handler_router.clone(),
     );
     // Wire typed SQLite storage for pending_recovery access (GW-2009).
-    gateway.set_sqlite_storage(Arc::clone(&storage));
+    gateway.set_sqlite_storage(Arc::clone(&storage)).await;
 
     // Expire stale pending_recovery records on startup (GW-2009 §2.8).
     {

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1012,12 +1012,51 @@ async fn run_gateway(
     )));
 
     // Create gateway engine with the shared handler router (D-485, GW-1407).
-    let gateway = Arc::new(Gateway::new_with_pending(
+    let mut gateway = Gateway::new_with_pending(
         storage.clone(),
         pending_commands.clone(),
         session_manager.clone(),
         handler_router.clone(),
-    ));
+    );
+    // Wire typed SQLite storage for pending_recovery access (GW-2009).
+    gateway.set_sqlite_storage(Arc::clone(&storage));
+
+    // Expire stale pending_recovery records on startup (GW-2009 §2.8).
+    {
+        const RECOVERY_MAX_AGE_SECS: u64 = 86400; // 24 hours
+        match storage.expire_pending_recovery(RECOVERY_MAX_AGE_SECS).await {
+            Ok(0) => {}
+            Ok(n) => info!(
+                expired = n,
+                "purged stale pending_recovery records on startup"
+            ),
+            Err(e) => warn!("failed to expire pending_recovery on startup: {e}"),
+        }
+    }
+
+    let gateway = Arc::new(gateway);
+
+    // Spawn periodic pending_recovery expiry task (GW-2009).
+    {
+        let recovery_storage = Arc::clone(&storage);
+        tokio::spawn(async move {
+            const RECOVERY_MAX_AGE_SECS: u64 = 86400;
+            let mut interval = tokio::time::interval(Duration::from_secs(3600));
+            interval.tick().await; // skip immediate tick (startup expiry already ran)
+            loop {
+                interval.tick().await;
+                match recovery_storage
+                    .expire_pending_recovery(RECOVERY_MAX_AGE_SECS)
+                    .await
+                {
+                    Ok(0) => {}
+                    Ok(n) => info!(expired = n, "purged stale pending_recovery records"),
+                    Err(e) => warn!("periodic pending_recovery expiry failed: {e}"),
+                }
+            }
+        });
+    }
+
     let connector_service = ConnectorService::new(
         storage.clone(),
         pending_commands.clone(),

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -3,16 +3,17 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
+use zeroize::Zeroizing;
 
 use sonde_protocol::{
-    decode_frame, encode_frame, open_frame, CommandPayload, FrameHeader, GatewayMessage,
-    NodeMessage, MSG_APP_DATA, MSG_APP_DATA_REPLY, MSG_CHUNK, MSG_COMMAND, MSG_DIAG_REPLY,
-    MSG_DIAG_REQUEST, MSG_GET_CHUNK, MSG_PEER_ACK, MSG_PEER_REQUEST, MSG_PROGRAM_ACK, MSG_WAKE,
-    PEER_ACK_KEY_STATUS, PEER_REQ_KEY_PAYLOAD,
+    decode_frame, encode_frame, open_frame, CommandPayload, DecodedFrame, FrameHeader,
+    GatewayMessage, NodeMessage, MSG_APP_DATA, MSG_APP_DATA_REPLY, MSG_CHUNK, MSG_COMMAND,
+    MSG_DIAG_REPLY, MSG_DIAG_REQUEST, MSG_GET_CHUNK, MSG_PEER_ACK, MSG_PEER_REQUEST,
+    MSG_PROGRAM_ACK, MSG_WAKE, PEER_ACK_KEY_STATUS, PEER_REQ_KEY_PAYLOAD,
 };
 
 use std::collections::BTreeMap;
@@ -25,8 +26,100 @@ use crate::phone_trust::PhonePskStatus;
 use crate::program::ProgramLibrary;
 use crate::registry::NodeRecord;
 use crate::session::{SessionManager, SessionState};
+use crate::sqlite_storage::{decrypt_psk_with_master_key, SqliteStorage};
 use crate::storage::Storage;
 use crate::transport::PeerAddress;
+
+// ── Missing key_hint tracker (GW-2009) ──────────────────────────────
+
+/// Maximum number of unique key_hints tracked before LRU eviction.
+const MISSING_HINT_MAX_ENTRIES: usize = 256;
+
+/// Minimum interval between reports for the same key_hint (seconds).
+const MISSING_HINT_RATE_LIMIT_SECS: u64 = 60;
+
+/// Tracks unknown `key_hint` values for reporting in gateway ACTUAL_STATE.
+///
+/// Bounded dedup set (max 256 entries, LRU eviction). Each key_hint is
+/// rate-limited to at most one report per 60 seconds. After draining,
+/// reported hints are cleared — the node's wake cycle provides natural retry.
+pub struct MissingKeyHintTracker {
+    /// Map from key_hint → (last_reported time, insertion order for LRU).
+    entries: HashMap<u16, Instant>,
+    /// Insertion-order queue for LRU eviction.
+    order: Vec<u16>,
+    /// Hints ready to be reported in the next ACTUAL_STATE emission.
+    pending: Vec<u16>,
+}
+
+impl MissingKeyHintTracker {
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: Vec::new(),
+            pending: Vec::new(),
+        }
+    }
+
+    /// Record an unknown key_hint. Returns `true` if the hint was accepted
+    /// (not rate-limited), `false` if suppressed.
+    pub fn report(&mut self, key_hint: u16) -> bool {
+        let now = Instant::now();
+
+        if let Some(last) = self.entries.get(&key_hint) {
+            if now.duration_since(*last).as_secs() < MISSING_HINT_RATE_LIMIT_SECS {
+                return false;
+            }
+            // Update timestamp and move to back of LRU order.
+            self.entries.insert(key_hint, now);
+            self.order.retain(|h| *h != key_hint);
+            self.order.push(key_hint);
+            if !self.pending.contains(&key_hint) {
+                self.pending.push(key_hint);
+            }
+            return true;
+        }
+
+        // Evict oldest if at capacity.
+        if self.entries.len() >= MISSING_HINT_MAX_ENTRIES {
+            if let Some(oldest) = self.order.first().copied() {
+                self.entries.remove(&oldest);
+                self.order.remove(0);
+                self.pending.retain(|h| *h != oldest);
+            }
+        }
+
+        self.entries.insert(key_hint, now);
+        self.order.push(key_hint);
+        self.pending.push(key_hint);
+        true
+    }
+
+    /// Drain all pending hints for inclusion in the next ACTUAL_STATE.
+    /// After this call, the pending set is empty. Timestamps are preserved
+    /// for rate limiting.
+    pub fn drain(&mut self) -> Vec<u16> {
+        std::mem::take(&mut self.pending)
+    }
+
+    /// Return the number of tracked key_hints (for diagnostics).
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if no key_hints are being tracked.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Default for MissingKeyHintTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Default chunk size for program transfers (bytes).
 const DEFAULT_CHUNK_SIZE: u32 = 128;
@@ -230,6 +323,10 @@ pub struct Gateway {
     deferred_replies: Arc<RwLock<HashMap<String, Vec<u8>>>>,
     /// Live event publication for connector processes.
     connector_event_hub: Arc<ConnectorEventHub>,
+    /// Tracks unknown key_hints for reporting in ACTUAL_STATE (GW-2009).
+    missing_hint_tracker: Arc<RwLock<MissingKeyHintTracker>>,
+    /// Typed storage reference for pending_recovery access (GW-2009).
+    sqlite_storage: Option<Arc<SqliteStorage>>,
 }
 
 impl Gateway {
@@ -246,6 +343,8 @@ impl Gateway {
             identity_cache: RwLock::new(None),
             deferred_replies: Arc::new(RwLock::new(HashMap::new())),
             connector_event_hub: Arc::new(ConnectorEventHub::default()),
+            missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
+            sqlite_storage: None,
         }
     }
 
@@ -273,6 +372,8 @@ impl Gateway {
             identity_cache: RwLock::new(None),
             deferred_replies: Arc::new(RwLock::new(HashMap::new())),
             connector_event_hub: Arc::new(ConnectorEventHub::default()),
+            missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
+            sqlite_storage: None,
         }
     }
 
@@ -293,6 +394,8 @@ impl Gateway {
             identity_cache: RwLock::new(None),
             deferred_replies: Arc::new(RwLock::new(HashMap::new())),
             connector_event_hub: Arc::new(ConnectorEventHub::default()),
+            missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
+            sqlite_storage: None,
         }
     }
 
@@ -319,6 +422,19 @@ impl Gateway {
     /// Return a clone of the connector event hub.
     pub fn connector_event_hub(&self) -> Arc<ConnectorEventHub> {
         Arc::clone(&self.connector_event_hub)
+    }
+
+    /// Set the typed SQLite storage reference for pending_recovery access (GW-2009).
+    ///
+    /// This must be called before `process_frame` can perform trial authentication
+    /// against `pending_recovery` candidates.
+    pub fn set_sqlite_storage(&mut self, storage: Arc<SqliteStorage>) {
+        self.sqlite_storage = Some(storage);
+    }
+
+    /// Return a clone of the missing key_hint tracker for ACTUAL_STATE emission.
+    pub fn missing_hint_tracker(&self) -> Arc<RwLock<MissingKeyHintTracker>> {
+        Arc::clone(&self.missing_hint_tracker)
     }
 
     /// Process a raw frame using AES-256-GCM authenticated encryption.
@@ -360,11 +476,8 @@ impl Gateway {
         let key_hint = decoded.header.key_hint;
         let candidates = self.storage.get_nodes_by_key_hint(key_hint).await.ok()?;
         if candidates.is_empty() {
-            warn!(
-                key_hint,
-                "discarding AEAD frame from unknown node (no key_hint match)"
-            );
-            return None;
+            // No known node for this key_hint — attempt trial recovery (GW-2009).
+            return self.try_recovery_auth(&decoded, key_hint, peer, rssi).await;
         }
 
         let aead = GatewayAead;
@@ -380,6 +493,125 @@ impl Gateway {
         let node = matched_node?;
         let payload = plaintext_payload?;
 
+        match decoded.header.msg_type {
+            MSG_WAKE => {
+                self.handle_wake(&node, &decoded.header, &payload, peer, rssi)
+                    .await
+            }
+            MSG_GET_CHUNK | MSG_PROGRAM_ACK | MSG_APP_DATA => {
+                self.handle_post_wake(&node, &decoded.header, &payload)
+                    .await
+            }
+            _ => None,
+        }
+    }
+
+    /// Attempt trial authentication against `pending_recovery` candidates (GW-2009).
+    ///
+    /// Called when no known node matches the frame's `key_hint`. If a pending
+    /// recovery PSK decrypts the frame, the node is promoted to the `nodes` table
+    /// and the frame is processed normally. Otherwise the `key_hint` is recorded
+    /// for reporting in the next gateway ACTUAL_STATE.
+    async fn try_recovery_auth(
+        &self,
+        decoded: &DecodedFrame<'_>,
+        key_hint: u16,
+        peer: PeerAddress,
+        rssi: Option<i8>,
+    ) -> Option<Vec<u8>> {
+        use crate::aead::GatewayAead;
+
+        let sqlite = match &self.sqlite_storage {
+            Some(s) => Arc::clone(s),
+            None => {
+                // No SQLite storage — can't do recovery. Record and discard.
+                self.missing_hint_tracker.write().await.report(key_hint);
+                warn!(
+                    key_hint,
+                    "discarding frame from unknown node (no recovery storage)"
+                );
+                return None;
+            }
+        };
+
+        let recovery_candidates = sqlite.lookup_pending_recovery(key_hint).await.ok()?;
+
+        if recovery_candidates.is_empty() {
+            // No recovery candidates — record the hint and discard.
+            self.missing_hint_tracker.write().await.report(key_hint);
+            warn!(
+                key_hint,
+                "discarding frame from unknown node (no pending_recovery match)"
+            );
+            return None;
+        }
+
+        let master_key = sqlite.master_key();
+        let aead = GatewayAead;
+        let mut promoted_node: Option<NodeRecord> = None;
+        let mut plaintext: Option<Vec<u8>> = None;
+        let mut promoted_node_id: Option<String> = None;
+
+        for candidate in &recovery_candidates {
+            // Decrypt the escrowed PSK with the master key into zeroized memory.
+            let psk = match decrypt_psk_with_master_key(
+                &master_key,
+                &candidate.node_id,
+                &candidate.encrypted_psk,
+            ) {
+                Ok(psk) => Zeroizing::new(psk),
+                Err(e) => {
+                    warn!(
+                        node_id = %candidate.node_id,
+                        key_hint,
+                        "recovery PSK decryption failed: {e}"
+                    );
+                    continue;
+                }
+            };
+
+            // Trial-decrypt the frame with the recovered PSK.
+            if let Ok(pt) = open_frame(decoded, &psk, &aead, &self.crypto_sha) {
+                info!(
+                    node_id = %candidate.node_id,
+                    key_hint,
+                    "trial authentication succeeded — promoting node"
+                );
+                let node = NodeRecord::new(candidate.node_id.clone(), key_hint, *psk);
+                promoted_node_id = Some(candidate.node_id.clone());
+                promoted_node = Some(node);
+                plaintext = Some(pt);
+                break;
+            }
+        }
+
+        let node = match promoted_node {
+            Some(n) => n,
+            None => {
+                // All candidates failed — record hint for reporting.
+                self.missing_hint_tracker.write().await.report(key_hint);
+                debug!(
+                    key_hint,
+                    candidates = recovery_candidates.len(),
+                    "trial authentication failed for all pending_recovery candidates"
+                );
+                return None;
+            }
+        };
+        let payload = plaintext?;
+        let promoted_id = promoted_node_id?;
+
+        // Promote: upsert into nodes table, delete from pending_recovery.
+        if let Err(e) = self.storage.upsert_node(&node).await {
+            warn!(node_id = %promoted_id, "failed to promote recovered node: {e}");
+            return None;
+        }
+        if let Err(e) = sqlite.delete_pending_recovery(key_hint, &promoted_id).await {
+            warn!(node_id = %promoted_id, "failed to delete pending_recovery after promotion: {e}");
+            // Continue processing — the node is already promoted.
+        }
+
+        // Process the frame normally.
         match decoded.header.msg_type {
             MSG_WAKE => {
                 self.handle_wake(&node, &decoded.header, &payload, peer, rssi)

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -537,7 +537,14 @@ impl Gateway {
             }
         };
 
-        let recovery_candidates = sqlite.lookup_pending_recovery(key_hint).await.ok()?;
+        let recovery_candidates = match sqlite.lookup_pending_recovery(key_hint).await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(key_hint, "pending_recovery lookup failed: {e}");
+                self.missing_hint_tracker.write().await.report(key_hint);
+                return None;
+            }
+        };
 
         if recovery_candidates.is_empty() {
             // No recovery candidates — record the hint and discard.

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -67,9 +67,13 @@ impl MissingKeyHintTracker {
 
         if let Some(last) = self.entries.get(&key_hint) {
             if now.duration_since(*last).as_secs() < MISSING_HINT_RATE_LIMIT_SECS {
+                // Rate-limited — but still refresh LRU position so a
+                // frequently-seen hint isn't evicted while suppressed.
+                self.order.retain(|h| *h != key_hint);
+                self.order.push(key_hint);
                 return false;
             }
-            // Update timestamp and move to back of LRU order.
+            // Rate limit expired — update timestamp and move to back of LRU.
             self.entries.insert(key_hint, now);
             self.order.retain(|h| *h != key_hint);
             self.order.push(key_hint);

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -330,6 +330,10 @@ pub struct Gateway {
     missing_hint_tracker: Arc<RwLock<MissingKeyHintTracker>>,
     /// Typed storage reference for pending_recovery access (GW-2009).
     sqlite_storage: Option<Arc<SqliteStorage>>,
+    /// Cached master_key_id for pending_recovery lookups (GW-2009).
+    /// Loaded once at `set_sqlite_storage` time to avoid calling
+    /// `init_master_key_id` on the per-frame path.
+    cached_master_key_id: Option<[u8; 16]>,
 }
 
 impl Gateway {
@@ -348,6 +352,7 @@ impl Gateway {
             connector_event_hub: Arc::new(ConnectorEventHub::default()),
             missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
             sqlite_storage: None,
+            cached_master_key_id: None,
         }
     }
 
@@ -377,6 +382,7 @@ impl Gateway {
             connector_event_hub: Arc::new(ConnectorEventHub::default()),
             missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
             sqlite_storage: None,
+            cached_master_key_id: None,
         }
     }
 
@@ -399,6 +405,7 @@ impl Gateway {
             connector_event_hub: Arc::new(ConnectorEventHub::default()),
             missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
             sqlite_storage: None,
+            cached_master_key_id: None,
         }
     }
 
@@ -429,15 +436,30 @@ impl Gateway {
 
     /// Set the typed SQLite storage reference for pending_recovery access (GW-2009).
     ///
+    /// Loads and caches the current `master_key_id` so `try_recovery_auth` does
+    /// not need to call `init_master_key_id` on the per-frame path.
+    ///
     /// This must be called before `process_frame` can perform trial authentication
     /// against `pending_recovery` candidates.
-    pub fn set_sqlite_storage(&mut self, storage: Arc<SqliteStorage>) {
+    pub async fn set_sqlite_storage(&mut self, storage: Arc<SqliteStorage>) {
+        match storage.init_master_key_id().await {
+            Ok((kid, _)) => {
+                self.cached_master_key_id = Some(kid);
+            }
+            Err(e) => {
+                warn!("failed to cache master_key_id during gateway init: {e}");
+                // Recovery will be unavailable until master_key_id is initialized.
+            }
+        }
         self.sqlite_storage = Some(storage);
     }
 
-    /// Return a clone of the missing key_hint tracker for ACTUAL_STATE emission.
-    pub fn missing_hint_tracker(&self) -> Arc<RwLock<MissingKeyHintTracker>> {
-        Arc::clone(&self.missing_hint_tracker)
+    /// Drain accumulated unknown `key_hint` values for ACTUAL_STATE emission.
+    ///
+    /// Returns the hints collected since the last drain and clears the
+    /// pending set. Rate-limit timestamps are preserved.
+    pub async fn drain_missing_hints(&self) -> Vec<u16> {
+        self.missing_hint_tracker.write().await.drain()
     }
 
     /// Process a raw frame using AES-256-GCM authenticated encryption.
@@ -537,11 +559,11 @@ impl Gateway {
             }
         };
 
-        // Load current master_key_id for pre-filtering candidates.
-        let current_key_id = match sqlite.init_master_key_id().await {
-            Ok((kid, _)) => kid,
-            Err(e) => {
-                warn!(key_hint, "failed to load master_key_id for recovery: {e}");
+        // Use cached master_key_id for pre-filtering candidates.
+        let current_key_id = match self.cached_master_key_id {
+            Some(kid) => kid,
+            None => {
+                warn!(key_hint, "no cached master_key_id — recovery unavailable");
                 self.missing_hint_tracker.write().await.report(key_hint);
                 return None;
             }

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
-use zeroize::Zeroizing;
 
 use sonde_protocol::{
     decode_frame, encode_frame, open_frame, CommandPayload, DecodedFrame, FrameHeader,
@@ -559,7 +558,7 @@ impl Gateway {
                 &candidate.node_id,
                 &candidate.encrypted_psk,
             ) {
-                Ok(psk) => Zeroizing::new(psk),
+                Ok(psk) => psk,
                 Err(e) => {
                     warn!(
                         node_id = %candidate.node_id,

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -43,7 +43,7 @@ const MISSING_HINT_RATE_LIMIT_SECS: u64 = 60;
 /// rate-limited to at most one report per 60 seconds. After draining,
 /// reported hints are cleared — the node's wake cycle provides natural retry.
 pub struct MissingKeyHintTracker {
-    /// Map from key_hint → (last_reported time, insertion order for LRU).
+    /// Map from key_hint → last_reported time (for rate limiting).
     entries: HashMap<u16, Instant>,
     /// Insertion-order queue for LRU eviction.
     order: Vec<u16>,

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -537,7 +537,23 @@ impl Gateway {
             }
         };
 
-        let recovery_candidates = match sqlite.lookup_pending_recovery(key_hint).await {
+        // Load current master_key_id for pre-filtering candidates.
+        let current_key_id = match sqlite.init_master_key_id().await {
+            Ok((kid, _)) => kid,
+            Err(e) => {
+                warn!(key_hint, "failed to load master_key_id for recovery: {e}");
+                self.missing_hint_tracker.write().await.report(key_hint);
+                return None;
+            }
+        };
+
+        // Cap candidates per frame to bound AES-GCM work.
+        const MAX_TRIAL_CANDIDATES: u32 = 8;
+
+        let recovery_candidates = match sqlite
+            .lookup_pending_recovery_filtered(key_hint, &current_key_id, MAX_TRIAL_CANDIDATES)
+            .await
+        {
             Ok(c) => c,
             Err(e) => {
                 warn!(key_hint, "pending_recovery lookup failed: {e}");

--- a/crates/sonde-gateway/src/lib.rs
+++ b/crates/sonde-gateway/src/lib.rs
@@ -32,7 +32,7 @@ pub use admin::AdminService;
 pub use aead::GatewayAead;
 pub use connector::{ConnectorEventHub, ConnectorPayloadOrigin, ConnectorService};
 pub use crypto::RustCryptoSha256;
-pub use engine::{resolve_espnow_channel, Gateway, MissingKeyHintTracker, PendingCommand};
+pub use engine::{resolve_espnow_channel, Gateway, PendingCommand};
 pub use gateway_identity::{GatewayIdentity, IdentityError};
 pub use handler::{
     load_handler_configs, HandlerConfig, HandlerConfigError, HandlerMessage, HandlerRouter,

--- a/crates/sonde-gateway/src/lib.rs
+++ b/crates/sonde-gateway/src/lib.rs
@@ -32,7 +32,7 @@ pub use admin::AdminService;
 pub use aead::GatewayAead;
 pub use connector::{ConnectorEventHub, ConnectorPayloadOrigin, ConnectorService};
 pub use crypto::RustCryptoSha256;
-pub use engine::{resolve_espnow_channel, Gateway, PendingCommand};
+pub use engine::{resolve_espnow_channel, Gateway, MissingKeyHintTracker, PendingCommand};
 pub use gateway_identity::{GatewayIdentity, IdentityError};
 pub use handler::{
     load_handler_configs, HandlerConfig, HandlerConfigError, HandlerMessage, HandlerRouter,

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -260,7 +260,6 @@ impl RotationEngine {
                 continue;
             }
 
-            // Convert key_hint to u16 (already validated by connector parser).
             let key_hint = rec.key_hint;
 
             match self

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -149,7 +149,7 @@ impl RotationEngine {
     }
 
     /// Handle a full DESIRED_STATE message — process rotation_payload if present,
-    /// then apply salt/KDF-params convergence (GW-2008).
+    /// then apply salt/KDF-params convergence (GW-2008) and recovered_psks (GW-2009).
     async fn handle_desired_state(&mut self, state: GatewayDesiredState) {
         if let Some(ref payload) = state.rotation_payload {
             // Errors from DESIRED_STATE rotation are silently discarded per spec.
@@ -166,7 +166,10 @@ impl RotationEngine {
             }
         }
 
-        // Future: handle recovered_psks, channel changes here.
+        // Process recovered_psks (GW-2009).
+        if let Some(records) = state.recovered_psks {
+            self.handle_recovered_psks(records).await;
+        }
     }
 
     /// Apply adopt-if-absent semantics for salt and KDF params (§23.13).
@@ -230,6 +233,63 @@ impl RotationEngine {
         }
 
         adopted
+    }
+
+    /// Process recovered PSK records from DESIRED_STATE (GW-2009).
+    ///
+    /// For each record, validates `master_key_id` against the gateway's current
+    /// key. Records with matching IDs are inserted into `pending_recovery`;
+    /// mismatched records are skipped with a warning.
+    async fn handle_recovered_psks(&self, records: Vec<crate::connector::RecoveredPskRecord>) {
+        let (current_key_id, current_epoch) = match self.storage.init_master_key_id().await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("failed to load master_key_id for recovery PSK processing: {e}");
+                return;
+            }
+        };
+
+        for rec in &records {
+            // Validate master_key_id matches current key (§2.8 step 1a).
+            if rec.master_key_id != current_key_id {
+                warn!(
+                    node_id = %rec.node_id,
+                    key_hint = rec.key_hint,
+                    "skipping recovered_psk: master_key_id mismatch"
+                );
+                continue;
+            }
+
+            // Convert key_hint to u16 (already validated by connector parser).
+            let key_hint = rec.key_hint;
+
+            match self
+                .storage
+                .insert_pending_recovery(
+                    key_hint,
+                    &rec.node_id,
+                    &rec.encrypted_psk,
+                    &current_key_id,
+                    current_epoch,
+                )
+                .await
+            {
+                Ok(()) => {
+                    info!(
+                        node_id = %rec.node_id,
+                        key_hint,
+                        "inserted recovered PSK into pending_recovery"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        node_id = %rec.node_id,
+                        key_hint,
+                        "failed to insert pending_recovery: {e}"
+                    );
+                }
+            }
+        }
     }
 
     /// Process a raw rotation payload from either gRPC or DESIRED_STATE.

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -107,7 +107,7 @@ fn decrypt_psk(
         .map_err(|_| StorageError::Internal("decrypted psk is not 32 bytes".into()))
 }
 
-/// Public wrapper for decrypting a PSK blob with a given master key (GW-2009).
+/// Crate-internal wrapper for decrypting a PSK blob with a given master key (GW-2009).
 ///
 /// Used by the recovery engine to trial-decrypt `pending_recovery` PSKs.
 /// Returns the plaintext PSK wrapped in [`Zeroizing`] so it is automatically

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1873,6 +1873,7 @@ impl SqliteStorage {
                     "SELECT key_hint, node_id, encrypted_psk, master_key_id, master_key_epoch \
                      FROM pending_recovery \
                      WHERE key_hint = ?1 AND master_key_id = ?2 \
+                     ORDER BY received_at DESC \
                      LIMIT ?3",
                 )
                 .map_err(map_err)?;

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -110,13 +110,14 @@ fn decrypt_psk(
 /// Public wrapper for decrypting a PSK blob with a given master key (GW-2009).
 ///
 /// Used by the recovery engine to trial-decrypt `pending_recovery` PSKs.
-/// The caller is responsible for zeroizing the returned key material.
+/// Returns the plaintext PSK wrapped in [`Zeroizing`] so it is automatically
+/// zeroed on drop.
 pub fn decrypt_psk_with_master_key(
     master_key: &[u8; 32],
     node_id: &str,
     blob: &[u8],
-) -> Result<[u8; 32], StorageError> {
-    decrypt_psk(master_key, node_id, blob)
+) -> Result<Zeroizing<[u8; 32]>, StorageError> {
+    decrypt_psk(master_key, node_id, blob).map(Zeroizing::new)
 }
 
 /// Encrypt a 32-byte Ed25519 seed using AES-256-GCM.

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -112,7 +112,7 @@ fn decrypt_psk(
 /// Used by the recovery engine to trial-decrypt `pending_recovery` PSKs.
 /// Returns the plaintext PSK wrapped in [`Zeroizing`] so it is automatically
 /// zeroed on drop.
-pub fn decrypt_psk_with_master_key(
+pub(crate) fn decrypt_psk_with_master_key(
     master_key: &[u8; 32],
     node_id: &str,
     blob: &[u8],
@@ -1852,6 +1852,48 @@ impl SqliteStorage {
                             .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(4, epoch_raw))?,
                     })
                 })
+                .map_err(map_err)?;
+            rows.collect::<Result<Vec<_>, _>>().map_err(map_err)
+        })
+        .await
+    }
+
+    /// Look up pending_recovery candidates by key_hint, filtered by master_key_id
+    /// and limited to `max_candidates` rows (GW-2009).
+    pub async fn lookup_pending_recovery_filtered(
+        &self,
+        key_hint: u16,
+        master_key_id: &[u8; 16],
+        max_candidates: u32,
+    ) -> Result<Vec<PendingRecoveryRecord>, StorageError> {
+        let mkid = *master_key_id;
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT key_hint, node_id, encrypted_psk, master_key_id, master_key_epoch \
+                     FROM pending_recovery \
+                     WHERE key_hint = ?1 AND master_key_id = ?2 \
+                     LIMIT ?3",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(
+                    params![key_hint as i64, mkid.as_slice(), max_candidates],
+                    |row| {
+                        let kh_raw: i64 = row.get(0)?;
+                        let epoch_raw: i64 = row.get(4)?;
+                        Ok(PendingRecoveryRecord {
+                            key_hint: u16::try_from(kh_raw)
+                                .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, kh_raw))?,
+                            node_id: row.get(1)?,
+                            encrypted_psk: row.get(2)?,
+                            master_key_id: row.get(3)?,
+                            master_key_epoch: u64::try_from(epoch_raw).map_err(|_| {
+                                rusqlite::Error::IntegralValueOutOfRange(4, epoch_raw)
+                            })?,
+                        })
+                    },
+                )
                 .map_err(map_err)?;
             rows.collect::<Result<Vec<_>, _>>().map_err(map_err)
         })

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -38,7 +38,7 @@ pub struct PendingRecoveryRecord {
 /// a ciphertext blob between node rows to cause PSK confusion.
 ///
 /// Returns a blob of the form `nonce (12 B) || ciphertext+tag (48 B)`.
-pub(crate) fn encrypt_psk(
+pub fn encrypt_psk(
     master_key: &[u8; 32],
     node_id: &str,
     psk: &[u8; 32],
@@ -105,6 +105,18 @@ fn decrypt_psk(
         .as_slice()
         .try_into()
         .map_err(|_| StorageError::Internal("decrypted psk is not 32 bytes".into()))
+}
+
+/// Public wrapper for decrypting a PSK blob with a given master key (GW-2009).
+///
+/// Used by the recovery engine to trial-decrypt `pending_recovery` PSKs.
+/// The caller is responsible for zeroizing the returned key material.
+pub fn decrypt_psk_with_master_key(
+    master_key: &[u8; 32],
+    node_id: &str,
+    blob: &[u8],
+) -> Result<[u8; 32], StorageError> {
+    decrypt_psk(master_key, node_id, blob)
 }
 
 /// Encrypt a 32-byte Ed25519 seed using AES-256-GCM.

--- a/crates/sonde-gateway/tests/node_recovery.rs
+++ b/crates/sonde-gateway/tests/node_recovery.rs
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Integration tests for the declarative node recovery engine (GW-2009).
+//!
+//! Test IDs: T-2006, T-2006a, T-2006b.
+//!
+//! T-2010 (pending recovery purge on rotation) is in `rotation.rs`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use zeroize::Zeroizing;
+
+use sonde_gateway::connector::{ConnectorEventHub, GatewayDesiredState, RecoveredPskRecord};
+use sonde_gateway::crypto::RustCryptoSha256;
+use sonde_gateway::engine::{Gateway, MissingKeyHintTracker};
+use sonde_gateway::gateway_identity::GatewayIdentity;
+use sonde_gateway::rotation_engine::RotationEngine;
+use sonde_gateway::sqlite_storage::{encrypt_psk, SqliteStorage};
+use sonde_gateway::storage::Storage;
+use sonde_gateway::transport::PeerAddress;
+use sonde_gateway::GatewayAead;
+
+use sonde_protocol::{
+    decode_frame, encode_frame, open_frame, FrameHeader, GatewayMessage, NodeMessage, MSG_WAKE,
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const TEST_MASTER_KEY: [u8; 32] = [0x42u8; 32];
+const TEST_PSK: [u8; 32] = [0xBBu8; 32];
+const TEST_KEY_HINT: u16 = 0x1234;
+
+fn make_gateway_with_sqlite(store: Arc<SqliteStorage>) -> Gateway {
+    let mut gw = Gateway::new(store.clone() as Arc<dyn Storage>, Duration::from_secs(30));
+    gw.set_sqlite_storage(store);
+    gw
+}
+
+fn build_wake_frame(key_hint: u16, psk: &[u8; 32], nonce: u64) -> Vec<u8> {
+    let header = FrameHeader {
+        key_hint,
+        msg_type: MSG_WAKE,
+        nonce,
+    };
+    let msg = NodeMessage::Wake {
+        firmware_abi_version: 1,
+        program_hash: vec![0u8; 32],
+        battery_mv: 3300,
+        firmware_version: "0.7.0".into(),
+        blob: None,
+    };
+    let cbor = msg.encode().unwrap();
+    encode_frame(&header, &cbor, psk, &GatewayAead, &RustCryptoSha256).unwrap()
+}
+
+fn peer_addr() -> PeerAddress {
+    b"test-node".to_vec()
+}
+
+// ── T-2006: Declarative node recovery ───────────────────────────────
+
+/// T-2006: Full recovery cycle — unknown key_hint reported, rate-limited,
+/// recovered PSK ingested, trial authentication succeeds, node promoted.
+#[tokio::test]
+async fn test_t2006_declarative_node_recovery() {
+    let master_key = Zeroizing::new(TEST_MASTER_KEY);
+    let store = Arc::new(SqliteStorage::in_memory(master_key.clone()).unwrap());
+
+    // Initialize master_key_id so recovered_psks validation works.
+    let (current_key_id, _current_epoch) = store.init_master_key_id().await.unwrap();
+
+    let gw = make_gateway_with_sqlite(store.clone());
+
+    // Step 2: Send a valid encrypted WAKE frame with unknown key_hint.
+    let frame = build_wake_frame(TEST_KEY_HINT, &TEST_PSK, 42);
+    let resp = gw.process_frame(&frame, peer_addr()).await;
+    assert!(
+        resp.is_none(),
+        "frame with unknown key_hint should be discarded"
+    );
+
+    // Step 3: Verify missing_key_hints includes the key_hint.
+    let hints = gw.missing_hint_tracker().write().await.drain();
+    assert!(
+        hints.contains(&TEST_KEY_HINT),
+        "missing_key_hints should contain the unknown key_hint"
+    );
+
+    // Step 4: Subsequent drain should be empty (cleared after reporting).
+    let hints2 = gw.missing_hint_tracker().write().await.drain();
+    assert!(
+        hints2.is_empty(),
+        "missing_key_hints should be cleared after drain"
+    );
+
+    // Step 5: Same key_hint within 60s should NOT be re-reported (rate limit).
+    let resp2 = gw.process_frame(&frame, peer_addr()).await;
+    assert!(resp2.is_none());
+    let hints3 = gw.missing_hint_tracker().write().await.drain();
+    assert!(
+        hints3.is_empty(),
+        "same key_hint should be rate-limited within 60s"
+    );
+
+    // Step 6: Deliver recovered_psks via DESIRED_STATE.
+    // Encrypt the PSK with the master key for the pending_recovery table.
+    let encrypted_psk = encrypt_psk(&master_key, "recovered-node", &TEST_PSK).unwrap();
+
+    // Process recovered_psks through the rotation engine.
+    let (_, grpc_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (ds_tx, ds_rx) = tokio::sync::mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+
+    // Load identity for rotation engine.
+    let identity = store
+        .load_gateway_identity()
+        .await
+        .unwrap()
+        .unwrap_or_else(|| {
+            // Generate one if none exists.
+            let id = GatewayIdentity::generate().unwrap();
+            // We won't persist it since we only need it for the engine constructor.
+            id
+        });
+
+    let engine = RotationEngine::new(store.clone(), identity, event_hub, grpc_rx, ds_rx);
+
+    // Send the DESIRED_STATE with recovered_psks through the channel.
+    let desired_state = GatewayDesiredState {
+        entity_id: "gateway-1".to_string(),
+        channel: None,
+        salt: None,
+        kdf_params: None,
+        rotation_payload: None,
+        recovered_psks: Some(vec![RecoveredPskRecord {
+            node_id: "recovered-node".to_string(),
+            key_hint: TEST_KEY_HINT,
+            encrypted_psk: encrypted_psk.clone(),
+            master_key_id: current_key_id.to_vec(),
+        }]),
+    };
+    ds_tx.send(desired_state).unwrap();
+
+    // Run the engine for one tick to process the DESIRED_STATE.
+    // We need to drop ds_tx so the engine loop terminates after processing.
+    drop(ds_tx);
+    engine.run().await;
+
+    // Step 7: Verify PSK stored in pending_recovery table.
+    let pending = store.lookup_pending_recovery(TEST_KEY_HINT).await.unwrap();
+    assert_eq!(pending.len(), 1, "should have 1 pending_recovery record");
+    assert_eq!(pending[0].node_id, "recovered-node");
+    assert_eq!(pending[0].key_hint, TEST_KEY_HINT);
+
+    // Step 8: Send another frame with same key_hint — verify frame is processed
+    // using the recovered PSK.
+    // Build a new gateway (the MissingKeyHintTracker rate limit would block
+    // reporting on the old instance, but we need to test trial auth, not
+    // rate limiting).
+    let gw2 = make_gateway_with_sqlite(store.clone());
+    let frame2 = build_wake_frame(TEST_KEY_HINT, &TEST_PSK, 43);
+    let resp3 = gw2.process_frame(&frame2, peer_addr()).await;
+    assert!(
+        resp3.is_some(),
+        "trial authentication should succeed and produce a COMMAND response"
+    );
+
+    // Verify the response is a valid AEAD frame decodable with the node's PSK.
+    let resp3_bytes = resp3.unwrap();
+    let decoded = decode_frame(&resp3_bytes).expect("response must decode");
+    let pt = open_frame(&decoded, &TEST_PSK, &GatewayAead, &RustCryptoSha256)
+        .expect("open must succeed with correct PSK");
+    let msg = GatewayMessage::decode(decoded.header.msg_type, &pt);
+    assert!(msg.is_ok(), "response payload must be valid CBOR");
+
+    // Step 9: Verify node promoted from pending_recovery to nodes table.
+    let promoted = store.get_nodes_by_key_hint(TEST_KEY_HINT).await.unwrap();
+    assert_eq!(promoted.len(), 1, "node should be promoted to nodes table");
+    assert_eq!(promoted[0].node_id, "recovered-node");
+
+    // Verify pending_recovery is empty after promotion.
+    let pending_after = store.lookup_pending_recovery(TEST_KEY_HINT).await.unwrap();
+    assert!(
+        pending_after.is_empty(),
+        "pending_recovery should be empty after promotion"
+    );
+}
+
+// ── T-2006a: Provisional recovery — wrong PSK ──────────────────────
+
+/// T-2006a: A bogus PSK in pending_recovery fails trial decryption and
+/// remains in the table (not promoted to nodes).
+#[tokio::test]
+async fn test_t2006a_wrong_psk_not_promoted() {
+    let master_key = Zeroizing::new(TEST_MASTER_KEY);
+    let store = Arc::new(SqliteStorage::in_memory(master_key.clone()).unwrap());
+    let (current_key_id, current_epoch) = store.init_master_key_id().await.unwrap();
+
+    // Step 1: Insert a bogus PSK into pending_recovery.
+    let bogus_psk = [0xDDu8; 32];
+    let encrypted_bogus = encrypt_psk(&master_key, "bogus-node", &bogus_psk).unwrap();
+    store
+        .insert_pending_recovery(
+            TEST_KEY_HINT,
+            "bogus-node",
+            &encrypted_bogus,
+            &current_key_id,
+            current_epoch,
+        )
+        .await
+        .unwrap();
+
+    let gw = make_gateway_with_sqlite(store.clone());
+
+    // Step 2: Send a frame with matching key_hint but different PSK.
+    let real_psk = [0xEEu8; 32];
+    let frame = build_wake_frame(TEST_KEY_HINT, &real_psk, 50);
+
+    // Step 3: Verify trial-decryption fails (no response).
+    let resp = gw.process_frame(&frame, peer_addr()).await;
+    assert!(
+        resp.is_none(),
+        "trial decryption with wrong PSK should fail"
+    );
+
+    // Step 4: Verify bogus record remains in pending_recovery (not promoted).
+    let pending = store.lookup_pending_recovery(TEST_KEY_HINT).await.unwrap();
+    assert_eq!(
+        pending.len(),
+        1,
+        "bogus record should remain in pending_recovery"
+    );
+    assert_eq!(pending[0].node_id, "bogus-node");
+
+    // Verify nodes table is empty.
+    let nodes = store.get_nodes_by_key_hint(TEST_KEY_HINT).await.unwrap();
+    assert!(
+        nodes.is_empty(),
+        "bogus PSK should not be promoted to nodes"
+    );
+
+    // Step 5: Verify the bogus record is purged after 24 hours.
+    // We can't wait 24h in a unit test. The expire_pending_recovery function
+    // uses `WHERE received_at < now - max_age_secs`. Since the record was
+    // just inserted (received_at ≈ now), calling with max_age_secs=0 is a
+    // boundary race. Instead, verify the existing sqlite_storage expiry tests
+    // cover this path, and verify the record is still present.
+    //
+    // The sqlite_storage::test_pending_recovery_expire test manipulates
+    // received_at directly to verify expiry semantics.
+    let pending_after = store.lookup_pending_recovery(TEST_KEY_HINT).await.unwrap();
+    assert_eq!(
+        pending_after.len(),
+        1,
+        "bogus record should still be in pending_recovery (not expired yet)"
+    );
+}
+
+// ── T-2006b: Provisional recovery — mismatched master_key_id ────────
+
+/// T-2006b: Recovered PSKs with a master_key_id that doesn't match the
+/// gateway's current key are skipped (not inserted into pending_recovery).
+#[tokio::test]
+async fn test_t2006b_mismatched_master_key_id_skipped() {
+    let master_key = Zeroizing::new(TEST_MASTER_KEY);
+    let store = Arc::new(SqliteStorage::in_memory(master_key.clone()).unwrap());
+    let (_current_key_id, _current_epoch) = store.init_master_key_id().await.unwrap();
+
+    let identity = store
+        .load_gateway_identity()
+        .await
+        .unwrap()
+        .unwrap_or_else(|| GatewayIdentity::generate().unwrap());
+
+    let (_, grpc_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (ds_tx, ds_rx) = tokio::sync::mpsc::unbounded_channel();
+    let event_hub = Arc::new(ConnectorEventHub::default());
+
+    let engine = RotationEngine::new(store.clone(), identity, event_hub, grpc_rx, ds_rx);
+
+    // Step 1: Deliver recovered_psks with wrong master_key_id.
+    let wrong_key_id = [0xFFu8; 16];
+    let encrypted_psk = encrypt_psk(&master_key, "orphan-node", &TEST_PSK).unwrap();
+
+    let desired_state = GatewayDesiredState {
+        entity_id: "gateway-1".to_string(),
+        channel: None,
+        salt: None,
+        kdf_params: None,
+        rotation_payload: None,
+        recovered_psks: Some(vec![RecoveredPskRecord {
+            node_id: "orphan-node".to_string(),
+            key_hint: TEST_KEY_HINT,
+            encrypted_psk,
+            master_key_id: wrong_key_id.to_vec(),
+        }]),
+    };
+    ds_tx.send(desired_state).unwrap();
+    drop(ds_tx);
+    engine.run().await;
+
+    // Step 2: Verify the record is skipped (not inserted into pending_recovery).
+    let pending = store.lookup_pending_recovery(TEST_KEY_HINT).await.unwrap();
+    assert!(
+        pending.is_empty(),
+        "recovered_psk with wrong master_key_id should be skipped"
+    );
+}
+
+// ── MissingKeyHintTracker unit tests ────────────────────────────────
+
+#[test]
+fn missing_hint_tracker_basic() {
+    let mut tracker = MissingKeyHintTracker::new();
+
+    // First report should be accepted.
+    assert!(tracker.report(100));
+    assert_eq!(tracker.len(), 1);
+
+    // Same key_hint immediately should be rate-limited.
+    assert!(!tracker.report(100));
+
+    // Different key_hint should be accepted.
+    assert!(tracker.report(200));
+    assert_eq!(tracker.len(), 2);
+
+    // Drain should return both.
+    let drained = tracker.drain();
+    assert_eq!(drained.len(), 2);
+    assert!(drained.contains(&100));
+    assert!(drained.contains(&200));
+
+    // Second drain should be empty.
+    assert!(tracker.drain().is_empty());
+}
+
+#[test]
+fn missing_hint_tracker_lru_eviction() {
+    let mut tracker = MissingKeyHintTracker::new();
+
+    // Fill to capacity.
+    for i in 0..256u16 {
+        assert!(tracker.report(i));
+    }
+    assert_eq!(tracker.len(), 256);
+
+    // Adding one more should evict the oldest (0).
+    assert!(tracker.report(999));
+    assert_eq!(tracker.len(), 256);
+
+    // The evicted key_hint (0) should now be accepted again.
+    assert!(tracker.report(0));
+}

--- a/crates/sonde-gateway/tests/node_recovery.rs
+++ b/crates/sonde-gateway/tests/node_recovery.rs
@@ -32,9 +32,9 @@ const TEST_MASTER_KEY: [u8; 32] = [0x42u8; 32];
 const TEST_PSK: [u8; 32] = [0xBBu8; 32];
 const TEST_KEY_HINT: u16 = 0x1234;
 
-fn make_gateway_with_sqlite(store: Arc<SqliteStorage>) -> Gateway {
+async fn make_gateway_with_sqlite(store: Arc<SqliteStorage>) -> Gateway {
     let mut gw = Gateway::new(store.clone() as Arc<dyn Storage>, Duration::from_secs(30));
-    gw.set_sqlite_storage(store);
+    gw.set_sqlite_storage(store).await;
     gw
 }
 
@@ -71,7 +71,7 @@ async fn test_t2006_declarative_node_recovery() {
     // Initialize master_key_id so recovered_psks validation works.
     let (current_key_id, _current_epoch) = store.init_master_key_id().await.unwrap();
 
-    let gw = make_gateway_with_sqlite(store.clone());
+    let gw = make_gateway_with_sqlite(store.clone()).await;
 
     // Step 2: Send a valid encrypted WAKE frame with unknown key_hint.
     let frame = build_wake_frame(TEST_KEY_HINT, &TEST_PSK, 42);
@@ -82,14 +82,14 @@ async fn test_t2006_declarative_node_recovery() {
     );
 
     // Step 3: Verify missing_key_hints includes the key_hint.
-    let hints = gw.missing_hint_tracker().write().await.drain();
+    let hints = gw.drain_missing_hints().await;
     assert!(
         hints.contains(&TEST_KEY_HINT),
         "missing_key_hints should contain the unknown key_hint"
     );
 
     // Step 4: Subsequent drain should be empty (cleared after reporting).
-    let hints2 = gw.missing_hint_tracker().write().await.drain();
+    let hints2 = gw.drain_missing_hints().await;
     assert!(
         hints2.is_empty(),
         "missing_key_hints should be cleared after drain"
@@ -98,7 +98,7 @@ async fn test_t2006_declarative_node_recovery() {
     // Step 5: Same key_hint within 60s should NOT be re-reported (rate limit).
     let resp2 = gw.process_frame(&frame, peer_addr()).await;
     assert!(resp2.is_none());
-    let hints3 = gw.missing_hint_tracker().write().await.drain();
+    let hints3 = gw.drain_missing_hints().await;
     assert!(
         hints3.is_empty(),
         "same key_hint should be rate-limited within 60s"
@@ -159,7 +159,7 @@ async fn test_t2006_declarative_node_recovery() {
     // Build a new gateway (the MissingKeyHintTracker rate limit would block
     // reporting on the old instance, but we need to test trial auth, not
     // rate limiting).
-    let gw2 = make_gateway_with_sqlite(store.clone());
+    let gw2 = make_gateway_with_sqlite(store.clone()).await;
     let frame2 = build_wake_frame(TEST_KEY_HINT, &TEST_PSK, 43);
     let resp3 = gw2.process_frame(&frame2, peer_addr()).await;
     assert!(
@@ -212,7 +212,7 @@ async fn test_t2006a_wrong_psk_not_promoted() {
         .await
         .unwrap();
 
-    let gw = make_gateway_with_sqlite(store.clone());
+    let gw = make_gateway_with_sqlite(store.clone()).await;
 
     // Step 2: Send a frame with matching key_hint but different PSK.
     let real_psk = [0xEEu8; 32];

--- a/crates/sonde-gateway/tests/node_recovery.rs
+++ b/crates/sonde-gateway/tests/node_recovery.rs
@@ -353,3 +353,31 @@ fn missing_hint_tracker_lru_eviction() {
     // The evicted key_hint (0) should now be accepted again.
     assert!(tracker.report(0));
 }
+
+/// Rate-limited hints should refresh their LRU position so they are not
+/// evicted while still actively appearing.
+#[test]
+fn missing_hint_tracker_rate_limited_refreshes_lru() {
+    let mut tracker = MissingKeyHintTracker::new();
+
+    // Insert hint 0, then fill 255 more slots (1..=255).
+    assert!(tracker.report(0));
+    for i in 1..256u16 {
+        assert!(tracker.report(i));
+    }
+    assert_eq!(tracker.len(), 256);
+
+    // Hint 0 is rate-limited (within 60s), but should refresh LRU position.
+    assert!(!tracker.report(0), "should be rate-limited");
+
+    // Now insert a new hint — it should evict hint 1 (the oldest that was
+    // NOT refreshed), not hint 0.
+    assert!(tracker.report(999));
+    assert_eq!(tracker.len(), 256);
+
+    // Hint 1 was evicted, so reporting it should succeed as new.
+    assert!(tracker.report(1), "hint 1 should have been evicted");
+
+    // Hint 0 is still tracked (not evicted), so it should still be rate-limited.
+    assert!(!tracker.report(0), "hint 0 should NOT have been evicted");
+}

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1994,11 +1994,27 @@ performed on the discarded payload.
 - Report in `missing_key_hints` (ACTUAL_STATE key 20), one-shot cleared after reporting.
 - Frame discarded. Node wake cycle provides natural retry.
 
+**`MissingKeyHintTracker`** — in-memory bounded LRU on `Gateway`.
+- `report(key_hint)` — records a key_hint, returns `true` if accepted (not rate-limited).
+- `drain()` — returns pending hints for ACTUAL_STATE, clears the pending set.
+- Timestamps preserved for rate limiting; only the pending-to-report set is cleared.
+
 **Recovery from DESIRED_STATE:**
+- `RotationEngine::handle_desired_state` processes `recovered_psks` (CBOR key 29).
 - Verify `master_key_id` matches current key. Skip if not.
 - Insert into `pending_recovery` table (key_hint, node_id, encrypted_psk, master_key_id, master_key_epoch, received_at).
-- Trial-decrypt on next frame with matching key_hint.
-- Promote to `nodes` on success. Expire after 24 hours.
+
+**Trial authentication in `process_frame_with_rssi`:**
+- When `get_nodes_by_key_hint` returns empty, call `try_recovery_auth`.
+- Look up `pending_recovery` candidates by key_hint.
+- For each candidate: decrypt `encrypted_psk` with master key into `Zeroizing` memory, trial-decrypt the frame with `open_frame`.
+- On success: promote via `upsert_node`, delete from `pending_recovery`, process frame normally.
+- On failure: leave in `pending_recovery`, record hint in tracker for ACTUAL_STATE reporting.
+- `Gateway` holds `Option<Arc<SqliteStorage>>` for typed access; wired via `set_sqlite_storage`.
+
+**Expiry:**
+- Startup: `expire_pending_recovery(86400)` purges records older than 24 hours.
+- Periodic: hourly tokio interval task runs the same expiry query.
 
 ### 23.9  Modem display pages (GW-2010)
 


### PR DESCRIPTION
## Summary

Implements the declarative node recovery flow specified in evolve-962 §2.8, and verifies the `pending_recovery` purge on rotation (GW-2013).

Closes #1056

## Changes

### Engine (`engine.rs`)
- **`MissingKeyHintTracker`** — bounded LRU dedup set (max 256 entries, 60s rate limit per `key_hint`). Records unknown `key_hint` values for reporting in gateway ACTUAL_STATE `missing_key_hints` field. Drains on ACTUAL_STATE emission.
- **`try_recovery_auth`** — trial authentication fallback in `process_frame_with_rssi`. When no known node matches a frame's `key_hint`, looks up `pending_recovery` candidates, decrypts each escrowed PSK with the master key into `Zeroizing` memory, trial-decrypts the frame with `open_frame`. On success: promotes via `upsert_node`, deletes from `pending_recovery`, processes frame normally.
- **New `Gateway` fields** — `missing_hint_tracker: Arc<RwLock<MissingKeyHintTracker>>`, `sqlite_storage: Option<Arc<SqliteStorage>>`. Wired via `set_sqlite_storage()`.

### Rotation engine (`rotation_engine.rs`)
- **`handle_recovered_psks`** — processes `recovered_psks` from DESIRED_STATE (CBOR key 29). Validates `master_key_id` matches gateway's current key; inserts matching records into `pending_recovery` table.

### Storage (`sqlite_storage.rs`)
- Made `encrypt_psk` public (needed by tests).
- Added `decrypt_psk_with_master_key` public wrapper for trial-decryption.

### Binary (`bin/gateway.rs`)
- Wires `set_sqlite_storage` on the `Gateway` after construction.
- Startup expiry: purges `pending_recovery` records older than 24h.
- Periodic expiry: hourly tokio interval task.

### Design spec (`gateway-design.md`)
- Expanded §23.8 with implementation-level detail for `MissingKeyHintTracker`, recovery PSK ingestion, trial authentication, and expiry.

## Tests

| Test ID | Description | Status |
|---------|-------------|--------|
| T-2006 | Full recovery cycle (unknown hint → report → recover → trial auth → promote) | ✅ New |
| T-2006a | Wrong PSK not promoted (trial decrypt fails, record stays in `pending_recovery`) | ✅ New |
| T-2006b | Mismatched `master_key_id` skipped (not inserted into `pending_recovery`) | ✅ New |
| T-2010 | Pending recovery purge on rotation | ✅ Existing |
| Unit | `MissingKeyHintTracker` basic + LRU eviction | ✅ New |

## Validation

- `cargo fmt --all` — clean
- `cargo clippy --workspace -- -D warnings` — zero warnings
- `cargo test -p sonde-gateway` — all tests pass