### PR TITLE
fix(modem): align watchdog runtime override with spec'd 35s timeout

### DIFF
--- a/crates/sonde-modem/src/bin/modem.rs
+++ b/crates/sonde-modem/src/bin/modem.rs
@@ -142,10 +142,10 @@ fn main() {
     let mut bridge =
         Bridge::with_ble_button_and_display(usb, espnow, ble, button_scanner, display, counters);
 
-    // Initialize the task watchdog with a 10-second timeout (MD-0302).
+    // Initialize the task watchdog with a 35-second timeout (MD-0302).
     unsafe {
         let wdt_config = esp_idf_sys::esp_task_wdt_config_t {
-            timeout_ms: 10_000,
+            timeout_ms: 35_000,
             idle_core_mask: 0,
             trigger_panic: true,
         };


### PR DESCRIPTION
## Summary

The modem firmware's `esp_task_wdt_reconfigure()` call hardcoded `timeout_ms: 10_000` (10 seconds), overriding the `CONFIG_ESP_TASK_WDT_TIMEOUT_S=35` value in `sdkconfig.defaults` and contradicting the spec stack reconciled by PR #996.

## Changes

**`crates/sonde-modem/src/bin/modem.rs`**
- `timeout_ms: 10_000` to `timeout_ms: 35_000`
- Comment updated from 10-second timeout to 35-second timeout

## Traceability

| Artifact | Value | Status |
|----------|-------|--------|
| MD-0302 (requirement) | 35s | Already correct |
| modem-design.md S11 | 35s | Already correct |
| T-0304 (validation) | 40s wait | Already correct |
| sdkconfig.defaults:26 | 35s | Already correct |
| modem.rs runtime override | 10s to 35s | Fixed |

No spec changes needed. The spec stack was already reconciled to 35 seconds by #996. This PR fixes the only remaining artifact (runtime code) that was missed.

## Verification

- `cargo clippy --workspace -- -D warnings` passes
- `cargo test --workspace` passes
- Full firmware build validated by ESP32-S3 Modem Firmware CI

Fixes #1002
