### PR TITLE
Wire gateway ACTUAL_STATE emission and rotation engine in binary startup (GW-2003, GW-2004)

### DIFF
--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1921,8 +1921,9 @@ async fn emit_gateway_actual_state_from_storage(
     let missing_key_hints = gateway.drain_missing_hints().await;
 
     let rotation_in_progress = storage
-        .get_config("pending_rotation_phase")
-        .await?
+        .read_pending_rotation()
+        .await
+        .unwrap_or(None)
         .is_some();
 
     let gateway_version = env!("CARGO_PKG_VERSION").to_string();

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -945,6 +945,35 @@ async fn run_gateway(
         }
     }
 
+    // 2a. Resume pending rotation if exists (§23.11 step 2a).
+    let pending_rotation_notification = {
+        let identity = storage
+            .load_gateway_identity()
+            .await?
+            .ok_or("gateway identity missing after init")?;
+        sonde_gateway::RotationEngine::resume_pending_rotation(&storage, &identity)
+            .await
+            .map_err(|e| format!("resume_pending_rotation: {e}"))?
+    };
+    if pending_rotation_notification.is_some() {
+        info!("pending rotation resumed on startup — will re-emit ACTUAL_STATE after connector starts");
+    }
+
+    // 2c. Load/generate master_key_id and master_key_epoch (§23.11 step 2c).
+    let (master_key_id, master_key_epoch) = storage.init_master_key_id().await?;
+    info!(
+        master_key_id = %hex::encode(master_key_id),
+        master_key_epoch,
+        "master key identification initialized"
+    );
+
+    // 2d. Load/generate rotation_code (§23.11 step 2d).
+    let rotation_code = storage.init_rotation_code().await?;
+    info!(
+        rotation_code_len = rotation_code.len(),
+        "rotation code initialized"
+    );
+
     // 3. Session manager
     let session_manager = Arc::new(SessionManager::new(Duration::from_secs(
         cli.session_timeout,
@@ -1057,12 +1086,34 @@ async fn run_gateway(
         });
     }
 
-    let connector_service = ConnectorService::new(
+    // ── Rotation engine + DESIRED_STATE wiring (GW-2003, GW-2004, §23.11) ──
+
+    // Channel: connector → rotation engine (DESIRED_STATE forwarding).
+    let (desired_state_tx, desired_state_rx) =
+        tokio::sync::mpsc::unbounded_channel::<sonde_gateway::connector::GatewayDesiredState>();
+
+    // Channel: admin gRPC → rotation engine (SubmitRotation RPC).
+    let (rotation_grpc_tx, rotation_grpc_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    // Channel: rotation engine → re-emission task (rotation complete).
+    let (rotation_complete_tx, mut rotation_complete_rx) = tokio::sync::mpsc::unbounded_channel::<
+        sonde_gateway::rotation_engine::RotationCompleteNotification,
+    >();
+
+    // Channel: rotation engine → re-emission task (salt/KDF adoption).
+    let (state_changed_tx, mut state_changed_rx) = tokio::sync::mpsc::unbounded_channel::<
+        sonde_gateway::rotation_engine::GatewayStateChanged,
+    >();
+
+    // Wire DESIRED_STATE forwarding on the connector service.
+    let mut connector_service = ConnectorService::new(
         storage.clone(),
         pending_commands.clone(),
         gateway.connector_event_hub(),
         cli.connector_max_message_size,
     );
+    connector_service.set_gateway_desired_state_tx(desired_state_tx);
+
     let connector_socket = cli.connector_socket.clone();
     let mut connector_handle = tokio::spawn(async move {
         if let Err(e) =
@@ -1071,6 +1122,125 @@ async fn run_gateway(
             error!("connector server error: {}", e);
         }
     });
+
+    // Construct and spawn the rotation engine (§23.11).
+    {
+        let identity = storage
+            .load_gateway_identity()
+            .await?
+            .ok_or("gateway identity missing for rotation engine")?;
+        let engine = sonde_gateway::RotationEngine::new(
+            Arc::clone(&storage),
+            identity,
+            gateway.connector_event_hub(),
+            rotation_grpc_rx,
+            desired_state_rx,
+        )
+        .with_rotation_complete_tx(rotation_complete_tx)
+        .with_state_changed_tx(state_changed_tx);
+
+        tokio::spawn(engine.run());
+        info!("rotation engine started");
+    }
+
+    // 9a. Emit initial gateway ACTUAL_STATE (§23.11 step 9a, GW-2003).
+    {
+        let identity = storage
+            .load_gateway_identity()
+            .await?
+            .ok_or("gateway identity missing for ACTUAL_STATE")?;
+
+        emit_gateway_actual_state_from_storage(
+            &gateway.connector_event_hub(),
+            &storage,
+            &identity,
+            &gateway,
+        )
+        .await?;
+        info!("initial gateway ACTUAL_STATE emitted");
+
+        // If a pending rotation was resumed on startup, re-emit ACTUAL_STATE
+        // with the updated master_key_id / epoch (GW-2003 AC-5).
+        if pending_rotation_notification.is_some() {
+            emit_gateway_actual_state_from_storage(
+                &gateway.connector_event_hub(),
+                &storage,
+                &identity,
+                &gateway,
+            )
+            .await?;
+            info!("re-emitted ACTUAL_STATE after resumed rotation completion");
+        }
+    }
+
+    // Clone rotation_grpc_tx for admin service wiring inside the reconnect loop.
+    let rotation_grpc_tx_for_admin = rotation_grpc_tx;
+
+    // Spawn ACTUAL_STATE re-emission task (§23.14).
+    {
+        let reemit_storage = Arc::clone(&storage);
+        let reemit_event_hub = gateway.connector_event_hub();
+        let reemit_gateway = Arc::clone(&gateway);
+        let missing_hints_notify = gateway.missing_hints_notify();
+
+        tokio::spawn(async move {
+            /// Debounce interval for missing key hint-triggered re-emission.
+            const HINT_DEBOUNCE: Duration = Duration::from_secs(60);
+
+            let mut hint_debounce: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
+
+            loop {
+                tokio::select! {
+                    biased;
+                    Some(_notification) = rotation_complete_rx.recv() => {
+                        info!("rotation complete — re-emitting gateway ACTUAL_STATE");
+                        if let Err(e) = reemit_gateway_actual_state(
+                            &reemit_event_hub,
+                            &reemit_storage,
+                            &reemit_gateway,
+                        ).await {
+                            error!("failed to re-emit ACTUAL_STATE on rotation complete: {e}");
+                        }
+                    }
+                    Some(_changed) = state_changed_rx.recv() => {
+                        info!("gateway state changed — re-emitting gateway ACTUAL_STATE");
+                        if let Err(e) = reemit_gateway_actual_state(
+                            &reemit_event_hub,
+                            &reemit_storage,
+                            &reemit_gateway,
+                        ).await {
+                            error!("failed to re-emit ACTUAL_STATE on state change: {e}");
+                        }
+                    }
+                    _ = missing_hints_notify.notified() => {
+                        // Start or reset the debounce timer.
+                        hint_debounce = Some(Box::pin(tokio::time::sleep(HINT_DEBOUNCE)));
+                    }
+                    _ = async {
+                        match hint_debounce.as_mut() {
+                            Some(sleep) => sleep.as_mut().await,
+                            None => std::future::pending().await,
+                        }
+                    } => {
+                        hint_debounce = None;
+                        info!("missing hint debounce elapsed — re-emitting gateway ACTUAL_STATE");
+                        if let Err(e) = reemit_gateway_actual_state(
+                            &reemit_event_hub,
+                            &reemit_storage,
+                            &reemit_gateway,
+                        ).await {
+                            error!("failed to re-emit ACTUAL_STATE on missing hints: {e}");
+                        }
+                    }
+                    else => {
+                        info!("ACTUAL_STATE re-emission task: all channels closed, shutting down");
+                        break;
+                    }
+                }
+            }
+        });
+        info!("ACTUAL_STATE re-emission task spawned");
+    }
 
     // 6–9. Modem transport + processing loops with reconnection (GW-1103).
     //
@@ -1191,7 +1361,8 @@ async fn run_gateway(
             Arc::clone(&status_page_scroll_task),
         )
         .with_handler_configs(handler_configs_from_db.clone())
-        .with_handler_router(handler_router.clone());
+        .with_handler_router(handler_router.clone())
+        .with_rotation_tx(rotation_grpc_tx_for_admin.clone());
         let admin_socket = cli.admin_socket.clone();
 
         let mut grpc_handle = tokio::spawn(async move {
@@ -1669,6 +1840,130 @@ async fn run_gateway(
 
     info!("gateway stopped");
     Ok(())
+}
+
+// ── ACTUAL_STATE emission helpers (GW-2003, §23.14) ──────────────────────────
+
+/// Emit a full gateway ACTUAL_STATE by reading all required fields from storage.
+///
+/// Used for the initial startup emission (§23.11 step 9a) where the identity
+/// is already loaded.
+async fn emit_gateway_actual_state_from_storage(
+    event_hub: &sonde_gateway::ConnectorEventHub,
+    storage: &SqliteStorage,
+    identity: &sonde_gateway::GatewayIdentity,
+    gateway: &Gateway,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let entity_id: String = identity
+        .gateway_id()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+
+    let (mk_id, mk_epoch) = storage.init_master_key_id().await?;
+
+    let (_, x25519_public) = identity
+        .to_x25519()
+        .map_err(|e| format!("X25519 conversion failed: {e}"))?;
+
+    let sha = sonde_gateway::RustCryptoSha256;
+    let fp = sonde_protocol::fingerprint::compute_fingerprint(x25519_public.as_bytes(), &sha);
+    let fingerprint_words: [String; 6] = fp.map(|w| w.to_string());
+
+    let channel: u32 = match storage.get_config("espnow_channel").await? {
+        Some(s) => s.parse().unwrap_or(1),
+        None => 1,
+    };
+
+    let salt: Option<Vec<u8>> = match storage.get_config("kdf_salt").await? {
+        Some(s) => {
+            let bytes = hex::decode(&s).map_err(|e| format!("invalid kdf_salt hex: {e}"))?;
+            if bytes.len() == 16 {
+                Some(bytes)
+            } else {
+                warn!(
+                    expected = 16,
+                    actual = bytes.len(),
+                    "kdf_salt in storage has invalid length — treating as absent"
+                );
+                None
+            }
+        }
+        None => None,
+    };
+
+    let kdf_params: Option<sonde_gateway::connector::KdfParams> =
+        match storage.get_config("kdf_params_json").await? {
+            Some(json) => {
+                #[derive(serde::Deserialize)]
+                struct Kdf {
+                    m_cost: u32,
+                    t_cost: u32,
+                    p_cost: u32,
+                    kdf_version: u32,
+                }
+                match serde_json::from_str::<Kdf>(&json) {
+                    Ok(p) => Some(sonde_gateway::connector::KdfParams {
+                        m_cost: p.m_cost,
+                        t_cost: p.t_cost,
+                        p_cost: p.p_cost,
+                        kdf_version: p.kdf_version,
+                    }),
+                    Err(e) => {
+                        warn!("invalid kdf_params_json in storage: {e}");
+                        None
+                    }
+                }
+            }
+            None => None,
+        };
+
+    let missing_key_hints = gateway.drain_missing_hints().await;
+
+    let rotation_in_progress = storage
+        .get_config("pending_rotation_phase")
+        .await?
+        .is_some();
+
+    let gateway_version = env!("CARGO_PKG_VERSION").to_string();
+    let gateway_commit = option_env!("SONDE_GIT_COMMIT")
+        .unwrap_or("unknown")
+        .to_string();
+
+    event_hub.emit_gateway_actual_state(
+        entity_id,
+        channel,
+        mk_id,
+        mk_epoch,
+        *x25519_public.as_bytes(),
+        fingerprint_words,
+        missing_key_hints,
+        salt,
+        kdf_params,
+        gateway_version,
+        gateway_commit,
+        None, // modem_firmware_version — not yet available at this point
+        None, // modem_firmware_commit
+        rotation_in_progress,
+    );
+
+    Ok(())
+}
+
+/// Re-emit gateway ACTUAL_STATE from the re-emission task context.
+///
+/// Loads identity from storage and delegates to [`emit_gateway_actual_state_from_storage`].
+async fn reemit_gateway_actual_state(
+    event_hub: &sonde_gateway::ConnectorEventHub,
+    storage: &SqliteStorage,
+    gateway: &Gateway,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let identity = storage
+        .load_gateway_identity()
+        .await?
+        .ok_or("gateway identity missing for ACTUAL_STATE re-emission")?;
+
+    emit_gateway_actual_state_from_storage(event_hub, storage, &identity, gateway).await
 }
 
 // ── Windows NT service implementation ────────────────────────────────────────

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -945,7 +945,7 @@ async fn run_gateway(
         }
     }
 
-    // 2a. Resume pending rotation if exists (§23.11 step 2a).
+    // 2b. Resume pending rotation if exists (§23.11 step 2b).
     let pending_rotation_notification = {
         let identity = storage
             .load_gateway_identity()

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1920,11 +1920,13 @@ async fn emit_gateway_actual_state_from_storage(
 
     let missing_key_hints = gateway.drain_missing_hints().await;
 
-    let rotation_in_progress = storage
-        .read_pending_rotation()
-        .await
-        .unwrap_or(None)
-        .is_some();
+    let rotation_in_progress = match storage.read_pending_rotation().await {
+        Ok(pending) => pending.is_some(),
+        Err(e) => {
+            warn!("failed to read pending_rotation for ACTUAL_STATE: {e}");
+            false
+        }
+    };
 
     let gateway_version = env!("CARGO_PKG_VERSION").to_string();
     let gateway_commit = option_env!("SONDE_GIT_COMMIT")

--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -411,6 +411,10 @@ impl ConnectorOutboundMessage {
 #[derive(Clone)]
 pub struct ConnectorEventHub {
     tx: broadcast::Sender<ConnectorOutboundMessage>,
+    /// Cached latest gateway ACTUAL_STATE for replay on new subscriber
+    /// connections (GW-2003 AC-4). Protected by a parking_lot Mutex for
+    /// synchronous access from `emit_gateway_actual_state`.
+    cached_gateway_state: Arc<std::sync::Mutex<Option<ConnectorOutboundMessage>>>,
 }
 
 impl Default for ConnectorEventHub {
@@ -423,11 +427,20 @@ impl ConnectorEventHub {
     pub fn new(capacity: usize) -> Self {
         let capacity = capacity.max(1);
         let (tx, _) = broadcast::channel(capacity);
-        Self { tx }
+        Self {
+            tx,
+            cached_gateway_state: Arc::new(std::sync::Mutex::new(None)),
+        }
     }
 
     fn subscribe(&self) -> broadcast::Receiver<ConnectorOutboundMessage> {
         self.tx.subscribe()
+    }
+
+    /// Return the cached latest gateway ACTUAL_STATE for replay to new
+    /// connector subscribers (GW-2003 AC-4).
+    fn cached_gateway_state(&self) -> Option<ConnectorOutboundMessage> {
+        self.cached_gateway_state.lock().ok()?.clone()
     }
 
     /// Number of active connector subscribers (companion processes).
@@ -575,27 +588,28 @@ impl ConnectorEventHub {
         modem_firmware_commit: Option<String>,
         rotation_in_progress: bool,
     ) {
-        let _ = self
-            .tx
-            .send(ConnectorOutboundMessage::GatewayActualState(Box::new(
-                GatewayActualStateData {
-                    entity_id,
-                    timestamp_ms: current_time_ms(),
-                    channel,
-                    master_key_id,
-                    master_key_epoch,
-                    x25519_public_key,
-                    fingerprint_words,
-                    missing_key_hints,
-                    salt,
-                    kdf_params,
-                    gateway_version,
-                    gateway_commit,
-                    modem_firmware_version,
-                    modem_firmware_commit,
-                    rotation_in_progress,
-                },
-            )));
+        let msg = ConnectorOutboundMessage::GatewayActualState(Box::new(GatewayActualStateData {
+            entity_id,
+            timestamp_ms: current_time_ms(),
+            channel,
+            master_key_id,
+            master_key_epoch,
+            x25519_public_key,
+            fingerprint_words,
+            missing_key_hints,
+            salt,
+            kdf_params,
+            gateway_version,
+            gateway_commit,
+            modem_firmware_version,
+            modem_firmware_commit,
+            rotation_in_progress,
+        }));
+        // Cache for replay to new connector subscribers (GW-2003 AC-4).
+        if let Ok(mut cached) = self.cached_gateway_state.lock() {
+            *cached = Some(msg.clone());
+        }
+        let _ = self.tx.send(msg);
     }
 
     pub fn emit_app_data(
@@ -688,6 +702,17 @@ impl ConnectorService {
     {
         let mut framed = Framed::new(stream, connector_codec(self.max_message_size));
         let mut outbound = self.event_hub.subscribe();
+
+        // Replay cached gateway ACTUAL_STATE to new subscriber so it receives
+        // current gateway state without waiting for the next state change
+        // (GW-2003 AC-4 — connector reconnection emission).
+        if let Some(cached) = self.event_hub.cached_gateway_state() {
+            let encoded = cached.encode()?;
+            if let Err(e) = framed.send(Bytes::from(encoded)).await {
+                warn!(error = %e, "failed to send cached gateway ACTUAL_STATE on connect");
+                return Ok(());
+            }
+        }
 
         loop {
             tokio::select! {
@@ -1551,5 +1576,56 @@ mod tests {
                 "escrow inbound channel not configured; message cannot be processed"
             );
         }
+    }
+
+    #[test]
+    fn gateway_actual_state_cached_for_replay() {
+        let hub = ConnectorEventHub::new(4);
+
+        // No cached state initially.
+        assert!(hub.cached_gateway_state().is_none());
+
+        // Emit gateway ACTUAL_STATE.
+        hub.emit_gateway_actual_state(
+            "aabbccdd11223344aabbccdd11223344".to_string(),
+            1,
+            [0x42u8; 16],
+            1,
+            [0x55u8; 32],
+            [
+                "abandon".to_string(),
+                "ability".to_string(),
+                "able".to_string(),
+                "about".to_string(),
+                "above".to_string(),
+                "absent".to_string(),
+            ],
+            vec![],
+            None,
+            None,
+            "0.7.0".to_string(),
+            "abc123".to_string(),
+            None,
+            None,
+            false,
+        );
+
+        // Cached state should now be available.
+        let cached = hub.cached_gateway_state();
+        assert!(cached.is_some());
+
+        // A new subscriber after the emission should still be able to
+        // get the cached state (simulating connector reconnection).
+        let _late_rx = hub.subscribe();
+        let replayed = hub.cached_gateway_state();
+        assert!(replayed.is_some());
+
+        // Verify it encodes correctly.
+        let encoded = replayed.unwrap().encode().unwrap();
+        let decoded = decode_map(&encoded).unwrap();
+        assert_eq!(
+            required_text(&decoded, 3, "entity_id").unwrap(),
+            "aabbccdd11223344aabbccdd11223344"
+        );
     }
 }

--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -412,7 +412,7 @@ impl ConnectorOutboundMessage {
 pub struct ConnectorEventHub {
     tx: broadcast::Sender<ConnectorOutboundMessage>,
     /// Cached latest gateway ACTUAL_STATE for replay on new subscriber
-    /// connections (GW-2003 AC-4). Protected by a parking_lot Mutex for
+    /// connections (GW-2003 AC-4). Protected by `std::sync::Mutex` for
     /// synchronous access from `emit_gateway_actual_state`.
     cached_gateway_state: Arc<std::sync::Mutex<Option<ConnectorOutboundMessage>>>,
 }

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -328,6 +328,10 @@ pub struct Gateway {
     connector_event_hub: Arc<ConnectorEventHub>,
     /// Tracks unknown key_hints for reporting in ACTUAL_STATE (GW-2009).
     missing_hint_tracker: Arc<RwLock<MissingKeyHintTracker>>,
+    /// Signalled when `MissingKeyHintTracker::report()` accepts a new hint,
+    /// allowing the ACTUAL_STATE re-emission task to debounce and re-emit
+    /// (GW-2003 AC-6, §23.14).
+    missing_hints_notify: Arc<tokio::sync::Notify>,
     /// Typed storage reference for pending_recovery access (GW-2009).
     sqlite_storage: Option<Arc<SqliteStorage>>,
     /// Cached master_key_id for pending_recovery lookups (GW-2009).
@@ -351,6 +355,7 @@ impl Gateway {
             deferred_replies: Arc::new(RwLock::new(HashMap::new())),
             connector_event_hub: Arc::new(ConnectorEventHub::default()),
             missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
+            missing_hints_notify: Arc::new(tokio::sync::Notify::new()),
             sqlite_storage: None,
             cached_master_key_id: None,
         }
@@ -381,6 +386,7 @@ impl Gateway {
             deferred_replies: Arc::new(RwLock::new(HashMap::new())),
             connector_event_hub: Arc::new(ConnectorEventHub::default()),
             missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
+            missing_hints_notify: Arc::new(tokio::sync::Notify::new()),
             sqlite_storage: None,
             cached_master_key_id: None,
         }
@@ -404,6 +410,7 @@ impl Gateway {
             deferred_replies: Arc::new(RwLock::new(HashMap::new())),
             connector_event_hub: Arc::new(ConnectorEventHub::default()),
             missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
+            missing_hints_notify: Arc::new(tokio::sync::Notify::new()),
             sqlite_storage: None,
             cached_master_key_id: None,
         }
@@ -460,6 +467,20 @@ impl Gateway {
     /// pending set. Rate-limit timestamps are preserved.
     pub async fn drain_missing_hints(&self) -> Vec<u16> {
         self.missing_hint_tracker.write().await.drain()
+    }
+
+    /// Return a clone of the `Notify` used to signal when the
+    /// `MissingKeyHintTracker` accepts a new hint (GW-2003 AC-6, §23.14).
+    pub fn missing_hints_notify(&self) -> Arc<tokio::sync::Notify> {
+        Arc::clone(&self.missing_hints_notify)
+    }
+
+    /// Record an unknown `key_hint` and notify the ACTUAL_STATE re-emission
+    /// task if the hint was accepted (not rate-limited).
+    async fn report_missing_hint(&self, key_hint: u16) {
+        if self.missing_hint_tracker.write().await.report(key_hint) {
+            self.missing_hints_notify.notify_one();
+        }
     }
 
     /// Process a raw frame using AES-256-GCM authenticated encryption.
@@ -550,7 +571,7 @@ impl Gateway {
             Some(s) => Arc::clone(s),
             None => {
                 // No SQLite storage — can't do recovery. Record and discard.
-                self.missing_hint_tracker.write().await.report(key_hint);
+                self.report_missing_hint(key_hint).await;
                 warn!(
                     key_hint,
                     "discarding frame from unknown node (no recovery storage)"
@@ -564,7 +585,7 @@ impl Gateway {
             Some(kid) => kid,
             None => {
                 warn!(key_hint, "no cached master_key_id — recovery unavailable");
-                self.missing_hint_tracker.write().await.report(key_hint);
+                self.report_missing_hint(key_hint).await;
                 return None;
             }
         };
@@ -579,14 +600,14 @@ impl Gateway {
             Ok(c) => c,
             Err(e) => {
                 warn!(key_hint, "pending_recovery lookup failed: {e}");
-                self.missing_hint_tracker.write().await.report(key_hint);
+                self.report_missing_hint(key_hint).await;
                 return None;
             }
         };
 
         if recovery_candidates.is_empty() {
             // No recovery candidates — record the hint and discard.
-            self.missing_hint_tracker.write().await.report(key_hint);
+            self.report_missing_hint(key_hint).await;
             warn!(
                 key_hint,
                 "discarding frame from unknown node (no pending_recovery match)"
@@ -637,7 +658,7 @@ impl Gateway {
             Some(n) => n,
             None => {
                 // All candidates failed — record hint for reporting.
-                self.missing_hint_tracker.write().await.report(key_hint);
+                self.report_missing_hint(key_hint).await;
                 debug!(
                     key_hint,
                     candidates = recovery_candidates.len(),

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -2135,3 +2135,62 @@ impl Gateway {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn report_missing_hint_fires_notify() {
+        let storage: Arc<dyn Storage> = Arc::new(crate::storage::InMemoryStorage::new());
+        let gw = Gateway::new(storage, Duration::from_secs(300));
+        let notify = gw.missing_hints_notify();
+
+        // Report a new hint — should fire notify.
+        gw.report_missing_hint(0x1234).await;
+
+        // Verify notification is pending (non-blocking check).
+        tokio::time::timeout(Duration::from_millis(50), notify.notified())
+            .await
+            .expect("notify should have been signalled for new hint");
+    }
+
+    #[tokio::test]
+    async fn report_missing_hint_rate_limited_does_not_fire() {
+        let storage: Arc<dyn Storage> = Arc::new(crate::storage::InMemoryStorage::new());
+        let gw = Gateway::new(storage, Duration::from_secs(300));
+        let notify = gw.missing_hints_notify();
+
+        // First report — accepted.
+        gw.report_missing_hint(0xABCD).await;
+        // Consume the notification.
+        tokio::time::timeout(Duration::from_millis(50), notify.notified())
+            .await
+            .expect("first report should fire notify");
+
+        // Second report of same hint — rate-limited.
+        gw.report_missing_hint(0xABCD).await;
+        // Should NOT fire.
+        let result = tokio::time::timeout(Duration::from_millis(50), notify.notified()).await;
+        assert!(result.is_err(), "rate-limited hint should not fire notify");
+    }
+
+    #[tokio::test]
+    async fn drain_missing_hints_returns_reported() {
+        let storage: Arc<dyn Storage> = Arc::new(crate::storage::InMemoryStorage::new());
+        let gw = Gateway::new(storage, Duration::from_secs(300));
+
+        gw.report_missing_hint(0x1111).await;
+        gw.report_missing_hint(0x2222).await;
+
+        let hints = gw.drain_missing_hints().await;
+        assert_eq!(hints.len(), 2);
+        assert!(hints.contains(&0x1111));
+        assert!(hints.contains(&0x2222));
+
+        // Second drain should be empty.
+        let empty = gw.drain_missing_hints().await;
+        assert!(empty.is_empty());
+    }
+}

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -148,17 +148,25 @@ impl RotationEngine {
         }
     }
 
-    /// Handle a full DESIRED_STATE message — process rotation_payload if present,
-    /// then apply salt/KDF-params convergence (GW-2008) and recovered_psks (GW-2009).
+    /// Handle a full DESIRED_STATE message — process channel convergence (GW-2004),
+    /// rotation_payload if present, salt/KDF-params convergence (GW-2008),
+    /// and recovered_psks (GW-2009).
     async fn handle_desired_state(&mut self, state: GatewayDesiredState) {
+        // Channel convergence (GW-2004 AC-1): switch if different from current.
+        let mut state_changed = false;
+        if let Some(desired_channel) = state.channel {
+            state_changed |= self.converge_channel(desired_channel).await;
+        }
+
         if let Some(ref payload) = state.rotation_payload {
             // Errors from DESIRED_STATE rotation are silently discarded per spec.
             let _ = self.handle_rotation_payload(payload, false).await;
         }
 
         // Salt/KDF-params convergence (GW-2008, §23.13).
-        let adopted = self.converge_salt_and_kdf(&state).await;
-        if adopted {
+        state_changed |= self.converge_salt_and_kdf(&state).await;
+
+        if state_changed {
             if let Some(ref tx) = self.state_changed_tx {
                 if tx.send(GatewayStateChanged).is_err() {
                     warn!("state_changed_tx receiver dropped — ACTUAL_STATE re-emission may be missed");
@@ -169,6 +177,57 @@ impl RotationEngine {
         // Process recovered_psks (GW-2009).
         if let Some(records) = state.recovered_psks {
             self.handle_recovered_psks(records).await;
+        }
+    }
+
+    /// Channel convergence (GW-2004 AC-1).
+    ///
+    /// If the desired channel differs from the currently persisted channel,
+    /// update storage. The new channel takes effect on the next modem
+    /// reconnect iteration (the modem transport loop re-reads
+    /// `espnow_channel` from storage on each iteration).
+    ///
+    /// Returns `true` if the channel was changed.
+    async fn converge_channel(&self, desired_channel: u32) -> bool {
+        // Validate range: ESP-NOW channels are 1..=14.
+        if !(1..=14).contains(&desired_channel) {
+            warn!(
+                desired_channel,
+                "ignoring DESIRED_STATE channel outside valid range 1..=14"
+            );
+            return false;
+        }
+
+        let current = match self.storage.get_config("espnow_channel").await {
+            Ok(Some(v)) => v.parse::<u32>().unwrap_or(1),
+            Ok(None) => 1,
+            Err(e) => {
+                warn!("failed to read espnow_channel for convergence: {e}");
+                return false;
+            }
+        };
+
+        if current == desired_channel {
+            return false;
+        }
+
+        match self
+            .storage
+            .set_config("espnow_channel", &desired_channel.to_string())
+            .await
+        {
+            Ok(()) => {
+                info!(
+                    from = current,
+                    to = desired_channel,
+                    "channel converged from DESIRED_STATE — takes effect on next modem reconnect"
+                );
+                true
+            }
+            Err(e) => {
+                error!("failed to persist channel convergence: {e}");
+                false
+            }
         }
     }
 
@@ -973,5 +1032,96 @@ mod tests {
         // Salt unchanged.
         let final_salt = store.get_config("kdf_salt").await.unwrap().unwrap();
         assert_eq!(final_salt, original_salt);
+    }
+
+    /// Channel convergence (GW-2004 AC-1): switch when desired differs,
+    /// no-op when same, reject out-of-range.
+    #[tokio::test]
+    async fn test_channel_convergence() {
+        let master_key = Zeroizing::new([0x42u8; 32]);
+        let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
+        store.set_config("espnow_channel", "1").await.unwrap();
+
+        let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
+        let (_ds_tx, desired_state_rx) = mpsc::unbounded_channel();
+        let identity = crate::gateway_identity::GatewayIdentity::generate().unwrap();
+        let event_hub = Arc::new(ConnectorEventHub::default());
+
+        let (state_tx, mut state_rx) = mpsc::unbounded_channel::<GatewayStateChanged>();
+        let mut engine = RotationEngine::new(
+            Arc::clone(&store),
+            identity,
+            event_hub,
+            grpc_rx,
+            desired_state_rx,
+        )
+        .with_state_changed_tx(state_tx);
+
+        // Switch from 1 to 5 — should converge and notify.
+        let ds = GatewayDesiredState {
+            entity_id: "aa".repeat(16),
+            channel: Some(5),
+            salt: None,
+            kdf_params: None,
+            rotation_payload: None,
+            recovered_psks: None,
+        };
+        engine.handle_desired_state(ds).await;
+
+        assert_eq!(
+            store.get_config("espnow_channel").await.unwrap().unwrap(),
+            "5"
+        );
+        assert!(
+            state_rx.try_recv().is_ok(),
+            "channel change should trigger state_changed notification"
+        );
+
+        // Same channel (5 → 5) — no change, no notification.
+        let ds_same = GatewayDesiredState {
+            entity_id: "aa".repeat(16),
+            channel: Some(5),
+            salt: None,
+            kdf_params: None,
+            rotation_payload: None,
+            recovered_psks: None,
+        };
+        engine.handle_desired_state(ds_same).await;
+        assert!(
+            state_rx.try_recv().is_err(),
+            "same channel should not trigger notification"
+        );
+
+        // Out-of-range channel (0) — rejected.
+        let ds_bad = GatewayDesiredState {
+            entity_id: "aa".repeat(16),
+            channel: Some(0),
+            salt: None,
+            kdf_params: None,
+            rotation_payload: None,
+            recovered_psks: None,
+        };
+        engine.handle_desired_state(ds_bad).await;
+        assert_eq!(
+            store.get_config("espnow_channel").await.unwrap().unwrap(),
+            "5",
+            "out-of-range channel should be rejected"
+        );
+
+        // Out-of-range channel (15) — rejected.
+        let ds_bad2 = GatewayDesiredState {
+            entity_id: "aa".repeat(16),
+            channel: Some(15),
+            salt: None,
+            kdf_params: None,
+            rotation_payload: None,
+            recovered_psks: None,
+        };
+        engine.handle_desired_state(ds_bad2).await;
+        assert_eq!(
+            store.get_config("espnow_channel").await.unwrap().unwrap(),
+            "5",
+            "channel 15 should be rejected"
+        );
     }
 }

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -152,6 +152,22 @@ impl RotationEngine {
     /// rotation_payload if present, salt/KDF-params convergence (GW-2008),
     /// and recovered_psks (GW-2009).
     async fn handle_desired_state(&mut self, state: GatewayDesiredState) {
+        // Verify entity_id matches this gateway (defense-in-depth).
+        let expected_id: String = self
+            .identity
+            .gateway_id()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
+        if state.entity_id != expected_id {
+            warn!(
+                expected = %expected_id,
+                received = %state.entity_id,
+                "ignoring DESIRED_STATE addressed to a different gateway"
+            );
+            return;
+        }
+
         // Channel convergence (GW-2004 AC-1): switch if different from current.
         let mut state_changed = false;
         if let Some(desired_channel) = state.channel {
@@ -770,6 +786,15 @@ mod tests {
     use super::*;
     use crate::sqlite_storage::SqliteStorage;
 
+    /// Derive the hex entity_id from a `GatewayIdentity` for test fixtures.
+    fn entity_id_for(identity: &crate::gateway_identity::GatewayIdentity) -> String {
+        identity
+            .gateway_id()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect()
+    }
+
     #[tokio::test]
     async fn test_rotation_engine_concurrent_check() {
         let master_key = Zeroizing::new([0x42u8; 32]);
@@ -805,6 +830,7 @@ mod tests {
         let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
         let (_ds_tx, desired_state_rx) = mpsc::unbounded_channel();
         let identity = crate::gateway_identity::GatewayIdentity::generate().unwrap();
+        let eid = entity_id_for(&identity);
         let event_hub = Arc::new(ConnectorEventHub::default());
 
         let mut engine = RotationEngine::new(
@@ -829,7 +855,7 @@ mod tests {
             kdf_version: 1,
         };
         let ds = GatewayDesiredState {
-            entity_id: "aa".repeat(16),
+            entity_id: eid.clone(),
             channel: None,
             salt: Some(salt_a.clone()),
             kdf_params: Some(kdf_a.clone()),
@@ -862,7 +888,7 @@ mod tests {
             kdf_version: 2,
         };
         let ds2 = GatewayDesiredState {
-            entity_id: "aa".repeat(16),
+            entity_id: eid.clone(),
             channel: None,
             salt: Some(salt_b),
             kdf_params: Some(kdf_b),
@@ -892,7 +918,7 @@ mod tests {
         // Reset DB to test partial delivery with only salt already set.
         // Salt already set above, so this should be a no-op for salt.
         let ds3 = GatewayDesiredState {
-            entity_id: "aa".repeat(16),
+            entity_id: eid.clone(),
             channel: None,
             salt: Some(vec![0xCCu8; 16]),
             kdf_params: None,
@@ -912,7 +938,7 @@ mod tests {
 
         // ── Step 7: KDF only (no salt) → KDF evaluated, salt unchanged ──
         let ds4 = GatewayDesiredState {
-            entity_id: "aa".repeat(16),
+            entity_id: eid.clone(),
             channel: None,
             salt: None,
             kdf_params: Some(KdfParams {
@@ -945,6 +971,7 @@ mod tests {
         let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
         let (_ds_tx, desired_state_rx) = mpsc::unbounded_channel();
         let identity = crate::gateway_identity::GatewayIdentity::generate().unwrap();
+        let eid = entity_id_for(&identity);
         let event_hub = Arc::new(ConnectorEventHub::default());
 
         let mut engine = RotationEngine::new(
@@ -957,7 +984,7 @@ mod tests {
 
         // Deliver salt with wrong length.
         let ds = GatewayDesiredState {
-            entity_id: "aa".repeat(16),
+            entity_id: eid,
             channel: None,
             salt: Some(vec![0xAAu8; 8]), // 8 bytes, not 16
             kdf_params: None,
@@ -978,6 +1005,7 @@ mod tests {
         let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
 
         let identity = crate::gateway_identity::GatewayIdentity::generate().unwrap();
+        let eid = entity_id_for(&identity);
 
         // First engine instance: adopt salt.
         {
@@ -993,7 +1021,7 @@ mod tests {
             );
 
             let ds = GatewayDesiredState {
-                entity_id: "aa".repeat(16),
+                entity_id: eid.clone(),
                 channel: None,
                 salt: Some(vec![0x11u8; 16]),
                 kdf_params: None,
@@ -1019,7 +1047,7 @@ mod tests {
             );
 
             let ds = GatewayDesiredState {
-                entity_id: "aa".repeat(16),
+                entity_id: eid.clone(),
                 channel: None,
                 salt: Some(vec![0x22u8; 16]),
                 kdf_params: None,
@@ -1045,6 +1073,7 @@ mod tests {
         let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
         let (_ds_tx, desired_state_rx) = mpsc::unbounded_channel();
         let identity = crate::gateway_identity::GatewayIdentity::generate().unwrap();
+        let eid = entity_id_for(&identity);
         let event_hub = Arc::new(ConnectorEventHub::default());
 
         let (state_tx, mut state_rx) = mpsc::unbounded_channel::<GatewayStateChanged>();
@@ -1059,7 +1088,7 @@ mod tests {
 
         // Switch from 1 to 5 — should converge and notify.
         let ds = GatewayDesiredState {
-            entity_id: "aa".repeat(16),
+            entity_id: eid.clone(),
             channel: Some(5),
             salt: None,
             kdf_params: None,
@@ -1079,7 +1108,7 @@ mod tests {
 
         // Same channel (5 → 5) — no change, no notification.
         let ds_same = GatewayDesiredState {
-            entity_id: "aa".repeat(16),
+            entity_id: eid.clone(),
             channel: Some(5),
             salt: None,
             kdf_params: None,
@@ -1094,7 +1123,7 @@ mod tests {
 
         // Out-of-range channel (0) — rejected.
         let ds_bad = GatewayDesiredState {
-            entity_id: "aa".repeat(16),
+            entity_id: eid.clone(),
             channel: Some(0),
             salt: None,
             kdf_params: None,
@@ -1110,7 +1139,7 @@ mod tests {
 
         // Out-of-range channel (15) — rejected.
         let ds_bad2 = GatewayDesiredState {
-            entity_id: "aa".repeat(16),
+            entity_id: eid.clone(),
             channel: Some(15),
             salt: None,
             kdf_params: None,

--- a/crates/sonde-gateway/tests/node_recovery.rs
+++ b/crates/sonde-gateway/tests/node_recovery.rs
@@ -280,6 +280,12 @@ async fn test_t2006b_mismatched_master_key_id_skipped() {
         .unwrap()
         .unwrap_or_else(|| GatewayIdentity::generate().unwrap());
 
+    let entity_id: String = identity
+        .gateway_id()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+
     let (_, grpc_rx) = tokio::sync::mpsc::unbounded_channel();
     let (ds_tx, ds_rx) = tokio::sync::mpsc::unbounded_channel();
     let event_hub = Arc::new(ConnectorEventHub::default());
@@ -291,7 +297,7 @@ async fn test_t2006b_mismatched_master_key_id_skipped() {
     let encrypted_psk = encrypt_psk(&master_key, "orphan-node", &TEST_PSK).unwrap();
 
     let desired_state = GatewayDesiredState {
-        entity_id: "gateway-1".to_string(),
+        entity_id,
         channel: None,
         salt: None,
         kdf_params: None,

--- a/crates/sonde-gateway/tests/node_recovery.rs
+++ b/crates/sonde-gateway/tests/node_recovery.rs
@@ -125,11 +125,17 @@ async fn test_t2006_declarative_node_recovery() {
             id
         });
 
+    let entity_id: String = identity
+        .gateway_id()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect();
+
     let engine = RotationEngine::new(store.clone(), identity, event_hub, grpc_rx, ds_rx);
 
     // Send the DESIRED_STATE with recovered_psks through the channel.
     let desired_state = GatewayDesiredState {
-        entity_id: "gateway-1".to_string(),
+        entity_id,
         channel: None,
         salt: None,
         kdf_params: None,

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -2121,7 +2121,8 @@ step 9a is inline.
 1. `rotation_complete_rx` — receives `RotationCompleteNotification` from
    `RotationEngine` after a successful rotation. Re-emit immediately.
 2. `state_changed_rx` — receives `GatewayStateChanged` from
-   `RotationEngine` after salt/KDF-params adoption. Re-emit immediately.
+   `RotationEngine` after channel convergence, salt/KDF-params adoption,
+   or other non-rotation state changes. Re-emit immediately.
 3. `missing_hints_notify` — a `tokio::sync::Notify` signalled by the
    `Gateway` engine when `MissingKeyHintTracker::report()` accepts a new
    hint. On notification, start a 60-second debounce timer. If the timer

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -2137,7 +2137,7 @@ On each trigger, the task:
 3. Reads `master_key_id`, `master_key_epoch`, `espnow_channel`,
    `kdf_salt`, `kdf_params_json` from `gateway_config`.
 4. Drains `missing_key_hints` from the gateway engine's tracker.
-5. Reads `pending_rotation_phase` to determine `rotation_in_progress`.
+5. Checks `storage.read_pending_rotation()` to determine `rotation_in_progress`.
 6. Calls `emit_gateway_actual_state()` on the connector event hub.
 
 **Hint notification mechanism:**

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -2032,16 +2032,41 @@ shared in `sonde-protocol`.
 
 Insert after step 2 (initialize storage):
 
-> 2a. Check `pending_rotation` — resume rotation if exists.
-> 2b. Load `GatewayIdentity`, derive X25519 public key.
-> 2c. Load/generate `master_key_id` and `master_key_epoch`.
-> 2d. Load/generate `rotation_code`.
+> 2a. Check `pending_rotation` — call
+>     `RotationEngine::resume_pending_rotation(&storage, &identity)`.
+>     If it returns `Some(notification)`, cache the notification for
+>     gateway ACTUAL_STATE re-emission after the connector starts.
+> 2b. Load `GatewayIdentity`, derive X25519 public key (already done
+>     by the existing identity-loading block).
+> 2c. Load/generate `master_key_id` and `master_key_epoch` via
+>     `storage.init_master_key_id()`.
+> 2d. Load/generate `rotation_code` via `storage.init_rotation_code()`.
+
+Insert between connector creation and modem transport setup:
+
+> Wire rotation and DESIRED_STATE channels:
+>
+> 1. Create `mpsc::unbounded_channel::<GatewayDesiredState>()` — pass
+>    sender to `connector_service.set_gateway_desired_state_tx(tx)`,
+>    pass receiver to `RotationEngine::new()`.
+> 2. Create `mpsc::unbounded_channel()` for gRPC rotation submissions —
+>    pass sender to `AdminService::with_rotation_tx(tx)`, pass receiver
+>    to `RotationEngine::new()`.
+> 3. Create `mpsc::unbounded_channel::<RotationCompleteNotification>()`
+>    and `mpsc::unbounded_channel::<GatewayStateChanged>()` — subscribe
+>    via `RotationEngine::with_rotation_complete_tx()` and
+>    `with_state_changed_tx()`.
+> 4. Spawn `RotationEngine::run()` as a tokio task.
+> 5. Spawn the ACTUAL_STATE re-emission task (§23.14).
 
 Insert after step 9 (start connector):
 
-> 9a. Emit gateway ACTUAL_STATE.
-> 9b. Compute BIP-39 fingerprint.
+> 9a. Emit gateway ACTUAL_STATE via
+>     `connector_event_hub.emit_gateway_actual_state()` with all
+>     current state fields.
+> 9b. Compute BIP-39 fingerprint. *(deferred to follow-up issue)*
 > 9c. Register fingerprint + rotation code as modem display pages.
+>     *(deferred to follow-up issue)*
 
 ### 23.12  gRPC rotation API (GW-2012)
 
@@ -2083,3 +2108,41 @@ for salt and KDF parameters from gateway DESIRED_STATE, per evolve-962 §2.5.
 6. **Rotation-path update:** Salt and KDF params can also be updated via
    rotation payload delivery — already handled by `commit_rotation()` in
    §23.7.
+
+### 23.14  ACTUAL_STATE re-emission task (GW-2003)
+
+The gateway binary spawns a single tokio task that listens for state-change
+events and re-emits a full gateway ACTUAL_STATE on each trigger. This task
+is the single owner of re-emission logic; the initial startup emission in
+step 9a is inline.
+
+**Trigger sources (via `tokio::select!`):**
+
+1. `rotation_complete_rx` — receives `RotationCompleteNotification` from
+   `RotationEngine` after a successful rotation. Re-emit immediately.
+2. `state_changed_rx` — receives `GatewayStateChanged` from
+   `RotationEngine` after salt/KDF-params adoption. Re-emit immediately.
+3. `missing_hints_notify` — a `tokio::sync::Notify` signalled by the
+   `Gateway` engine when `MissingKeyHintTracker::report()` accepts a new
+   hint. On notification, start a 60-second debounce timer. If the timer
+   completes without interruption, drain hints and re-emit. Additional
+   notifications during the debounce window reset the timer to coalesce
+   concurrent hint arrivals.
+
+**Re-emission procedure:**
+
+On each trigger, the task:
+1. Loads the current gateway identity from storage.
+2. Derives the X25519 public key and BIP-39 fingerprint.
+3. Reads `master_key_id`, `master_key_epoch`, `espnow_channel`,
+   `kdf_salt`, `kdf_params_json` from `gateway_config`.
+4. Drains `missing_key_hints` from the gateway engine's tracker.
+5. Reads `pending_rotation_phase` to determine `rotation_in_progress`.
+6. Calls `emit_gateway_actual_state()` on the connector event hub.
+
+**Hint notification mechanism:**
+
+`Gateway` exposes `pub fn missing_hints_notify(&self) -> Arc<Notify>`.
+The `MissingKeyHintTracker` integration in `process_frame` calls
+`notify.notify_one()` when `report()` returns `true` (hint accepted).
+The re-emission task awaits `notify.notified()`.

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -2032,12 +2032,12 @@ shared in `sonde-protocol`.
 
 Insert after step 2 (initialize storage):
 
-> 2a. Check `pending_rotation` — call
+> 2a. Load `GatewayIdentity`, derive X25519 public key (already done
+>     by the existing identity-loading block before these steps).
+> 2b. Check `pending_rotation` — call
 >     `RotationEngine::resume_pending_rotation(&storage, &identity)`.
 >     If it returns `Some(notification)`, cache the notification for
 >     gateway ACTUAL_STATE re-emission after the connector starts.
-> 2b. Load `GatewayIdentity`, derive X25519 public key (already done
->     by the existing identity-loading block).
 > 2c. Load/generate `master_key_id` and `master_key_epoch` via
 >     `storage.init_master_key_id()`.
 > 2d. Load/generate `rotation_code` via `storage.init_rotation_code()`.

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2621,6 +2621,12 @@ whenever gateway state changes.
 2. `entity_kind = "gateway"`, `entity_id = hex(gateway_id)`.
 3. Node-specific CBOR keys 4–8, 10–11 are absent.
 4. Emitted on startup and connector reconnection.
+5. Re-emitted on rotation completion with updated `master_key_id` and
+   `master_key_epoch`.
+6. Re-emitted within 60 seconds when `MissingKeyHintTracker` accepts a
+   previously-unseen `key_hint`, using a debounce window to coalesce
+   concurrent arrivals.
+7. Re-emitted when salt or KDF params are adopted from DESIRED_STATE.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4482,17 +4482,15 @@ A configurable stub handler process (or in-process mock) that:
 2. Verify initial gateway ACTUAL_STATE received (empty `missing_key_hints`).
 3. Send a frame with an unknown `key_hint` (not matching any registered node).
 4. Verify no immediate ACTUAL_STATE re-emission within 30 seconds.
-5. Wait 60 seconds from the unknown-hint frame.
-6. Verify gateway ACTUAL_STATE re-emitted with `missing_key_hints` containing
-   the unknown hint value.
-7. Send another frame with a different unknown `key_hint` within 10 seconds.
-8. Wait 60 seconds from the second frame.
-9. Verify ACTUAL_STATE re-emitted with both hints (if first not yet drained)
-   or just the new one.
+5. Send another frame with a different unknown `key_hint` (within the
+   60-second debounce window of step 3).
+6. Wait 60 seconds from the second frame (debounce timer resets).
+7. Verify gateway ACTUAL_STATE re-emitted with `missing_key_hints` containing
+   both unknown hint values in a single coalesced emission.
 
 **Expected:**
-1. ACTUAL_STATE re-emission is debounced: no emission during the 60-second
-   window, then a single emission containing all accumulated hints.
+1. ACTUAL_STATE re-emission is debounced: a second hint during the window
+   resets the timer, and a single emission contains all accumulated hints.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4473,6 +4473,67 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-2011  Missing key hint triggers debounced ACTUAL_STATE re-emission
+
+**Traces to:** GW-2003 (AC-6)
+
+**Steps:**
+1. Start gateway with identity, master key, and a connector consumer.
+2. Verify initial gateway ACTUAL_STATE received (empty `missing_key_hints`).
+3. Send a frame with an unknown `key_hint` (not matching any registered node).
+4. Verify no immediate ACTUAL_STATE re-emission within 30 seconds.
+5. Wait 60 seconds from the unknown-hint frame.
+6. Verify gateway ACTUAL_STATE re-emitted with `missing_key_hints` containing
+   the unknown hint value.
+7. Send another frame with a different unknown `key_hint` within 10 seconds.
+8. Wait 60 seconds from the second frame.
+9. Verify ACTUAL_STATE re-emitted with both hints (if first not yet drained)
+   or just the new one.
+
+**Expected:**
+1. ACTUAL_STATE re-emission is debounced: no emission during the 60-second
+   window, then a single emission containing all accumulated hints.
+
+---
+
+### T-2012  Rotation complete triggers ACTUAL_STATE re-emission
+
+**Traces to:** GW-2003 (AC-5)
+
+**Steps:**
+1. Start gateway with identity, master key, and a connector consumer.
+2. Verify initial gateway ACTUAL_STATE received.
+3. Record the initial `master_key_id` and `master_key_epoch`.
+4. Submit a valid rotation payload (via gRPC or DESIRED_STATE).
+5. Verify gateway ACTUAL_STATE re-emitted after rotation completes.
+6. Verify `master_key_id` and `master_key_epoch` in the new ACTUAL_STATE
+   differ from the initial values.
+
+**Expected:**
+1. Gateway ACTUAL_STATE re-emitted with updated key material after rotation.
+
+---
+
+### T-2013  Salt/KDF adoption triggers ACTUAL_STATE re-emission
+
+**Traces to:** GW-2003 (AC-7)
+
+**Steps:**
+1. Start gateway with no local salt or KDF params.
+2. Connect a connector consumer and verify initial ACTUAL_STATE
+   (salt = null, kdf_params = null).
+3. Deliver a gateway DESIRED_STATE with `salt` (16 bytes) and `kdf_params`.
+4. Verify gateway ACTUAL_STATE re-emitted with the adopted `salt` and
+   `kdf_params` values.
+5. Deliver another DESIRED_STATE with different salt.
+6. Verify ACTUAL_STATE is NOT re-emitted (local salt is immutable).
+
+**Expected:**
+1. First adoption triggers ACTUAL_STATE re-emission with new values.
+2. Subsequent DESIRED_STATE with different salt does not trigger re-emission.
+
+---
+
 | GW-1306 | T-1306a, T-1306b, T-1306c, T-1306d |
 | GW-1307 | T-1307a, T-1307b, T-1307c, T-1307d, T-1307e, T-1307f, T-1307g, T-1307h, T-1307i |
 | GW-1308 | T-1308 |
@@ -4508,7 +4569,7 @@ A configurable stub handler process (or in-process mock) that:
 | GW-2000 | T-2001 |
 | GW-2001 | T-2000 |
 | GW-2002 | T-2003 |
-| GW-2003 | T-2001 |
+| GW-2003 | T-2001, T-2011, T-2012, T-2013 |
 | GW-2004 | T-2002 |
 | GW-2005 | T-2001, T-2006c |
 | GW-2006 | T-2004, T-2004a |


### PR DESCRIPTION
## Summary

Wire the gateway binary startup sequence to call existing library infrastructure for ACTUAL_STATE publication and DESIRED_STATE handling, completing the binary-level plumbing for the escrow/rotation subsystem.

Closes #1071

## Changes

### Binary startup (in/gateway.rs)

- **Step 2a**: Call `RotationEngine::resume_pending_rotation()` to recover crash-interrupted rotations; re-emit ACTUAL_STATE if a pending rotation was completed.
- **Steps 2c/2d**: Initialize `master_key_id`/`master_key_epoch` and `rotation_code`.
- **Channel wiring**: Create and wire DESIRED_STATE channel (connector → rotation engine), rotation gRPC channel (admin → rotation engine), `rotation_complete` and `state_changed` notification channels.
- **RotationEngine**: Construct with all channels and spawn as tokio task.
- **AdminService**: Wire `.with_rotation_tx()` for gRPC rotation submissions.
- **Initial ACTUAL_STATE (§23.11 step 9a)**: Emit with all required fields after connector starts.
- **Re-emission task (§23.14)**: Spawn a tokio task with three trigger sources:
  1. `rotation_complete_rx` — immediate re-emission on rotation complete
  2. `state_changed_rx` — immediate re-emission on salt/KDF adoption
  3. `missing_hints_notify` — 60-second debounced re-emission on new missing key hints

### Engine (ngine.rs)

- Add `missing_hints_notify: Arc<Notify>` to `Gateway` struct (all 3 constructors).
- Add `report_missing_hint()` helper combining `report()` + `notify_one()` for all 5 call sites in the frame processing path.
- Add `missing_hints_notify()` accessor for the re-emission task.

### Specification updates

- **GW-2003**: Add AC-5 (rotation complete re-emission), AC-6 (60s debounced hint re-emission), AC-7 (salt/KDF adoption re-emission).
- **§23.11**: Expand startup sequence with detailed wiring steps.
- **§23.14** (new): ACTUAL_STATE re-emission task design — trigger sources, re-emission procedure, hint notification mechanism.
- **T-2011, T-2012, T-2013**: New validation entries for re-emission triggers.

## Follow-up

- Display pages (§23.11 steps 9b-9c) deferred to #1075.

## Testing

- `cargo test --workspace` — all tests pass
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all` — applied