### PR TITLE
feat(admin): add key rotate, key fingerprint, key status subcommands (ADMIN-0900–0902)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4815,6 +4836,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6465,9 +6497,13 @@ dependencies = [
 name = "sonde-admin"
 version = "0.7.0"
 dependencies = [
+ "aes-gcm",
+ "argon2",
  "chrono",
  "clap",
+ "getrandom 0.3.4",
  "hex",
+ "hkdf",
  "hyper-util",
  "prost",
  "rpassword",
@@ -6482,6 +6518,8 @@ dependencies = [
  "tonic-prost",
  "tonic-prost-build",
  "tower",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/sonde-admin/Cargo.toml
+++ b/crates/sonde-admin/Cargo.toml
@@ -9,8 +9,12 @@ name = "sonde-admin"
 path = "src/main.rs"
 
 [dependencies]
+aes-gcm = "0.10"
+argon2 = "0.5"
 clap = { version = "4", features = ["derive", "env"] }
+getrandom = "0.3"
 hex = "0.4"
+hkdf = "0.12"
 prost = "0.14"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -24,6 +28,8 @@ rpassword = "7.5.3"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 sonde-protocol = { path = "../sonde-protocol", features = ["fingerprint"] }
 sha2 = "0.10"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+zeroize = "1.8.2"
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/crates/sonde-admin/src/grpc_client.rs
+++ b/crates/sonde-admin/src/grpc_client.rs
@@ -355,4 +355,22 @@ impl AdminClient {
         let resp = self.inner.list_handlers(Empty {}).await?;
         Ok(resp.into_inner().handlers)
     }
+
+    // -- Key management (ADMIN-0900–0902) --
+
+    pub async fn get_gateway_state(&mut self) -> Result<GatewayState, tonic::Status> {
+        let resp = self.inner.get_gateway_state(Empty {}).await?;
+        Ok(resp.into_inner())
+    }
+
+    pub async fn submit_rotation(
+        &mut self,
+        rotation_payload: Vec<u8>,
+    ) -> Result<SubmitRotationResponse, tonic::Status> {
+        let resp = self
+            .inner
+            .submit_rotation(SubmitRotationRequest { rotation_payload })
+            .await?;
+        Ok(resp.into_inner())
+    }
 }

--- a/crates/sonde-admin/src/main.rs
+++ b/crates/sonde-admin/src/main.rs
@@ -6,6 +6,7 @@ use std::io::IsTerminal;
 use std::process;
 
 use clap::{Parser, Subcommand, ValueEnum};
+use zeroize::Zeroizing;
 
 use sonde_admin::format_epoch_ms;
 use sonde_admin::grpc_client::AdminClient;
@@ -107,6 +108,11 @@ enum Commands {
     Handler {
         #[command(subcommand)]
         action: HandlerAction,
+    },
+    /// Master key management.
+    Key {
+        #[command(subcommand)]
+        action: KeyAction,
     },
 }
 
@@ -264,6 +270,16 @@ enum HandlerAction {
     },
     /// List all configured handlers.
     List,
+}
+
+#[derive(Subcommand)]
+enum KeyAction {
+    /// Perform master key rotation (interactive).
+    Rotate,
+    /// Display the gateway's BIP-39 key fingerprint.
+    Fingerprint,
+    /// Display master key status (epoch, ID, rotation state).
+    Status,
 }
 
 #[tokio::main]
@@ -884,6 +900,64 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
                 }
             }
         },
+
+        Commands::Key { action } => match action {
+            KeyAction::Fingerprint => {
+                let state = client.get_gateway_state().await?;
+                if json {
+                    print_json(&serde_json::json!({
+                        "fingerprint_words": state.fingerprint_words,
+                    }))?;
+                } else {
+                    println!("{}", state.fingerprint_words.join(" "));
+                }
+            }
+            KeyAction::Status => {
+                let state = client.get_gateway_state().await?;
+                if json {
+                    let mut obj = serde_json::json!({
+                        "master_key_epoch": state.master_key_epoch,
+                        "master_key_id": hex::encode(&state.master_key_id),
+                        "rotation_in_progress": state.rotation_in_progress,
+                        "salt": state.salt.as_ref().map(hex::encode),
+                    });
+                    if let Some(kdf) = &state.kdf_params {
+                        obj["kdf_params"] = serde_json::json!({
+                            "m_cost": kdf.m_cost,
+                            "t_cost": kdf.t_cost,
+                            "p_cost": kdf.p_cost,
+                            "kdf_version": kdf.kdf_version,
+                        });
+                    } else {
+                        obj["kdf_params"] = serde_json::Value::Null;
+                    }
+                    print_json(&obj)?;
+                } else {
+                    println!("Master key epoch:      {}", state.master_key_epoch);
+                    println!(
+                        "Master key ID:         {}",
+                        hex::encode(&state.master_key_id)
+                    );
+                    println!("Rotation in progress:  {}", state.rotation_in_progress);
+                    match &state.salt {
+                        Some(s) => println!("Salt:                  {}", hex::encode(s)),
+                        None => println!("Salt:                  (not set)"),
+                    }
+                    match &state.kdf_params {
+                        Some(kdf) => {
+                            println!(
+                                "KDF params:            m={}, t={}, p={}, version={}",
+                                kdf.m_cost, kdf.t_cost, kdf.p_cost, kdf.kdf_version,
+                            );
+                        }
+                        None => println!("KDF params:            (not set)"),
+                    }
+                }
+            }
+            KeyAction::Rotate => {
+                key_rotate(client, cli).await?;
+            }
+        },
     }
 
     Ok(())
@@ -892,6 +966,373 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
 fn print_json(value: &impl serde::Serialize) -> Result<(), serde_json::Error> {
     println!("{}", serde_json::to_string_pretty(value)?);
     Ok(())
+}
+
+/// Default Argon2id parameters used when the gateway has no stored KDF params
+/// (i.e. first rotation). Per `admin-design.md` §11.3.
+const DEFAULT_KDF_M_COST: u32 = 65536;
+const DEFAULT_KDF_T_COST: u32 = 3;
+const DEFAULT_KDF_P_COST: u32 = 1;
+const DEFAULT_KDF_VERSION: u32 = 1;
+
+/// Validate a rotation passphrase per ADMIN-0900.
+///
+/// Rejects passphrases shorter than 20 characters **and** fewer than 6 words.
+/// A passphrase passes if it has >= 20 chars OR >= 6 words.
+fn validate_passphrase(passphrase: &str) -> Result<(), String> {
+    let char_count = passphrase.chars().count();
+    let word_count = passphrase.split_whitespace().count();
+    if char_count < 20 && word_count < 6 {
+        return Err(format!(
+            "passphrase too short: {char_count} characters, {word_count} words \
+             (need at least 20 characters or 6 words)"
+        ));
+    }
+    Ok(())
+}
+
+/// Build a `RotationPayloadV1` binary envelope per `evolve-962-specification.md` §2.6.1.
+///
+/// Returns the serialized payload suitable for `SubmitRotation`.
+#[allow(clippy::too_many_arguments)]
+fn build_rotation_payload(
+    gw_x25519_public: &[u8; 32],
+    gateway_id_raw: &[u8; 16],
+    master_key_epoch: u64,
+    new_master_key: &[u8; 32],
+    rotation_code: &str,
+    new_master_key_id: &[u8; 16],
+    salt: Option<&[u8; 16]>,
+    kdf_params: Option<(u32, u32, u32, u32)>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use aes_gcm::aead::{Aead, OsRng};
+    use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+    use hkdf::Hkdf;
+    use sha2::Sha256;
+    use x25519_dalek::{EphemeralSecret, PublicKey};
+
+    // Generate ephemeral X25519 keypair.
+    let ephemeral_secret = EphemeralSecret::random_from_rng(OsRng);
+    let ephemeral_public = PublicKey::from(&ephemeral_secret);
+
+    // Compute shared secret.
+    let gw_public = PublicKey::from(*gw_x25519_public);
+    let shared_secret = ephemeral_secret.diffie_hellman(&gw_public);
+
+    // Reject non-contributory DH results (low-order public key).
+    if !shared_secret.was_contributory() {
+        return Err("X25519 shared secret is non-contributory (low-order point)".into());
+    }
+
+    // Derive AES-256-GCM key via HKDF-SHA-256.
+    // HKDF salt (protocol constant): b"sonde-rotation-v1"
+    // info: gateway_id_raw || master_key_epoch_be64
+    let hkdf_salt = b"sonde-rotation-v1";
+    let mut info = Vec::with_capacity(24);
+    info.extend_from_slice(gateway_id_raw);
+    info.extend_from_slice(&master_key_epoch.to_be_bytes());
+
+    let hkdf = Hkdf::<Sha256>::new(Some(hkdf_salt), shared_secret.as_bytes());
+    let mut aes_key = Zeroizing::new([0u8; 32]);
+    hkdf.expand(&info, &mut *aes_key)
+        .map_err(|_| "HKDF expand failed")?;
+
+    // Encode CBOR plaintext map with integer keys 1–5, deterministic ordering.
+    // Wrapped in Zeroizing because it contains new_master_key in the clear.
+    let plaintext = Zeroizing::new(encode_rotation_plaintext(
+        new_master_key,
+        rotation_code,
+        new_master_key_id,
+        salt,
+        kdf_params,
+    ));
+
+    // Encrypt with AES-256-GCM.
+    // AAD: gateway_id_raw || master_key_epoch_be64
+    let cipher = Aes256Gcm::new((&*aes_key).into());
+    let mut nonce_bytes = [0u8; 12];
+    getrandom::fill(&mut nonce_bytes).map_err(|e| format!("failed to generate nonce: {e}"))?;
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext_and_tag = cipher
+        .encrypt(
+            nonce,
+            aes_gcm::aead::Payload {
+                msg: &plaintext,
+                aad: &info,
+            },
+        )
+        .map_err(|e| format!("AES-256-GCM encryption failed: {e}"))?;
+
+    // Serialize: version(1) || ephemeral_public(32) || nonce(12) || ciphertext_and_tag
+    let mut payload = Vec::with_capacity(1 + 32 + 12 + ciphertext_and_tag.len());
+    payload.push(0x01); // version
+    payload.extend_from_slice(ephemeral_public.as_bytes());
+    payload.extend_from_slice(&nonce_bytes);
+    payload.extend_from_slice(&ciphertext_and_tag);
+
+    Ok(payload)
+}
+
+/// Encode the CBOR plaintext map for `RotationPayloadV1`.
+///
+/// Deterministic CBOR encoding per RFC 8949 §4.2: integer keys in ascending
+/// order, minimal-length encoding.
+fn encode_rotation_plaintext(
+    new_master_key: &[u8; 32],
+    rotation_code: &str,
+    new_master_key_id: &[u8; 16],
+    salt: Option<&[u8; 16]>,
+    kdf_params: Option<(u32, u32, u32, u32)>,
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(128);
+
+    // CBOR map with 5 entries: A5
+    buf.push(0xA5);
+
+    // Key 1: new_master_key (bstr, 32 bytes)
+    buf.push(0x01);
+    buf.push(0x58); // bytes, 1-byte length
+    buf.push(32);
+    buf.extend_from_slice(new_master_key);
+
+    // Key 2: rotation_code (tstr)
+    buf.push(0x02);
+    cbor_encode_tstr(&mut buf, rotation_code);
+
+    // Key 3: new_master_key_id (bstr, 16 bytes)
+    buf.push(0x03);
+    buf.push(0x50); // bytes(16)
+    buf.extend_from_slice(new_master_key_id);
+
+    // Key 4: salt (bstr 16 bytes or null)
+    buf.push(0x04);
+    match salt {
+        Some(s) => {
+            buf.push(0x50); // bytes(16)
+            buf.extend_from_slice(s);
+        }
+        None => buf.push(0xF6), // null
+    }
+
+    // Key 5: kdf_params (map or null)
+    buf.push(0x05);
+    match kdf_params {
+        Some((m_cost, t_cost, p_cost, kdf_version)) => {
+            buf.push(0xA4); // map(4)
+            buf.push(0x01);
+            cbor_encode_uint(&mut buf, m_cost as u64);
+            buf.push(0x02);
+            cbor_encode_uint(&mut buf, t_cost as u64);
+            buf.push(0x03);
+            cbor_encode_uint(&mut buf, p_cost as u64);
+            buf.push(0x04);
+            cbor_encode_uint(&mut buf, kdf_version as u64);
+        }
+        None => buf.push(0xF6), // null
+    }
+
+    buf
+}
+
+/// Encode a CBOR unsigned integer in minimal form.
+fn cbor_encode_uint(buf: &mut Vec<u8>, value: u64) {
+    if value < 24 {
+        buf.push(value as u8);
+    } else if value <= 0xFF {
+        buf.push(0x18);
+        buf.push(value as u8);
+    } else if value <= 0xFFFF {
+        buf.push(0x19);
+        buf.extend_from_slice(&(value as u16).to_be_bytes());
+    } else if value <= 0xFFFF_FFFF {
+        buf.push(0x1A);
+        buf.extend_from_slice(&(value as u32).to_be_bytes());
+    } else {
+        buf.push(0x1B);
+        buf.extend_from_slice(&value.to_be_bytes());
+    }
+}
+
+/// Encode a CBOR text string.
+fn cbor_encode_tstr(buf: &mut Vec<u8>, s: &str) {
+    let len = s.len() as u64;
+    if len < 24 {
+        buf.push(0x60 + len as u8);
+    } else if len <= 0xFF {
+        buf.push(0x78);
+        buf.push(len as u8);
+    } else if len <= 0xFFFF {
+        buf.push(0x79);
+        buf.extend_from_slice(&(len as u16).to_be_bytes());
+    } else {
+        buf.push(0x7A);
+        buf.extend_from_slice(&(len as u32).to_be_bytes());
+    }
+    buf.extend_from_slice(s.as_bytes());
+}
+
+/// Interactive key rotation flow per ADMIN-0900 and `admin-design.md` §11.3.
+async fn key_rotate(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::error::Error>> {
+    let json = matches!(cli.format, OutputFormat::Json);
+
+    // Step 1: Fetch gateway ACTUAL_STATE.
+    let state = client.get_gateway_state().await?;
+
+    // Validate field lengths from proto (proto does not enforce byte sizes).
+    if state.gateway_id.len() != 16 {
+        return Err(format!(
+            "gateway_id has unexpected length: {} (expected 16)",
+            state.gateway_id.len()
+        )
+        .into());
+    }
+    if state.x25519_public_key.len() != 32 {
+        return Err(format!(
+            "x25519_public_key has unexpected length: {} (expected 32)",
+            state.x25519_public_key.len()
+        )
+        .into());
+    }
+    if state.master_key_id.len() != 16 {
+        return Err(format!(
+            "master_key_id has unexpected length: {} (expected 16)",
+            state.master_key_id.len()
+        )
+        .into());
+    }
+    if let Some(ref salt) = state.salt {
+        if salt.len() != 16 {
+            return Err(format!("salt has unexpected length: {} (expected 16)", salt.len()).into());
+        }
+    }
+
+    // Step 2: Display fingerprint and prompt for confirmation.
+    let fingerprint = state.fingerprint_words.join(" ");
+    eprintln!("Gateway fingerprint: {fingerprint}");
+    confirm("Verify this matches the modem display. Continue?", cli.yes)?;
+
+    // Step 3: Prompt for rotation code.
+    eprint!("Rotation code: ");
+    std::io::Write::flush(&mut std::io::stderr()).ok();
+    let mut rotation_code = String::new();
+    std::io::stdin()
+        .read_line(&mut rotation_code)
+        .map_err(|e| format!("failed to read rotation code: {e}"))?;
+    let rotation_code = rotation_code.trim().to_uppercase();
+    if rotation_code.is_empty() {
+        return Err("rotation code must not be empty".into());
+    }
+
+    // Step 4: Prompt for passphrase (masked).
+    eprint!("Passphrase: ");
+    std::io::Write::flush(&mut std::io::stderr()).ok();
+    let passphrase = Zeroizing::new(
+        rpassword::read_password().map_err(|e| format!("failed to read passphrase: {e}"))?,
+    );
+    validate_passphrase(&passphrase)?;
+
+    // Step 5: Select KDF parameters.
+    let (m_cost, t_cost, p_cost, kdf_version) = match &state.kdf_params {
+        Some(kdf) => (kdf.m_cost, kdf.t_cost, kdf.p_cost, kdf.kdf_version),
+        None => (
+            DEFAULT_KDF_M_COST,
+            DEFAULT_KDF_T_COST,
+            DEFAULT_KDF_P_COST,
+            DEFAULT_KDF_VERSION,
+        ),
+    };
+
+    // Step 6: Select or generate salt.
+    let (salt_bytes, include_salt_in_payload) = match &state.salt {
+        Some(s) => {
+            let mut arr = [0u8; 16];
+            arr.copy_from_slice(s);
+            (arr, false)
+        }
+        None => {
+            let mut arr = [0u8; 16];
+            getrandom::fill(&mut arr).map_err(|e| format!("failed to generate salt: {e}"))?;
+            (arr, true)
+        }
+    };
+
+    // Step 7: Derive new master key with Argon2id.
+    let argon2_params = argon2::Params::new(m_cost, t_cost, p_cost, Some(32))
+        .map_err(|e| format!("invalid Argon2id params: {e}"))?;
+    let argon2 = argon2::Argon2::new(
+        argon2::Algorithm::Argon2id,
+        argon2::Version::V0x13,
+        argon2_params,
+    );
+    let mut new_master_key = Zeroizing::new([0u8; 32]);
+    argon2
+        .hash_password_into(passphrase.as_bytes(), &salt_bytes, &mut *new_master_key)
+        .map_err(|e| format!("Argon2id key derivation failed: {e}"))?;
+
+    // Step 8: Generate random new_master_key_id.
+    let mut new_master_key_id = [0u8; 16];
+    getrandom::fill(&mut new_master_key_id)
+        .map_err(|e| format!("failed to generate new_master_key_id: {e}"))?;
+
+    // Step 9: Build RotationPayloadV1.
+    let gateway_id_raw: [u8; 16] = state.gateway_id[..16].try_into().unwrap();
+    let gw_x25519_public: [u8; 32] = state.x25519_public_key[..32].try_into().unwrap();
+
+    let payload_salt = if include_salt_in_payload {
+        Some(&salt_bytes)
+    } else {
+        None
+    };
+    let payload_kdf = if state.kdf_params.is_none() {
+        Some((m_cost, t_cost, p_cost, kdf_version))
+    } else {
+        None
+    };
+
+    let rotation_payload = build_rotation_payload(
+        &gw_x25519_public,
+        &gateway_id_raw,
+        state.master_key_epoch,
+        &new_master_key,
+        &rotation_code,
+        &new_master_key_id,
+        payload_salt,
+        payload_kdf,
+    )?;
+
+    // Step 10: Submit rotation.
+    let resp = client.submit_rotation(rotation_payload).await?;
+    if !resp.accepted {
+        return Err(format!("rotation rejected: {}", resp.error).into());
+    }
+
+    // Step 11: Poll until master_key_epoch increments or timeout.
+    let original_epoch = state.master_key_epoch;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        let new_state = client.get_gateway_state().await?;
+        if new_state.master_key_epoch > original_epoch {
+            if json {
+                print_json(&serde_json::json!({
+                    "rotated": true,
+                    "new_master_key_epoch": new_state.master_key_epoch,
+                    "new_master_key_id": hex::encode(&new_state.master_key_id),
+                }))?;
+            } else {
+                eprintln!(
+                    "Rotation complete. New epoch: {}, new key ID: {}",
+                    new_state.master_key_epoch,
+                    hex::encode(&new_state.master_key_id),
+                );
+            }
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err("rotation timed out waiting for epoch increment".into());
+        }
+    }
 }
 
 async fn load_program_name_map(
@@ -1006,5 +1447,113 @@ mod tests {
         );
 
         assert!(program_names.is_empty());
+    }
+
+    // ── Passphrase validation (T-0902) ──────────────────────────────────
+
+    #[test]
+    fn passphrase_short_chars_few_words_rejected() {
+        // 10 chars, 2 words → both below threshold → rejected.
+        let result = validate_passphrase("short pass");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn passphrase_long_chars_passes() {
+        // >= 20 chars, 3 words → passes (char threshold met).
+        let result = validate_passphrase("a very long passphrase indeed here");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn passphrase_many_words_passes() {
+        // 19 chars, 6 words → passes (word threshold met).
+        let result = validate_passphrase("a b c d e f");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn passphrase_exactly_20_chars_passes() {
+        // Exactly 20 chars, 1 word → passes (char threshold met).
+        let result = validate_passphrase("12345678901234567890");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn passphrase_19_chars_5_words_rejected() {
+        // 19 chars, 5 words → both below threshold → rejected.
+        let result = validate_passphrase("abc def ghi jkl mno");
+        assert!(result.is_err());
+    }
+
+    // ── CBOR encoding ───────────────────────────────────────────────────
+
+    #[test]
+    fn cbor_plaintext_round_trip_structure() {
+        let master_key = [0x42u8; 32];
+        let key_id = [0xABu8; 16];
+        let salt = [0xCDu8; 16];
+
+        let plaintext = encode_rotation_plaintext(
+            &master_key,
+            "ABC123",
+            &key_id,
+            Some(&salt),
+            Some((65536, 3, 1, 1)),
+        );
+
+        // Must start with A5 (map of 5 entries).
+        assert_eq!(plaintext[0], 0xA5);
+        // Key 1 follows.
+        assert_eq!(plaintext[1], 0x01);
+    }
+
+    #[test]
+    fn cbor_plaintext_null_salt_and_params() {
+        let master_key = [0x42u8; 32];
+        let key_id = [0xABu8; 16];
+
+        let plaintext = encode_rotation_plaintext(&master_key, "XYZ789", &key_id, None, None);
+
+        // Must start with A5 (map of 5 entries).
+        assert_eq!(plaintext[0], 0xA5);
+        // Salt (key 4) and kdf_params (key 5) should be null (0xF6).
+        // Find the null values by scanning for key 4 and key 5.
+        let pos4 = plaintext.windows(2).position(|w| w == [0x04, 0xF6]);
+        assert!(pos4.is_some(), "key 4 should be followed by null");
+        let pos5 = plaintext.windows(2).position(|w| w == [0x05, 0xF6]);
+        assert!(pos5.is_some(), "key 5 should be followed by null");
+    }
+
+    // ── CBOR uint encoding ──────────────────────────────────────────────
+
+    #[test]
+    fn cbor_uint_small() {
+        let mut buf = Vec::new();
+        cbor_encode_uint(&mut buf, 0);
+        assert_eq!(buf, vec![0x00]);
+        buf.clear();
+        cbor_encode_uint(&mut buf, 23);
+        assert_eq!(buf, vec![0x17]);
+    }
+
+    #[test]
+    fn cbor_uint_one_byte() {
+        let mut buf = Vec::new();
+        cbor_encode_uint(&mut buf, 24);
+        assert_eq!(buf, vec![0x18, 24]);
+        buf.clear();
+        cbor_encode_uint(&mut buf, 255);
+        assert_eq!(buf, vec![0x18, 0xFF]);
+    }
+
+    #[test]
+    fn cbor_uint_two_byte() {
+        let mut buf = Vec::new();
+        cbor_encode_uint(&mut buf, 256);
+        assert_eq!(buf, vec![0x19, 0x01, 0x00]);
+        buf.clear();
+        cbor_encode_uint(&mut buf, 65536);
+        assert_eq!(buf, vec![0x1A, 0x00, 0x01, 0x00, 0x00]);
     }
 }

--- a/crates/sonde-admin/tests/integration.rs
+++ b/crates/sonde-admin/tests/integration.rs
@@ -17,10 +17,12 @@ use tokio::sync::RwLock;
 use sonde_admin::grpc_client::AdminClient;
 use sonde_gateway::admin::AdminService;
 use sonde_gateway::engine::PendingCommand;
+use sonde_gateway::gateway_identity::GatewayIdentity;
 use sonde_gateway::program::{ProgramRecord, VerificationProfile};
 use sonde_gateway::registry::NodeRecord;
 use sonde_gateway::session::SessionManager;
 use sonde_gateway::storage::{InMemoryStorage, Storage};
+use zeroize::Zeroizing;
 
 // ── Test harness ────────────────────────────────────────────────────────────
 
@@ -840,4 +842,415 @@ async fn cli_node_remove_with_yes_succeeds() {
     );
     let mut client = AdminClient::connect(&endpoint).await.unwrap();
     assert!(client.list_nodes().await.unwrap().is_empty());
+}
+
+// ── Key management integration tests (T-0900 through T-0905) ───────────────
+
+/// Seed a deterministic gateway identity and master key metadata into storage.
+///
+/// Returns the identity so callers can derive expected fingerprint words, etc.
+async fn seed_gateway_identity(storage: &Arc<InMemoryStorage>) -> GatewayIdentity {
+    let seed = Zeroizing::new([0x42u8; 32]);
+    let gateway_id = [0x01u8; 16];
+    let identity = GatewayIdentity::from_parts(seed, gateway_id);
+    storage.store_gateway_identity(&identity).await.unwrap();
+
+    // Master key ID: deterministic 16-byte hex value.
+    storage
+        .set_config("master_key_id", &hex::encode([0xAA; 16]))
+        .await
+        .unwrap();
+    // Master key epoch starts at 1.
+    storage.set_config("master_key_epoch", "1").await.unwrap();
+
+    identity
+}
+
+/// Start an admin gRPC server with a seeded gateway identity and a rotation
+/// channel.  Returns the endpoint, storage, identity, and a receiver that
+/// accepts rotation payloads (for use in T-0900/T-0901).
+async fn start_server_with_rotation(
+    test_name: &str,
+) -> (
+    String,
+    Arc<InMemoryStorage>,
+    GatewayIdentity,
+    tokio::sync::mpsc::UnboundedReceiver<(
+        Vec<u8>,
+        tokio::sync::oneshot::Sender<Result<(), String>>,
+    )>,
+) {
+    let storage = Arc::new(InMemoryStorage::new());
+    let identity = seed_gateway_identity(&storage).await;
+
+    let pending: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
+        Arc::new(RwLock::new(HashMap::new()));
+    let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let admin = AdminService::new(storage.clone(), pending, session_manager).with_rotation_tx(tx);
+
+    let endpoint = unique_endpoint(test_name);
+    let server_endpoint = endpoint.clone();
+
+    tokio::spawn(async move {
+        if let Err(e) = sonde_gateway::admin::serve_admin(admin, &server_endpoint).await {
+            eprintln!("admin server ended: {e}");
+        }
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        match AdminClient::connect(&endpoint).await {
+            Ok(_) => return (endpoint, storage, identity, rx),
+            Err(_) if tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => panic!("failed to connect to admin server: {e}"),
+        }
+    }
+}
+
+/// Build a rotation payload for testing. Mirrors the logic in `main.rs`
+/// `build_rotation_payload()` without requiring it to be public.
+#[allow(clippy::too_many_arguments)]
+fn build_test_rotation_payload(
+    gw_x25519_public: &[u8; 32],
+    gateway_id_raw: &[u8; 16],
+    master_key_epoch: u64,
+    new_master_key: &[u8; 32],
+    rotation_code: &str,
+    new_master_key_id: &[u8; 16],
+    salt: Option<&[u8; 16]>,
+    kdf_params: Option<(u32, u32, u32, u32)>,
+) -> Vec<u8> {
+    use aes_gcm::aead::{Aead, OsRng};
+    use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+    use hkdf::Hkdf;
+    use sha2::Sha256;
+    use x25519_dalek::{EphemeralSecret, PublicKey};
+
+    let ephemeral_secret = EphemeralSecret::random_from_rng(OsRng);
+    let ephemeral_public = PublicKey::from(&ephemeral_secret);
+
+    let gw_public = PublicKey::from(*gw_x25519_public);
+    let shared_secret = ephemeral_secret.diffie_hellman(&gw_public);
+
+    let hkdf_salt = b"sonde-rotation-v1";
+    let mut info = Vec::with_capacity(24);
+    info.extend_from_slice(gateway_id_raw);
+    info.extend_from_slice(&master_key_epoch.to_be_bytes());
+
+    let hkdf = Hkdf::<Sha256>::new(Some(hkdf_salt), shared_secret.as_bytes());
+    let mut aes_key = [0u8; 32];
+    hkdf.expand(&info, &mut aes_key).unwrap();
+
+    // Deterministic CBOR: 5-entry map with integer keys 1–5.
+    let mut plaintext = Vec::with_capacity(128);
+    plaintext.push(0xA5); // map(5)
+                          // key 1: new_master_key (bstr 32)
+    plaintext.push(0x01);
+    plaintext.push(0x58);
+    plaintext.push(32);
+    plaintext.extend_from_slice(new_master_key);
+    // key 2: rotation_code (tstr)
+    plaintext.push(0x02);
+    let code_bytes = rotation_code.as_bytes();
+    if code_bytes.len() < 24 {
+        plaintext.push(0x60 | code_bytes.len() as u8);
+    } else {
+        plaintext.push(0x78);
+        plaintext.push(code_bytes.len() as u8);
+    }
+    plaintext.extend_from_slice(code_bytes);
+    // key 3: new_master_key_id (bstr 16)
+    plaintext.push(0x03);
+    plaintext.push(0x50);
+    plaintext.extend_from_slice(new_master_key_id);
+    // key 4: salt or null
+    plaintext.push(0x04);
+    if let Some(s) = salt {
+        plaintext.push(0x50);
+        plaintext.extend_from_slice(s);
+    } else {
+        plaintext.push(0xF6); // null
+    }
+    // key 5: kdf_params or null
+    plaintext.push(0x05);
+    if let Some((m, t, p, v)) = kdf_params {
+        plaintext.push(0xA4); // map(4)
+        for (key, val) in [(1u8, m), (2, t), (3, p), (4, v)] {
+            plaintext.push(key);
+            if val < 24 {
+                plaintext.push(val as u8);
+            } else if val <= 0xFF {
+                plaintext.push(0x18);
+                plaintext.push(val as u8);
+            } else if val <= 0xFFFF {
+                plaintext.push(0x19);
+                plaintext.extend_from_slice(&(val as u16).to_be_bytes());
+            } else {
+                plaintext.push(0x1A);
+                plaintext.extend_from_slice(&val.to_be_bytes());
+            }
+        }
+    } else {
+        plaintext.push(0xF6); // null
+    }
+
+    let cipher = Aes256Gcm::new((&aes_key).into());
+    let mut nonce_bytes = [0u8; 12];
+    getrandom::fill(&mut nonce_bytes).unwrap();
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext_and_tag = cipher
+        .encrypt(
+            nonce,
+            aes_gcm::aead::Payload {
+                msg: &plaintext,
+                aad: &info,
+            },
+        )
+        .unwrap();
+
+    let mut payload = Vec::with_capacity(1 + 32 + 12 + ciphertext_and_tag.len());
+    payload.push(0x01);
+    payload.extend_from_slice(ephemeral_public.as_bytes());
+    payload.extend_from_slice(&nonce_bytes);
+    payload.extend_from_slice(&ciphertext_and_tag);
+    payload
+}
+
+/// T-0903: `key fingerprint` returns the BIP-39 fingerprint words.
+#[tokio::test(flavor = "multi_thread")]
+async fn key_fingerprint_returns_six_words() {
+    let (endpoint, _storage, _identity, _rx) =
+        start_server_with_rotation("key_fingerprint_returns_six_words").await;
+
+    // Fetch state via AdminClient to get expected fingerprint.
+    let mut client = AdminClient::connect(&endpoint).await.unwrap();
+    let state = client.get_gateway_state().await.unwrap();
+    assert_eq!(
+        state.fingerprint_words.len(),
+        6,
+        "BIP-39 fingerprint should be 6 words"
+    );
+
+    drop(client);
+
+    // Verify the CLI binary produces the same words.
+    let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args(["--socket", &endpoint, "key", "fingerprint"])
+        .output()
+        .expect("failed to run sonde-admin key fingerprint");
+    assert!(
+        output.status.success(),
+        "CLI key fingerprint should succeed"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected = state.fingerprint_words.join(" ");
+    assert_eq!(
+        stdout.trim(),
+        expected,
+        "CLI output must match gRPC fingerprint"
+    );
+
+    // JSON format.
+    let json_output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args([
+            "--socket",
+            &endpoint,
+            "--format",
+            "json",
+            "key",
+            "fingerprint",
+        ])
+        .output()
+        .expect("failed to run sonde-admin key fingerprint --format json");
+    assert!(json_output.status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&json_output.stdout))
+            .expect("stdout must be valid JSON");
+    assert_eq!(parsed["fingerprint_words"].as_array().unwrap().len(), 6);
+}
+
+/// T-0904: `key status` returns epoch, master_key_id, rotation_in_progress, and
+/// optional salt/kdf_params.
+#[tokio::test(flavor = "multi_thread")]
+async fn key_status_shows_all_fields() {
+    let (endpoint, storage, _identity, _rx) =
+        start_server_with_rotation("key_status_shows_all_fields").await;
+
+    // Seed optional KDF fields.
+    storage
+        .set_config("kdf_salt", &hex::encode([0xBB; 16]))
+        .await
+        .unwrap();
+    storage
+        .set_config(
+            "kdf_params_json",
+            r#"{"m_cost":65536,"t_cost":3,"p_cost":1,"kdf_version":1}"#,
+        )
+        .await
+        .unwrap();
+
+    let json_output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args(["--socket", &endpoint, "--format", "json", "key", "status"])
+        .output()
+        .expect("failed to run sonde-admin key status");
+    assert!(
+        json_output.status.success(),
+        "CLI key status should succeed"
+    );
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&json_output.stdout))
+            .expect("stdout must be valid JSON");
+
+    assert_eq!(parsed["master_key_epoch"], 1);
+    assert_eq!(parsed["master_key_id"], hex::encode([0xAA; 16]));
+    assert_eq!(parsed["rotation_in_progress"], false);
+    assert_eq!(parsed["salt"], hex::encode([0xBB; 16]));
+    assert_eq!(parsed["kdf_params"]["m_cost"], 65536);
+    assert_eq!(parsed["kdf_params"]["t_cost"], 3);
+    assert_eq!(parsed["kdf_params"]["p_cost"], 1);
+    assert_eq!(parsed["kdf_params"]["kdf_version"], 1);
+}
+
+/// T-0904 supplement: `key status` with no salt/kdf_params shows null.
+#[tokio::test(flavor = "multi_thread")]
+async fn key_status_no_salt_shows_null() {
+    let (endpoint, _storage, _identity, _rx) =
+        start_server_with_rotation("key_status_no_salt_shows_null").await;
+
+    let json_output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args(["--socket", &endpoint, "--format", "json", "key", "status"])
+        .output()
+        .expect("failed to run sonde-admin key status");
+    assert!(json_output.status.success());
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&json_output.stdout))
+            .expect("stdout must be valid JSON");
+    assert!(parsed["salt"].is_null(), "salt should be null when absent");
+    assert!(
+        parsed["kdf_params"].is_null(),
+        "kdf_params should be null when absent"
+    );
+}
+
+/// T-0900: `key rotate` happy path — submit a valid rotation payload to the
+/// gateway and receive acceptance.
+#[tokio::test(flavor = "multi_thread")]
+async fn key_rotate_submit_accepted() {
+    let (endpoint, storage, _identity, mut rx) =
+        start_server_with_rotation("key_rotate_submit_accepted").await;
+
+    // Spawn a mock rotation handler that accepts the first payload.
+    let storage_clone = storage.clone();
+    let handler = tokio::spawn(async move {
+        let (payload, resp_tx) = rx.recv().await.expect("should receive rotation payload");
+        assert!(!payload.is_empty(), "payload must not be empty");
+        // Simulate successful rotation: bump epoch.
+        storage_clone
+            .set_config("master_key_epoch", "2")
+            .await
+            .unwrap();
+        resp_tx.send(Ok(())).ok();
+    });
+
+    // Build a rotation payload using the AdminClient directly (not the CLI
+    // binary, because the CLI prompts for interactive input).
+    let mut client = AdminClient::connect(&endpoint).await.unwrap();
+    let state = client.get_gateway_state().await.unwrap();
+    assert_eq!(state.master_key_epoch, 1);
+
+    // Construct payload the same way the CLI does.
+    let gw_x25519_pub: [u8; 32] = state.x25519_public_key.try_into().unwrap();
+    let gateway_id_raw: [u8; 16] = state.gateway_id.try_into().unwrap();
+
+    let payload = build_test_rotation_payload(
+        &gw_x25519_pub,
+        &gateway_id_raw,
+        state.master_key_epoch,
+        &[0x42u8; 32],
+        "TESTCODE",
+        &[0xCC; 16],
+        Some(&[0xDD; 16]),
+        Some((65536, 3, 1, 1)),
+    );
+
+    let resp = client.submit_rotation(payload).await.unwrap();
+    assert!(resp.accepted, "rotation should be accepted: {}", resp.error);
+
+    handler.await.unwrap();
+
+    // Verify epoch bumped.
+    let state2 = client.get_gateway_state().await.unwrap();
+    assert_eq!(state2.master_key_epoch, 2, "epoch must have incremented");
+}
+
+/// T-0901: `key rotate` with wrong rotation code — gateway rejects.
+#[tokio::test(flavor = "multi_thread")]
+async fn key_rotate_rejected_by_engine() {
+    let (endpoint, _storage, _identity, mut rx) =
+        start_server_with_rotation("key_rotate_rejected_by_engine").await;
+
+    // Spawn a mock rotation handler that rejects.
+    tokio::spawn(async move {
+        let (_payload, resp_tx) = rx.recv().await.expect("should receive rotation payload");
+        resp_tx.send(Err("invalid rotation code".to_string())).ok();
+    });
+
+    let mut client = AdminClient::connect(&endpoint).await.unwrap();
+    let state = client.get_gateway_state().await.unwrap();
+
+    let gw_x25519_pub: [u8; 32] = state.x25519_public_key.try_into().unwrap();
+    let gateway_id_raw: [u8; 16] = state.gateway_id.try_into().unwrap();
+
+    let payload = build_test_rotation_payload(
+        &gw_x25519_pub,
+        &gateway_id_raw,
+        state.master_key_epoch,
+        &[0x42u8; 32],
+        "WRONGCODE",
+        &[0xCC; 16],
+        Some(&[0xDD; 16]),
+        Some((65536, 3, 1, 1)),
+    );
+
+    let resp = client.submit_rotation(payload).await.unwrap();
+    assert!(!resp.accepted, "rotation should be rejected");
+    assert!(
+        resp.error.contains("invalid rotation code"),
+        "error should mention the reason: {}",
+        resp.error
+    );
+}
+
+/// T-0905: Key material must not appear in CLI output.
+#[tokio::test(flavor = "multi_thread")]
+async fn key_material_not_in_cli_output() {
+    let (endpoint, _storage, _identity, _rx) =
+        start_server_with_rotation("key_material_not_in_cli_output").await;
+
+    // Run fingerprint and status commands, capture all output.
+    for subcmd in &["fingerprint", "status"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+            .args(["--socket", &endpoint, "key", subcmd])
+            .output()
+            .expect("failed to run sonde-admin");
+
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        // The seed [0x42; 32] and master key should never appear in output.
+        let seed_hex = hex::encode([0x42u8; 32]);
+        assert!(
+            !combined.contains(&seed_hex),
+            "key `{subcmd}` output must not contain the Ed25519 seed"
+        );
+    }
 }

--- a/crates/sonde-gateway/tests/escrow.rs
+++ b/crates/sonde-gateway/tests/escrow.rs
@@ -1,0 +1,729 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+//! Integration tests for PSK escrow, master key identification, and ACTUAL_STATE
+//! publication (GW-2001, GW-2003, GW-2004, GW-2005).
+//!
+//! Test IDs: T-2000, T-2001, T-2002, T-2006c.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciborium::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+use tokio::sync::mpsc;
+use zeroize::Zeroizing;
+
+use sonde_gateway::connector::{
+    ConnectorEventHub, ConnectorService, GatewayDesiredState, MSG_TYPE_ACTUAL_STATE,
+    MSG_TYPE_DESIRED_STATE,
+};
+use sonde_gateway::gateway_identity::GatewayIdentity;
+use sonde_gateway::phone_trust::{PhonePskRecord, PhonePskStatus};
+use sonde_gateway::registry::NodeRecord;
+use sonde_gateway::rotation_engine::RotationEngine;
+use sonde_gateway::sqlite_storage::SqliteStorage;
+use sonde_gateway::storage::Storage;
+
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use hkdf::Hkdf;
+use sha2::Sha256;
+use x25519_dalek::PublicKey as X25519PublicKey;
+
+// ── helpers ──────────────────────────────────────────────────────
+
+/// Create a test gateway with identity and storage, but do NOT call
+/// `init_master_key_id()` — the caller must do that after registering nodes
+/// so the backfill picks them up.
+async fn setup_test_storage() -> (Arc<SqliteStorage>, GatewayIdentity) {
+    let master_key = Zeroizing::new([0x42u8; 32]);
+    let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
+
+    let identity = GatewayIdentity::generate().unwrap();
+    store.store_gateway_identity(&identity).await.unwrap();
+
+    (store, identity)
+}
+
+/// Convenience: create storage + identity, init master key & rotation code.
+/// Use only when no nodes need to be registered before init.
+async fn setup_test_gateway() -> (
+    Arc<SqliteStorage>,
+    GatewayIdentity,
+    [u8; 16], // master_key_id
+    u64,      // epoch
+    String,   // rotation_code
+) {
+    let (store, identity) = setup_test_storage().await;
+    let (key_id, epoch) = store.init_master_key_id().await.unwrap();
+    let code = store.init_rotation_code().await.unwrap();
+    (store, identity, key_id, epoch, code)
+}
+
+/// Register a test node with a deterministic PSK derived from key_hint.
+async fn register_test_node(store: &Arc<SqliteStorage>, node_id: &str, key_hint: u16) {
+    let mut psk = [0u8; 32];
+    psk[0] = key_hint as u8;
+    psk[1] = (key_hint >> 8) as u8;
+
+    let record = NodeRecord {
+        node_id: node_id.to_string(),
+        key_hint,
+        psk,
+        assigned_program_hash: None,
+        current_program_hash: None,
+        desired_schedule_interval_s: Some(60),
+        schedule_interval_s: 60,
+        firmware_abi_version: Some(1),
+        firmware_version: Some("0.1.0".to_string()),
+        rf_channel: Some(1),
+        sensors: vec![],
+        registered_by_phone_id: None,
+        key_version: 0,
+    };
+    store.upsert_node(&record).await.unwrap();
+}
+
+/// Store a phone PSK in the database.
+async fn register_phone_psk(store: &Arc<SqliteStorage>, phone_id: u32, key_hint: u16) {
+    let phone = PhonePskRecord {
+        phone_id,
+        phone_key_hint: key_hint,
+        psk: Zeroizing::new([0xCCu8; 32]),
+        label: format!("test-phone-{phone_id}"),
+        issued_at: std::time::SystemTime::now(),
+        status: PhonePskStatus::Active,
+        key_version: 0,
+    };
+    store.store_phone_psk(&phone).await.unwrap();
+}
+
+/// Build a valid RotationPayloadV1 for testing (same as rotation.rs helper).
+fn build_rotation_payload(
+    gateway_identity: &GatewayIdentity,
+    current_epoch: u64,
+    new_master_key: &[u8; 32],
+    rotation_code: &str,
+    new_master_key_id: &[u8; 16],
+    salt: Option<&[u8; 16]>,
+) -> Vec<u8> {
+    let mut rng_bytes = [0u8; 32];
+    getrandom::fill(&mut rng_bytes).unwrap();
+    let ephemeral_secret = x25519_dalek::StaticSecret::from(rng_bytes);
+    let ephemeral_public = X25519PublicKey::from(&ephemeral_secret);
+
+    let (_, gw_x25519_public) = gateway_identity.to_x25519().unwrap();
+    let shared_secret = ephemeral_secret.diffie_hellman(&gw_x25519_public);
+
+    let gateway_id = gateway_identity.gateway_id();
+    let mut info = Vec::with_capacity(24);
+    info.extend_from_slice(gateway_id);
+    info.extend_from_slice(&current_epoch.to_be_bytes());
+
+    let hk = Hkdf::<Sha256>::new(Some(b"sonde-rotation-v1"), shared_secret.as_bytes());
+    let mut derived_key = [0u8; 32];
+    hk.expand(&info, &mut derived_key).unwrap();
+
+    let mut cbor_pairs: Vec<(Value, Value)> = vec![
+        (
+            Value::Integer(1.into()),
+            Value::Bytes(new_master_key.to_vec()),
+        ),
+        (
+            Value::Integer(2.into()),
+            Value::Text(rotation_code.to_string()),
+        ),
+        (
+            Value::Integer(3.into()),
+            Value::Bytes(new_master_key_id.to_vec()),
+        ),
+    ];
+    if let Some(s) = salt {
+        cbor_pairs.push((Value::Integer(4.into()), Value::Bytes(s.to_vec())));
+    } else {
+        cbor_pairs.push((Value::Integer(4.into()), Value::Null));
+    }
+    cbor_pairs.push((Value::Integer(5.into()), Value::Null));
+    let cbor_map = Value::Map(cbor_pairs);
+    let mut plaintext = Vec::new();
+    ciborium::into_writer(&cbor_map, &mut plaintext).unwrap();
+
+    let key = Key::<Aes256Gcm>::from_slice(&derived_key);
+    let cipher = Aes256Gcm::new(key);
+    let mut nonce_bytes = [0u8; 12];
+    getrandom::fill(&mut nonce_bytes).unwrap();
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let gcm_payload = Payload {
+        msg: &plaintext,
+        aad: &info,
+    };
+    let ciphertext = cipher.encrypt(nonce, gcm_payload).unwrap();
+
+    let mut payload = Vec::with_capacity(1 + 32 + 12 + ciphertext.len());
+    payload.push(0x01);
+    payload.extend_from_slice(ephemeral_public.as_bytes());
+    payload.extend_from_slice(&nonce_bytes);
+    payload.extend_from_slice(&ciphertext);
+    payload
+}
+
+/// Spawn a ConnectorService with a duplex stream and return the client side.
+async fn spawn_connector(
+    event_hub: Arc<ConnectorEventHub>,
+    storage: Arc<dyn Storage>,
+) -> (DuplexStream, tokio::task::JoinHandle<()>) {
+    let pending = Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+    let service = ConnectorService::new(storage, pending, event_hub.clone(), 64 * 1024);
+    let (client, server) = tokio::io::duplex(64 * 1024);
+    let handle = tokio::spawn(async move {
+        service.handle_connection(server).await.ok();
+    });
+    // Wait for the connector to subscribe to the broadcast channel.
+    while event_hub.subscriber_count() == 0 {
+        tokio::task::yield_now().await;
+    }
+    (client, handle)
+}
+
+/// Spawn a ConnectorService wired to a gateway_desired_state channel.
+async fn spawn_connector_with_desired_state(
+    event_hub: Arc<ConnectorEventHub>,
+    storage: Arc<dyn Storage>,
+) -> (
+    DuplexStream,
+    tokio::task::JoinHandle<()>,
+    mpsc::UnboundedReceiver<GatewayDesiredState>,
+) {
+    let pending = Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+    let (ds_tx, ds_rx) = mpsc::unbounded_channel();
+    let mut service = ConnectorService::new(storage, pending, event_hub.clone(), 64 * 1024);
+    service.set_gateway_desired_state_tx(ds_tx);
+    let (client, server) = tokio::io::duplex(64 * 1024);
+    let handle = tokio::spawn(async move {
+        service.handle_connection(server).await.ok();
+    });
+    while event_hub.subscriber_count() == 0 {
+        tokio::task::yield_now().await;
+    }
+    (client, handle, ds_rx)
+}
+
+/// Write a length-delimited frame to a stream (4-byte big-endian length prefix).
+async fn write_framed(stream: &mut DuplexStream, payload: &[u8]) {
+    let len = u32::try_from(payload.len()).unwrap().to_be_bytes();
+    stream.write_all(&len).await.unwrap();
+    stream.write_all(payload).await.unwrap();
+    stream.flush().await.unwrap();
+}
+
+/// Read a length-delimited frame from a stream.
+async fn read_framed(stream: &mut DuplexStream) -> Vec<u8> {
+    let mut len = [0u8; 4];
+    tokio::time::timeout(Duration::from_secs(2), stream.read_exact(&mut len))
+        .await
+        .expect("timed out waiting for connector frame length")
+        .unwrap();
+    let len = usize::try_from(u32::from_be_bytes(len)).unwrap();
+    let mut payload = vec![0u8; len];
+    tokio::time::timeout(Duration::from_secs(2), stream.read_exact(&mut payload))
+        .await
+        .expect("timed out waiting for connector frame payload")
+        .unwrap();
+    payload
+}
+
+/// Decode CBOR bytes into a map of integer-keyed entries.
+fn decode_cbor_map(bytes: &[u8]) -> Vec<(i128, Value)> {
+    let value: Value = ciborium::from_reader(bytes).expect("invalid CBOR");
+    match value {
+        Value::Map(pairs) => pairs
+            .into_iter()
+            .filter_map(|(k, v)| {
+                if let Value::Integer(i) = k {
+                    Some((i.into(), v))
+                } else {
+                    None
+                }
+            })
+            .collect(),
+        _ => panic!("expected CBOR map"),
+    }
+}
+
+/// Look up a key in a decoded CBOR map.
+fn map_get(map: &[(i128, Value)], key: i128) -> Option<&Value> {
+    map.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
+}
+
+// ── T-2000: Master key identification — first startup ────────
+
+/// T-2000: Master key identification — first startup (GW-2001).
+///
+/// Verifies:
+/// 1. No `master_key_id` or `master_key_epoch` on fresh DB.
+/// 2. After `init_master_key_id()`, a random 16-byte ID and epoch=1 are set.
+/// 3. All existing PSK records are backfilled.
+/// 4. On restart (re-call), the same values are returned.
+#[tokio::test]
+async fn test_t2000_master_key_identification() {
+    let master_key = Zeroizing::new([0x42u8; 32]);
+    let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
+
+    // Pre-populate with nodes before init_master_key_id.
+    register_test_node(&store, "node-alpha", 100).await;
+    register_test_node(&store, "node-beta", 200).await;
+    register_phone_psk(&store, 0, 300).await;
+
+    // Step 1-2: Verify no master_key_id/epoch before init.
+    let config_id = store.get_config("master_key_id").await.unwrap();
+    assert!(
+        config_id.is_none(),
+        "master_key_id should not exist before init"
+    );
+    let config_epoch = store.get_config("master_key_epoch").await.unwrap();
+    assert!(
+        config_epoch.is_none(),
+        "master_key_epoch should not exist before init"
+    );
+
+    // Step 3: Run init_master_key_id.
+    let (key_id, epoch) = store.init_master_key_id().await.unwrap();
+
+    // Step 4: Verify master_key_id is 16 bytes, non-zero.
+    assert_eq!(key_id.len(), 16);
+    assert_ne!(key_id, [0u8; 16], "master_key_id must be non-zero");
+
+    // Step 5: Verify epoch = 1.
+    assert_eq!(epoch, 1);
+
+    // Step 6: Verify all existing node PSK records are backfilled.
+    let escrow = store.list_node_escrow_state().await.unwrap();
+    assert_eq!(escrow.len(), 2);
+    for node in &escrow {
+        assert_eq!(
+            node.master_key_id,
+            key_id.to_vec(),
+            "node {} should have master_key_id backfilled",
+            node.node_id
+        );
+    }
+
+    // Step 6b: Verify phone PSK records are also backfilled (loadable after init).
+    let phones = store.list_phone_psks().await.unwrap();
+    assert_eq!(phones.len(), 1, "phone PSK should be backfilled");
+    // Phone PSK must be loadable (decrypt succeeds with current master key).
+    assert_ne!(
+        phones[0].psk.as_ref(),
+        &[0u8; 32],
+        "phone PSK must be non-zero after backfill"
+    );
+
+    // Step 7: Restart — verify same values are returned.
+    let (key_id_2, epoch_2) = store.init_master_key_id().await.unwrap();
+    assert_eq!(
+        key_id, key_id_2,
+        "master_key_id must be stable across restarts"
+    );
+    assert_eq!(epoch, epoch_2, "epoch must be stable across restarts");
+}
+
+// ── T-2001: Gateway ACTUAL_STATE publication ─────────────────
+
+/// T-2001: Gateway ACTUAL_STATE publication (GW-2003).
+///
+/// Verifies:
+/// 1. Gateway ACTUAL_STATE is emitted with `entity_kind = "gateway"` and all
+///    required fields (entity_id, channel, master_key_id, master_key_epoch,
+///    x25519_public_key, fingerprint_words, gateway_version, gateway_commit).
+/// 2. `fingerprint_words` matches independent computation from the public key.
+/// 3. `rotation_in_progress = false`.
+/// 4. Node ACTUAL_STATE includes escrow fields (encrypted_psk key 12,
+///    escrow_key_hint key 13, master_key_id key 14).
+#[tokio::test]
+async fn test_t2001_gateway_actual_state_publication() {
+    let (store, identity) = setup_test_storage().await;
+
+    // Register nodes BEFORE init_master_key_id so the backfill sets master_key_id.
+    register_test_node(&store, "node-1", 101).await;
+    register_test_node(&store, "node-2", 202).await;
+
+    let (key_id, epoch) = store.init_master_key_id().await.unwrap();
+    let _code = store.init_rotation_code().await.unwrap();
+
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let (mut client, _handle) =
+        spawn_connector(event_hub.clone(), store.clone() as Arc<dyn Storage>).await;
+
+    // Derive X25519 public key for verification.
+    let (_, x25519_public) = identity.to_x25519().unwrap();
+
+    // Compute expected fingerprint.
+    let sha = sonde_gateway::crypto::RustCryptoSha256;
+    let expected_fp = sonde_protocol::compute_fingerprint(x25519_public.as_bytes(), &sha);
+
+    // Emit gateway ACTUAL_STATE.
+    let gateway_id_hex = hex::encode(identity.gateway_id());
+    event_hub.emit_gateway_actual_state(
+        gateway_id_hex.clone(),
+        1, // channel
+        key_id,
+        epoch,
+        *x25519_public.as_bytes(),
+        expected_fp.map(|s| s.to_string()),
+        vec![], // missing_key_hints
+        None,   // salt
+        None,   // kdf_params
+        "0.7.0".to_string(),
+        "abc123".to_string(),
+        None, // modem_firmware_version
+        None, // modem_firmware_commit
+        false,
+    );
+
+    // Read the gateway ACTUAL_STATE from the connector.
+    let frame = read_framed(&mut client).await;
+    let map = decode_cbor_map(&frame);
+
+    // Verify msg_type = ACTUAL_STATE.
+    let msg_type: i128 = match map_get(&map, 1).unwrap() {
+        Value::Integer(i) => (*i).into(),
+        other => panic!("expected integer msg_type, got {other:?}"),
+    };
+    assert_eq!(msg_type, MSG_TYPE_ACTUAL_STATE as i128);
+
+    // Verify entity_kind = "gateway".
+    let entity_kind = match map_get(&map, 2).unwrap() {
+        Value::Text(s) => s.clone(),
+        other => panic!("expected text entity_kind, got {other:?}"),
+    };
+    assert_eq!(entity_kind, "gateway");
+
+    // Verify entity_id matches gateway_id hex.
+    let entity_id = match map_get(&map, 3).unwrap() {
+        Value::Text(s) => s.clone(),
+        other => panic!("expected text entity_id, got {other:?}"),
+    };
+    assert_eq!(entity_id, gateway_id_hex);
+
+    // Verify channel (key 15).
+    let channel: i128 = match map_get(&map, 15).unwrap() {
+        Value::Integer(i) => (*i).into(),
+        other => panic!("expected integer channel, got {other:?}"),
+    };
+    assert_eq!(channel, 1);
+
+    // Verify master_key_id (key 16).
+    let mk_id = match map_get(&map, 16).unwrap() {
+        Value::Bytes(b) => b.clone(),
+        other => panic!("expected bytes master_key_id, got {other:?}"),
+    };
+    assert_eq!(mk_id, key_id.to_vec());
+
+    // Verify master_key_epoch (key 17).
+    let mk_epoch: i128 = match map_get(&map, 17).unwrap() {
+        Value::Integer(i) => (*i).into(),
+        other => panic!("expected integer master_key_epoch, got {other:?}"),
+    };
+    assert_eq!(mk_epoch, epoch as i128);
+
+    // Verify x25519_public_key (key 18).
+    let x25519 = match map_get(&map, 18).unwrap() {
+        Value::Bytes(b) => b.clone(),
+        other => panic!("expected bytes x25519_public_key, got {other:?}"),
+    };
+    assert_eq!(x25519, x25519_public.as_bytes().to_vec());
+
+    // Verify fingerprint_words (key 19) matches independent computation.
+    let fp_words = match map_get(&map, 19).unwrap() {
+        Value::Array(arr) => arr
+            .iter()
+            .map(|v| match v {
+                Value::Text(s) => s.clone(),
+                other => panic!("expected text in fingerprint array, got {other:?}"),
+            })
+            .collect::<Vec<_>>(),
+        other => panic!("expected array fingerprint_words, got {other:?}"),
+    };
+    assert_eq!(fp_words.len(), 6);
+    let expected_strs: Vec<String> = expected_fp.iter().map(|s| s.to_string()).collect();
+    assert_eq!(fp_words, expected_strs);
+
+    // Verify rotation_in_progress = false (key 27).
+    let rip = match map_get(&map, 27).unwrap() {
+        Value::Bool(b) => *b,
+        other => panic!("expected bool rotation_in_progress, got {other:?}"),
+    };
+    assert!(!rip);
+
+    // Verify gateway_version (key 23) and gateway_commit (key 24).
+    let gw_version = match map_get(&map, 23).unwrap() {
+        Value::Text(s) => s.clone(),
+        other => panic!("expected text gateway_version, got {other:?}"),
+    };
+    assert_eq!(gw_version, "0.7.0");
+
+    let gw_commit = match map_get(&map, 24).unwrap() {
+        Value::Text(s) => s.clone(),
+        other => panic!("expected text gateway_commit, got {other:?}"),
+    };
+    assert_eq!(gw_commit, "abc123");
+
+    // Now test node ACTUAL_STATE with escrow fields.
+    let escrow_records = store.list_node_escrow_state().await.unwrap();
+    assert_eq!(escrow_records.len(), 2, "should have 2 nodes");
+
+    // Emit a node ACTUAL_STATE with escrow fields.
+    let node = &escrow_records[0];
+    event_hub.emit_actual_state_for_node_with_escrow(
+        node.node_id.clone(),
+        node.current_program_hash.clone(),
+        node.assigned_program_hash.clone(),
+        node.schedule_interval_s,
+        node.last_battery_mv,
+        node.firmware_abi_version,
+        node.firmware_version.clone(),
+        1000,
+        Some(node.encrypted_psk.clone()),
+        Some(node.key_hint),
+        Some(node.master_key_id.clone()),
+        None,
+    );
+
+    let node_frame = read_framed(&mut client).await;
+    let node_map = decode_cbor_map(&node_frame);
+
+    // Verify msg_type = ACTUAL_STATE.
+    let node_msg_type: i128 = match map_get(&node_map, 1).unwrap() {
+        Value::Integer(i) => (*i).into(),
+        other => panic!("expected integer, got {other:?}"),
+    };
+    assert_eq!(node_msg_type, MSG_TYPE_ACTUAL_STATE as i128);
+
+    // Verify entity_kind = "node" (key 2).
+    let node_entity_kind = match map_get(&node_map, 2).unwrap() {
+        Value::Text(s) => s.clone(),
+        other => panic!("expected text, got {other:?}"),
+    };
+    assert_eq!(node_entity_kind, "node");
+
+    // Verify encrypted_psk (key 12) is present and 60 bytes.
+    let encrypted_psk = match map_get(&node_map, 12).unwrap() {
+        Value::Bytes(b) => b.clone(),
+        other => panic!("expected bytes encrypted_psk, got {other:?}"),
+    };
+    assert_eq!(encrypted_psk.len(), 60, "encrypted_psk must be 60 bytes");
+
+    // Verify escrow_key_hint (key 13).
+    let escrow_kh: i128 = match map_get(&node_map, 13).unwrap() {
+        Value::Integer(i) => (*i).into(),
+        other => panic!("expected integer escrow_key_hint, got {other:?}"),
+    };
+    assert_eq!(escrow_kh, node.key_hint as i128);
+
+    // Verify master_key_id (key 14) matches.
+    let node_mk_id = match map_get(&node_map, 14).unwrap() {
+        Value::Bytes(b) => b.clone(),
+        other => panic!("expected bytes master_key_id, got {other:?}"),
+    };
+    assert_eq!(node_mk_id, key_id.to_vec());
+}
+
+// ── T-2002: Gateway DESIRED_STATE channel change ─────────────
+
+/// T-2002: Gateway DESIRED_STATE channel change (GW-2004).
+///
+/// Verifies:
+/// 1. DESIRED_STATE with `channel = 5` is parsed and forwarded.
+/// 2. The parsed `GatewayDesiredState` contains the correct channel value.
+#[tokio::test]
+async fn test_t2002_desired_state_channel_change() {
+    let (store, identity, _key_id, _epoch, _code) = setup_test_gateway().await;
+    let event_hub = Arc::new(ConnectorEventHub::default());
+
+    let (mut client, _handle, mut ds_rx) =
+        spawn_connector_with_desired_state(event_hub.clone(), store.clone() as Arc<dyn Storage>)
+            .await;
+
+    // Build a DESIRED_STATE message with entity_kind=gateway, channel=5.
+    let gateway_id_hex = hex::encode(identity.gateway_id());
+    let desired_state_inner =
+        Value::Map(vec![(Value::Integer(15.into()), Value::Integer(5.into()))]);
+    let message = Value::Map(vec![
+        (
+            Value::Integer(1.into()),
+            Value::Integer(MSG_TYPE_DESIRED_STATE.into()),
+        ),
+        (Value::Integer(2.into()), Value::Text("gateway".to_string())),
+        (Value::Integer(3.into()), Value::Text(gateway_id_hex)),
+        (Value::Integer(4.into()), desired_state_inner),
+    ]);
+    let mut bytes = Vec::new();
+    ciborium::into_writer(&message, &mut bytes).unwrap();
+
+    // Send DESIRED_STATE to the connector.
+    write_framed(&mut client, &bytes).await;
+
+    // Read the forwarded GatewayDesiredState from the channel.
+    let ds = tokio::time::timeout(Duration::from_secs(2), ds_rx.recv())
+        .await
+        .expect("timed out waiting for DESIRED_STATE")
+        .expect("channel closed");
+
+    // Verify the parsed channel value.
+    assert_eq!(ds.channel, Some(5), "channel should be 5");
+}
+
+// ── T-2006c: Phone PSKs not escrowed ─────────────────────────
+
+/// T-2006c: Phone PSKs not escrowed (GW-2005).
+///
+/// Verifies:
+/// 1. Node ACTUAL_STATE includes escrow fields for each node.
+/// 2. No ACTUAL_STATE is emitted with entity_kind = "phone".
+/// 3. After key rotation, node ACTUAL_STATE is re-emitted with updated escrow.
+/// 4. Phone PSK is re-encrypted with new key in local DB.
+/// 5. Still no phone ACTUAL_STATE emitted after rotation.
+#[tokio::test]
+async fn test_t2006c_phone_psks_not_escrowed() {
+    let (store, identity) = setup_test_storage().await;
+
+    // Register nodes and phone PSK BEFORE init_master_key_id for backfill.
+    register_test_node(&store, "node-x", 100).await;
+    register_test_node(&store, "node-y", 200).await;
+    register_phone_psk(&store, 0, 400).await;
+
+    let (_key_id, epoch) = store.init_master_key_id().await.unwrap();
+    let code = store.init_rotation_code().await.unwrap();
+
+    let event_hub = Arc::new(ConnectorEventHub::default());
+    let (mut client, _handle) =
+        spawn_connector(event_hub.clone(), store.clone() as Arc<dyn Storage>).await;
+
+    // Step 1: Emit node escrow state and verify escrow fields are present.
+    let escrow = store.list_node_escrow_state().await.unwrap();
+    assert_eq!(escrow.len(), 2);
+
+    for node in &escrow {
+        event_hub.emit_actual_state_for_node_with_escrow(
+            node.node_id.clone(),
+            node.current_program_hash.clone(),
+            node.assigned_program_hash.clone(),
+            node.schedule_interval_s,
+            node.last_battery_mv,
+            node.firmware_abi_version,
+            node.firmware_version.clone(),
+            1000,
+            Some(node.encrypted_psk.clone()),
+            Some(node.key_hint),
+            Some(node.master_key_id.clone()),
+            None,
+        );
+    }
+
+    // Read 2 node ACTUAL_STATE messages.
+    for _ in 0..2 {
+        let frame = read_framed(&mut client).await;
+        let map = decode_cbor_map(&frame);
+
+        let entity_kind = match map_get(&map, 2).unwrap() {
+            Value::Text(s) => s.clone(),
+            other => panic!("expected text, got {other:?}"),
+        };
+        assert_eq!(
+            entity_kind, "node",
+            "only node ACTUAL_STATE should be emitted"
+        );
+
+        // Verify escrow fields present.
+        assert!(
+            matches!(map_get(&map, 12), Some(Value::Bytes(_))),
+            "encrypted_psk (key 12) must be present"
+        );
+        assert!(
+            matches!(map_get(&map, 13), Some(Value::Integer(_))),
+            "escrow_key_hint (key 13) must be present"
+        );
+        assert!(
+            matches!(map_get(&map, 14), Some(Value::Bytes(_))),
+            "master_key_id (key 14) must be present"
+        );
+    }
+
+    // Step 2: Verify NO phone ACTUAL_STATE is emitted.
+    // The ConnectorEventHub only emits node and gateway ACTUAL_STATE — there is no
+    // emit method for phone ACTUAL_STATE. This is the design-level guarantee (GW-2005).
+    // We verify by checking that list_node_escrow_state returns only nodes.
+    let phones = store.list_phone_psks().await.unwrap();
+    assert_eq!(phones.len(), 1, "phone PSK should exist in DB");
+
+    // Step 3: Perform key rotation.
+    let new_key = [0xAAu8; 32];
+    let new_id = [0xBBu8; 16];
+    let payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+
+    let (_, grpc_rx) = mpsc::unbounded_channel();
+    let (_, desired_state_rx) = mpsc::unbounded_channel();
+    // Use the same event_hub so post-rotation ACTUAL_STATE goes to the connector.
+    let mut engine = RotationEngine::new(
+        store.clone(),
+        identity.clone(),
+        event_hub.clone(),
+        grpc_rx,
+        desired_state_rx,
+    );
+
+    let result = engine.handle_rotation_payload(&payload, true).await;
+    assert!(result.is_ok(), "rotation should succeed: {:?}", result);
+
+    // Step 4: Read the re-emitted node ACTUAL_STATE messages after rotation.
+    // The rotation engine calls emit_post_rotation_state which re-emits
+    // node ACTUAL_STATE with updated escrow fields.
+    for _ in 0..2 {
+        let frame = read_framed(&mut client).await;
+        let map = decode_cbor_map(&frame);
+
+        let entity_kind = match map_get(&map, 2).unwrap() {
+            Value::Text(s) => s.clone(),
+            other => panic!("expected text, got {other:?}"),
+        };
+        // After rotation, only "node" ACTUAL_STATE should appear — never "phone".
+        assert_eq!(
+            entity_kind, "node",
+            "post-rotation ACTUAL_STATE must be for nodes only, not phones"
+        );
+
+        // Verify updated master_key_id (key 14).
+        let mk = match map_get(&map, 14).unwrap() {
+            Value::Bytes(b) => b.clone(),
+            other => panic!("expected bytes, got {other:?}"),
+        };
+        assert_eq!(mk, new_id.to_vec(), "master_key_id should be updated");
+    }
+
+    // Step 5: Verify phone PSK was re-encrypted (still loadable after rotation).
+    // `list_phone_psks()` decrypts using the rotation key; if migrate_phone_psk
+    // didn't re-encrypt, this would fail with a decryption error.
+    let phones_after = store.list_phone_psks().await.unwrap();
+    assert_eq!(
+        phones_after.len(),
+        1,
+        "phone PSK should still exist after rotation"
+    );
+    // The plaintext PSK value must be preserved through rotation.
+    assert_eq!(
+        phones_after[0].psk.as_ref(),
+        &[0xCCu8; 32],
+        "phone PSK plaintext must survive rotation"
+    );
+
+    // Step 6: Verify no additional messages on the connector stream.
+    // A short timeout ensures no phone ACTUAL_STATE was emitted.
+    let timeout_result =
+        tokio::time::timeout(Duration::from_millis(100), read_framed(&mut client)).await;
+    assert!(
+        timeout_result.is_err(),
+        "no additional ACTUAL_STATE should be emitted (phone PSKs are not escrowed)"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the three key management CLI subcommands specified in issue #1059:

- **\key fingerprint\** (ADMIN-0901) — displays the gateway master key fingerprint as a 6-word BIP39-style mnemonic (text or JSON)
- **\key status\** (ADMIN-0902) — shows master key metadata: \key_id\, \poch\, KDF salt, KDF params, \x25519_public_key\ (text or JSON)
- **\key rotate\** (ADMIN-0900) — full interactive rotation flow: passphrase entry → Argon2id KDF → X25519 ephemeral DH → HKDF-SHA-256 key derivation → AES-256-GCM encrypted \RotationPayloadV1\ → gRPC \SubmitRotation\

## Changes

### \crates/sonde-admin/src/main.rs\ (+543 lines)
- \KeyAction\ enum with \Rotate\, \Fingerprint\, \Status\ variants
- \key_rotate()\ async function implementing the 11-step interactive flow
- \uild_rotation_payload()\ — constructs \RotationPayloadV1\ binary envelope
- \ncode_rotation_plaintext()\ — deterministic CBOR encoding (RFC 8949 §4.2)
- \alidate_passphrase()\ — rejects if \chars().count() < 20 AND word_count < 6\
- \cbor_encode_uint()\ / \cbor_encode_tstr()\ — minimal CBOR helpers
- 7 unit tests for passphrase validation and CBOR encoding

### \crates/sonde-admin/src/grpc_client.rs\ (+18 lines)
- \get_gateway_state()\ and \submit_rotation()\ RPC wrapper methods

### \crates/sonde-admin/tests/integration.rs\ (+412 lines)
- 6 integration tests (T-0900 through T-0905):
  - \key_fingerprint_returns_six_words\
  - \key_status_shows_all_fields\
  - \key_status_no_salt_shows_null\
  - \key_rotate_submit_accepted\
  - \key_rotate_rejected_by_engine\
  - \key_material_not_in_cli_output\

### \crates/sonde-admin/Cargo.toml\
- Added: \es-gcm\, \rgon2\, \getrandom\, \hkdf\, \sha2\, \x25519-dalek\, \zeroize\

## Security

- Plaintext CBOR buffer wrapped in \Zeroizing<Vec<u8>>\ — zeroed on drop
- \SharedSecret\ zeroized via x25519-dalek default features
- AES key wrapped in \Zeroizing<[u8; 32]>\
- \was_contributory()\ check rejects low-order X25519 public keys
- Passphrase validation uses \chars().count()\ (Unicode-correct), not byte length
- \getrandom::fill()\ for all cryptographic randomness

## Test results

All 53 sonde-admin tests pass. Full workspace clippy and tests clean.

Closes #1059