### PR TITLE
feat(gateway): periodic ACTUAL_STATE heartbeat (GW-2003 AC-8)

### DIFF
--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1259,22 +1259,6 @@ async fn run_gateway(
                         // Start or reset the debounce timer.
                         hint_debounce = Some(Box::pin(tokio::time::sleep(HINT_DEBOUNCE)));
                     }
-                    _ = async {
-                        match hint_debounce.as_mut() {
-                            Some(sleep) => sleep.as_mut().await,
-                            None => std::future::pending().await,
-                        }
-                    } => {
-                        hint_debounce = None;
-                        info!("missing hint debounce elapsed — re-emitting gateway ACTUAL_STATE");
-                        if let Err(e) = reemit_gateway_actual_state(
-                            &reemit_event_hub,
-                            &reemit_storage,
-                            &reemit_gateway,
-                        ).await {
-                            error!("failed to re-emit ACTUAL_STATE on missing hints: {e}");
-                        }
-                    }
                     _ = heartbeat.tick() => {
                         // Cancel any active hint debounce — the heartbeat
                         // emission drains pending hints via the shared
@@ -1289,6 +1273,22 @@ async fn run_gateway(
                             &reemit_gateway,
                         ).await {
                             error!("failed to re-emit ACTUAL_STATE on heartbeat: {e}");
+                        }
+                    }
+                    _ = async {
+                        match hint_debounce.as_mut() {
+                            Some(sleep) => sleep.as_mut().await,
+                            None => std::future::pending().await,
+                        }
+                    } => {
+                        hint_debounce = None;
+                        info!("missing hint debounce elapsed — re-emitting gateway ACTUAL_STATE");
+                        if let Err(e) = reemit_gateway_actual_state(
+                            &reemit_event_hub,
+                            &reemit_storage,
+                            &reemit_gateway,
+                        ).await {
+                            error!("failed to re-emit ACTUAL_STATE on missing hints: {e}");
                         }
                     }
                     else => {

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1220,7 +1220,17 @@ async fn run_gateway(
             /// Debounce interval for missing key hint-triggered re-emission.
             const HINT_DEBOUNCE: Duration = Duration::from_secs(60);
 
+            /// Periodic heartbeat interval for gateway ACTUAL_STATE
+            /// re-emission (GW-2003 AC-8). Ensures the control-plane
+            /// handler regularly evaluates pending desired state.
+            const GATEWAY_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(900);
+
             let mut hint_debounce: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
+            let mut heartbeat = tokio::time::interval_at(
+                tokio::time::Instant::now() + GATEWAY_HEARTBEAT_INTERVAL,
+                GATEWAY_HEARTBEAT_INTERVAL,
+            );
+            heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
             loop {
                 tokio::select! {
@@ -1263,6 +1273,22 @@ async fn run_gateway(
                             &reemit_gateway,
                         ).await {
                             error!("failed to re-emit ACTUAL_STATE on missing hints: {e}");
+                        }
+                    }
+                    _ = heartbeat.tick() => {
+                        // Cancel any active hint debounce — the heartbeat
+                        // emission drains pending hints via the shared
+                        // re-emission procedure.
+                        if hint_debounce.take().is_some() {
+                            info!("heartbeat pre-empted missing hint debounce");
+                        }
+                        info!("periodic heartbeat — re-emitting gateway ACTUAL_STATE");
+                        if let Err(e) = reemit_gateway_actual_state(
+                            &reemit_event_hub,
+                            &reemit_storage,
+                            &reemit_gateway,
+                        ).await {
+                            error!("failed to re-emit ACTUAL_STATE on heartbeat: {e}");
                         }
                     }
                     else => {

--- a/crates/sonde-gateway/tests/escrow.rs
+++ b/crates/sonde-gateway/tests/escrow.rs
@@ -4,7 +4,7 @@
 //! Integration tests for PSK escrow, master key identification, and ACTUAL_STATE
 //! publication (GW-2001, GW-2003, GW-2004, GW-2005).
 //!
-//! Test IDs: T-2000, T-2001, T-2002, T-2006c, T-2011, T-2012, T-2013.
+//! Test IDs: T-2000, T-2001, T-2002, T-2006c, T-2011, T-2012, T-2013, T-2014.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -1185,4 +1185,87 @@ async fn test_t2011_missing_key_hint_debounced_reemission() {
     );
     assert!(missing_hints.contains(&0x9999));
     assert!(missing_hints.contains(&0x8888));
+}
+
+// ── T-2014: Periodic gateway ACTUAL_STATE heartbeat ──────────────
+
+/// T-2014: Periodic gateway ACTUAL_STATE heartbeat (GW-2003 AC-8).
+///
+/// Verifies:
+/// 1. No duplicate ACTUAL_STATE is emitted immediately after the initial
+///    startup emission.
+/// 2. A second ACTUAL_STATE is emitted after the heartbeat interval elapses,
+///    without any state change trigger.
+#[tokio::test]
+async fn test_t2014_periodic_gateway_actual_state_heartbeat() {
+    let (store, identity) = setup_test_storage().await;
+    let (_key_id, _epoch) = store.init_master_key_id().await.unwrap();
+    let _code = store.init_rotation_code().await.unwrap();
+
+    let event_hub = Arc::new(ConnectorEventHub::new(16));
+    let gateway = Arc::new(Gateway::new(
+        store.clone() as Arc<dyn Storage>,
+        Duration::from_secs(300),
+    ));
+
+    // Spawn connector.
+    let (mut client, _handle) =
+        spawn_connector(event_hub.clone(), store.clone() as Arc<dyn Storage>).await;
+
+    // Emit initial ACTUAL_STATE (inline, same as production startup).
+    emit_gateway_actual_state_from_storage(&event_hub, &store, &identity, &gateway).await;
+    let initial_frame = read_framed(&mut client).await;
+    let initial_map = decode_cbor_map(&initial_frame);
+    // Sanity: verify this is a gateway ACTUAL_STATE.
+    assert_eq!(
+        map_get(&initial_map, 1),
+        Some(&Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
+        "initial frame must be ACTUAL_STATE"
+    );
+
+    // Spawn a test re-emission loop with a SHORT heartbeat (200ms).
+    let reemit_store = store.clone();
+    let reemit_hub = event_hub.clone();
+    let reemit_gw = Arc::clone(&gateway);
+    tokio::spawn(async move {
+        const TEST_HEARTBEAT: Duration = Duration::from_millis(200);
+        let mut heartbeat =
+            tokio::time::interval_at(tokio::time::Instant::now() + TEST_HEARTBEAT, TEST_HEARTBEAT);
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            heartbeat.tick().await;
+            let id = reemit_store.load_gateway_identity().await.unwrap().unwrap();
+            emit_gateway_actual_state_from_storage(&reemit_hub, &reemit_store, &id, &reemit_gw)
+                .await;
+        }
+    });
+
+    // Verify NO ACTUAL_STATE emitted before the heartbeat interval (within 50ms).
+    let early_result =
+        tokio::time::timeout(Duration::from_millis(50), read_framed(&mut client)).await;
+    assert!(
+        early_result.is_err(),
+        "no ACTUAL_STATE should arrive before the heartbeat interval"
+    );
+
+    // Wait for heartbeat to fire (200ms + some margin).
+    let heartbeat_frame =
+        tokio::time::timeout(Duration::from_millis(500), read_framed(&mut client))
+            .await
+            .expect("ACTUAL_STATE should be re-emitted after heartbeat interval");
+    let heartbeat_map = decode_cbor_map(&heartbeat_frame);
+
+    // Verify the heartbeat emission is a valid gateway ACTUAL_STATE.
+    assert_eq!(
+        map_get(&heartbeat_map, 1),
+        Some(&Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
+        "heartbeat frame must be ACTUAL_STATE"
+    );
+    // Verify entity_kind = "gateway" (key 2).
+    assert_eq!(
+        map_get(&heartbeat_map, 2),
+        Some(&Value::Text("gateway".to_string())),
+        "heartbeat ACTUAL_STATE must have entity_kind = gateway"
+    );
 }

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -2156,3 +2156,17 @@ On each trigger, the task:
 The `MissingKeyHintTracker` integration in `process_frame` calls
 `notify.notify_one()` when `report()` returns `true` (hint accepted).
 The re-emission task awaits `notify.notified()`.
+
+4. `heartbeat_interval` — a
+   `tokio::time::interval_at(Instant::now() + GATEWAY_HEARTBEAT_INTERVAL, GATEWAY_HEARTBEAT_INTERVAL)`
+   with `MissedTickBehavior::Delay`. On tick, re-emit gateway ACTUAL_STATE
+   using the same re-emission procedure (including draining any pending
+   `missing_key_hints`). The heartbeat runs independently of event-driven
+   emissions — rotation, state-change, and missing-hint triggers do not
+   reset the heartbeat schedule. If a heartbeat fires during the
+   missing-hint debounce window, pending hints are drained and emitted
+   with the heartbeat; the debounce timer is then cancelled.
+   `GATEWAY_HEARTBEAT_INTERVAL` is a compile-time constant (default:
+   `Duration::from_secs(900)`). Tests may duplicate the re-emission loop
+   with a shorter interval constant, following the existing test pattern
+   for `HINT_DEBOUNCE`.

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2612,8 +2612,9 @@ x25519_public_key, fingerprint_words, missing_key_hints, salt, kdf_params,
 gateway_version, gateway_commit, modem_firmware_version, modem_firmware_commit,
 rotation_in_progress. Node-specific keys 4–8, 10–11 MUST be omitted.
 
-Gateway ACTUAL_STATE is emitted on startup, connector reconnection, and
-whenever gateway state changes.
+Gateway ACTUAL_STATE is emitted on startup, connector reconnection,
+whenever gateway state changes, and periodically at a compile-time
+heartbeat interval (default 900 seconds).
 
 **Acceptance criteria:**
 
@@ -2627,6 +2628,11 @@ whenever gateway state changes.
    previously-unseen `key_hint`, using a debounce window to coalesce
    concurrent arrivals.
 7. Re-emitted when salt or KDF params are adopted from DESIRED_STATE.
+8. Re-emitted periodically at a compile-time heartbeat interval (default
+   900 seconds) to ensure the control-plane handler regularly evaluates
+   pending desired state. The heartbeat schedule is process-local (resets
+   on gateway restart), independent of event-driven emissions, and does
+   not require an attached connector subscriber.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4576,6 +4576,30 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-2014  Periodic gateway ACTUAL_STATE heartbeat
+
+**Traces to:** GW-2003 (AC-8)
+
+**Steps:**
+1. Start gateway with identity and master key, using a short heartbeat
+   interval (e.g., 2 seconds).
+2. Connect a mock connector consumer.
+3. Consume the initial startup ACTUAL_STATE.
+4. Verify no second ACTUAL_STATE arrives before the heartbeat interval.
+5. Wait for the heartbeat interval to elapse.
+6. Verify a second gateway ACTUAL_STATE is received without any state
+   change trigger.
+
+**Expected:**
+1. No ACTUAL_STATE emitted between startup and first heartbeat tick.
+2. Gateway ACTUAL_STATE re-emitted after heartbeat interval elapses.
+
+**Note:** This test validates gateway-level periodic emission. Handler-side
+delivery of DESIRED_STATE in response to heartbeat ACTUAL_STATE is covered
+by existing handler tests.
+
+---
+
 | GW-1306 | T-1306a, T-1306b, T-1306c, T-1306d |
 | GW-1307 | T-1307a, T-1307b, T-1307c, T-1307d, T-1307e, T-1307f, T-1307g, T-1307h, T-1307i |
 | GW-1308 | T-1308 |
@@ -4611,7 +4635,7 @@ A configurable stub handler process (or in-process mock) that:
 | GW-2000 | T-2001 |
 | GW-2001 | T-2000 |
 | GW-2002 | T-2003 |
-| GW-2003 | T-2001, T-2011, T-2012, T-2013 |
+| GW-2003 | T-2001, T-2011, T-2012, T-2013, T-2014 |
 | GW-2004 | T-2002 |
 | GW-2005 | T-2001, T-2006c |
 | GW-2006 | T-2004, T-2004a |


### PR DESCRIPTION
## Summary

Adds a 900-second periodic heartbeat to the gateway ACTUAL_STATE re-emission task, closing a reconciliation gap in the master key rotation flow.

## Problem

After the SPA writes gateway desired state (e.g. \otation_payload\, salt, recovered PSKs) to the Azure \desiredstate\ table, the handler only evaluates it reactively when it receives an ACTUAL_STATE from the gateway. But gateway ACTUAL_STATE was only emitted on startup, connector reconnection, and state changes — no periodic trigger existed. This meant desired state could sit undelivered indefinitely.

Nodes don't have this problem because they check in every ~15 minutes on their wake cycle.

## Solution

Add a periodic heartbeat (default 900s / 15 minutes) to the gateway's \	okio::select!\ re-emission loop, mirroring the node pattern. The heartbeat:
- Uses \interval_at(Instant::now() + INTERVAL, INTERVAL)\ — no immediate duplicate after startup
- Uses \MissedTickBehavior::Delay\ — no catch-up bursts after delays
- Runs independently of event-driven emissions (rotation, state change, missing hints)
- Cancels any active missing-hint debounce when it fires (hints are drained by the shared re-emission procedure)

## Changes

| File | Change |
|------|--------|
| \docs/gateway-requirements.md\ | GW-2003: updated description + added AC-8 |
| \docs/gateway-design.md\ | §23.14: added heartbeat trigger #4 |
| \docs/gateway-validation.md\ | Added T-2014 + updated traceability matrix |
| \crates/sonde-gateway/src/bin/gateway.rs\ | Added \heartbeat\ arm to re-emission \select!\ loop |
| \crates/sonde-gateway/tests/escrow.rs\ | Added \	est_t2014_periodic_gateway_actual_state_heartbeat\ |

## Traceability

- **Requirement:** GW-2003 AC-8
- **Design:** §23.14 trigger #4
- **Validation:** T-2014
- **Related:** #1092 (gateway convergence UI — separate issue)