### PR TITLE
feat: environment settings import/export for web UI

### DIFF
--- a/crates/sonde-azure-companion/src/main.rs
+++ b/crates/sonde-azure-companion/src/main.rs
@@ -55,6 +55,7 @@ const DEFAULT_BOOTSTRAP_IMAGE_REPOSITORY: &str = "ghcr.io/alan-jowett/sonde-azur
 const CERT_PEM_FILENAME: &str = "cert.pem";
 const KEY_PEM_FILENAME: &str = "key.pem";
 const STORAGE_QUEUES_CONFIG_FILENAME: &str = "storage-queues.json";
+const WEB_UI_ENVIRONMENT_FILENAME: &str = "web-ui-environment.json";
 const STAGING_DIR_NAME: &str = ".staging";
 const ACTIVE_STATE_FILENAME: &str = ".current-state";
 const STATE_GENERATION_PREFIX: &str = ".state-";
@@ -217,6 +218,28 @@ struct StorageQueuesConfigFile {
     downstream_queue: String,
 }
 
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+struct WebUiEnvironmentFile {
+    version: u8,
+    name: String,
+    #[serde(rename = "clientId")]
+    client_id: String,
+    #[serde(rename = "tenantId")]
+    tenant_id: String,
+    #[serde(rename = "storageAccount")]
+    storage_account: String,
+    #[serde(rename = "functionAppName")]
+    function_app_name: String,
+}
+
+/// Artifacts produced by parsing Bicep deployment outputs.
+#[derive(Debug)]
+struct BootstrapArtifacts {
+    service_principal: ServicePrincipalStateFile,
+    storage_queues: StorageQueuesConfigFile,
+    web_ui_environment: WebUiEnvironmentFile,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RuntimeCredentialState {
     tenant_id: String,
@@ -269,6 +292,16 @@ struct BicepBootstrapValues {
         deserialize_with = "deserialize_bicep_string"
     )]
     downstream_queue: String,
+    #[serde(
+        rename = "storageAccountName",
+        deserialize_with = "deserialize_bicep_string"
+    )]
+    storage_account_name: String,
+    #[serde(
+        rename = "functionAppName",
+        deserialize_with = "deserialize_bicep_string"
+    )]
+    function_app_name: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1323,9 +1356,7 @@ fn validate_certificate_matches_private_key(
     Ok(())
 }
 
-fn parse_bicep_outputs(
-    json: &str,
-) -> Result<(ServicePrincipalStateFile, StorageQueuesConfigFile), CompanionError> {
+fn parse_bicep_outputs(json: &str) -> Result<BootstrapArtifacts, CompanionError> {
     let outputs: BicepOutputs = serde_json::from_str(json).map_err(|e| {
         CompanionError::Config(format!("failed to parse Bicep deployment outputs: {e}"))
     })?;
@@ -1336,8 +1367,8 @@ fn parse_bicep_outputs(
         })?;
 
     let sp = ServicePrincipalStateFile {
-        tenant_id: bootstrap_values.tenant_id,
-        client_id: bootstrap_values.client_id,
+        tenant_id: bootstrap_values.tenant_id.clone(),
+        client_id: bootstrap_values.client_id.clone(),
         login_endpoint: Some(bootstrap_values.login_endpoint),
         certificate_path: CERT_PEM_FILENAME.to_string(),
         private_key_path: KEY_PEM_FILENAME.to_string(),
@@ -1349,7 +1380,20 @@ fn parse_bicep_outputs(
         downstream_queue: bootstrap_values.downstream_queue,
     };
 
-    Ok((sp, sb))
+    let web_ui = WebUiEnvironmentFile {
+        version: 1,
+        name: String::new(),
+        client_id: bootstrap_values.client_id,
+        tenant_id: bootstrap_values.tenant_id,
+        storage_account: bootstrap_values.storage_account_name,
+        function_app_name: bootstrap_values.function_app_name,
+    };
+
+    Ok(BootstrapArtifacts {
+        service_principal: sp,
+        storage_queues: sb,
+        web_ui_environment: web_ui,
+    })
 }
 
 fn default_bootstrap_image() -> String {
@@ -2160,7 +2204,7 @@ async fn run_bootstrap_deployment(
     admin_socket: &str,
     cert_base64: &str,
     args: &BootstrapArgs,
-) -> Result<(ServicePrincipalStateFile, StorageQueuesConfigFile), CompanionError> {
+) -> Result<BootstrapArtifacts, CompanionError> {
     let docker = Docker::connect_with_local_defaults()
         .map_err(|e| CompanionError::Config(format!("failed to connect to Docker daemon: {e}")))?;
     run_bootstrap_deployment_with_docker(&docker, admin_socket, cert_base64, args).await
@@ -2171,7 +2215,7 @@ async fn run_bootstrap_deployment_with_docker(
     admin_socket: &str,
     cert_base64: &str,
     args: &BootstrapArgs,
-) -> Result<(ServicePrincipalStateFile, StorageQueuesConfigFile), CompanionError> {
+) -> Result<BootstrapArtifacts, CompanionError> {
     let bootstrap_image = resolve_bootstrap_image(args.bootstrap_image.as_deref())?;
     run_bootstrap_deployment_with_docker_and_image(
         docker,
@@ -2189,7 +2233,7 @@ async fn run_bootstrap_deployment_with_docker_and_image(
     cert_base64: &str,
     args: &BootstrapArgs,
     bootstrap_image: &str,
-) -> Result<(ServicePrincipalStateFile, StorageQueuesConfigFile), CompanionError> {
+) -> Result<BootstrapArtifacts, CompanionError> {
     eprintln!("Pulling bootstrap image...");
     let pull_opts = CreateImageOptionsBuilder::default()
         .from_image(bootstrap_image)
@@ -2336,11 +2380,10 @@ async fn bootstrap(
         return Err(err);
     }
     eprintln!("Starting sonde-azure-bootstrap for device-code auth and Bicep deployment");
-    let (sp_state, sb_config) =
-        match run_bootstrap_deployment(admin_socket, &cert_base64, &args).await {
-            Ok(result) => result,
-            Err(e) => return report_bootstrap_failure(admin_socket, &staging_dir, e).await,
-        };
+    let artifacts = match run_bootstrap_deployment(admin_socket, &cert_base64, &args).await {
+        Ok(artifacts) => artifacts,
+        Err(e) => return report_bootstrap_failure(admin_socket, &staging_dir, e).await,
+    };
 
     if let Err(err) = display_progress(admin_socket, "Writing config...").await {
         cleanup_staging(&staging_dir);
@@ -2349,12 +2392,16 @@ async fn bootstrap(
     eprintln!("Writing runtime artifacts to state volume");
 
     let sp_path = staging_dir.join(SERVICE_PRINCIPAL_STATE_FILENAME);
-    let sp_json = serde_json::to_string_pretty(&sp_state)?;
+    let sp_json = serde_json::to_string_pretty(&artifacts.service_principal)?;
     std::fs::write(&sp_path, sp_json.as_bytes())?;
 
     let sb_path = staging_dir.join(STORAGE_QUEUES_CONFIG_FILENAME);
-    let sb_json = serde_json::to_string_pretty(&sb_config)?;
+    let sb_json = serde_json::to_string_pretty(&artifacts.storage_queues)?;
     std::fs::write(&sb_path, sb_json.as_bytes())?;
+
+    let web_ui_path = staging_dir.join(WEB_UI_ENVIRONMENT_FILENAME);
+    let web_ui_json = serde_json::to_string_pretty(&artifacts.web_ui_environment)?;
+    std::fs::write(&web_ui_path, web_ui_json.as_bytes())?;
 
     if let Err(e) = commit_staging(&staging_dir, state_dir) {
         return report_bootstrap_failure(admin_socket, &staging_dir, e).await;
@@ -2850,9 +2897,10 @@ mod tests {
         trim_buffer_to_max_len, urlencoding_encode, validate_display_lines, write_framed,
         ClientAssertionCredential, CompanionError, DownstreamConsumer, RuntimeConfig,
         RuntimeCredentialState, ServicePrincipalStateFile, StorageQueuesConfigFile,
-        UpstreamPublisher, ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME, CONNECTOR_MAX_FRAME_LENGTH,
-        DEFAULT_LOGIN_ENDPOINT, KEY_PEM_FILENAME, SERVICE_PRINCIPAL_STATE_FILENAME,
-        STAGING_DIR_NAME, STATE_GENERATION_PREFIX, STORAGE_QUEUES_CONFIG_FILENAME,
+        UpstreamPublisher, WebUiEnvironmentFile, ACTIVE_STATE_FILENAME, CERT_PEM_FILENAME,
+        CONNECTOR_MAX_FRAME_LENGTH, DEFAULT_LOGIN_ENDPOINT, KEY_PEM_FILENAME,
+        SERVICE_PRINCIPAL_STATE_FILENAME, STAGING_DIR_NAME, STATE_GENERATION_PREFIX,
+        STORAGE_QUEUES_CONFIG_FILENAME, WEB_UI_ENVIRONMENT_FILENAME,
     };
     #[cfg(windows)]
     use super::{
@@ -3759,14 +3807,16 @@ mod tests {
                     "loginEndpoint": "https://login.microsoftonline.com/",
                     "storageQueueEndpoint": "https://example.queue.core.windows.net",
                     "upstreamQueue": "upstream",
-                    "downstreamQueue": "downstream"
+                    "downstreamQueue": "downstream",
+                    "storageAccountName": "examplestorage",
+                    "functionAppName": "sonde-decoder-abc123"
                 }
             }
         }"#;
 
-        let (sp, sb) = parse_bicep_outputs(json).unwrap();
+        let artifacts = parse_bicep_outputs(json).unwrap();
         assert_eq!(
-            sp,
+            artifacts.service_principal,
             ServicePrincipalStateFile {
                 tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
                 client_id: "22222222-2222-2222-2222-222222222222".to_string(),
@@ -3776,11 +3826,22 @@ mod tests {
             }
         );
         assert_eq!(
-            sb,
+            artifacts.storage_queues,
             StorageQueuesConfigFile {
                 queue_endpoint: "https://example.queue.core.windows.net".to_string(),
                 upstream_queue: "upstream".to_string(),
                 downstream_queue: "downstream".to_string(),
+            }
+        );
+        assert_eq!(
+            artifacts.web_ui_environment,
+            WebUiEnvironmentFile {
+                version: 1,
+                name: String::new(),
+                client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+                tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+                storage_account: "examplestorage".to_string(),
+                function_app_name: "sonde-decoder-abc123".to_string(),
             }
         );
     }
@@ -3795,21 +3856,42 @@ mod tests {
                     "loginEndpoint": { "value": "https://login.microsoftonline.com/" },
                     "storageQueueEndpoint": { "value": "https://example.queue.core.windows.net" },
                     "upstreamQueue": { "value": "upstream" },
-                    "downstreamQueue": { "value": "downstream" }
+                    "downstreamQueue": { "value": "downstream" },
+                    "storageAccountName": { "value": "examplestorage" },
+                    "functionAppName": { "value": "sonde-decoder-abc123" }
                 }
             }
         }"#;
 
-        let (sp, sb) = parse_bicep_outputs(json).unwrap();
-        assert_eq!(sp.tenant_id, "11111111-1111-1111-1111-111111111111");
-        assert_eq!(sp.client_id, "22222222-2222-2222-2222-222222222222");
+        let artifacts = parse_bicep_outputs(json).unwrap();
         assert_eq!(
-            sp.login_endpoint.as_deref(),
+            artifacts.service_principal.tenant_id,
+            "11111111-1111-1111-1111-111111111111"
+        );
+        assert_eq!(
+            artifacts.service_principal.client_id,
+            "22222222-2222-2222-2222-222222222222"
+        );
+        assert_eq!(
+            artifacts.service_principal.login_endpoint.as_deref(),
             Some("https://login.microsoftonline.com/")
         );
-        assert_eq!(sb.queue_endpoint, "https://example.queue.core.windows.net");
-        assert_eq!(sb.upstream_queue, "upstream");
-        assert_eq!(sb.downstream_queue, "downstream");
+        assert_eq!(
+            artifacts.storage_queues.queue_endpoint,
+            "https://example.queue.core.windows.net"
+        );
+        assert_eq!(artifacts.storage_queues.upstream_queue, "upstream");
+        assert_eq!(artifacts.storage_queues.downstream_queue, "downstream");
+        assert_eq!(
+            artifacts.web_ui_environment.storage_account,
+            "examplestorage"
+        );
+        assert_eq!(
+            artifacts.web_ui_environment.function_app_name,
+            "sonde-decoder-abc123"
+        );
+        assert_eq!(artifacts.web_ui_environment.version, 1);
+        assert_eq!(artifacts.web_ui_environment.name, "");
     }
 
     #[test]
@@ -3821,7 +3903,9 @@ mod tests {
                     "clientId": "22222222-2222-2222-2222-222222222222",
                     "storageQueueEndpoint": "https://example.queue.core.windows.net",
                     "upstreamQueue": "upstream",
-                    "downstreamQueue": "downstream"
+                    "downstreamQueue": "downstream",
+                    "storageAccountName": "examplestorage",
+                    "functionAppName": "sonde-decoder-abc123"
                 }
             }
         }"#;
@@ -3830,6 +3914,45 @@ mod tests {
         assert!(err
             .to_string()
             .contains("failed to parse companionBootstrapValues"));
+    }
+
+    #[test]
+    fn test_web_ui_environment_file_round_trip() {
+        let env = WebUiEnvironmentFile {
+            version: 1,
+            name: String::new(),
+            client_id: "22222222-2222-2222-2222-222222222222".to_string(),
+            tenant_id: "11111111-1111-1111-1111-111111111111".to_string(),
+            storage_account: "examplestorage".to_string(),
+            function_app_name: "sonde-decoder-abc123".to_string(),
+        };
+        let json = serde_json::to_string_pretty(&env).unwrap();
+        let parsed: WebUiEnvironmentFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(env, parsed);
+        assert!(json.contains(r#""version": 1"#));
+        assert!(json.contains(r#""name": """#));
+        assert!(json.contains(r#""clientId":"#));
+        assert!(json.contains(r#""tenantId":"#));
+        assert!(json.contains(r#""storageAccount":"#));
+        assert!(json.contains(r#""functionAppName":"#));
+    }
+
+    #[test]
+    fn test_check_runtime_ready_ignores_missing_web_ui_environment() {
+        let temp = TempDir::new().unwrap();
+        write_service_principal_state(&temp);
+        write_storage_queues_config(
+            &temp,
+            "https://example.queue.core.windows.net",
+            "upstream",
+            "downstream",
+        );
+        // Deliberately do NOT write web-ui-environment.json.
+        let result = check_runtime_ready(temp.path());
+        assert!(
+            result.is_ok(),
+            "check_runtime_ready must not depend on {WEB_UI_ENVIRONMENT_FILENAME}"
+        );
     }
 
     #[test]

--- a/deploy/bicep/main.bicep
+++ b/deploy/bicep/main.bicep
@@ -146,6 +146,7 @@ output companionBootstrapValues object = {
   storageQueueEndpoint: stack.outputs.queueServiceUri
   upstreamQueue: stack.outputs.upstreamQueueName
   downstreamQueue: stack.outputs.downstreamQueueName
+  storageAccountName: stack.outputs.storageAccountName
   functionAppName: stack.outputs.functionAppName
   deploymentContainerName: stack.outputs.deploymentContainerName
   deploymentContainerUrl: stack.outputs.deploymentContainerUrl

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -74,7 +74,144 @@ function loadActiveEnvironment() {
   return env;
 }
 
-const STORAGE_SCOPES = ['https://storage.azure.com/.default'];
+// 1b. Environment field validation helpers (shared by manual form and import)
+const ENV_GUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const ENV_STORAGE_ACCOUNT_PATTERN = /^[a-z0-9]{3,24}$/;
+const ENV_FUNCTION_APP_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,58}[a-zA-Z0-9]$/;
+
+function validateEnvironmentFields(fields) {
+  if (!fields.clientId || typeof fields.clientId !== 'string') return 'Client ID is required.';
+  if (!fields.tenantId || typeof fields.tenantId !== 'string') return 'Tenant ID is required.';
+  if (!fields.storageAccount || typeof fields.storageAccount !== 'string') return 'Storage Account is required.';
+  if (!fields.functionAppName || typeof fields.functionAppName !== 'string') return 'Function App Name is required.';
+  if (!ENV_GUID_PATTERN.test(fields.clientId)) return 'Client ID must be a valid GUID.';
+  if (!ENV_GUID_PATTERN.test(fields.tenantId)) return 'Tenant ID must be a valid GUID.';
+  if (!ENV_STORAGE_ACCOUNT_PATTERN.test(fields.storageAccount)) return 'Storage Account must be 3–24 lowercase alphanumeric characters.';
+  if (!ENV_FUNCTION_APP_PATTERN.test(fields.functionAppName) || fields.functionAppName.length < 2) return 'Function App Name must be 2–60 alphanumeric characters with optional hyphens.';
+  return null;
+}
+
+// 1c. Environment import/export
+function importEnvironmentFromFile() {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.json,application/json';
+  input.addEventListener('change', () => {
+    const file = input.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        handleImportedJson(reader.result);
+      } catch (err) {
+        showViewMessage('error', `Import failed: ${err.message}`);
+      }
+    };
+    reader.onerror = () => {
+      showViewMessage('error', 'Failed to read the selected file.');
+    };
+    reader.readAsText(file);
+  });
+  input.click();
+}
+
+function handleImportedJson(text) {
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error('File does not contain valid JSON.');
+  }
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('File must contain a JSON object (not an array or primitive).');
+  }
+  if (data.version !== 1) {
+    throw new Error(`Unsupported environment file version: ${data.version ?? 'missing'}. Expected version 1.`);
+  }
+  const fields = {
+    clientId: typeof data.clientId === 'string' ? data.clientId.trim() : '',
+    tenantId: typeof data.tenantId === 'string' ? data.tenantId.trim() : '',
+    storageAccount: typeof data.storageAccount === 'string' ? data.storageAccount.trim() : '',
+    functionAppName: typeof data.functionAppName === 'string' ? data.functionAppName.trim() : '',
+  };
+  const validationError = validateEnvironmentFields(fields);
+  if (validationError) throw new Error(validationError);
+
+  let name = typeof data.name === 'string' ? data.name.trim() : '';
+  if (!name) {
+    name = window.prompt('Enter a name for this environment:');
+    if (!name || !name.trim()) throw new Error('Import cancelled — no name provided.');
+    name = name.trim();
+  }
+
+  const envs = loadEnvironments();
+  const existing = envs.find((e) => e.name === name);
+  if (existing) {
+    const choice = window.confirm(
+      `An environment named "${name}" already exists.\n\nClick OK to overwrite it, or Cancel to rename.`
+    );
+    if (!choice) {
+      const newName = window.prompt('Enter a different name for this environment:', `${name} (2)`);
+      if (!newName || !newName.trim()) throw new Error('Import cancelled — no name provided.');
+      name = newName.trim();
+      if (envs.some((e) => e.name === name)) {
+        throw new Error(`An environment named "${name}" already exists.`);
+      }
+    }
+  }
+
+  const envData = { name, ...fields };
+  const idx = envs.findIndex((e) => e.name === name);
+  if (idx >= 0) {
+    envs[idx] = envData;
+  } else {
+    envs.push(envData);
+  }
+
+  if (!saveEnvironments(envs)) {
+    throw new Error('Failed to save environment. Browser storage may be disabled or full.');
+  }
+
+  const isFirstEnv = envs.length === 1;
+  const isActiveEnv = getActiveEnvironmentName() === name;
+
+  document.getElementById('env-form-overlay')?.remove();
+  document.getElementById('env-manager-overlay')?.remove();
+
+  if (isFirstEnv || isActiveEnv) {
+    switchEnvironment(name).catch((error) => renderError('Switch failed', error));
+  } else {
+    showEnvironmentManager();
+  }
+}
+
+function exportEnvironment(env) {
+  const data = {
+    version: 1,
+    name: env.name || '',
+    clientId: env.clientId || '',
+    tenantId: env.tenantId || '',
+    storageAccount: env.storageAccount || '',
+    functionAppName: env.functionAppName || '',
+  };
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+
+  const safeName = (env.name || '')
+    .replace(/[/\\:*?"<>|\x00-\x1F\x7F]/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .trim();
+  const filename = safeName ? `${safeName}.json` : 'sonde-environment.json';
+
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
 function functionScopes() {
   return [`api://${CONFIG.msalClientId}/user_impersonation`];
 }
@@ -2211,6 +2348,7 @@ function showEnvironmentManager() {
           <td><code>${escapeHtml(env.functionAppName || '')}</code></td>
           <td style="white-space:nowrap">
             ${env.name !== activeName ? `<button type="button" class="secondary env-use-btn" data-env="${escapeHtml(env.name)}">Use</button> ` : ''}
+            <button type="button" class="secondary env-export-btn" data-env="${escapeHtml(env.name)}">Export</button>
             <button type="button" class="secondary env-edit-btn" data-env="${escapeHtml(env.name)}">Edit</button>
             <button type="button" class="secondary env-delete-btn" data-env="${escapeHtml(env.name)}" style="color:var(--danger)">Delete</button>
           </td>
@@ -2223,6 +2361,7 @@ function showEnvironmentManager() {
       ${envListHtml}
       <div style="margin-top:1rem;display:flex;gap:0.5rem;flex-wrap:wrap">
         <button type="button" class="primary" id="env-add-btn">Add Environment</button>
+        <button type="button" class="secondary" id="env-import-btn">Import</button>
         ${envs.length > 0 ? '<button type="button" class="secondary" id="env-close-btn">Close</button>' : ''}
       </div>
     </div>
@@ -2233,6 +2372,7 @@ function showEnvironmentManager() {
   document.body.insertAdjacentHTML('beforeend', overlayHtml);
 
   document.getElementById('env-add-btn')?.addEventListener('click', () => showEnvironmentForm(null));
+  document.getElementById('env-import-btn')?.addEventListener('click', () => importEnvironmentFromFile());
   document.getElementById('env-close-btn')?.addEventListener('click', () => {
     document.getElementById('env-manager-overlay')?.remove();
   });
@@ -2247,6 +2387,12 @@ function showEnvironmentManager() {
     btn.addEventListener('click', () => {
       const env = loadEnvironments().find((e) => e.name === btn.dataset.env);
       if (env) showEnvironmentForm(env);
+    });
+  }
+  for (const btn of document.querySelectorAll('.env-export-btn')) {
+    btn.addEventListener('click', () => {
+      const env = loadEnvironments().find((e) => e.name === btn.dataset.env);
+      if (env) exportEnvironment(env);
     });
   }
   for (const btn of document.querySelectorAll('.env-delete-btn')) {
@@ -2325,21 +2471,9 @@ function showEnvironmentForm(existingEnv) {
       return;
     }
 
-    const guidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!guidPattern.test(clientId)) {
-      if (errorEl) { errorEl.textContent = 'Client ID must be a valid GUID.'; errorEl.style.display = ''; }
-      return;
-    }
-    if (!guidPattern.test(tenantId)) {
-      if (errorEl) { errorEl.textContent = 'Tenant ID must be a valid GUID.'; errorEl.style.display = ''; }
-      return;
-    }
-    if (!/^[a-z0-9]{3,24}$/.test(storageAccount)) {
-      if (errorEl) { errorEl.textContent = 'Storage Account must be 3–24 lowercase alphanumeric characters.'; errorEl.style.display = ''; }
-      return;
-    }
-    if (!/^[a-zA-Z0-9][a-zA-Z0-9-]{0,58}[a-zA-Z0-9]$/.test(functionAppName)) {
-      if (errorEl) { errorEl.textContent = 'Function App Name must be 2–60 alphanumeric characters with optional hyphens.'; errorEl.style.display = ''; }
+    const fieldError = validateEnvironmentFields({ clientId, tenantId, storageAccount, functionAppName });
+    if (fieldError) {
+      if (errorEl) { errorEl.textContent = fieldError; errorEl.style.display = ''; }
       return;
     }
 

--- a/docs/azure-companion-design.md
+++ b/docs/azure-companion-design.md
@@ -143,7 +143,9 @@ The current runtime artifact shape is a companion-owned `service-principal.json`
 file containing the Entra tenant ID, client ID, login endpoint, PEM certificate
 path, and PEM private-key path, plus the referenced certificate and key files in
 the state directory. After bootstrap, the state directory also contains
-`storage-queues.json` with the Storage Queue endpoint and queue names. New bootstrap
+`storage-queues.json` with the Storage Queue endpoint and queue names, and
+`web-ui-environment.json` with the Web UI connection details for import into the
+SPA environment manager (see AZC-0413). New bootstrap
 commits are written into a generation directory under the state directory and made
 current by atomically updating a `.current-state` marker file. For backward
 compatibility, startup also accepts the legacy flat-file layout when the marker
@@ -330,11 +332,11 @@ When bootstrap is required, the Azure companion performs this sequence:
 15. Wait for the container to finish. On success, the bootstrap script produces
     JSON deployment outputs on stdout. The Rust companion captures and parses
     the JSON outputs to extract `tenantId`, `clientId`, Storage Queue endpoint,
-    queue names, Function App name, and deployment container values from the
-    `companionBootstrapValues` output object.
-16. Write `service-principal.json` and `storage-queues.json` to the staging
-    directory with the extracted values and relative paths to the certificate
-    and private-key PEM files.
+    queue names, `storageAccountName`, `functionAppName`, and deployment
+    container values from the `companionBootstrapValues` output object.
+16. Write `service-principal.json`, `storage-queues.json`, and
+    `web-ui-environment.json` to the staging directory with the extracted values
+    and relative paths to the certificate and private-key PEM files.
 17. Rename the staging directory into a new generation directory under the state
     volume, then atomically update the `.current-state` marker to point at that
     generation, leaving the previous generation untouched until the new one is
@@ -359,7 +361,7 @@ non-zero status. It does not continue to a console-only fallback.
 ## 5  Rust binary interface
 
 > **Requirements:** AZC-0100, AZC-0102, AZC-0103, AZC-0104, AZC-0105, AZC-0201, AZC-0202, AZC-0205, AZC-0300, AZC-0301, AZC-0302, AZC-0304, AZC-0305,
-> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0410, AZC-0411, AZC-0412
+> AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405, AZC-0406, AZC-0410, AZC-0411, AZC-0412, AZC-0413
 
 The `sonde-azure-companion` binary exposes three cross-platform runtime modes
 plus Windows service-management entrypoints:
@@ -370,7 +372,7 @@ plus Windows service-management entrypoints:
    ECDSA P-256 certificate generation, launching the version-matched
    `sonde-azure-bootstrap` image via the Bollard Docker API, and runtime
    artifact creation (`service-principal.json`, `storage-queues.json`,
-   certificate PEM, private-key PEM). The Rust code monitors the bootstrap
+   `web-ui-environment.json`, certificate PEM, private-key PEM). The Rust code monitors the bootstrap
    container's output to extract the device code and display it on the modem
    via the gateway admin API. If valid bootstrap-complete state already exists
    and `--force` is not passed, the subcommand exits successfully without
@@ -512,7 +514,7 @@ a detected bridge failure.
 ## 8  Provisioning orchestration internals
 
 > **Requirements:** AZC-0400, AZC-0401, AZC-0402, AZC-0403, AZC-0404, AZC-0405,
-> AZC-0406, AZC-0407, AZC-0408, AZC-0409, AZC-0412
+> AZC-0406, AZC-0407, AZC-0408, AZC-0409, AZC-0412, AZC-0413
 
 ### 8.1  Certificate generation
 
@@ -622,6 +624,19 @@ staging directory:
      "downstream_queue": "<from companionBootstrapValues.downstreamQueue>"
    }
    ```
+4. **`web-ui-environment.json`** (AZC-0413) containing:
+   ```json
+   {
+     "version": 1,
+     "name": "",
+     "clientId": "<from companionBootstrapValues.clientId>",
+     "tenantId": "<from companionBootstrapValues.tenantId>",
+     "storageAccount": "<from companionBootstrapValues.storageAccountName>",
+     "functionAppName": "<from companionBootstrapValues.functionAppName>"
+   }
+   ```
+   This file is a convenience artifact for Web UI onboarding. It is NOT
+   required by `check-runtime-ready` or runtime startup.
 
 Only after all staging writes succeed does the bootstrap atomically move the
 staged files into the state volume root, replacing any previous artifacts.

--- a/docs/azure-companion-requirements.md
+++ b/docs/azure-companion-requirements.md
@@ -687,6 +687,7 @@ the state volume.
 3. The `tenant_id`, `client_id`, and `login_endpoint` values are extracted from the Bicep deployment outputs. The `login_endpoint` is sourced from `environment().authentication.loginEndpoint` exposed through the `companionBootstrapValues` output.
 4. The `certificate_path` and `private_key_path` values are relative paths within the state volume pointing to the generated PEM files.
 5. The resulting state satisfies the `check-runtime-ready` validation without manual intervention.
+6. The `storageAccountName` and `functionAppName` values are extracted from the `companionBootstrapValues` Bicep output and available for use by bootstrap artifact creation (see AZC-0413). Verified by T-AZC-0433.
 
 ---
 
@@ -927,3 +928,47 @@ variables; they are passed through for future use.
 2. All three parameters are optional; omitting them does not affect the rest of the bootstrap sequence.
 3. Each custom domain parameter that is set is forwarded to the bootstrap container as its corresponding environment variable, independently of the others.
 4. When none of the three parameters are set, none of the three custom domain environment variables are present in the container environment.
+
+---
+
+### AZC-0413  Web UI environment file from bootstrap
+
+**Priority:** Should
+**Source:** [issue #1074](https://github.com/Alan-Jowett/sonde/issues/1074)
+
+**Description:**
+After successful Bicep deployment, the unified `bootstrap` subcommand SHOULD
+write a `web-ui-environment.json` file to the staging directory alongside
+`service-principal.json` and `storage-queues.json`. The file contains the
+connection details needed to configure a Web UI environment without manual
+transcription.
+
+The file uses a single-object schema with a `version` field for forward
+compatibility:
+
+```json
+{
+  "version": 1,
+  "name": "",
+  "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "storageAccount": "mystorageaccount",
+  "functionAppName": "sonde-handler-xxxx"
+}
+```
+
+The `name` field MUST be an empty string — the Web UI prompts the user for a
+name during import. The `storageAccountName` and `functionAppName` values are
+extracted from the `companionBootstrapValues` Bicep output alongside the
+existing `tenantId` and `clientId` values.
+
+This file is a convenience artifact for Web UI onboarding. It is NOT required
+for bootstrap-complete state or `check-runtime-ready` validation.
+
+**Acceptance criteria:**
+
+1. Bootstrap writes `web-ui-environment.json` to the staging directory after successful Bicep deployment.
+2. The file contains `version` (integer 1), `name` (empty string), `clientId`, `tenantId`, `storageAccount`, and `functionAppName`.
+3. The `clientId`, `tenantId`, `storageAccount`, and `functionAppName` values are extracted from the Bicep deployment outputs.
+4. The file is committed to the state generation directory alongside other bootstrap artifacts.
+5. Absence of `web-ui-environment.json` does not affect `check-runtime-ready` or runtime startup.

--- a/docs/azure-companion-validation.md
+++ b/docs/azure-companion-validation.md
@@ -510,6 +510,7 @@
 6. Assert: `service-principal.json` has been rewritten.
 7. Assert: the Bicep deployment phase received the newly regenerated certificate material (not the original certificate from step 1).
 8. Assert: `check-runtime-ready` succeeds after re-bootstrap.
+9. Assert: `web-ui-environment.json` exists in the new state generation directory with valid content.
 
 ---
 
@@ -846,3 +847,17 @@
 4. Assert: the bootstrap container environment contains `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP=my-rg` but does not contain `SONDE_AZURE_CUSTOM_DOMAIN_NAME` or `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME`.
 5. Run `sonde-azure-companion bootstrap` with only `--custom-domain-dns-zone-name myzone.com` and with `SONDE_AZURE_CUSTOM_DOMAIN_NAME` and `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP` unset. Use stubbed Docker/admin services.
 6. Assert: the bootstrap container environment contains `SONDE_AZURE_CUSTOM_DOMAIN_DNS_ZONE_NAME=myzone.com` but does not contain `SONDE_AZURE_CUSTOM_DOMAIN_NAME` or `SONDE_AZURE_CUSTOM_DOMAIN_DNS_RESOURCE_GROUP`.
+
+---
+
+### T-AZC-0433  Bootstrap writes web-ui-environment.json
+
+**Validates:** AZC-0413
+
+**Procedure:**
+1. Run the bootstrap subcommand with device-flow stubbed to succeed and Bicep deployment stubbed to return known output values (tenantId, clientId, storageAccountName, functionAppName).
+2. Assert: `web-ui-environment.json` exists in the state volume after bootstrap completes.
+3. Parse `web-ui-environment.json` and assert: it contains `version` (integer 1), `name` (empty string), `clientId`, `tenantId`, `storageAccount`, and `functionAppName`.
+4. Assert: `clientId`, `tenantId`, `storageAccount`, and `functionAppName` match the stubbed Bicep output values.
+5. Assert: `check-runtime-ready` does not depend on the presence of `web-ui-environment.json` (removing the file still passes the check).
+6. Assert: runtime startup (`sonde-azure-companion run`) does not depend on the presence of `web-ui-environment.json` (removing the file still proceeds to the runtime bridge path).

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -398,7 +398,7 @@ devices.
 
 ## 11. Environment Manager (WEB-0800)
 
-> **Requirements:** WEB-0800, WEB-0801, WEB-0802, WEB-0803, WEB-0804, WEB-0805, WEB-0806
+> **Requirements:** WEB-0800, WEB-0801, WEB-0802, WEB-0803, WEB-0804, WEB-0805, WEB-0806, WEB-0807, WEB-0808
 
 ### 11.1 Overview
 
@@ -406,6 +406,8 @@ The environment manager replaces the deploy-time `config.json` with a runtime
 configuration system. Users define named environments (e.g., "production",
 "staging", "dev") with the Azure backend connection details needed by the SPA.
 A single SPA instance can connect to any environment without redeployment.
+Environments can be imported from JSON files (e.g., the `web-ui-environment.json`
+emitted by Azure companion bootstrap) and exported for backup or sharing.
 
 ### 11.2 Data Model
 
@@ -428,6 +430,29 @@ Each environment is a JSON object stored in `localStorage`:
 | `sonde_environments` | JSON array of environment objects |
 | `sonde_active_environment` | Name of the currently active environment |
 
+### 11.2b Import/Export File Schema (WEB-0807, WEB-0808)
+
+The import/export file uses a single-object JSON schema with a `version` field
+for forward compatibility:
+
+```json
+{
+  "version": 1,
+  "name": "production",
+  "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "storageAccount": "mystorageaccount",
+  "functionAppName": "sonde-decoder-xxxx"
+}
+```
+
+The `version` field MUST be integer `1`. Files with any other version value are
+rejected. Extra properties beyond the defined schema are silently ignored to
+allow forward-compatible extensions.
+
+The Azure companion bootstrap emits this file as `web-ui-environment.json` with
+`name` set to empty string — the SPA prompts the user for a name during import.
+
 ### 11.3 Authority Derivation
 
 `msalAuthority` is derived from the tenant ID as:
@@ -440,16 +465,39 @@ This targets Azure public cloud. Sovereign cloud support is out of scope.
 **First load (no environments):** A full-screen modal prompts the user to add
 their first environment. The main app UI (tabs, dashboard) is inaccessible until
 at least one environment is configured. The modal cannot be closed without adding
-an environment.
+an environment. The modal includes both "Add Environment" and "Import" buttons.
 
 **Environment list modal:** A full-screen modal displaying all configured
 environments in a table (Name, Storage Account, Function App), with action
-buttons: Use (switch to this environment), Edit, Delete. The active environment
-is marked with a badge. An "Add Environment" button opens the add/edit form.
+buttons: Use (switch to this environment), Export, Edit, Delete. The active
+environment is marked with a badge. "Add Environment" and "Import" buttons are
+shown below the table.
 
 **Add/edit form:** A stacked form with fields for Name (read-only on edit),
 Client ID, Tenant ID, Storage Account, Function App Name. All fields are
 required. Duplicate names are rejected on add.
+
+**Import flow (WEB-0807):** Clicking Import opens a browser file picker
+accepting `.json` files. After selection:
+
+1. Parse the file as JSON. Reject non-JSON or non-object content with an error.
+2. Validate `version === 1`. Reject other values with "Unsupported environment
+   file version" error.
+3. Validate the four data fields using the same rules as the manual form
+   (WEB-0802).
+4. If `name` is blank/missing, show a name input prompt before saving.
+5. If `name` matches an existing environment, show a conflict dialog offering
+   "Overwrite" or "Rename" options.
+6. If overwriting the active environment, trigger the full re-initialization
+   sequence (WEB-0806): clear MSAL state, re-create MSAL instance, re-render.
+7. Save the environment to `localStorage` and refresh the environment list.
+
+**Export (WEB-0808):** Each row's Export button serializes the environment to a
+JSON file using the import/export schema (§11.2b) and triggers a browser
+download. The filename is derived from the environment name with characters
+unsafe for filesystems (slashes, colons, control characters) replaced by
+hyphens. If the sanitized name is empty, the fallback `sonde-environment.json`
+is used.
 
 **Header indicator:** The active environment name is displayed in the top bar
 next to a ⚙ gear button that opens the environment manager modal.

--- a/docs/web-ui-requirements.md
+++ b/docs/web-ui-requirements.md
@@ -870,24 +870,25 @@ The environment form MUST validate all fields before saving.
 **Description:**
 On first load with no environments configured, the SPA MUST show a full-screen
 setup modal. The main app UI MUST be inaccessible until at least one environment
-is configured.
+is configured. The modal MUST offer both manual entry and file import.
 
 **Acceptance criteria:**
 
 1. With no environments in `localStorage`, the setup modal is shown.
 2. The modal cannot be closed without adding an environment (no "Close" button).
 3. Tab bar and content area are not interactive.
+4. The setup modal includes an Import button that accepts a `.json` environment file (see WEB-0807).
 
 ---
 
-### WEB-0804  Edit and Delete Environments
+### WEB-0804  Edit, Export, and Delete Environments
 
 **Priority:** Must
 **Source:** web-ui-design.md §11.4, app.js `showEnvironmentManager()`
 **Confidence:** High
 
 **Description:**
-The SPA MUST support editing and deleting existing environments.
+The SPA MUST support editing, exporting, and deleting existing environments.
 
 **Acceptance criteria:**
 
@@ -895,6 +896,55 @@ The SPA MUST support editing and deleting existing environments.
 2. The name field is read-only during edit.
 3. Deleting an environment removes it from `localStorage`.
 4. Deleting the active environment switches to the next available environment or shows the setup modal.
+5. Each environment row shows Use (for non-active), Export, Edit, and Delete buttons.
+
+---
+
+### WEB-0807  Environment Import from JSON File
+
+**Priority:** Should
+**Source:** [issue #1074](https://github.com/Alan-Jowett/sonde/issues/1074)
+**Confidence:** High
+
+**Description:**
+The environment manager and the first-load setup modal MUST offer an Import
+button that reads a JSON environment file and adds the environment to
+`localStorage`. The import flow validates the file schema, prompts for a name
+when the `name` field is blank, and handles conflicts with existing environments.
+
+**Acceptance criteria:**
+
+1. An "Import" button is visible in both the environment manager panel and the first-load setup modal.
+2. Clicking Import opens a file picker accepting `.json` files.
+3. The file MUST contain `version` equal to integer `1`; files with missing, non-numeric, zero, or greater-than-1 version values are rejected with an error message.
+4. The four data fields (`clientId`, `tenantId`, `storageAccount`, `functionAppName`) are validated using the same rules as WEB-0802.
+5. If `name` is blank or missing, a name prompt is shown before saving.
+6. If `name` conflicts with an existing environment, a prompt offers overwrite or rename.
+7. Overwriting the active environment triggers the full re-initialization sequence defined by WEB-0806.
+8. Successfully imported environments appear in the environment list and are persisted to `localStorage`.
+9. Non-JSON files, files with missing required fields, and files with a top-level type other than object are rejected with a descriptive error message.
+10. Extra JSON properties beyond the defined schema are ignored.
+
+---
+
+### WEB-0808  Per-Environment Export to JSON File
+
+**Priority:** Should
+**Source:** [issue #1074](https://github.com/Alan-Jowett/sonde/issues/1074)
+**Confidence:** High
+
+**Description:**
+Each environment row in the environment manager MUST have an Export button that
+downloads a JSON file containing that environment's settings in the
+import-compatible schema.
+
+**Acceptance criteria:**
+
+1. Each environment row has an Export button alongside Use, Edit, and Delete.
+2. Clicking Export triggers a browser download of a `.json` file.
+3. The filename is derived from the environment name with unsafe filesystem characters replaced; if the result is empty, the fallback filename `sonde-environment.json` is used.
+4. The exported file contains `version` (integer 1) and all five fields (`name`, `clientId`, `tenantId`, `storageAccount`, `functionAppName`).
+5. The exported file is valid for re-import via WEB-0807.
 
 ---
 

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -95,8 +95,10 @@ and verifies one or more acceptance criteria.
 | WEB-0800 | T-WEB-0801, T-WEB-0802, T-WEB-0803, T-WEB-0804, T-WEB-0805, T-WEB-0806 |
 | WEB-0801 | T-WEB-0802 |
 | WEB-0802 | T-WEB-0806, T-WEB-0807, T-WEB-0808, T-WEB-0809 |
-| WEB-0803 | T-WEB-0801, T-WEB-0801b |
-| WEB-0804 | T-WEB-0805, T-WEB-0805b |
+| WEB-0803 | T-WEB-0801, T-WEB-0801b, T-WEB-0818 |
+| WEB-0804 | T-WEB-0805, T-WEB-0805b, T-WEB-0805c |
+| WEB-0807 | T-WEB-0810, T-WEB-0811, T-WEB-0812, T-WEB-0813, T-WEB-0814, T-WEB-0815, T-WEB-0819, T-WEB-0820, T-WEB-0821, T-WEB-0822 |
+| WEB-0808 | T-WEB-0816, T-WEB-0816b, T-WEB-0816c, T-WEB-0817 |
 | WEB-0805 | T-WEB-0804, T-WEB-0804b |
 | WEB-0806 | T-WEB-0803, T-WEB-0803b, T-WEB-0803c, T-WEB-0803d, T-WEB-0803d2, T-WEB-0803e, T-WEB-0803f, T-WEB-0803g |
 | WEB-0901 | T-WEB-0901, T-WEB-0901b, T-WEB-0901c |
@@ -258,7 +260,28 @@ and verifies one or more acceptance criteria.
 | T-WEB-0804b | WEB-0805 | Environment indicator updates when environment is switched | Manual | Planned |
 | T-WEB-0805 | WEB-0804 | Edit and delete operations on environments work correctly | Manual | Planned |
 | T-WEB-0805b | WEB-0804 | Deleting active environment switches to next available or shows setup modal | Manual | Planned |
+| T-WEB-0805c | WEB-0804 | Each environment row shows Use, Export, Edit, and Delete buttons | Manual | Planned |
 | T-WEB-0806 | WEB-0802 | Environment fields validated (all required, duplicate name rejected) | Manual | Planned |
+
+### 5.8b  Import / Export
+
+| Test ID | Requirement | Description | Method | Status |
+|---|---|---|---|---|
+| T-WEB-0810 | WEB-0807 | Importing a valid `.json` file with all fields adds the environment to the list | Manual | Planned |
+| T-WEB-0811 | WEB-0807 | Importing a file with blank `name` prompts user for a name before saving | Manual | Planned |
+| T-WEB-0812 | WEB-0807 | Importing a file with a name that conflicts with an existing environment offers overwrite or rename | Manual | Planned |
+| T-WEB-0813 | WEB-0807 | Importing a file with `version` other than `1` (missing, zero, greater) is rejected with error | Manual | Planned |
+| T-WEB-0814 | WEB-0807, WEB-0802 | Importing a file with invalid field values (bad GUID, wrong storage account format) is rejected | Manual | Planned |
+| T-WEB-0815 | WEB-0807 | Overwriting the active environment via import triggers MSAL re-initialization | Manual | Planned |
+| T-WEB-0816 | WEB-0808 | Export button downloads a `.json` file with `version: 1` and all five fields | Manual | Planned |
+| T-WEB-0816b | WEB-0808 | Export of an environment with unsafe filename characters (slashes, colons) produces a sanitized filename | Manual | Planned |
+| T-WEB-0816c | WEB-0808 | Export of an environment whose sanitized name is empty uses fallback `sonde-environment.json` | Manual | Planned |
+| T-WEB-0817 | WEB-0807, WEB-0808 | Exported file round-trips through import: export → import into fresh browser → environment is functional | Manual | Planned |
+| T-WEB-0818 | WEB-0803 | First-load setup modal includes Import button and accepts environment file | Manual | Planned |
+| T-WEB-0819 | WEB-0807 | Importing a non-JSON file (e.g., plain text, binary) is rejected with a descriptive error | Manual | Planned |
+| T-WEB-0820 | WEB-0807 | Importing a JSON file with top-level array, null, or string is rejected | Manual | Planned |
+| T-WEB-0821 | WEB-0807 | Importing a JSON file with missing required data fields is rejected | Manual | Planned |
+| T-WEB-0822 | WEB-0807 | Extra JSON properties in the import file are silently ignored | Manual | Planned |
 
 ### 5.9  Deployment
 


### PR DESCRIPTION
## Summary

Add import/export support for environment settings in the SPA and have the Azure companion bootstrap emit a `web-ui-environment.json` file.

Closes #1074

## Changes

### Azure companion (Rust)
- `WebUiEnvironmentFile` struct with schema `{version, name, clientId, tenantId, storageAccount, functionAppName}`
- `BootstrapArtifacts` struct replaces 3-tuple return from `parse_bicep_outputs`
- Parse `storageAccountName` and `functionAppName` from Bicep outputs
- Write `web-ui-environment.json` during bootstrap (not required for runtime readiness)
- Tests for round-trip serialization and runtime independence

### Bicep
- Add `storageAccountName` to `companionBootstrapValues` output

### Web UI (JavaScript)
- Per-environment **Export** button downloads sanitized JSON file
- **Import** button in environment manager and first-load setup modal
- Validates: version === 1, GUID patterns for clientId/tenantId, storage account/function app patterns
- Extra JSON properties silently ignored (forward compatibility)
- Blank name prompts user; conflicts offer overwrite or rename
- Overwriting active env triggers MSAL re-initialization
- Shared `validateEnvironmentFields()` reduces duplication

### Specifications (6 docs updated)
- New: AZC-0413, WEB-0807, WEB-0808
- Modified: AZC-0403, WEB-0803, WEB-0804
- Design + validation docs with T-AZC-0433, T-WEB-0810–0822

## Testing
- `cargo build --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅ (65 azure-companion tests pass)
- `cargo fmt --all` ✅
