### PR TITLE
fix: restore deleted \STORAGE_SCOPES\ constant in web UI

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -74,6 +74,8 @@ function loadActiveEnvironment() {
   return env;
 }
 
+const STORAGE_SCOPES = ['https://storage.azure.com/.default'];
+
 // 1b. Environment field validation helpers (shared by manual form and import)
 const ENV_GUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ENV_STORAGE_ACCOUNT_PATTERN = /^[a-z0-9]{3,24}$/;


### PR DESCRIPTION
Commit 8d33b71 (environment import/export, #1077) accidentally replaced the \STORAGE_SCOPES\ constant definition with validation helpers, leaving three references in \login()\ and \getToken()\ unresolved. This broke the SPA with a \ReferenceError\ on any auth flow.

Restores the constant at its original position.