### PR TITLE
azure-handler: inject synthetic Server header for Azure Table Storage stamps that omit it

### DIFF
--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -11,7 +11,7 @@ use azure_core_legacy::auth::TokenCredential as LegacyTokenCredential;
 use azure_core_legacy::error::ErrorKind as LegacyAzureErrorKind;
 use azure_core_legacy::Error as LegacyAzureError;
 use azure_core_legacy::StatusCode as LegacyStatusCode;
-use azure_data_tables::prelude::TableServiceClient;
+use azure_data_tables::clients::TableServiceClientBuilder;
 use azure_identity::ManagedIdentityCredential;
 use azure_identity_legacy::{AppServiceManagedIdentityCredential, TokenCredentialOptions};
 use base64::Engine as _;
@@ -905,6 +905,45 @@ pub fn format_ingest_response(status_code: u16, body: &serde_json::Value) -> ser
     })
 }
 
+/// Workaround for azure-sdk-for-rust#4489: some Azure Table Storage stamps
+/// omit the `Server` HTTP response header, but `azure_storage` 0.21.0
+/// `CommonStorageResponseHeaders` unconditionally requires it, failing with
+/// `"header not found server"`. This policy injects a synthetic header when
+/// one is missing so the SDK's response parsing succeeds.
+#[derive(Debug)]
+struct InjectServerHeaderPolicy;
+
+#[async_trait]
+impl azure_core_legacy::Policy for InjectServerHeaderPolicy {
+    async fn send(
+        &self,
+        ctx: &azure_core_legacy::Context,
+        request: &mut azure_core_legacy::Request,
+        next: &[Arc<dyn azure_core_legacy::Policy>],
+    ) -> azure_core_legacy::PolicyResult {
+        let response = next[0].send(ctx, request, &next[1..]).await?;
+        if response
+            .headers()
+            .get_optional_str(&azure_core_legacy::headers::SERVER)
+            .is_none()
+        {
+            // Deconstruct, inject, reconstruct — Response has no headers_mut().
+            let (status, mut headers, body) = response.deconstruct();
+            headers.insert(
+                azure_core_legacy::headers::SERVER,
+                "Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0",
+            );
+            Ok(azure_core_legacy::Response::new(
+                status,
+                headers,
+                Box::pin(body),
+            ))
+        } else {
+            Ok(response)
+        }
+    }
+}
+
 pub struct AzureTablesStore {
     actual_state_table: azure_data_tables::clients::TableClient,
     desired_state_table: azure_data_tables::clients::TableClient,
@@ -920,7 +959,12 @@ impl AzureTablesStore {
                     HandlerError::Config(format!("create Azure Table credential failed: {e}"))
                 })?,
         );
-        let service = TableServiceClient::new(config.storage_account.clone(), credential);
+        let mut opts = azure_core_legacy::ClientOptions::default();
+        opts.per_call_policies_mut()
+            .push(Arc::new(InjectServerHeaderPolicy));
+        let service = TableServiceClientBuilder::new(config.storage_account.clone(), credential)
+            .client_options(opts)
+            .build();
         Ok(Self {
             actual_state_table: service.table_client(config.actual_state_table.clone()),
             desired_state_table: service.table_client(config.desired_state_table.clone()),
@@ -5122,5 +5166,101 @@ mod tests {
 
         let result = decode_connector_message(&bytes);
         assert!(result.is_err(), "string value at key 28 should fail decode");
+    }
+
+    // --- T-AZH-0700: InjectServerHeaderPolicy injects Server when missing ---
+    #[tokio::test]
+    async fn t_azh_0700_inject_server_header_when_missing() {
+        use azure_core_legacy::headers::{Headers, SERVER};
+        use azure_core_legacy::{Context, Policy, Response, StatusCode};
+
+        // Terminal policy that returns a response with no Server header.
+        #[derive(Debug)]
+        struct NoServerHeaderTerminal;
+
+        #[async_trait]
+        impl Policy for NoServerHeaderTerminal {
+            async fn send(
+                &self,
+                _ctx: &Context,
+                _request: &mut azure_core_legacy::Request,
+                _next: &[Arc<dyn Policy>],
+            ) -> azure_core_legacy::PolicyResult {
+                let headers = Headers::new();
+                Ok(Response::new(
+                    StatusCode::Ok,
+                    headers,
+                    Box::pin(azure_core_legacy::BytesStream::new_empty()),
+                ))
+            }
+        }
+
+        let policy = InjectServerHeaderPolicy;
+        let terminal: Arc<dyn Policy> = Arc::new(NoServerHeaderTerminal);
+        let next = vec![terminal];
+
+        let ctx = Context::new();
+        let mut request = azure_core_legacy::Request::new(
+            "https://example.table.core.windows.net/Tables"
+                .parse()
+                .unwrap(),
+            azure_core_legacy::Method::Get,
+        );
+
+        let response = policy.send(&ctx, &mut request, &next).await.unwrap();
+        let server = response.headers().get_optional_str(&SERVER);
+        assert_eq!(
+            server,
+            Some("Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0"),
+            "policy must inject Server header when absent"
+        );
+    }
+
+    // --- T-AZH-0701: InjectServerHeaderPolicy preserves existing Server header ---
+    #[tokio::test]
+    async fn t_azh_0701_preserve_existing_server_header() {
+        use azure_core_legacy::headers::{Headers, SERVER};
+        use azure_core_legacy::{Context, Policy, Response, StatusCode};
+
+        #[derive(Debug)]
+        struct HasServerHeaderTerminal;
+
+        #[async_trait]
+        impl Policy for HasServerHeaderTerminal {
+            async fn send(
+                &self,
+                _ctx: &Context,
+                _request: &mut azure_core_legacy::Request,
+                _next: &[Arc<dyn Policy>],
+            ) -> azure_core_legacy::PolicyResult {
+                let mut headers = Headers::new();
+                headers.insert(SERVER, "OriginalServer/1.0");
+                Ok(Response::new(
+                    StatusCode::Ok,
+                    headers,
+                    Box::pin(azure_core_legacy::BytesStream::new_empty()),
+                ))
+            }
+        }
+
+        let policy = InjectServerHeaderPolicy;
+        let terminal: Arc<dyn Policy> = Arc::new(HasServerHeaderTerminal);
+        let next = vec![terminal];
+
+        let ctx = Context::new();
+        let mut request = azure_core_legacy::Request::new(
+            "https://example.table.core.windows.net/Tables"
+                .parse()
+                .unwrap(),
+            azure_core_legacy::Method::Get,
+        );
+
+        let response = policy.send(&ctx, &mut request, &next).await.unwrap();
+        let server = response.headers().get_optional_str(&SERVER);
+        assert_eq!(
+            server,
+            Some("OriginalServer/1.0"),
+            "policy must not overwrite existing Server header"
+        );
     }
 }

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -397,7 +397,7 @@ configuration.
 
 ## 7  Failure handling
 
-> **Requirements:** AZH-0400
+> **Requirements:** AZH-0400, AZH-0700
 
 The handler follows a fail-closed rule for all Azure Table and Storage Queue
 operations that determine externally visible control-plane behavior:
@@ -409,6 +409,22 @@ operations that determine externally visible control-plane behavior:
 This failure model preserves at-least-once retry behavior from the Azure
 Function runtime instead of silently pretending that state was reconciled or
 sensor data was stored.
+
+### 7.1  SDK workaround — missing `Server` response header
+
+> **Requirements:** AZH-0700
+
+Some Azure Table Storage stamps omit the `Server` HTTP response header that
+`azure_storage` 0.21.0 `CommonStorageResponseHeaders` unconditionally
+requires (upstream: azure-sdk-for-rust#4489). Without mitigation, all table
+operations fail with `"header not found server"`.
+
+The handler injects an `InjectServerHeaderPolicy` into the
+`TableServiceClientBuilder` pipeline (via `per_call_policies`) that adds a
+synthetic `Server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0` header to
+responses when one is missing. The policy is a no-op when the header is
+already present. This uses the SDK's intended extension mechanism and is
+removable when the upstream fix lands.
 
 ---
 

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -503,3 +503,25 @@ Gateway `DESIRED_STATE` is written to the `desiredstate` Azure Table with
 
 1. Gateway `DESIRED_STATE` uses the correct CBOR key numbers.
 2. The `PartitionKey` uses the `"g:"` prefix.
+
+---
+
+### AZH-0700  SDK workaround — missing `Server` response header
+
+**Priority:** Must
+**Source:** Issue #1089, azure-sdk-for-rust#4489
+
+**Description:**
+Some Azure Table Storage stamps omit the `Server` HTTP response header.
+`azure_storage` 0.21.0 `CommonStorageResponseHeaders` unconditionally
+requires this header, causing all table operations to fail with
+`"header not found server"`. The handler MUST inject a synthetic `Server`
+header into Azure Table Storage responses that lack one, using the SDK's
+`Policy` pipeline extension mechanism.
+
+**Acceptance criteria:**
+
+1. When the `Server` header is absent, the policy injects
+   `"Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0"`.
+2. When the `Server` header is already present, it is not modified.
+3. The workaround is removable when the upstream SDK fix lands.

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -462,3 +462,29 @@ divergence publication instead of treating that redelivery as permanently stale.
    escrow-related status update.
 2. Query the `actualstate` table for rows associated with that phone identity.
 3. Assert: no row is created with `entity_kind = "phone"`.
+
+---
+
+### T-AZH-0700  `InjectServerHeaderPolicy` injects `Server` when missing
+
+**Validates:** AZH-0700
+
+**Procedure:**
+1. Create an `InjectServerHeaderPolicy` instance and a terminal policy that
+   returns a response with no `Server` header.
+2. Send a request through the policy chain.
+3. Assert: the returned response contains a `Server` header with value
+   `"Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0"`.
+
+---
+
+### T-AZH-0701  `InjectServerHeaderPolicy` preserves existing `Server` header
+
+**Validates:** AZH-0700
+
+**Procedure:**
+1. Create an `InjectServerHeaderPolicy` instance and a terminal policy that
+   returns a response with `Server: OriginalServer/1.0`.
+2. Send a request through the policy chain.
+3. Assert: the returned response contains a `Server` header with value
+   `"OriginalServer/1.0"` (unmodified).


### PR DESCRIPTION
## Summary

Fixes #1089 — work around missing `Server` HTTP response header in Azure Table Storage responses from some storage stamps.

## Root Cause

`azure_storage` 0.21.0 `CommonStorageResponseHeaders` unconditionally requires a `Server` response header via `server_from_headers(headers)?`. When the header is absent, this fails with `"header not found server"` (upstream: [azure-sdk-for-rust#4489](https://github.com/Azure/azure-sdk-for-rust/issues/4489)).

### Verification

Direct HTTP calls to both storage accounts confirm the behavior is deterministic and stamp-dependent:

| Account | Resource Group | Created | `Server` Header |
|---------|---------------|---------|-------------------|
| `sts2jb46h7tqwje` | sonde-azure | 2026-05-28 | **Never** returned |
| `st7ikf25ddv4vmg` | sondeproduction-azure | 2026-05-18 | **Always** returned |

Both accounts are identical SKU (`StorageV2`, `Standard_LRS`, `eastus`). The difference is the underlying Azure storage stamp — newer stamps appear to have stopped emitting this header.

## Fix

Adds an `InjectServerHeaderPolicy` to the `TableServiceClientBuilder` pipeline (via `per_call_policies`) that injects a synthetic `Server: Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0` header into responses when one is missing.

This uses the SDK's intended `Policy` extension mechanism and is trivially removable when the upstream fix lands.

## Changes

- `crates/sonde-azure-handler/src/lib.rs`: Add `InjectServerHeaderPolicy` struct implementing `azure_core::Policy`; switch `AzureTablesStore::new()` from `TableServiceClient::new()` to `TableServiceClientBuilder` with custom `ClientOptions`.