### PR TITLE
feat: add fingerprint and rotation code display pages

### DIFF
--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -17,8 +17,9 @@ use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
 use sonde_gateway::display_banner::{
-    render_display_message, render_status_text_page, send_display_message,
-    send_gateway_version_banner, ScrollableFramebuffer, STATUS_TEXT_COLUMNS,
+    render_display_message, render_fingerprint_page, render_rotation_code_page,
+    render_status_text_page, send_display_message, send_gateway_version_banner,
+    ScrollableFramebuffer, STATUS_TEXT_COLUMNS,
 };
 use sonde_gateway::display_control::{
     cancel_status_page_scroll, claim_display_generation, invalidate_display_restore,
@@ -62,10 +63,17 @@ enum ButtonDisplayState {
 enum StatusPage {
     Channel,
     Nodes,
+    Fingerprint,
+    RotationCode,
 }
 
 impl StatusPage {
-    const ALL: [StatusPage; 2] = [StatusPage::Channel, StatusPage::Nodes];
+    const ALL: [StatusPage; 4] = [
+        StatusPage::Channel,
+        StatusPage::Nodes,
+        StatusPage::Fingerprint,
+        StatusPage::RotationCode,
+    ];
 }
 
 enum RenderedStatusPage {
@@ -260,6 +268,7 @@ async fn render_status_page(
     session_manager: Option<&Arc<SessionManager>>,
     default_channel: u8,
     page: StatusPage,
+    fingerprint_words: &[&'static str; 6],
 ) -> RenderedStatusPage {
     match page {
         StatusPage::Channel => {
@@ -308,6 +317,23 @@ async fn render_status_page(
                 RenderedStatusPage::Static(Box::new(render_display_message(&["Nodes", "Error"])))
             }
         },
+        StatusPage::Fingerprint => {
+            RenderedStatusPage::Static(Box::new(render_fingerprint_page(fingerprint_words)))
+        }
+        StatusPage::RotationCode => {
+            let code = match storage.get_config("rotation_code").await {
+                Ok(Some(code)) => code,
+                Ok(None) => {
+                    warn!("rotation_code not found in storage for status page");
+                    "------".to_string()
+                }
+                Err(e) => {
+                    warn!(error = %e, "failed to load rotation_code for status page");
+                    "Error".to_string()
+                }
+            };
+            RenderedStatusPage::Static(Box::new(render_rotation_code_page(&code)))
+        }
     }
 }
 
@@ -601,6 +627,7 @@ async fn handle_idle_button_short_event(
     display_generation: &Arc<AtomicU64>,
     status_page_cycle: &Arc<tokio::sync::Mutex<StatusPageCycle>>,
     scroll_task: &StatusPageScrollTask,
+    fingerprint_words: &[&'static str; 6],
 ) -> bool {
     if controller.session_origin().await.is_some() {
         return false;
@@ -614,8 +641,14 @@ async fn handle_idle_button_short_event(
         cycle.next_page_index = (cycle.next_page_index + 1) % StatusPage::ALL.len();
         page
     };
-    let rendered_page =
-        render_status_page(storage, Some(session_manager), default_channel, page).await;
+    let rendered_page = render_status_page(
+        storage,
+        Some(session_manager),
+        default_channel,
+        page,
+        fingerprint_words,
+    )
+    .await;
     let initial_frame = rendered_page.initial_frame();
     let initial_send_ok = match transport.send_display_frame(initial_frame).await {
         Ok(()) => true,
@@ -1423,6 +1456,19 @@ async fn run_gateway(
                 }
             };
 
+            // Compute BIP-39 fingerprint from the gateway's X25519 public key.
+            // Identity is immutable during a run, so compute once and reuse.
+            let fingerprint_words = match identity.to_x25519() {
+                Ok((_, x25519_public)) => {
+                    let sha = sonde_gateway::crypto::RustCryptoSha256;
+                    sonde_protocol::compute_fingerprint(x25519_public.as_bytes(), &sha)
+                }
+                Err(e) => {
+                    error!("BLE loop: X25519 conversion failed for fingerprint: {e}");
+                    return;
+                }
+            };
+
             // Use the shared registration window via the controller.
             let mut window = sonde_gateway::ble_pairing::RegistrationWindow::new();
             let button_timeout = tokio::time::sleep(Duration::from_secs(24 * 60 * 60));
@@ -1646,6 +1692,7 @@ async fn run_gateway(
                                     &display_generation,
                                     &status_page_cycle,
                                     &status_page_scroll_task,
+                                    &fingerprint_words,
                                 )
                                 .await;
                             }
@@ -2281,6 +2328,13 @@ mod tests {
         DISPLAY_FRAME_BODY_SIZE, DISPLAY_FRAME_CHUNK_COUNT, DISPLAY_FRAME_CHUNK_SIZE,
     };
 
+    /// Compute BIP-39 fingerprint words for tests using the conventional
+    /// non-zero test key `[0x42u8; 32]`.
+    fn test_fingerprint_words() -> [&'static str; 6] {
+        use sonde_gateway::crypto::RustCryptoSha256;
+        sonde_protocol::compute_fingerprint(&[0x42u8; 32], &RustCryptoSha256)
+    }
+
     async fn read_next_message(
         stream: &mut DuplexStream,
         decoder: &mut FrameDecoder,
@@ -2639,8 +2693,14 @@ mod tests {
         seed_runtime_observation(&session_manager, &node.node_id, last_seen, battery_mv).await;
         let storage: Arc<dyn Storage> = storage;
 
-        let rendered =
-            render_status_page(&storage, Some(&session_manager), 6, StatusPage::Nodes).await;
+        let rendered = render_status_page(
+            &storage,
+            Some(&session_manager),
+            6,
+            StatusPage::Nodes,
+            &test_fingerprint_words(),
+        )
+        .await;
         let mut last_seen_by_node = HashMap::new();
         last_seen_by_node.insert(node.node_id.clone(), last_seen);
         let mut battery_mv_by_node = HashMap::new();
@@ -2685,8 +2745,14 @@ mod tests {
             .await;
         session_manager.record_battery_mv("runtime", 3300).await;
 
-        let rendered =
-            render_status_page(&storage, Some(&session_manager), 6, StatusPage::Nodes).await;
+        let rendered = render_status_page(
+            &storage,
+            Some(&session_manager),
+            6,
+            StatusPage::Nodes,
+            &test_fingerprint_words(),
+        )
+        .await;
         let mut last_seen_by_node = HashMap::new();
         last_seen_by_node.insert(node.node_id.clone(), observed_at);
         let mut battery_mv_by_node = HashMap::new();
@@ -3150,6 +3216,7 @@ mod tests {
                     &display_generation,
                     &status_page_cycle,
                     &status_page_scroll_task,
+                    &test_fingerprint_words(),
                 )
                 .await
             }
@@ -3184,6 +3251,7 @@ mod tests {
                     &display_generation,
                     &status_page_cycle,
                     &status_page_scroll_task,
+                    &test_fingerprint_words(),
                 )
                 .await
             }
@@ -3287,6 +3355,7 @@ mod tests {
                         &display_generation,
                         &status_page_cycle,
                         &status_page_scroll_task,
+                        &test_fingerprint_words(),
                     )
                     .await
                 }
@@ -3378,6 +3447,7 @@ mod tests {
                         &display_generation,
                         &status_page_cycle,
                         &status_page_scroll_task,
+                        &test_fingerprint_words(),
                     )
                     .await
                 }
@@ -3392,6 +3462,36 @@ mod tests {
             framebuffer,
             expected_nodes_page.visible_window(NODE_STATUS_SCROLL_STEP_PX)
         );
+
+        // Cycle through the remaining pages (Fingerprint, RotationCode) then
+        // back to Channel and finally Nodes to verify scroll restarts from top.
+        for _ in 0..2 {
+            let press = tokio::spawn({
+                let transport = Arc::clone(&transport);
+                let controller = Arc::clone(&controller);
+                let storage = Arc::clone(&storage);
+                let session_manager = Arc::clone(&session_manager);
+                let display_generation = Arc::clone(&display_generation);
+                let status_page_cycle = Arc::clone(&status_page_cycle);
+                let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
+                async move {
+                    handle_idle_button_short_event(
+                        &transport,
+                        &controller,
+                        &storage,
+                        &session_manager,
+                        6,
+                        &display_generation,
+                        &status_page_cycle,
+                        &status_page_scroll_task,
+                        &test_fingerprint_words(),
+                    )
+                    .await
+                }
+            });
+            let _ = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+            assert!(press.await.unwrap());
+        }
 
         for expected_frame in [
             render_display_message(&["Channel", "11"]),
@@ -3415,6 +3515,7 @@ mod tests {
                         &display_generation,
                         &status_page_cycle,
                         &status_page_scroll_task,
+                        &test_fingerprint_words(),
                     )
                     .await
                 }
@@ -3474,6 +3575,7 @@ mod tests {
                         &display_generation,
                         &status_page_cycle,
                         &status_page_scroll_task,
+                        &test_fingerprint_words(),
                     )
                     .await
                 }
@@ -3526,6 +3628,7 @@ mod tests {
                     &display_generation,
                     &status_page_cycle,
                     &status_page_scroll_task,
+                    &test_fingerprint_words(),
                 )
                 .await
             }
@@ -3595,6 +3698,220 @@ mod tests {
         );
         assert_eq!(status_page_cycle.lock().await.next_page_index, 0);
         dummy_scroll_watcher.join().unwrap();
+    }
+
+    /// T-1103h: Verify all 4 status pages cycle in order
+    /// Channel → Nodes → Fingerprint → RotationCode.
+    #[tokio::test]
+    async fn status_pages_cycle_through_all_four_pages() {
+        use sonde_gateway::display_banner::{render_fingerprint_page, render_rotation_code_page};
+
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
+        let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
+        let storage = Arc::new(InMemoryStorage::new());
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(60)));
+        storage.set_config("espnow_channel", "11").await.unwrap();
+        storage.set_config("rotation_code", "ABC123").await.unwrap();
+        let storage: Arc<dyn Storage> = storage;
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        let fp_words = test_fingerprint_words();
+        let expected_pages: Vec<_> = vec![
+            render_display_message(&["Channel", "11"]),
+            render_status_text_page(&build_node_status_lines(
+                &[] as &[NodeRecord],
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+                &HashMap::new(),
+            ))
+            .visible_window(0),
+            render_fingerprint_page(&fp_words),
+            render_rotation_code_page("ABC123"),
+        ];
+
+        tokio::time::pause();
+        for (i, expected_frame) in expected_pages.iter().enumerate() {
+            let press = tokio::spawn({
+                let transport = Arc::clone(&transport);
+                let controller = Arc::clone(&controller);
+                let storage = Arc::clone(&storage);
+                let session_manager = Arc::clone(&session_manager);
+                let display_generation = Arc::clone(&display_generation);
+                let status_page_cycle = Arc::clone(&status_page_cycle);
+                let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
+                let fp = fp_words;
+                async move {
+                    handle_idle_button_short_event(
+                        &transport,
+                        &controller,
+                        &storage,
+                        &session_manager,
+                        6,
+                        &display_generation,
+                        &status_page_cycle,
+                        &status_page_scroll_task,
+                        &fp,
+                    )
+                    .await
+                }
+            });
+            let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+            assert_eq!(
+                framebuffer, *expected_frame,
+                "page {i} mismatch (0=Channel, 1=Nodes, 2=Fingerprint, 3=RotationCode)"
+            );
+            assert!(press.await.unwrap());
+        }
+    }
+
+    /// T-1103i: Verify rotation code reads fresh from storage on each render.
+    #[tokio::test]
+    async fn rotation_code_page_reads_fresh_from_storage() {
+        use sonde_gateway::display_banner::render_rotation_code_page;
+
+        let (transport, mut server) = create_transport_and_server(6).await;
+        let controller = Arc::new(BlePairingController::new());
+        let display_generation = Arc::new(AtomicU64::new(0));
+        let status_page_cycle = Arc::new(tokio::sync::Mutex::new(StatusPageCycle::default()));
+        let status_page_scroll_task: StatusPageScrollTask = Arc::new(tokio::sync::Mutex::new(None));
+        let storage = Arc::new(InMemoryStorage::new());
+        let session_manager = Arc::new(SessionManager::new(Duration::from_secs(60)));
+        storage.set_config("espnow_channel", "11").await.unwrap();
+        storage.set_config("rotation_code", "OLD111").await.unwrap();
+        let storage_dyn: Arc<dyn Storage> = storage.clone();
+        let mut decoder = FrameDecoder::new();
+        let mut buf = [0u8; 2048];
+
+        let fp_words = test_fingerprint_words();
+
+        // Advance cycle to the RotationCode page (page index 3).
+        // Press 3 times: Channel, Nodes, Fingerprint.
+        tokio::time::pause();
+        for _ in 0..3 {
+            let press = tokio::spawn({
+                let transport = Arc::clone(&transport);
+                let controller = Arc::clone(&controller);
+                let storage = Arc::clone(&storage_dyn);
+                let session_manager = Arc::clone(&session_manager);
+                let display_generation = Arc::clone(&display_generation);
+                let status_page_cycle = Arc::clone(&status_page_cycle);
+                let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
+                let fp = fp_words;
+                async move {
+                    handle_idle_button_short_event(
+                        &transport,
+                        &controller,
+                        &storage,
+                        &session_manager,
+                        6,
+                        &display_generation,
+                        &status_page_cycle,
+                        &status_page_scroll_task,
+                        &fp,
+                    )
+                    .await
+                }
+            });
+            let _ = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+            assert!(press.await.unwrap());
+        }
+
+        // Press 4: RotationCode page — should show OLD111.
+        let press = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let storage = Arc::clone(&storage_dyn);
+            let session_manager = Arc::clone(&session_manager);
+            let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
+            let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
+            let fp = fp_words;
+            async move {
+                handle_idle_button_short_event(
+                    &transport,
+                    &controller,
+                    &storage,
+                    &session_manager,
+                    6,
+                    &display_generation,
+                    &status_page_cycle,
+                    &status_page_scroll_task,
+                    &fp,
+                )
+                .await
+            }
+        });
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_rotation_code_page("OLD111"));
+        assert!(press.await.unwrap());
+
+        // Change the rotation code in storage between renders.
+        storage.set_config("rotation_code", "NEW222").await.unwrap();
+
+        // Cycle through Channel, Nodes, Fingerprint (3 presses) to reach
+        // RotationCode again.
+        for _ in 0..3 {
+            let press = tokio::spawn({
+                let transport = Arc::clone(&transport);
+                let controller = Arc::clone(&controller);
+                let storage = Arc::clone(&storage_dyn);
+                let session_manager = Arc::clone(&session_manager);
+                let display_generation = Arc::clone(&display_generation);
+                let status_page_cycle = Arc::clone(&status_page_cycle);
+                let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
+                let fp = fp_words;
+                async move {
+                    handle_idle_button_short_event(
+                        &transport,
+                        &controller,
+                        &storage,
+                        &session_manager,
+                        6,
+                        &display_generation,
+                        &status_page_cycle,
+                        &status_page_scroll_task,
+                        &fp,
+                    )
+                    .await
+                }
+            });
+            let _ = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+            assert!(press.await.unwrap());
+        }
+
+        // Press again: RotationCode page — should show NEW222.
+        let press = tokio::spawn({
+            let transport = Arc::clone(&transport);
+            let controller = Arc::clone(&controller);
+            let storage = Arc::clone(&storage_dyn);
+            let session_manager = Arc::clone(&session_manager);
+            let display_generation = Arc::clone(&display_generation);
+            let status_page_cycle = Arc::clone(&status_page_cycle);
+            let status_page_scroll_task = Arc::clone(&status_page_scroll_task);
+            let fp = fp_words;
+            async move {
+                handle_idle_button_short_event(
+                    &transport,
+                    &controller,
+                    &storage,
+                    &session_manager,
+                    6,
+                    &display_generation,
+                    &status_page_cycle,
+                    &status_page_scroll_task,
+                    &fp,
+                )
+                .await
+            }
+        });
+        let framebuffer = receive_display_transfer(&mut server, &mut decoder, &mut buf).await;
+        assert_eq!(framebuffer, render_rotation_code_page("NEW222"));
+        assert!(press.await.unwrap());
     }
 }
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1387,7 +1387,7 @@ The passkey screen has priority over the generic connected state until Numeric C
 
 Outside an active BLE pairing session, `EVENT_BUTTON(BUTTON_SHORT)` advances the modem display through a gateway-owned sequence of status pages. The gateway chooses the sequence contents and renders each page into the same 128×64 framebuffer format used for the default banner and pairing screens.
 
-The default page sequence remains `[Channel, Nodes]`. The `Channel` page uses the existing centered two-line renderer. The `Nodes` page uses a node-status renderer that shows the operational node details most useful on the display: node ID, assigned/current program identifiers, battery, last seen, and schedule, with nodes ordered by `node_id`, `key_hint` intentionally omitted, and `No nodes registered.` shown when the registry is empty. For assigned/current programs, the renderer resolves the default identifier from the stored `source_filename` basename when available and falls back to the hash when the metadata is absent. `last seen` is converted to the host's local timezone and formatted with locale-style date/time output rather than fixed UTC text. On the display, each field is formatted as a left-aligned property line followed by a left-aligned `- value` line so property names and values remain distinguishable on the small screen.
+The default page sequence is `[Channel, Nodes, Fingerprint, RotationCode]` (see §23.11 steps 9b–9c for the Fingerprint and RotationCode additions). The `Channel` page uses the existing centered two-line renderer. The `Nodes` page uses a node-status renderer that shows the operational node details most useful on the display: node ID, assigned/current program identifiers, battery, last seen, and schedule, with nodes ordered by `node_id`, `key_hint` intentionally omitted, and `No nodes registered.` shown when the registry is empty. For assigned/current programs, the renderer resolves the default identifier from the stored `source_filename` basename when available and falls back to the hash when the metadata is absent. `last seen` is converted to the host's local timezone and formatted with locale-style date/time output rather than fixed UTC text. On the display, each field is formatted as a left-aligned property line followed by a left-aligned `- value` line so property names and values remain distinguishable on the small screen. The `Fingerprint` page shows the 6 BIP-39 words computed from the gateway identity's X25519 public key, cached once at startup. The `RotationCode` page reads the current rotation code from storage on each render.
 
 The gateway tracks the status-page cycle as a cursor over the configured page sequence (`StatusPageCycle { next_page_index }` in `bin/gateway.rs`) together with a monotonically increasing `display_generation` used to invalidate older timeout tasks. When the active page is `Nodes`, the gateway also tracks node-page-local scroll state: the current vertical window offset and whether an autonomous 50 ms scroll ticker is active for the current display generation.
 
@@ -2064,9 +2064,18 @@ Insert after step 9 (start connector):
 > 9a. Emit gateway ACTUAL_STATE via
 >     `connector_event_hub.emit_gateway_actual_state()` with all
 >     current state fields.
-> 9b. Compute BIP-39 fingerprint. *(deferred to follow-up issue)*
+> 9b. Compute BIP-39 fingerprint from the gateway identity's X25519
+>     public key using `compute_fingerprint()` (§23.10).  Cache the
+>     resulting 6 words as `[String; 6]` for the lifetime of the
+>     process — the identity is immutable, so the fingerprint never
+>     changes during a single run.
 > 9c. Register fingerprint + rotation code as modem display pages.
->     *(deferred to follow-up issue)*
+>     Extend `StatusPage` with two new variants (`Fingerprint`,
+>     `RotationCode`) so the idle short-press cycle becomes
+>     Channel → Nodes → Fingerprint → Rotation Code → Channel → …
+>     The fingerprint page uses the cached words from step 9b.
+>     The rotation code page reads the current value from storage
+>     on each render (the code may change during a rotation).
 
 ### 23.12  gRPC rotation API (GW-2012)
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -2066,9 +2066,9 @@ Insert after step 9 (start connector):
 >     current state fields.
 > 9b. Compute BIP-39 fingerprint from the gateway identity's X25519
 >     public key using `compute_fingerprint()` (§23.10).  Cache the
->     resulting 6 words as `[String; 6]` for the lifetime of the
->     process — the identity is immutable, so the fingerprint never
->     changes during a single run.
+>     resulting 6 words for the lifetime of the process — the
+>     identity is immutable, so the fingerprint never changes during
+>     a single run.
 > 9c. Register fingerprint + rotation code as modem display pages.
 >     Extend `StatusPage` with two new variants (`Fingerprint`,
 >     `RotationCode`) so the idle short-press cycle becomes

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -2131,6 +2131,40 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-1103h  Short press cycles through all four status pages in order
+
+**Validates:** GW-1101b, GW-2010
+
+**Procedure:**
+1. Start a gateway instance with a mock modem, a known gateway identity, and a known rotation code in storage. Complete the startup handshake.
+2. Inject `EVENT_BUTTON(BUTTON_SHORT)` while no BLE pairing session is active.
+3. Reassemble the framebuffer and assert: it renders the `Channel` status page.
+4. Inject a second `EVENT_BUTTON(BUTTON_SHORT)`.
+5. Reassemble the framebuffer and assert: it renders the `Nodes` status page.
+6. Inject a third `EVENT_BUTTON(BUTTON_SHORT)`.
+7. Reassemble the framebuffer and assert: it matches `render_fingerprint_page()` called with the 6 BIP-39 words independently computed from the gateway identity's X25519 public key.
+8. Inject a fourth `EVENT_BUTTON(BUTTON_SHORT)`.
+9. Reassemble the framebuffer and assert: it matches `render_rotation_code_page()` called with the rotation code from storage.
+10. Inject a fifth `EVENT_BUTTON(BUTTON_SHORT)`.
+11. Assert: the cycle wraps and the page shown is `Channel` again.
+
+---
+
+### T-1103i  Rotation Code page reads fresh value from storage on each render
+
+**Validates:** GW-2010
+
+**Procedure:**
+1. Start a gateway instance with a mock modem and a known rotation code `"ABCDEF"` in storage. Complete the startup handshake.
+2. Inject `EVENT_BUTTON(BUTTON_SHORT)` four times to reach the `Rotation Code` page.
+3. Reassemble the framebuffer and assert: it renders `"ABCDEF"`.
+4. Continue pressing to cycle back through Channel, Nodes, Fingerprint.
+5. Update the rotation code in storage to `"ZYXWVU"`.
+6. Inject `EVENT_BUTTON(BUTTON_SHORT)` to reach the `Rotation Code` page again.
+7. Reassemble the framebuffer and assert: it renders `"ZYXWVU"`, not `"ABCDEF"`.
+
+---
+
 ### T-1104a  Serial disconnect — reconnection with backoff
 
 **Validates:** GW-1103 (criteria 3–5)
@@ -4574,7 +4608,7 @@ A configurable stub handler process (or in-process mock) that:
 | GW-2007 | T-2005, T-2009 |
 | GW-2008 | T-2007 |
 | GW-2009 | T-2006, T-2006a, T-2006b |
-| GW-2010 | T-2001 |
+| GW-2010 | T-2001, T-1103h, T-1103i |
 | GW-2011 | T-2001 |
 | GW-2012 | T-2008 |
 | GW-2013 | T-2010 |


### PR DESCRIPTION
Closes #1075

## Summary

Adds \\Fingerprint\\ and \\RotationCode\\ as new status pages in the modem display cycle, accessible via button short-press. The cycle is now 4 pages: **Channel → Nodes → Fingerprint → RotationCode**.

### Fingerprint page
Renders the gateway's BIP-39 fingerprint words (6 words derived from the X25519 public key). Computed once at BLE loop startup — identity is immutable during a run.

### Rotation code page
Reads \\otation_code\\ fresh from storage on each render via \\get_config()\\, so code rotations are reflected immediately without restart.

## Spec changes
- \\docs/gateway-design.md\\ §17.4b: 4-page cycle sequence
- \\docs/gateway-design.md\\ §23.11 steps 9b-9c: concrete rendering details
- \\docs/gateway-validation.md\\: T-1103h (4-page cycle test), T-1103i (rotation code fresh-read test), traceability matrix updated

## Implementation
All changes in \\crates/sonde-gateway/src/bin/gateway.rs\\:
- \\StatusPage\\ enum: +\\Fingerprint\\, +\\RotationCode\\; \\ALL\\ array → 4 elements
- \\ender_status_page\\: new \\ingerprint_words\\ parameter, 2 new match arms
- BLE loop: computes fingerprint from gateway identity at startup
- 2 new tests (\\status_pages_cycle_through_all_four_pages\\, \\otation_code_page_reads_fresh_from_storage\\)
- Existing \\eentering_nodes_page\\ test updated for 4-page cycle

## Validation
- \\cargo build --workspace\\ ✅
- \\cargo clippy --workspace -- -D warnings\\ ✅
- \\cargo test -p sonde-gateway --bin sonde-gateway\\ — 22/22 tests pass ✅
- \\cargo fmt --all\\ ✅