### PR TITLE
fix: persist rotated master key to KeyProvider backend (GW-2014)

### DIFF
--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -948,14 +948,27 @@ async fn run_gateway(
         // Try loading existing identity — may fail for post-commit crash
         // (seed rewrapped under new key, but old key in memory).  That's OK:
         // post-commit recovery only needs the pending_rotation record and the
-        // key provider, not the identity.  Pre-commit recovery needs identity
-        // for migration phases; if identity load fails for pre-commit, the
-        // resume call will error out and we'll surface it.
+        // key provider, not the identity.  Pre-commit crashes never hit this
+        // because encrypted_seed hasn't been promoted yet, so load succeeds
+        // with the old key.
         let identity = match storage.load_gateway_identity().await {
             Ok(Some(id)) => id,
             Ok(None) => GatewayIdentity::generate()
                 .map_err(|e| format!("cannot generate dummy identity for recovery: {e}"))?,
-            Err(e) => return Err(format!("cannot load gateway identity for recovery: {e}").into()),
+            Err(e) => {
+                // Identity decryption failure during recovery is expected in
+                // the post-commit/pre-provider-write crash window: the seed
+                // was already rewrapped under the new key by commit_rotation(),
+                // but the provider still has the old key.  The post-commit
+                // recovery path does not use identity, so a dummy is safe.
+                warn!(
+                    error = %e,
+                    "cannot decrypt gateway identity — expected during \
+                     post-commit rotation recovery; using placeholder"
+                );
+                GatewayIdentity::generate()
+                    .map_err(|e| format!("cannot generate dummy identity for recovery: {e}"))?
+            }
         };
         sonde_gateway::RotationEngine::resume_pending_rotation(
             &storage,

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -953,8 +953,9 @@ async fn run_gateway(
         // resume call will error out and we'll surface it.
         let identity = match storage.load_gateway_identity().await {
             Ok(Some(id)) => id,
-            _ => GatewayIdentity::generate()
+            Ok(None) => GatewayIdentity::generate()
                 .map_err(|e| format!("cannot generate dummy identity for recovery: {e}"))?,
+            Err(e) => return Err(format!("cannot load gateway identity for recovery: {e}").into()),
         };
         sonde_gateway::RotationEngine::resume_pending_rotation(
             &storage,

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -922,7 +922,8 @@ async fn run_gateway(
 
     // 1. Load master key for at-rest PSK encryption (GW-0601a).
     //    Build the appropriate KeyProvider from CLI arguments, then invoke it.
-    let provider = build_key_provider(cli)?;
+    let provider: Arc<dyn sonde_gateway::key_provider::KeyProvider> =
+        Arc::from(build_key_provider(cli)?);
     let master_key = Zeroizing::new(if cli.generate_master_key {
         let k = provider.generate_or_load_master_key()?;
         *k
@@ -935,6 +936,37 @@ async fn run_gateway(
     // 2. Open persistent storage
     let storage: Arc<SqliteStorage> = Arc::new(SqliteStorage::open(&cli.db, master_key)?);
     info!("storage opened: {}", cli.db);
+
+    // 2a. Check for post-commit rotation recovery BEFORE loading identity
+    //     (GW-2007).  If pending_rotation exists with epoch == DB epoch, the
+    //     key provider may still have the old key.  Recovery writes the new
+    //     key to the provider and swaps the in-memory key before identity
+    //     decryption (which uses the new key after commit).
+    let pending_rotation_notification = {
+        use sonde_gateway::gateway_identity::GatewayIdentity;
+
+        // Try loading existing identity — may fail for post-commit crash
+        // (seed rewrapped under new key, but old key in memory).  That's OK:
+        // post-commit recovery only needs the pending_rotation record and the
+        // key provider, not the identity.  Pre-commit recovery needs identity
+        // for migration phases; if identity load fails for pre-commit, the
+        // resume call will error out and we'll surface it.
+        let identity = match storage.load_gateway_identity().await {
+            Ok(Some(id)) => id,
+            _ => GatewayIdentity::generate()
+                .map_err(|e| format!("cannot generate dummy identity for recovery: {e}"))?,
+        };
+        sonde_gateway::RotationEngine::resume_pending_rotation(
+            &storage,
+            &identity,
+            provider.as_ref(),
+        )
+        .await
+        .map_err(|e| format!("resume_pending_rotation: {e}"))?
+    };
+    if pending_rotation_notification.is_some() {
+        info!("pending rotation resumed on startup — will re-emit ACTUAL_STATE after connector starts");
+    }
 
     // 2b. Seed or load persisted ESP-NOW channel (GW-0808).
     //     If the database already has a channel, use it (ignoring --channel).
@@ -978,21 +1010,10 @@ async fn run_gateway(
         }
     }
 
-    // 2b. Resume pending rotation if exists (§23.11 step 2b).
-    let pending_rotation_notification = {
-        let identity = storage
-            .load_gateway_identity()
-            .await?
-            .ok_or("gateway identity missing after init")?;
-        sonde_gateway::RotationEngine::resume_pending_rotation(&storage, &identity)
-            .await
-            .map_err(|e| format!("resume_pending_rotation: {e}"))?
-    };
-    if pending_rotation_notification.is_some() {
-        info!("pending rotation resumed on startup — will re-emit ACTUAL_STATE after connector starts");
-    }
+    // 2d. Resume pending rotation if needed (already done in 2a — this
+    //     comment retained for section numbering continuity).
 
-    // 2c. Load/generate master_key_id and master_key_epoch (§23.11 step 2c).
+    // 2e. Load/generate master_key_id and master_key_epoch (§23.11 step 2c).
     let (master_key_id, master_key_epoch) = storage.init_master_key_id().await?;
     info!(
         master_key_id = %hex::encode(master_key_id),
@@ -1166,6 +1187,7 @@ async fn run_gateway(
             Arc::clone(&storage),
             identity,
             gateway.connector_event_hub(),
+            Arc::clone(&provider),
             rotation_grpc_rx,
             desired_state_rx,
         )

--- a/crates/sonde-gateway/src/key_provider.rs
+++ b/crates/sonde-gateway/src/key_provider.rs
@@ -273,6 +273,34 @@ impl KeyProvider for FileKeyProvider {
 
         {
             use std::io::Write as _;
+
+            #[cfg(unix)]
+            let mut f = {
+                use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+                let file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .mode(0o600)
+                    .open(&tmp_path)
+                    .map_err(|e| {
+                        KeyProviderError::Io(format!(
+                            "cannot create temp key file {}: {e}",
+                            tmp_path.display()
+                        ))
+                    })?;
+                // Explicitly set permissions to override any umask restriction.
+                file.set_permissions(std::fs::Permissions::from_mode(0o600))
+                    .map_err(|e| {
+                        let _ = std::fs::remove_file(&tmp_path);
+                        KeyProviderError::Io(format!(
+                            "cannot set permissions on temp key file: {e}"
+                        ))
+                    })?;
+                file
+            };
+
+            #[cfg(not(unix))]
             let mut f = std::fs::OpenOptions::new()
                 .write(true)
                 .create(true)
@@ -284,6 +312,7 @@ impl KeyProvider for FileKeyProvider {
                         tmp_path.display()
                     ))
                 })?;
+
             f.write_all(hex.as_bytes()).map_err(|e| {
                 let _ = std::fs::remove_file(&tmp_path);
                 KeyProviderError::Io(format!("cannot write temp key file: {e}"))

--- a/crates/sonde-gateway/src/key_provider.rs
+++ b/crates/sonde-gateway/src/key_provider.rs
@@ -37,8 +37,7 @@ use zeroize::Zeroizing;
 // Error type
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Errors returned by [`KeyProvider::load_master_key`] and
-/// [`KeyProvider::generate_or_load_master_key`].
+/// Errors returned by [`KeyProvider`] methods.
 #[derive(Debug)]
 pub enum KeyProviderError {
     /// An I/O error occurred while reading the key material.
@@ -51,6 +50,8 @@ pub enum KeyProviderError {
     Backend(String),
     /// No key exists in this backend (used to distinguish absence from errors).
     NotFound(String),
+    /// The backend does not support writing (e.g., [`EnvKeyProvider`]).
+    NotWritable(String),
 }
 
 impl fmt::Display for KeyProviderError {
@@ -61,6 +62,7 @@ impl fmt::Display for KeyProviderError {
             Self::NotAvailable(msg) => write!(f, "backend not available: {msg}"),
             Self::Backend(msg) => write!(f, "backend error: {msg}"),
             Self::NotFound(msg) => write!(f, "key not found: {msg}"),
+            Self::NotWritable(msg) => write!(f, "backend not writable: {msg}"),
         }
     }
 }
@@ -71,7 +73,7 @@ impl std::error::Error for KeyProviderError {}
 // KeyProvider trait
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Abstracts how the 32-byte gateway master key is obtained.
+/// Abstracts how the 32-byte gateway master key is obtained and persisted.
 ///
 /// Implementations range from a simple plaintext hex file to OS-native secret
 /// storage that provides hardware-backed or OS-managed encryption at rest.
@@ -83,6 +85,29 @@ pub trait KeyProvider: Send + Sync {
     ///
     /// This method is called once at gateway startup.  Errors are fatal.
     fn load_master_key(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError>;
+
+    /// Persist a new 32-byte master key, replacing the existing key.
+    ///
+    /// Called by the rotation engine after DB commit to persist the rotated key.
+    /// Implementations SHOULD write atomically (write-to-temp + rename) where
+    /// the backend supports it.
+    ///
+    /// The default implementation returns [`KeyProviderError::NotWritable`].
+    fn write_master_key(&self, _key: &[u8; 32]) -> Result<(), KeyProviderError> {
+        Err(KeyProviderError::NotWritable(
+            "this key provider does not support writing; \
+             use --key-provider file, dpapi, or secret-service for key rotation"
+                .into(),
+        ))
+    }
+
+    /// Returns `true` if this backend supports [`write_master_key`](Self::write_master_key).
+    ///
+    /// The rotation engine checks this before starting a rotation and rejects
+    /// the request if the provider is not writable (GW-2014).
+    fn is_writable(&self) -> bool {
+        false
+    }
 
     /// Generate a random 32-byte master key and write it to the backend if no
     /// key exists, or load the existing key if one is already present.
@@ -224,6 +249,64 @@ impl KeyProvider for FileKeyProvider {
             ))
         })?;
         parse_hex_key(&raw)
+    }
+
+    fn write_master_key(&self, key: &[u8; 32]) -> Result<(), KeyProviderError> {
+        let mut hex = String::with_capacity(64);
+        for b in key.iter() {
+            use std::fmt::Write as _;
+            write!(hex, "{b:02x}").expect("write to String is infallible");
+        }
+
+        // Write to a temporary file in the same directory, then rename atomically.
+        let parent = self
+            .path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let tmp_path = parent.join(format!(
+            ".{}.tmp",
+            self.path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("master-key")
+        ));
+
+        {
+            use std::io::Write as _;
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp_path)
+                .map_err(|e| {
+                    KeyProviderError::Io(format!(
+                        "cannot create temp key file {}: {e}",
+                        tmp_path.display()
+                    ))
+                })?;
+            f.write_all(hex.as_bytes()).map_err(|e| {
+                let _ = std::fs::remove_file(&tmp_path);
+                KeyProviderError::Io(format!("cannot write temp key file: {e}"))
+            })?;
+            f.sync_all().map_err(|e| {
+                let _ = std::fs::remove_file(&tmp_path);
+                KeyProviderError::Io(format!("cannot sync temp key file: {e}"))
+            })?;
+        }
+
+        std::fs::rename(&tmp_path, &self.path).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            KeyProviderError::Io(format!(
+                "cannot rename temp key file to {}: {e}",
+                self.path.display()
+            ))
+        })?;
+
+        Ok(())
+    }
+
+    fn is_writable(&self) -> bool {
+        true
     }
 
     fn generate_or_load_master_key(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
@@ -423,6 +506,60 @@ impl KeyProvider for DpapiKeyProvider {
                 self.blob_path.display()
             ))),
         }
+    }
+
+    fn write_master_key(&self, key: &[u8; 32]) -> Result<(), KeyProviderError> {
+        let blob = dpapi::encrypt(key)
+            .map_err(|e| KeyProviderError::Backend(format!("DPAPI encryption failed: {e}")))?;
+
+        let parent = self
+            .blob_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let tmp_path = parent.join(format!(
+            ".{}.tmp",
+            self.blob_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("master-key")
+        ));
+
+        {
+            use std::io::Write as _;
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp_path)
+                .map_err(|e| {
+                    KeyProviderError::Io(format!(
+                        "cannot create temp DPAPI blob {}: {e}",
+                        tmp_path.display()
+                    ))
+                })?;
+            f.write_all(&blob).map_err(|e| {
+                let _ = std::fs::remove_file(&tmp_path);
+                KeyProviderError::Io(format!("cannot write temp DPAPI blob: {e}"))
+            })?;
+            f.sync_all().map_err(|e| {
+                let _ = std::fs::remove_file(&tmp_path);
+                KeyProviderError::Io(format!("cannot sync temp DPAPI blob: {e}"))
+            })?;
+        }
+
+        std::fs::rename(&tmp_path, &self.blob_path).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            KeyProviderError::Io(format!(
+                "cannot rename temp DPAPI blob to {}: {e}",
+                self.blob_path.display()
+            ))
+        })?;
+
+        Ok(())
+    }
+
+    fn is_writable(&self) -> bool {
+        true
     }
 }
 
@@ -659,6 +796,14 @@ impl KeyProvider for SecretServiceKeyProvider {
             "master key set in Secret Service for the first time"
         );
         Ok(canonical)
+    }
+
+    fn write_master_key(&self, key: &[u8; 32]) -> Result<(), KeyProviderError> {
+        store_in_secret_service(key, &self.label)
+    }
+
+    fn is_writable(&self) -> bool {
+        true
     }
 }
 
@@ -1012,5 +1157,47 @@ mod tests {
             mode, 0o600,
             "key file should have mode 0o600, got {mode:#o}"
         );
+    }
+
+    // ── write_master_key ───────────────────────────────────────────────────
+
+    /// T-2014a: FileKeyProvider write round-trip.
+    #[test]
+    fn file_provider_write_master_key_round_trip() {
+        // Start with a known key.
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "{HEX_KEY}").unwrap();
+        let provider = FileKeyProvider::new(f.path().to_path_buf());
+
+        // Write a different key.
+        let new_key = [0xAAu8; 32];
+        provider.write_master_key(&new_key).unwrap();
+
+        // Load should return the new key.
+        let loaded = provider.load_master_key().unwrap();
+        assert_eq!(*loaded, new_key);
+    }
+
+    #[test]
+    fn file_provider_is_writable() {
+        let provider = FileKeyProvider::new(PathBuf::from("/tmp/test.key"));
+        assert!(provider.is_writable());
+    }
+
+    /// T-2014b: EnvKeyProvider write is rejected.
+    #[test]
+    fn env_provider_write_rejected() {
+        let provider = EnvKeyProvider::default();
+        let err = provider.write_master_key(&[0xBBu8; 32]).unwrap_err();
+        assert!(
+            matches!(err, KeyProviderError::NotWritable(_)),
+            "EnvKeyProvider must return NotWritable, got: {err}"
+        );
+    }
+
+    #[test]
+    fn env_provider_not_writable() {
+        let provider = EnvKeyProvider::default();
+        assert!(!provider.is_writable());
     }
 }

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -800,22 +800,23 @@ impl RotationEngine {
                 {
                     Ok(k) => k,
                     Err(_) => {
-                        // The in-memory key (from provider) might already be the new key
-                        // if the crash happened after provider write but before deletion.
-                        // Try decrypting with the provider key as the "old" key.
-                        // This is a no-op if old_key == provider_key.
-                        if *provider_key == *old_key {
-                            return Err("post-commit recovery: cannot decrypt pending new key — \
-                                 the provider key matches the current in-memory key but \
-                                 decryption still failed; possible data corruption"
-                                .into());
-                        }
-                        // Provider already has the new key; pending_rotation is encrypted
-                        // under the old key which we no longer have.  This means the
-                        // provider was already updated — just clean up.
+                        // Decryption failed.  The in-memory key (from provider) is the
+                        // startup key.  Two cases:
+                        //
+                        // 1. provider_key != old_key: the provider was already updated to
+                        //    the new key during a previous run; the in-memory key differs
+                        //    from what was used to encrypt pending_rotation.
+                        //
+                        // 2. provider_key == old_key: the provider was already updated AND
+                        //    the in-memory key IS the new key (post-write/pre-delete crash).
+                        //    Since `SqliteStorage::open()` already validated PSKs with the
+                        //    current key, the DB is consistent — we just need to clean up
+                        //    the stale marker.
+                        //
+                        // In both cases the provider already has the new key.  Clean up.
                         info!(
-                            "provider key differs from in-memory key — provider write \
-                               already completed; cleaning up pending_rotation"
+                            "cannot decrypt pending_rotation with current key — \
+                             provider already holds the rotated key; cleaning up stale marker"
                         );
                         storage.swap_master_key(provider_key);
                         storage

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -66,6 +66,8 @@ pub struct RotationEngine {
     identity: GatewayIdentity,
     event_hub: Arc<ConnectorEventHub>,
     rate_limiter: RotationRateLimiter,
+    /// Reference to the key provider backend for persisting rotated keys (GW-2006).
+    key_provider: Arc<dyn crate::key_provider::KeyProvider>,
     /// Receives rotation payloads from the gRPC `SubmitRotation` RPC.
     grpc_rx: RotationSubmitReceiver,
     /// Receives parsed DESIRED_STATE from the connector.
@@ -86,6 +88,7 @@ impl RotationEngine {
         storage: Arc<SqliteStorage>,
         identity: GatewayIdentity,
         event_hub: Arc<ConnectorEventHub>,
+        key_provider: Arc<dyn crate::key_provider::KeyProvider>,
         grpc_rx: RotationSubmitReceiver,
         desired_state_rx: mpsc::UnboundedReceiver<GatewayDesiredState>,
     ) -> Self {
@@ -94,6 +97,7 @@ impl RotationEngine {
             identity,
             event_hub,
             rate_limiter: RotationRateLimiter::default(),
+            key_provider,
             grpc_rx,
             desired_state_rx,
             rotation_active: Arc::new(AtomicBool::new(false)),
@@ -375,6 +379,17 @@ impl RotationEngine {
         payload: &[u8],
         is_grpc: bool,
     ) -> Result<(), String> {
+        // GW-2014: reject rotation if the key provider cannot persist the new key.
+        if !self.key_provider.is_writable() {
+            let msg = "rotation rejected: key provider is not writable; \
+                       use --key-provider file, dpapi, or secret-service";
+            if is_grpc {
+                return Err(msg.into());
+            }
+            warn!("{msg} — discarding incoming rotation payload");
+            return Err(msg.into());
+        }
+
         // Check for concurrent rotation — reject before any crypto work.
         if self.rotation_active.load(Ordering::SeqCst) {
             let msg = "rotation already in progress";
@@ -507,7 +522,27 @@ impl RotationEngine {
             return result;
         }
 
-        // Step 7 post: swap in-memory master key.
+        // Step 7a: Persist rotated key to the key provider backend (GW-2006 step 6).
+        // pending_rotation is retained as a crash-recovery marker until this succeeds.
+        if let Err(e) = self
+            .key_provider
+            .write_master_key(&decrypted.new_master_key)
+        {
+            error!(error = %e, "failed to persist rotated key to key provider — \
+                   rotation committed to DB but key not persisted; \
+                   pending_rotation retained for crash recovery");
+            return Err(format!("key provider write failed: {e}"));
+        }
+        info!("rotated master key persisted to key provider");
+
+        // Step 7b: Delete pending_rotation now that the provider has the new key.
+        if let Err(e) = self.storage.delete_pending_rotation().await {
+            // Non-fatal: the record is stale and will be cleaned up on next restart.
+            warn!(error = %e, "failed to delete pending_rotation after key write — \
+                  will be cleaned up on next restart");
+        }
+
+        // Step 7c: Swap in-memory master key.
         self.storage
             .swap_master_key(Zeroizing::new(*decrypted.new_master_key));
         self.storage.clear_rotation_new_key();
@@ -677,17 +712,25 @@ impl RotationEngine {
 
     /// Resume a pending rotation from crash recovery (GW-2007).
     ///
-    /// Called at startup before the main event loop. If `pending_rotation`
-    /// exists in the database, decrypts the new key and resumes from the
-    /// recorded phase.
+    /// Called at startup **before** gateway identity loading.  If
+    /// `pending_rotation` exists in the database, the current DB epoch is
+    /// compared to the pending epoch to determine the crash point:
+    ///
+    /// - `epoch < pending_epoch` — pre-commit crash: resume migration
+    ///   (existing phase-based logic).
+    /// - `epoch == pending_epoch` — post-commit crash: DB is committed but
+    ///   the key provider may not have the new key yet.  Decrypt the new key
+    ///   from `pending_rotation`, write it to the provider if needed, delete
+    ///   the record, and swap in-memory key.
+    /// - `epoch > pending_epoch` — stale record from a completed rotation
+    ///   whose cleanup was interrupted.  Delete the record.
     ///
     /// Returns `Ok(Some(notification))` if a rotation was resumed and committed,
-    /// `Ok(None)` if no pending rotation existed. The caller should use the
-    /// returned notification to trigger gateway ACTUAL_STATE re-emission
-    /// and node escrow re-emission once the connector is ready.
+    /// `Ok(None)` if no pending rotation existed.
     pub async fn resume_pending_rotation(
         storage: &Arc<SqliteStorage>,
         identity: &GatewayIdentity,
+        key_provider: &dyn crate::key_provider::KeyProvider,
     ) -> Result<Option<RotationCompleteNotification>, String> {
         let pending = storage
             .read_pending_rotation()
@@ -705,6 +748,115 @@ impl RotationEngine {
             "detected pending rotation — resuming crash recovery"
         );
 
+        let db_epoch = storage
+            .get_master_key_epoch()
+            .await
+            .map_err(|e| format!("get_master_key_epoch: {e}"))?;
+
+        if db_epoch > pending.new_epoch {
+            // Stale record — a later rotation already completed.
+            warn!(
+                db_epoch,
+                pending_epoch = pending.new_epoch,
+                "stale pending_rotation record (epoch surpassed) — deleting"
+            );
+            storage
+                .delete_pending_rotation()
+                .await
+                .map_err(|e| format!("delete stale pending_rotation: {e}"))?;
+            return Ok(None);
+        }
+
+        if db_epoch == pending.new_epoch {
+            // Post-commit crash: DB committed but key provider / pending_rotation
+            // cleanup may not have completed.
+            info!(
+                db_epoch,
+                "post-commit crash detected — completing key provider write"
+            );
+
+            // Decrypt the pending new key using the CURRENT (old, pre-rotation)
+            // in-memory key to extract the new key from pending_rotation.  But
+            // since the DB is already committed to the new epoch, the in-memory
+            // key at startup is the OLD key from the provider (which may or may
+            // not have been updated).
+            //
+            // We try the current provider key first: if it matches the new key,
+            // the provider write already completed and we just need cleanup.
+            let provider_key = key_provider
+                .load_master_key()
+                .map_err(|e| format!("load provider key for recovery: {e}"))?;
+
+            // Decrypt pending key using old (pre-rotation) key.
+            // The in-memory key is what was loaded from the provider, which is the
+            // old key if the crash happened before provider write.
+            let old_key = {
+                let mk = storage.master_key();
+                Zeroizing::new(**mk)
+            };
+
+            let new_key =
+                match SqliteStorage::decrypt_pending_new_key(&old_key, &pending.new_master_key_enc)
+                {
+                    Ok(k) => k,
+                    Err(_) => {
+                        // The in-memory key (from provider) might already be the new key
+                        // if the crash happened after provider write but before deletion.
+                        // Try decrypting with the provider key as the "old" key.
+                        // This is a no-op if old_key == provider_key.
+                        if *provider_key == *old_key {
+                            return Err("post-commit recovery: cannot decrypt pending new key — \
+                                 the provider key matches the current in-memory key but \
+                                 decryption still failed; possible data corruption"
+                                .into());
+                        }
+                        // Provider already has the new key; pending_rotation is encrypted
+                        // under the old key which we no longer have.  This means the
+                        // provider was already updated — just clean up.
+                        info!(
+                            "provider key differs from in-memory key — provider write \
+                               already completed; cleaning up pending_rotation"
+                        );
+                        storage.swap_master_key(provider_key);
+                        storage
+                            .delete_pending_rotation()
+                            .await
+                            .map_err(|e| format!("delete pending_rotation: {e}"))?;
+                        return Ok(Some(RotationCompleteNotification {
+                            new_master_key_id: pending.new_master_key_id,
+                            new_epoch: pending.new_epoch,
+                        }));
+                    }
+                };
+
+            // Check if provider already has the new key.
+            if *provider_key == *new_key {
+                // Post-write/pre-delete crash — just clean up.
+                info!("provider already has the rotated key — deleting pending_rotation");
+            } else {
+                // Post-commit/pre-write crash — persist to provider.
+                key_provider
+                    .write_master_key(&new_key)
+                    .map_err(|e| format!("post-commit recovery: key provider write: {e}"))?;
+                info!("rotated master key persisted to key provider during recovery");
+            }
+
+            // Delete pending_rotation.
+            storage
+                .delete_pending_rotation()
+                .await
+                .map_err(|e| format!("delete pending_rotation: {e}"))?;
+
+            // Swap in-memory key to the new key.
+            storage.swap_master_key(Zeroizing::new(*new_key));
+
+            return Ok(Some(RotationCompleteNotification {
+                new_master_key_id: pending.new_master_key_id,
+                new_epoch: pending.new_epoch,
+            }));
+        }
+
+        // Pre-commit crash (db_epoch < pending.new_epoch): resume migration.
         // Decrypt the pending new key using the current (old) master key.
         let old_key = {
             let mk = storage.master_key();
@@ -718,11 +870,15 @@ impl RotationEngine {
         storage.set_rotation_new_key(Zeroizing::new(*new_key), pending.new_epoch);
 
         // Create a temporary engine for executing the phases.
+        let dummy_kp: Arc<dyn crate::key_provider::KeyProvider> = Arc::new(
+            crate::key_provider::EnvKeyProvider::new("__SONDE_DUMMY_RECOVERY__"),
+        );
         let engine = RotationEngine {
             storage: Arc::clone(storage),
             identity: identity.clone(),
             event_hub: Arc::new(ConnectorEventHub::default()),
             rate_limiter: RotationRateLimiter::default(),
+            key_provider: dummy_kp,
             grpc_rx: mpsc::unbounded_channel().1,
             desired_state_rx: mpsc::unbounded_channel().1,
             rotation_active: Arc::new(AtomicBool::new(true)),
@@ -756,6 +912,18 @@ impl RotationEngine {
             error!(error = %e, "crash recovery rotation failed");
             // Keep dual-key state — some PSKs may be partially migrated.
             return Err(format!("crash recovery failed: {e}"));
+        }
+
+        // Persist the new key to the key provider.
+        key_provider
+            .write_master_key(&new_key)
+            .map_err(|e| format!("crash recovery: key provider write: {e}"))?;
+        info!("rotated master key persisted to key provider during pre-commit recovery");
+
+        // Delete pending_rotation.
+        if let Err(e) = storage.delete_pending_rotation().await {
+            warn!(error = %e, "failed to delete pending_rotation after recovery — \
+                  will be cleaned up on next restart");
         }
 
         // Swap in-memory master key.
@@ -837,6 +1005,9 @@ mod tests {
             Arc::clone(&store),
             identity,
             event_hub,
+            Arc::new(crate::key_provider::EnvKeyProvider::new(
+                "__SONDE_TEST_UNUSED__",
+            )),
             grpc_rx,
             desired_state_rx,
         )
@@ -978,6 +1149,9 @@ mod tests {
             Arc::clone(&store),
             identity,
             event_hub,
+            Arc::new(crate::key_provider::EnvKeyProvider::new(
+                "__SONDE_TEST_UNUSED__",
+            )),
             grpc_rx,
             desired_state_rx,
         );
@@ -1016,6 +1190,9 @@ mod tests {
                 Arc::clone(&store),
                 identity.clone(),
                 event_hub,
+                Arc::new(crate::key_provider::EnvKeyProvider::new(
+                    "__SONDE_TEST_UNUSED__",
+                )),
                 grpc_rx,
                 desired_state_rx,
             );
@@ -1042,6 +1219,9 @@ mod tests {
                 Arc::clone(&store),
                 identity,
                 event_hub,
+                Arc::new(crate::key_provider::EnvKeyProvider::new(
+                    "__SONDE_TEST_UNUSED__",
+                )),
                 grpc_rx,
                 desired_state_rx,
             );
@@ -1081,6 +1261,9 @@ mod tests {
             Arc::clone(&store),
             identity,
             event_hub,
+            Arc::new(crate::key_provider::EnvKeyProvider::new(
+                "__SONDE_TEST_UNUSED__",
+            )),
             grpc_rx,
             desired_state_rx,
         )

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -480,21 +480,30 @@ fn validate_master_key(
 /// Called during `open()` before `validate_master_key` to support crash
 /// recovery (GW-2007): some PSKs may already be re-encrypted with the
 /// new key.
+///
+/// **Post-write/pre-delete tolerance (GW-2014):** If the provider already
+/// persisted the new key but `pending_rotation` was not yet deleted, the
+/// current startup key *is* the new key and decrypting `new_master_key_enc`
+/// (which was encrypted under the old key) will fail.  When the DB
+/// `master_key_epoch` already equals `pending_rotation.new_epoch`, this
+/// decryption failure is benign — the record is a stale marker.  We log a
+/// warning and return `None` so that `open()` proceeds; the marker will be
+/// cleaned up by `resume_pending_rotation()`.
 fn load_pending_rotation_key(
     conn: &Connection,
     current_key: &[u8; 32],
 ) -> Result<Option<Zeroizing<[u8; 32]>>, StorageError> {
-    let pending: Option<Vec<u8>> = conn
+    let row: Option<(Vec<u8>, i64)> = conn
         .query_row(
-            "SELECT new_master_key_enc FROM pending_rotation WHERE id = 1",
+            "SELECT new_master_key_enc, new_epoch FROM pending_rotation WHERE id = 1",
             [],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .optional()
         .map_err(map_err)?;
 
-    let enc_blob = match pending {
-        Some(blob) => blob,
+    let (enc_blob, pending_epoch) = match row {
+        Some(r) => r,
         None => return Ok(None),
     };
 
@@ -513,24 +522,54 @@ fn load_pending_rotation_key(
         aad: PENDING_ROTATION_AAD,
     };
 
-    let plaintext = Zeroizing::new(cipher.decrypt(nonce, payload).map_err(|_| {
-        StorageError::Internal(
-            "cannot decrypt pending_rotation.new_master_key_enc — wrong master key \
-             or data corruption"
-                .into(),
-        )
-    })?);
+    match cipher.decrypt(nonce, payload) {
+        Ok(plaintext) => {
+            let plaintext = Zeroizing::new(plaintext);
+            if plaintext.len() != 32 {
+                return Err(StorageError::Internal(format!(
+                    "decrypted pending new master key is {} bytes, expected 32",
+                    plaintext.len()
+                )));
+            }
+            let mut arr = Zeroizing::new([0u8; 32]);
+            arr.copy_from_slice(&plaintext);
+            Ok(Some(arr))
+        }
+        Err(_) => {
+            // Decryption failed. Check if this is the post-write/pre-delete
+            // state: DB epoch already advanced to pending epoch, meaning the
+            // commit succeeded and the provider key was updated, but the
+            // pending_rotation marker wasn't deleted before shutdown.
+            let db_epoch: Option<String> = conn
+                .query_row(
+                    "SELECT value FROM gateway_config WHERE key = 'master_key_epoch'",
+                    [],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(map_err)?;
+            let db_epoch: u64 = db_epoch.as_deref().unwrap_or("0").parse().unwrap_or(0);
 
-    if plaintext.len() != 32 {
-        return Err(StorageError::Internal(format!(
-            "decrypted pending new master key is {} bytes, expected 32",
-            plaintext.len()
-        )));
+            if db_epoch == pending_epoch as u64 {
+                // Post-commit state: the startup key is already the new key,
+                // so the old-key-encrypted blob is expected to fail decryption.
+                // resume_pending_rotation() will delete this stale marker.
+                tracing::warn!(
+                    db_epoch,
+                    "pending_rotation record is a stale post-commit marker \
+                     (cannot decrypt with current key, epoch matches) — \
+                     deferring cleanup to resume_pending_rotation"
+                );
+                Ok(None)
+            } else {
+                Err(StorageError::Internal(
+                    "cannot decrypt pending_rotation.new_master_key_enc — wrong master key \
+                     or data corruption"
+                        .into(),
+                ))
+            }
+        }
     }
-
-    let mut arr = Zeroizing::new([0u8; 32]);
-    arr.copy_from_slice(&plaintext);
-    Ok(Some(arr))
 }
 
 const SCHEMA: &str = "
@@ -1570,7 +1609,11 @@ impl SqliteStorage {
     /// - Update `master_key_id` and `master_key_epoch` in `gateway_config`
     /// - Store salt and KDF params if non-null
     /// - Generate new rotation code
-    /// - Delete `pending_rotation`
+    ///
+    /// **Note (GW-2014):** `pending_rotation` is intentionally **not** deleted
+    /// here.  It is retained as a crash-recovery marker until the new key has
+    /// been persisted to the `KeyProvider` backend.  Call
+    /// [`delete_pending_rotation()`] after `write_master_key()` succeeds.
     pub async fn commit_rotation(
         &self,
         new_key_id: &[u8; 16],
@@ -1656,9 +1699,11 @@ impl SqliteStorage {
             )
             .map_err(map_err)?;
 
-            // Delete pending_rotation.
-            tx.execute("DELETE FROM pending_rotation", [])
-                .map_err(map_err)?;
+            // NOTE: pending_rotation is NOT deleted here.  It is retained as a
+            // crash-recovery marker so that the rotation engine can detect the
+            // post-commit/pre-provider-write state on restart and complete the
+            // key write.  Call `delete_pending_rotation()` after the key
+            // provider has persisted the new key (GW-2006 step 7, GW-2007).
 
             tx.commit().map_err(map_err)?;
             Ok(new_code)
@@ -1673,6 +1718,47 @@ impl SqliteStorage {
     /// the next startup will load the new key from gateway_config.
     pub fn swap_master_key(&self, new_key: Zeroizing<[u8; 32]>) {
         *self.master_key.write().unwrap() = Arc::new(new_key);
+    }
+
+    /// Delete the `pending_rotation` record after the key provider has
+    /// persisted the rotated master key (GW-2006 step 7).
+    ///
+    /// This is called outside the commit transaction so that the record acts
+    /// as a crash-recovery marker: if the process crashes between DB commit
+    /// and provider write, the record survives and startup recovery can
+    /// complete the provider write.
+    pub async fn delete_pending_rotation(&self) -> Result<(), StorageError> {
+        self.with_conn(move |conn| {
+            conn.execute("DELETE FROM pending_rotation", [])
+                .map_err(map_err)?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Return the current `master_key_epoch` from `gateway_config`, or 0 if
+    /// not yet set.
+    ///
+    /// Used at startup to detect post-commit crash state by comparing against
+    /// the epoch stored in `pending_rotation` (GW-2007).
+    pub async fn get_master_key_epoch(&self) -> Result<u64, StorageError> {
+        self.with_conn(move |conn| {
+            let epoch: Option<String> = conn
+                .query_row(
+                    "SELECT value FROM gateway_config WHERE key = 'master_key_epoch'",
+                    [],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(map_err)?;
+            match epoch {
+                Some(s) => s.parse::<u64>().map_err(|e| {
+                    StorageError::Internal(format!("invalid master_key_epoch value: {e}"))
+                }),
+                None => Ok(0),
+            }
+        })
+        .await
     }
 
     /// Set the rotation new key for dual-key PSK decryption during rotation.

--- a/crates/sonde-gateway/tests/escrow.rs
+++ b/crates/sonde-gateway/tests/escrow.rs
@@ -35,6 +35,30 @@ use x25519_dalek::PublicKey as X25519PublicKey;
 
 // ── helpers ──────────────────────────────────────────────────────
 
+/// A writable key provider for tests that don't need actual key persistence.
+struct NoopWritableKeyProvider;
+
+impl sonde_gateway::key_provider::KeyProvider for NoopWritableKeyProvider {
+    fn load_master_key(
+        &self,
+    ) -> Result<Zeroizing<[u8; 32]>, sonde_gateway::key_provider::KeyProviderError> {
+        Err(sonde_gateway::key_provider::KeyProviderError::NotFound(
+            "test provider".into(),
+        ))
+    }
+
+    fn write_master_key(
+        &self,
+        _key: &[u8; 32],
+    ) -> Result<(), sonde_gateway::key_provider::KeyProviderError> {
+        Ok(())
+    }
+
+    fn is_writable(&self) -> bool {
+        true
+    }
+}
+
 /// Create a test gateway with identity and storage, but do NOT call
 /// `init_master_key_id()` — the caller must do that after registering nodes
 /// so the backfill picks them up.
@@ -672,6 +696,7 @@ async fn test_t2006c_phone_psks_not_escrowed() {
         store.clone(),
         identity.clone(),
         event_hub.clone(),
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -851,6 +876,7 @@ async fn test_t2012_rotation_complete_triggers_reemission() {
         store.clone(),
         identity.clone(),
         event_hub.clone(),
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         ds_rx,
     )
@@ -972,6 +998,7 @@ async fn test_t2013_salt_kdf_adoption_triggers_reemission() {
         store.clone(),
         identity.clone(),
         event_hub.clone(),
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         ds_rx,
     )

--- a/crates/sonde-gateway/tests/node_recovery.rs
+++ b/crates/sonde-gateway/tests/node_recovery.rs
@@ -118,12 +118,7 @@ async fn test_t2006_declarative_node_recovery() {
         .load_gateway_identity()
         .await
         .unwrap()
-        .unwrap_or_else(|| {
-            // Generate one if none exists.
-            let id = GatewayIdentity::generate().unwrap();
-            // We won't persist it since we only need it for the engine constructor.
-            id
-        });
+        .unwrap_or_else(|| GatewayIdentity::generate().unwrap());
 
     let entity_id: String = identity
         .gateway_id()
@@ -131,7 +126,16 @@ async fn test_t2006_declarative_node_recovery() {
         .map(|b| format!("{b:02x}"))
         .collect();
 
-    let engine = RotationEngine::new(store.clone(), identity, event_hub, grpc_rx, ds_rx);
+    let engine = RotationEngine::new(
+        store.clone(),
+        identity,
+        event_hub,
+        Arc::new(sonde_gateway::key_provider::EnvKeyProvider::new(
+            "__UNUSED__",
+        )),
+        grpc_rx,
+        ds_rx,
+    );
 
     // Send the DESIRED_STATE with recovered_psks through the channel.
     let desired_state = GatewayDesiredState {
@@ -290,7 +294,16 @@ async fn test_t2006b_mismatched_master_key_id_skipped() {
     let (ds_tx, ds_rx) = tokio::sync::mpsc::unbounded_channel();
     let event_hub = Arc::new(ConnectorEventHub::default());
 
-    let engine = RotationEngine::new(store.clone(), identity, event_hub, grpc_rx, ds_rx);
+    let engine = RotationEngine::new(
+        store.clone(),
+        identity,
+        event_hub,
+        Arc::new(sonde_gateway::key_provider::EnvKeyProvider::new(
+            "__UNUSED__",
+        )),
+        grpc_rx,
+        ds_rx,
+    );
 
     // Step 1: Deliver recovered_psks with wrong master_key_id.
     let wrong_key_id = [0xFFu8; 16];

--- a/crates/sonde-gateway/tests/rotation.rs
+++ b/crates/sonde-gateway/tests/rotation.rs
@@ -153,6 +153,53 @@ async fn register_test_node(store: &Arc<SqliteStorage>, node_id: &str, key_hint:
     store.upsert_node(&record).await.unwrap();
 }
 
+/// Create a writable test key provider backed by a temp file.
+///
+/// The temp file is initialized with the given master key in hex format.
+/// Returns both the provider (as `Arc<dyn KeyProvider>`) and the
+/// `NamedTempFile` handle (must be kept alive for the file to persist).
+#[allow(dead_code)] // useful for post-commit recovery tests (T-2014b)
+fn test_key_provider(
+    master_key: &[u8; 32],
+) -> (
+    Arc<dyn sonde_gateway::key_provider::KeyProvider>,
+    tempfile::NamedTempFile,
+) {
+    use sonde_gateway::key_provider::FileKeyProvider;
+    use std::io::Write as _;
+
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    let hex: String = master_key.iter().map(|b| format!("{b:02x}")).collect();
+    writeln!(f, "{hex}").unwrap();
+    let provider = FileKeyProvider::new(f.path().to_path_buf());
+    (Arc::new(provider), f)
+}
+
+/// A writable key provider for tests that don't need actual key persistence.
+/// Implements `is_writable() → true` and `write_master_key` as a no-op success.
+struct NoopWritableKeyProvider;
+
+impl sonde_gateway::key_provider::KeyProvider for NoopWritableKeyProvider {
+    fn load_master_key(
+        &self,
+    ) -> Result<Zeroizing<[u8; 32]>, sonde_gateway::key_provider::KeyProviderError> {
+        Err(sonde_gateway::key_provider::KeyProviderError::NotFound(
+            "test provider".into(),
+        ))
+    }
+
+    fn write_master_key(
+        &self,
+        _key: &[u8; 32],
+    ) -> Result<(), sonde_gateway::key_provider::KeyProviderError> {
+        Ok(())
+    }
+
+    fn is_writable(&self) -> bool {
+        true
+    }
+}
+
 /// T-2003: Rotation code authentication.
 #[tokio::test]
 async fn test_t2003_rotation_code_authentication() {
@@ -181,6 +228,7 @@ async fn test_t2003_rotation_code_authentication() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -199,6 +247,7 @@ async fn test_t2003_rotation_code_authentication() {
         store.clone(),
         identity.clone(),
         event_hub2,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx2,
         desired_state_rx2,
     );
@@ -251,6 +300,7 @@ async fn test_t2004_rotation_happy_path() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -300,6 +350,7 @@ async fn test_t2004a_rotation_validation_failures() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -318,6 +369,7 @@ async fn test_t2004a_rotation_validation_failures() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -338,6 +390,7 @@ async fn test_t2004a_rotation_validation_failures() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -353,6 +406,7 @@ async fn test_t2004a_rotation_validation_failures() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -367,6 +421,7 @@ async fn test_t2004a_rotation_validation_failures() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -404,6 +459,7 @@ async fn test_t2004b_concurrent_rotation_discard() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -422,6 +478,7 @@ async fn test_t2004b_concurrent_rotation_discard() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -472,9 +529,10 @@ async fn test_t2005_crash_safe_rotation() {
     assert_eq!(still_unmigrated.len(), 5);
 
     // Simulate crash recovery.
-    let recovered = RotationEngine::resume_pending_rotation(&store, &identity)
-        .await
-        .unwrap();
+    let recovered =
+        RotationEngine::resume_pending_rotation(&store, &identity, &NoopWritableKeyProvider)
+            .await
+            .unwrap();
     assert!(
         recovered.is_some(),
         "crash recovery should detect and resume rotation"
@@ -520,6 +578,7 @@ async fn test_t2008_grpc_rotation_path() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );
@@ -596,9 +655,10 @@ async fn test_t2009_crash_recovery_all_phases() {
             .unwrap();
 
         // Crash recovery.
-        let recovered = RotationEngine::resume_pending_rotation(&store, &identity)
-            .await
-            .unwrap();
+        let recovered =
+            RotationEngine::resume_pending_rotation(&store, &identity, &NoopWritableKeyProvider)
+                .await
+                .unwrap();
         assert!(recovered.is_some());
 
         // Verify identity is loadable with the new key.
@@ -639,9 +699,10 @@ async fn test_t2009_crash_recovery_all_phases() {
         store.update_rotation_phase("committing").await.unwrap();
 
         // Crash recovery.
-        let recovered = RotationEngine::resume_pending_rotation(&store, &identity)
-            .await
-            .unwrap();
+        let recovered =
+            RotationEngine::resume_pending_rotation(&store, &identity, &NoopWritableKeyProvider)
+                .await
+                .unwrap();
         assert!(recovered.is_some());
         assert!(!store.is_rotation_in_progress().await.unwrap());
 
@@ -683,6 +744,7 @@ async fn test_t2010_pending_recovery_purge() {
         store.clone(),
         identity.clone(),
         event_hub,
+        Arc::new(NoopWritableKeyProvider),
         grpc_rx,
         desired_state_rx,
     );

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -756,16 +756,27 @@ implementation selected by the `--key-provider` CLI flag (GW-0601b).
 ### 10a.1  Trait
 
 ```rust
-/// Abstracts how the 32-byte gateway master key is obtained.
+/// Abstracts how the 32-byte gateway master key is obtained and persisted.
 pub trait KeyProvider: Send + Sync {
     fn load_master_key(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError>;
+    fn write_master_key(&self, key: &[u8; 32]) -> Result<(), KeyProviderError>;
+    fn is_writable(&self) -> bool;
 }
 ```
 
-The trait is intentionally synchronous; key loading is a one-time startup
-operation.  For async backends (e.g. Secret Service over D-Bus), the
-implementation uses `tokio::task::block_in_place` when called from within a
-tokio runtime, or a temporary `current_thread` runtime otherwise.
+The trait is intentionally synchronous; key loading and writing are
+startup/rotation operations, not hot-path.  For async backends (e.g.
+Secret Service over D-Bus), the implementation uses
+`tokio::task::block_in_place` when called from within a tokio runtime,
+or a temporary `current_thread` runtime otherwise.
+
+`write_master_key` replaces the stored key with the given 32-byte key.
+Implementations SHOULD write atomically (write-to-temp + rename) where
+the backend supports it.  `EnvKeyProvider` returns
+`Err(KeyProviderError::NotWritable(_))`.
+
+`is_writable` returns whether `write_master_key` is supported.  The
+rotation engine checks this before starting a rotation.
 
 ### 10a.2  Backends
 
@@ -805,7 +816,7 @@ keyring during initial deployment.
 
 ### 10a.6  Error type
 
-`KeyProviderError` has four variants:
+`KeyProviderError` has five variants:
 
 | Variant | Meaning |
 |---------|---------|
@@ -813,6 +824,7 @@ keyring during initial deployment.
 | `Format(String)` | Key material is present but malformed (wrong length, non-hex characters, wrong byte count) |
 | `NotAvailable(String)` | The requested backend is not supported on this platform |
 | `Backend(String)` | The backend itself returned an error (DPAPI failure, D-Bus error, keyring locked) |
+| `NotWritable(String)` | The backend does not support `write_master_key` (e.g., `EnvKeyProvider`) |
 
 ---
 
@@ -1975,9 +1987,35 @@ info=gateway_id_raw||epoch_be64) → AES-256-GCM(key, nonce, plaintext, aad=gate
 1. **Prepare:** Write `pending_rotation`, purge `pending_recovery` (same transaction).
 2. **Migrate PSKs** (`migrating_psks`): Re-encrypt all `nodes` and `phone_psks` records.
 3. **Rewrap identity** (`rewrapping_identity`): Re-encrypt `GatewayIdentity` seed under new key into `encrypted_seed_new`.
-4. **Commit** (`committing`): Atomic transaction — promote `encrypted_seed_new`, update `master_key_id`/`epoch`, generate new rotation code, delete `pending_rotation`.
+4. **Commit** (`committing`): Atomic transaction — promote `encrypted_seed_new`, update `master_key_id`/`epoch`, generate new rotation code. `pending_rotation` is **NOT** deleted in this transaction.
+5. **Persist key** (`persisting_key`): Write new master key to `KeyProvider` backend via `write_master_key`. On success, delete `pending_rotation`.
 
 **Key invariant:** During all pre-commit phases, original `encrypted_seed` remains usable with the old key. `GatewayIdentity` is always loadable on restart.
+
+**Post-commit crash recovery:** If `pending_rotation` exists and
+`master_key_epoch` equals the pending epoch, the startup sequence must
+determine whether the provider write completed:
+
+- Try loading identity with the provider key.  If successful, the provider
+  already has the new key (post-write/pre-delete crash) — delete
+  `pending_rotation` and proceed.
+- If identity loading fails, the provider still has the old key
+  (post-commit/pre-write crash) — decrypt `new_master_key_enc` using the
+  old provider key, write the new key to the provider, reload the master
+  key, and delete `pending_rotation`.
+- If `master_key_epoch` > pending epoch (stale record), log a warning and
+  delete `pending_rotation`.
+
+Post-commit recovery MUST run before `GatewayIdentity` loading to avoid
+fatal startup errors.
+
+**Provider writability gate:** Before phase 1, the rotation engine checks `KeyProvider::is_writable()`. Non-writable providers (e.g., `EnvKeyProvider`) block rotation with a clear error (GW-2014).
+
+**Note:** `persisting_key` (phase 5) is not stored as a `phase` value in the
+`pending_rotation` table.  The post-commit state is inferred from
+`master_key_epoch` matching the pending epoch with `pending_rotation` still
+present.  The three stored phase values remain `migrating_psks`,
+`rewrapping_identity`, and `committing`.
 
 **Dual-key frame processing:** During migration, PSK records have mixed epochs. Frame processing uses the master key matching each record's `master_key_epoch`.
 
@@ -2032,15 +2070,22 @@ shared in `sonde-protocol`.
 
 Insert after step 2 (initialize storage):
 
-> 2a. Load `GatewayIdentity`, derive X25519 public key (already done
->     by the existing identity-loading block before these steps).
-> 2b. Check `pending_rotation` — call
->     `RotationEngine::resume_pending_rotation(&storage, &identity)`.
+> 2a. Check `pending_rotation` with post-commit detection:
+>     - If `pending_rotation` exists AND `master_key_epoch` = pending epoch,
+>       run post-commit recovery (try provider key for identity; if fail,
+>       decrypt new key from `pending_rotation`, write to provider, reload).
+>     - If `pending_rotation` exists AND `master_key_epoch` > pending epoch,
+>       delete stale record and log warning.
+>     - If `pending_rotation` exists AND `master_key_epoch` < pending epoch,
+>       defer to pre-commit resume (step 2b).
+> 2b. Load `GatewayIdentity`, derive X25519 public key.
+> 2c. If `pending_rotation` exists (pre-commit), call
+>     `RotationEngine::resume_pending_rotation(&storage, &identity, &key_provider)`.
 >     If it returns `Some(notification)`, cache the notification for
 >     gateway ACTUAL_STATE re-emission after the connector starts.
-> 2c. Load/generate `master_key_id` and `master_key_epoch` via
+> 2d. Load/generate `master_key_id` and `master_key_epoch` via
 >     `storage.init_master_key_id()`.
-> 2d. Load/generate `rotation_code` via `storage.init_rotation_code()`.
+> 2e. Load/generate `rotation_code` via `storage.init_rotation_code()`.
 
 Insert between connector creation and modem transport setup:
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -649,11 +649,14 @@ The gateway SHOULD support pluggable key-provider backends so that the master
 key itself can benefit from OS-native protection (hardware-backed or
 OS-managed encryption) rather than relying solely on file-system permissions.
 
-A `KeyProvider` trait abstracts how the 32-byte master key is obtained:
+A `KeyProvider` trait abstracts how the 32-byte master key is obtained and
+persisted:
 
 ```rust
 pub trait KeyProvider: Send + Sync {
     fn load_master_key(&self) -> Result<Zeroizing<[u8; 32]>, KeyProviderError>;
+    fn write_master_key(&self, key: &[u8; 32]) -> Result<(), KeyProviderError>;
+    fn is_writable(&self) -> bool;
 }
 ```
 
@@ -662,14 +665,22 @@ pub trait KeyProvider: Send + Sync {
 type implements the `Zeroize` trait so the guard can clear it when the value
 goes out of scope.
 
+`write_master_key` atomically persists a new 32-byte master key to the
+backend, replacing the existing key.  Implementations MUST write to a
+temporary location and rename/swap atomically where the backend supports it
+(file, DPAPI) to avoid leaving a partial key on crash.
+
+`is_writable` returns `true` if the backend supports `write_master_key`.
+Backends that cannot persist (e.g., `EnvKeyProvider`) return `false`.
+
 The following backends MUST be provided:
 
 | Backend | `--key-provider` value | Platform | Mechanism |
 |---------|------------------------|----------|-----------|
-| `FileKeyProvider` | `file` *(default)* | All | Read 64 hex chars from `--master-key-file`. Preserves existing `--master-key-file` workflow unchanged. |
-| `EnvKeyProvider` | `env` | All | Read 64 hex chars from `SONDE_MASTER_KEY` env var. Preserves existing env-var workflow unchanged. |
-| `DpapiKeyProvider` | `dpapi` | Windows | Decrypt a DPAPI blob at `--master-key-file` using `CryptProtectData` / `CryptUnprotectData`. The blob is tied to the Windows user or machine account. |
-| `SecretServiceKeyProvider` | `secret-service` | Linux | Retrieve the key from the D-Bus Secret Service (GNOME Keyring / KWallet) via `--key-label`. |
+| `FileKeyProvider` | `file` *(default)* | All | Read 64 hex chars from `--master-key-file`. Preserves existing `--master-key-file` workflow unchanged. `write_master_key` writes to a `.tmp` file and renames atomically. `is_writable` returns `true`. |
+| `EnvKeyProvider` | `env` | All | Read 64 hex chars from `SONDE_MASTER_KEY` env var. Preserves existing env-var workflow unchanged. `write_master_key` returns `KeyProviderError::NotWritable`. `is_writable` returns `false`. |
+| `DpapiKeyProvider` | `dpapi` | Windows | Decrypt a DPAPI blob at `--master-key-file` using `CryptProtectData` / `CryptUnprotectData`. The blob is tied to the Windows user or machine account. `write_master_key` re-encrypts with `CryptProtectData` and writes atomically. `is_writable` returns `true`. |
+| `SecretServiceKeyProvider` | `secret-service` | Linux | Retrieve the key from the D-Bus Secret Service (GNOME Keyring / KWallet) via `--key-label`. `write_master_key` calls `store_in_secret_service()` with `replace=true`. `is_writable` returns `true`. |
 
 The trait is designed to be extensible for future backends (macOS Keychain,
 HSM/PKCS#11, cloud KMS) without changes to the gateway startup code.
@@ -680,8 +691,10 @@ HSM/PKCS#11, cloud KMS) without changes to the gateway startup code.
 2. On Windows, `--key-provider dpapi` reads a DPAPI-protected blob and decrypts it using `CryptUnprotectData`, returning the raw 32-byte key.
 3. On Linux, `--key-provider secret-service` retrieves a 32-byte binary secret from the system keyring under the specified `--key-label`.
 4. Requesting a platform-specific backend on an unsupported platform (e.g., `--key-provider dpapi` on Linux) returns a clear error at startup, before the database is opened.
-5. `KeyProviderError` variants distinguish I/O errors, format errors, platform availability errors, and backend errors.
+5. `KeyProviderError` variants distinguish I/O errors, format errors, platform availability errors, backend errors, and not-writable errors.
 6. The `KeyProvider` trait is publicly exported from the `sonde-gateway` library crate so external backends can be implemented downstream.
+7. `write_master_key` persists a new 32-byte key to the backend, replacing the existing key. Backends that support writing (`is_writable() == true`) MUST perform the write atomically where the platform supports it.
+8. `EnvKeyProvider::is_writable()` returns `false`; calling `write_master_key` on `EnvKeyProvider` returns `Err(KeyProviderError::NotWritable(_))`.
 
 ---
 
@@ -2693,7 +2706,18 @@ The gateway MUST: (1) decrypt using GatewayIdentity X25519 private key,
 (2) verify rotation code, (3) verify master_key_epoch via AAD,
 (4) prepare pending_rotation record and purge pending_recovery,
 (5) migrate all PSK records (nodes and phone_psks) to new key,
-(6) rewrap identity seed, (7) atomic commit.
+(6) rewrap identity seed, (7) atomic commit (but retain `pending_rotation`),
+(8) persist new master key to the `KeyProvider` backend via `write_master_key`,
+(9) delete `pending_rotation`.
+
+The `pending_rotation` record MUST NOT be deleted in the atomic commit
+transaction (step 7).  It serves as a crash-recovery marker: if the
+gateway crashes between step 7 and step 9, the `pending_rotation` record
+allows the new key to be recovered on restart (see GW-2007).
+
+Before starting rotation, the gateway MUST check `KeyProvider::is_writable()`.
+If the provider is not writable, rotation MUST be rejected with a clear
+error before any cryptographic work (see GW-2014).
 
 A rotation payload received while a rotation is already in progress
 MUST be silently discarded.
@@ -2705,28 +2729,69 @@ MUST be silently discarded.
 3. Wrong rotation code rejected with warning.
 4. Replay (same epoch) rejected.
 5. Concurrent rotation payload silently discarded.
+6. New master key persisted to `KeyProvider` backend after DB commit.
+7. `pending_rotation` deleted only after successful key provider write.
+8. After rotation + gateway restart, the gateway starts successfully using the new key.
 
 ---
 
 ### GW-2007  Crash-safe key rotation
 
 **Priority:** Must
-**Source:** Issue #962 (supersedes evolve-887 GW-2007)
+**Source:** Issue #962, Issue #1091
 
 **Description:**
 Key rotation MUST be crash-safe via a `pending_rotation` table with
 three phases: `migrating_psks`, `rewrapping_identity`, `committing`.
-On startup, if `pending_rotation` exists, the gateway MUST resume from
-the recorded phase. During all pre-commit phases, the original
-`encrypted_seed` remains encrypted with the old key, ensuring
-`GatewayIdentity` is always loadable on restart.
+On startup, if `pending_rotation` exists, the gateway MUST determine
+which recovery path to take based on the current `master_key_epoch`:
+
+- **Pre-commit crash** (`master_key_epoch` < pending epoch): The DB
+  commit has not occurred.  Resume from the recorded phase using the
+  old master key (existing behavior).  During all pre-commit phases,
+  the original `encrypted_seed` remains encrypted with the old key,
+  ensuring `GatewayIdentity` is always loadable on restart.
+
+- **Post-commit, pre-provider-write crash** (`master_key_epoch` =
+  pending epoch AND provider key ≠ pending new key): The DB commit
+  completed but the new key was not persisted to the `KeyProvider`
+  backend.  Decrypt `new_master_key_enc` from `pending_rotation`
+  using the old key (still in the provider), write the new key to
+  the provider via `write_master_key`, then delete `pending_rotation`.
+
+- **Post-provider-write, pre-delete crash** (`master_key_epoch` =
+  pending epoch AND provider key = new key): The provider write
+  succeeded but `pending_rotation` was not deleted.  Simply delete
+  `pending_rotation`.  Recovery MUST attempt to load identity and
+  validate PSKs with the provider key first; if successful, the
+  provider already has the correct key.
+
+- **Stale `pending_rotation`** (`master_key_epoch` > pending epoch):
+  An impossible state under normal operation.  Log a warning, delete
+  the stale `pending_rotation` record, and proceed with the current
+  provider key.
+
+Post-commit recovery MUST run before `GatewayIdentity` loading to
+avoid fatal decryption errors when the identity seed has been
+rewrapped under the new key but the provider still holds the old key.
+
+In all cases, `pending_rotation` is deleted only after the key
+provider write succeeds (or is determined unnecessary).
 
 **Acceptance criteria:**
 
-1. Crash during any phase resumes correctly on restart.
-2. GatewayIdentity is loadable after crash at any phase.
+1. Crash during any pre-commit phase resumes correctly on restart.
+2. GatewayIdentity is loadable after crash at any pre-commit phase.
 3. All PSKs fully migrated after recovery.
-4. `pending_rotation` deleted after successful commit.
+4. `pending_rotation` deleted after successful commit and key provider write.
+5. Crash after DB commit but before key provider write: on restart, new key
+   is recovered from `pending_rotation`, written to the provider, and
+   `pending_rotation` is deleted.  The gateway starts successfully.
+6. Crash after key provider write but before `pending_rotation` delete: on
+   restart, gateway detects provider already has the correct key, deletes
+   `pending_rotation`, and starts successfully.
+7. Post-commit recovery runs before `GatewayIdentity` loading to prevent
+   fatal decryption errors.
 
 ---
 
@@ -2851,6 +2916,33 @@ reprovisioning.
 
 1. `pending_recovery` purged atomically with `pending_rotation` creation.
 2. Known nodes re-emitted with new `master_key_id` after rotation.
+
+---
+
+### GW-2014  Rotation blocked for non-writable key providers
+
+**Priority:** Must
+**Source:** Issue #1091
+
+**Description:**
+Before initiating a key rotation (either via DESIRED_STATE or gRPC
+`SubmitRotation`), the gateway MUST check `KeyProvider::is_writable()`.
+If the provider returns `false`, the gateway MUST reject the rotation
+with a clear error message indicating that the key provider backend
+does not support key persistence, and that rotation requires a writable
+key provider.  No cryptographic operations or database mutations are
+performed on the rejected rotation.
+
+For the gRPC path, `SubmitRotation` returns `accepted = false` with an
+error string.  For the DESIRED_STATE path, a warning-level log is
+emitted and the payload is discarded.
+
+**Acceptance criteria:**
+
+1. Rotation via gRPC is rejected with `accepted = false` and an error message mentioning the key provider when `is_writable()` returns `false`.
+2. Rotation via DESIRED_STATE is discarded with a warning log when `is_writable()` returns `false`.
+3. No database mutations or cryptographic operations occur before the rejection.
+4. Writable providers (`file`, `dpapi`, `secret-service`) are not affected.
 
 ---
 
@@ -3001,3 +3093,4 @@ reprovisioning.
 | GW-2011 | Fingerprint computation | Must |
 | GW-2012 | gRPC rotation API | Must |
 | GW-2013 | Pending recovery purge on rotation | Must |
+| GW-2014 | Rotation blocked for non-writable key providers | Must |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4293,10 +4293,11 @@ A configurable stub handler process (or in-process mock) that:
 
 ### T-2004  Master key rotation — happy path
 
-**Traces to:** GW-2006 (AC-1, AC-2)
+**Traces to:** GW-2006 (AC-1, AC-2, AC-6, AC-7, AC-8)
 
 **Steps:**
-1. Start gateway with 3 registered nodes and 1 phone PSK.
+1. Start gateway with 3 registered nodes, 1 phone PSK, and a writable
+   `FileKeyProvider` (using a temp key file).
 2. Record old `master_key_id` and `master_key_epoch`.
 3. Submit valid rotation payload via DESIRED_STATE.
 4. Verify all PSK records (nodes and phone_psks) updated with new
@@ -4307,6 +4308,11 @@ A configurable stub handler process (or in-process mock) that:
    `rotation_in_progress = false`.
 8. Verify node ACTUAL_STATE re-emitted with new `encrypted_psk`
    and `master_key_id`.
+9. Verify the key file on disk contains the new master key (hex-encoded).
+10. Verify `pending_rotation` table is empty.
+11. Stop the gateway.  Reload the key from the key file and re-open the
+    database — verify all PSKs decrypt successfully with the reloaded key
+    (simulates restart).
 
 **Expected:**
 1. All PSKs migrated; old key unusable; state updated.
@@ -4351,18 +4357,31 @@ A configurable stub handler process (or in-process mock) that:
 
 ### T-2005  Crash-safe key rotation
 
-**Traces to:** GW-2007 (AC-1, AC-2, AC-3, AC-4)
+**Traces to:** GW-2007 (AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-7)
 
 **Steps:**
-1. Start gateway with 10 registered nodes.
-2. Begin key rotation, simulate crash after 5 nodes migrated.
+1. Start gateway with 10 registered nodes and a writable `FileKeyProvider`.
+2. Begin key rotation, simulate crash after 5 nodes migrated (pre-commit).
 3. Restart gateway — verify `pending_rotation` detected during storage
    initialization (step 2a of startup sequence).
 4. Verify auto-resume migrates remaining 5 nodes before ACTUAL_STATE emission.
 5. Verify all 10 nodes have new `master_key_id` and `master_key_epoch`.
 6. Verify `pending_rotation` deleted.
-7. Verify first ACTUAL_STATE after restart reports `rotation_in_progress = false`
+7. Verify key file on disk contains the new master key.
+8. Verify first ACTUAL_STATE after restart reports `rotation_in_progress = false`
    (rotation completed during startup before ACTUAL_STATE emission).
+9. Simulate crash after DB commit but before key provider write:
+   leave `pending_rotation` in DB with epoch already incremented,
+   key file still has old key.
+10. Restart gateway — verify gateway recovers new key from
+    `pending_rotation`, writes it to key file, deletes
+    `pending_rotation`, and starts successfully.
+11. Simulate crash after key provider write but before `pending_rotation`
+    delete: key file has new key, `pending_rotation` still in DB.
+12. Restart gateway — verify gateway detects provider already has
+    correct key, deletes `pending_rotation`, and starts successfully.
+13. Verify post-commit recovery runs before `GatewayIdentity` loading
+    (no fatal decryption error on startup).
 
 **Expected:**
 1. Partial rotation is resumed and completed after crash.
@@ -4485,7 +4504,7 @@ A configurable stub handler process (or in-process mock) that:
 
 ### T-2009  Crash recovery — all rotation phases
 
-**Traces to:** GW-2007 (AC-1, AC-2)
+**Traces to:** GW-2007 (AC-1, AC-2, AC-5, AC-6)
 
 **Steps:**
 1. Crash during `migrating_psks` phase — verify PSK migration resumes.
@@ -4493,8 +4512,17 @@ A configurable stub handler process (or in-process mock) that:
    resumes and identity is loadable with old key on restart.
 3. Crash during `committing` phase — verify recovery completes the
    atomic commit and identity is loadable after recovery.
-4. For each phase, verify the gateway identity is always loadable on
+4. Crash after `committing` but before key provider write — verify
+   gateway decrypts new key from `pending_rotation` using old key
+   (still in provider), writes to provider, deletes `pending_rotation`,
+   and starts successfully with new key.
+5. Crash after key provider write but before `pending_rotation` delete —
+   verify gateway detects provider already has correct key, deletes
+   `pending_rotation`, and starts successfully.
+6. For each phase, verify the gateway identity is always loadable on
    restart (no key/identity mismatch).
+7. Verify recovery is idempotent: restart twice after post-commit crash
+   produces the same correct result.
 
 **Expected:**
 1. Crash at any phase boundary recovers correctly.
@@ -4576,6 +4604,60 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-2014  Rotation blocked for non-writable key provider
+
+**Traces to:** GW-2014 (AC-1, AC-2, AC-3, AC-4)
+
+**Steps:**
+1. Start gateway with a non-writable key provider (e.g., `EnvKeyProvider`)
+   and at least one registered node.
+2. Submit a valid rotation payload via gRPC `SubmitRotation`.
+3. Verify gRPC returns `accepted = false` with an error message mentioning
+   the key provider not supporting key persistence.
+4. Verify no database mutations occurred (no `pending_rotation`, PSKs
+   unchanged, epoch unchanged).
+5. Submit a valid rotation payload via DESIRED_STATE.
+6. Verify warning log emitted mentioning non-writable key provider.
+7. Verify payload is discarded (no `pending_rotation`, PSKs unchanged).
+8. Repeat steps 1–4 with a writable `FileKeyProvider` — verify rotation
+   is accepted and completes successfully.
+
+**Expected:**
+1. Non-writable providers block rotation; writable providers work normally.
+
+---
+
+### T-2014a  Key provider write_master_key — FileKeyProvider round-trip
+
+**Traces to:** GW-0601b (AC-7)
+
+**Steps:**
+1. Create a `FileKeyProvider` with a temp key file containing key A.
+2. Call `write_master_key(&key_B)`.
+3. Call `load_master_key()` — verify returns key B.
+4. Read the key file directly — verify it contains key B hex-encoded.
+5. Verify no `.tmp` file remains after write.
+
+**Expected:**
+1. Key file updated atomically; round-trips correctly.
+
+---
+
+### T-2014b  Key provider write_master_key — EnvKeyProvider rejected
+
+**Traces to:** GW-0601b (AC-8)
+
+**Steps:**
+1. Create an `EnvKeyProvider`.
+2. Verify `is_writable()` returns `false`.
+3. Call `write_master_key(&key)` — verify returns
+   `Err(KeyProviderError::NotWritable(_))`.
+
+**Expected:**
+1. `EnvKeyProvider` rejects writes with the correct error variant.
+
+---
+
 | GW-1306 | T-1306a, T-1306b, T-1306c, T-1306d |
 | GW-1307 | T-1307a, T-1307b, T-1307c, T-1307d, T-1307e, T-1307f, T-1307g, T-1307h, T-1307i |
 | GW-1308 | T-1308 |
@@ -4622,3 +4704,4 @@ A configurable stub handler process (or in-process mock) that:
 | GW-2011 | T-2001 |
 | GW-2012 | T-2008 |
 | GW-2013 | T-2010 |
+| GW-2014 | T-2014, T-2014a, T-2014b |


### PR DESCRIPTION
## Summary

After master key rotation the new key was only swapped in memory and committed to the database, but never written back to the \KeyProvider\ backend (file, DPAPI blob, or keyring). On restart the old key was loaded from the provider and PSK decryption failed fatally.

## Root Cause

\KeyProvider\ trait had no write capability. \RotationEngine\ didn't hold a reference to the key provider. After rotation: in-memory key swapped, DB PSKs re-encrypted, but key file/DPAPI blob/keyring still had old key.

## Fix

### \KeyProvider\ trait (\key_provider.rs\)
- Add \write_master_key()\ and \is_writable()\ with default not-writable implementations
- **FileKeyProvider**: atomic write-to-tmp + rename
- **DpapiKeyProvider**: DPAPI encrypt + atomic file write
- **SecretServiceKeyProvider**: delegates to \store_in_secret_service()\
- **EnvKeyProvider**: returns \NotWritable\
- Unit tests for write round-trip and not-writable rejection

### Storage (\sqlite_storage.rs\)
- \commit_rotation()\ retains \pending_rotation\ as crash-recovery marker
- Add \delete_pending_rotation()\ for explicit cleanup after \write_master_key()\
- Add \get_master_key_epoch()\ for three-way epoch comparison
- \load_pending_rotation_key()\ tolerates post-write/pre-delete state (epoch match → warn + proceed)

### Rotation engine (\otation_engine.rs\)
- Accept \Arc<dyn KeyProvider>\ in constructor; gate \handle_rotation_payload()\ on \is_writable()\
- Post-commit persistence: DB commit → \write_master_key()\ → \delete_pending_rotation()\ → swap in-memory key
- Rewritten \esume_pending_rotation()\ with three-way epoch comparison covering all crash windows

### Gateway startup (\in/gateway.rs\)
- Convert provider to \Arc<dyn KeyProvider>\ for shared ownership
- Post-commit recovery runs **before** identity loading (seed was rewrapped under new key)

### Specs
- \gateway-requirements.md\: add GW-2014, update GW-0601b/GW-2006/GW-2007
- \gateway-design.md\: update §10a.1, §10a.6, §23.7, §23.11
- \gateway-validation.md\: add T-2014/T-2014a/T-2014b, update T-2004/T-2005/T-2009

## Crash Safety

Four recovery paths on startup when \pending_rotation\ exists:

| State | DB epoch vs pending | Provider key | Action |
|-------|-------------------|--------------|--------|
| Pre-commit crash | epoch < pending | old | Resume migration phases, write key, delete marker |
| Post-commit/pre-write | epoch == pending | old (≠ new) | Decrypt new key from pending, write to provider, delete marker |
| Post-write/pre-delete | epoch == pending | new (= new) | Delete stale marker |
| Stale record | epoch > pending | — | Warn + delete |

## Validation

- \cargo build --workspace\ ✓
- \cargo test --workspace\ ✓ (0 failures)
- \cargo clippy --workspace --all-targets -- -D warnings\ ✓
- \cargo fmt --all\ ✓

Fixes #1091