### PR TITLE
fix(ci): cancel superseded builds on main via concurrency groups

### DIFF
--- a/.github/workflows/android-dev-container.yml
+++ b/.github/workflows/android-dev-container.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ci-${{ github.head_ref || github.run_id }}
+  group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/esp-dev-container.yml
+++ b/.github/workflows/esp-dev-container.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/esp32-modem.yml
+++ b/.github/workflows/esp32-modem.yml
@@ -20,7 +20,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: esp32-s3-${{ github.head_ref || github.run_id }}
+  group: esp32-s3-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -21,7 +21,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: esp32-c3-${{ github.head_ref || github.run_id }}
+  group: esp32-c3-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ietf-draft.yml
+++ b/.github/workflows/ietf-draft.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/ietf-draft.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/release.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/tauri-android.yml
+++ b/.github/workflows/tauri-android.yml
@@ -29,7 +29,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: tauri-android-${{ github.head_ref || github.run_id }}
+  group: tauri-android-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tauri-desktop.yml
+++ b/.github/workflows/tauri-desktop.yml
@@ -28,7 +28,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: tauri-desktop-${{ github.head_ref || github.run_id }}
+  group: tauri-desktop-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Problem

When merging multiple dependabot PRs in quick succession, every merge triggers a full CI run on `main`. These runs pile up even though only the latest commit matters — earlier runs are redundant because they've been superseded.

## Root Cause

Nine workflows used `github.head_ref || github.run_id` for their concurrency group key. On `push` events (merges to `main`), `github.head_ref` is empty, so the expression fell back to `github.run_id` — which is **unique per run**. Every push to `main` got its own concurrency group, so `cancel-in-progress: true` had no effect.

## Fix

Replaced `github.run_id` with `github.ref` in all nine affected workflows:

| Workflow | Old group | New group |
|----------|-----------|-----------|
| `ci.yml` | `ci-{head_ref \|\| run_id}` | `ci-{head_ref \|\| ref}` |
| `esp32.yml` | `esp32-c3-{head_ref \|\| run_id}` | `esp32-c3-{head_ref \|\| ref}` |
| `esp32-modem.yml` | `esp32-s3-{head_ref \|\| run_id}` | `esp32-s3-{head_ref \|\| ref}` |
| `release.yml` | `{workflow}-{head_ref \|\| run_id}` | `{workflow}-{head_ref \|\| ref}` |
| `tauri-android.yml` | `tauri-android-{head_ref \|\| run_id}` | `tauri-android-{head_ref \|\| ref}` |
| `tauri-desktop.yml` | `tauri-desktop-{head_ref \|\| run_id}` | `tauri-desktop-{head_ref \|\| ref}` |
| `ietf-draft.yml` | `{workflow}-{head_ref \|\| run_id}` | `{workflow}-{head_ref \|\| ref}` |
| `android-dev-container.yml` | `{workflow}-{head_ref \|\| run_id}` | `{workflow}-{head_ref \|\| ref}` |
| `esp-dev-container.yml` | `{workflow}-{head_ref \|\| run_id}` | `{workflow}-{head_ref \|\| ref}` |

## Behavior After Fix

- **PR builds**: `head_ref` is set → each PR gets its own concurrency group (unchanged)
- **Main pushes**: `head_ref` is empty → falls back to `github.ref` (`refs/heads/main`) → all runs share one group → newer runs cancel older superseded ones

## Unaffected Workflows

Six workflows already used correct patterns (`github.ref` directly, or static group names): `azure-bootstrap-container`, `azure-companion-container`, `azure-live-ci`, `gateway-container`, `nightly-release`, `web-ui`.