### PR TITLE
Reject DESIRED_STATE with inline ELF but no `assigned_program_hash`

### DIFF
--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -768,9 +768,18 @@ impl ConnectorService {
         let ephemeral_program_hash =
             optional_bytes_field(desired_state, 3, "ephemeral_program_hash")?;
 
-        // Ingest inline ELF (key 5) only when assigned_program_hash (key 1) is present.
+        // Parse inline ELF (key 5) up front so we can reject the entire
+        // DESIRED_STATE when key 5 is present but key 1 is missing (GW-0811).
+        let inline_elf = optional_bytes_field(desired_state, 5, "assigned_program_elf")?;
+        if inline_elf.is_some() && assigned_program_hash.is_none() {
+            return Err(
+                "`assigned_program_elf` (key 5) present but `assigned_program_hash` (key 1) \
+                 missing; the entire DESIRED_STATE is rejected per GW-0811"
+                    .to_string(),
+            );
+        }
+
         if assigned_program_hash.is_some() {
-            let inline_elf = optional_bytes_field(desired_state, 5, "assigned_program_elf")?;
             if let Some(elf_bytes) = inline_elf.as_deref() {
                 // Validate declared hash format before expensive Prevail verification.
                 let declared_hash = assigned_program_hash.as_deref().unwrap();

--- a/crates/sonde-gateway/tests/connector_api.rs
+++ b/crates/sonde-gateway/tests/connector_api.rs
@@ -1047,3 +1047,88 @@ async fn connector_wake_blob_delivers_decoder_enriched_readings() {
     drop(client);
     handle.await.unwrap();
 }
+
+// ── T-0819d: Inline ELF without assigned_program_hash is rejected ──
+
+#[tokio::test]
+async fn connector_inline_elf_without_hash_is_rejected() {
+    let harness = ConnectorHarness::new();
+    let node = TestNode::new("alpha-elf-no-hash", 0x1313, [0x55; 32]);
+    let sentinel_node = TestNode::new("beta-sentinel", 0x1414, [0x66; 32]);
+    let program_hash = store_program(&harness.storage, 0x71).await;
+
+    register_node(&harness.storage, &node).await;
+    register_node(&harness.storage, &sentinel_node).await;
+
+    // Pre-populate desired state so we can verify it is NOT overwritten.
+    let mut stored = harness
+        .storage
+        .get_node(&node.node_id)
+        .await
+        .unwrap()
+        .unwrap();
+    stored.assigned_program_hash = Some(program_hash.clone());
+    stored.desired_schedule_interval_s = Some(120);
+    stored.schedule_interval_s = 120;
+    harness.storage.upsert_node(&stored).await.unwrap();
+
+    let (mut client, handle) = spawn_connection(harness.service.clone()).await;
+
+    // Send invalid DESIRED_STATE: key 5 present, key 1 absent.
+    let invalid = Value::Map(vec![
+        map_entry(1, Value::Integer(MSG_TYPE_DESIRED_STATE.into())),
+        map_entry(2, Value::Text("node".to_string())),
+        map_entry(3, Value::Text(node.node_id.clone())),
+        map_entry(
+            4,
+            Value::Map(vec![
+                map_entry(2, Value::Integer(900u64.into())),
+                map_entry(5, Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF])),
+            ]),
+        ),
+    ]);
+    write_framed(&mut client, &encode_value(&invalid)).await;
+
+    // Send a valid sentinel DESIRED_STATE for a different node.
+    // Because connector messages are processed in FIFO order on the same
+    // connection, observing the sentinel's state change proves the invalid
+    // message was already processed (and rejected).
+    let sentinel_desired = Value::Map(vec![
+        map_entry(1, Value::Integer(MSG_TYPE_DESIRED_STATE.into())),
+        map_entry(2, Value::Text("node".to_string())),
+        map_entry(3, Value::Text(sentinel_node.node_id.clone())),
+        map_entry(
+            4,
+            Value::Map(vec![map_entry(2, Value::Integer(300u64.into()))]),
+        ),
+    ]);
+    write_framed(&mut client, &encode_value(&sentinel_desired)).await;
+
+    // Wait for sentinel to be applied — proves the invalid message was processed.
+    wait_for_desired_state(&harness, &sentinel_node.node_id, None, 300).await;
+
+    // Assert: original node's desired state is unchanged.
+    let stored = harness
+        .storage
+        .get_node(&node.node_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        stored.assigned_program_hash,
+        Some(program_hash),
+        "assigned_program_hash must be preserved after rejection"
+    );
+    assert_eq!(
+        stored.desired_schedule_interval_s,
+        Some(120),
+        "desired_schedule_interval_s must be preserved after rejection"
+    );
+    assert_eq!(
+        stored.schedule_interval_s, 120,
+        "schedule_interval_s must be preserved after rejection"
+    );
+
+    drop(client);
+    handle.await.unwrap();
+}

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -1804,6 +1804,16 @@ A configurable stub handler process (or in-process mock) that:
 3. Send a `DESIRED_STATE` message with `assigned_program_hash` (key 1) set to a **different** 32-byte hash, and `assigned_program_elf` (key 5) set to the valid ELF.
 4. Assert: the gateway rejects the message because the ingested program's hash does not match the declared `assigned_program_hash`.
 
+### T-0819d  Inline ELF without `assigned_program_hash` is rejected
+
+**Validates:** GW-0811
+
+**Procedure:**
+1. Start the gateway and register a node with pre-existing desired state (e.g., an assigned program hash and schedule interval).
+2. Send a `DESIRED_STATE` message with `assigned_program_elf` (key 5) set to arbitrary bytes, but `assigned_program_hash` (key 1) absent.
+3. Assert: the gateway rejects the message with an error mentioning the missing `assigned_program_hash`.
+4. Assert: the node's desired state is NOT updated — the pre-existing assigned program hash and schedule interval remain unchanged.
+
 ---
 
 ### T-0820  Upstream actual-state/status update after `WAKE`


### PR DESCRIPTION
## Summary

Fixes #1001 — the connector's `apply_node_desired_state` silently ignored `assigned_program_elf` (CBOR key 5) when `assigned_program_hash` (key 1) was absent. GW-0811 requires the gateway to **reject** the entire `DESIRED_STATE` message in this case.

## Changes

### `crates/sonde-gateway/src/connector.rs`
- Moved key 5 parsing before the hash-gated block so the presence of an inline ELF without a declared hash is detected early.
- Returns a specific error naming the missing key instead of silently applying the rest of the desired state.

### `docs/gateway-validation.md`
- Added **T-0819d** validation test case: \\Inline ELF without assigned_program_hash is rejected\\.

### `crates/sonde-gateway/tests/connector_api.rs`
- Added `connector_inline_elf_without_hash_is_rejected` test using a deterministic sentinel pattern (FIFO ordering proof instead of sleep) to verify the target node's desired state is preserved after rejection.

## Traceability

| Requirement | Validation | Test |
|---|---|---|
| GW-0811 (unchanged) | T-0819d (new) | `connector_inline_elf_without_hash_is_rejected` (new) |

## Verification

- All 13 connector_api tests pass
- `cargo clippy -p sonde-gateway -- -D warnings` clean
- `cargo fmt --all -- --check` clean