### PR TITLE
fix: replace `desiredstate` upsert with append-only insert

### DIFF
--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -312,9 +312,10 @@ pub trait HandlerStore: Send + Sync {
         gateway_id: &str,
     ) -> Result<Option<GatewayDesiredStateRow>, HandlerError>;
 
-    /// Upsert gateway desired-state row (for clearing rotation_payload after
-    /// epoch increment).
-    async fn upsert_gateway_desired_state(
+    /// Append gateway desired-state row (for clearing rotation_payload after
+    /// epoch increment). Appends a new row with a unique RowKey; never
+    /// overwrites existing rows.
+    async fn append_gateway_desired_state(
         &self,
         row: &GatewayDesiredStateRow,
     ) -> Result<(), HandlerError>;
@@ -592,16 +593,17 @@ where
         // Load rotation_payload from SPA-written desired-state row.
         let gw_desired = self.store.load_gateway_desired_state(gateway_id).await?;
         let rotation_payload = if epoch_incremented {
-            // Epoch incremented — clear rotation_payload.
+            // Epoch incremented — clear rotation_payload by appending a new
+            // row (append-only; original SPA-written row is preserved).
             if let Some(ref existing) = gw_desired {
                 if existing.rotation_payload.is_some() {
                     let cleared = GatewayDesiredStateRow {
                         gateway_id: gateway_id.clone(),
-                        row_key: existing.row_key.clone(),
+                        row_key: next_history_row_key(msg.timestamp_ms)?,
                         rotation_payload: None,
-                        timestamp_ms: existing.timestamp_ms,
+                        timestamp_ms: msg.timestamp_ms,
                     };
-                    self.store.upsert_gateway_desired_state(&cleared).await?;
+                    self.store.append_gateway_desired_state(&cleared).await?;
                 }
             }
             None
@@ -1309,7 +1311,7 @@ impl HandlerStore for AzureTablesStore {
         }
     }
 
-    async fn upsert_gateway_desired_state(
+    async fn append_gateway_desired_state(
         &self,
         row: &GatewayDesiredStateRow,
     ) -> Result<(), HandlerError> {
@@ -1323,18 +1325,14 @@ impl HandlerStore for AzureTablesStore {
                 .map(|b| base64::engine::general_purpose::STANDARD.encode(b)),
             timestamp_ms: row.timestamp_ms,
         };
-        let entity_client = self
-            .desired_state_table
-            .partition_key_client(&partition_key)
-            .entity_client(&row.row_key);
-        entity_client
-            .insert_or_replace(entity)
+        self.desired_state_table
+            .insert::<_, GatewayDesiredStateEntity>(&entity)
             .map_err(|e| {
-                HandlerError::Store(format!("prepare gateway desired-state upsert failed: {e}"))
+                HandlerError::Store(format!("prepare gateway desired-state insert failed: {e}"))
             })?
             .await
             .map_err(|e| {
-                HandlerError::Store(format!("upsert gateway desired-state row failed: {e}"))
+                HandlerError::Store(format!("append gateway desired-state row failed: {e}"))
             })?;
         Ok(())
     }
@@ -2542,7 +2540,7 @@ mod tests {
         stored_program_rows: Mutex<Vec<ProgramImageRow>>,
         sensor_data_rows: Mutex<Vec<SensorDataRow>>,
         gateway_actual_states: Mutex<HashMap<String, Vec<GatewayActualStateRow>>>,
-        gateway_desired_states: Mutex<HashMap<String, GatewayDesiredStateRow>>,
+        gateway_desired_states: Mutex<HashMap<String, Vec<GatewayDesiredStateRow>>>,
     }
 
     impl MemoryStore {
@@ -2720,17 +2718,20 @@ mod tests {
                 .lock()
                 .await
                 .get(gateway_id)
+                .and_then(|rows| rows.iter().min_by_key(|r| &r.row_key))
                 .cloned())
         }
 
-        async fn upsert_gateway_desired_state(
+        async fn append_gateway_desired_state(
             &self,
             row: &GatewayDesiredStateRow,
         ) -> Result<(), HandlerError> {
             self.gateway_desired_states
                 .lock()
                 .await
-                .insert(row.gateway_id.clone(), row.clone());
+                .entry(row.gateway_id.clone())
+                .or_default()
+                .push(row.clone());
             Ok(())
         }
     }
@@ -2856,7 +2857,7 @@ mod tests {
             Ok(None)
         }
 
-        async fn upsert_gateway_desired_state(
+        async fn append_gateway_desired_state(
             &self,
             _row: &GatewayDesiredStateRow,
         ) -> Result<(), HandlerError> {
@@ -2934,7 +2935,7 @@ mod tests {
             Ok(None)
         }
 
-        async fn upsert_gateway_desired_state(
+        async fn append_gateway_desired_state(
             &self,
             _row: &GatewayDesiredStateRow,
         ) -> Result<(), HandlerError> {
@@ -3013,7 +3014,7 @@ mod tests {
             Ok(None)
         }
 
-        async fn upsert_gateway_desired_state(
+        async fn append_gateway_desired_state(
             &self,
             _row: &GatewayDesiredStateRow,
         ) -> Result<(), HandlerError> {
@@ -4204,7 +4205,7 @@ mod tests {
             ) -> Result<Option<GatewayDesiredStateRow>, HandlerError> {
                 Ok(None)
             }
-            async fn upsert_gateway_desired_state(
+            async fn append_gateway_desired_state(
                 &self,
                 _: &GatewayDesiredStateRow,
             ) -> Result<(), HandlerError> {
@@ -4878,7 +4879,7 @@ mod tests {
             rotation_payload: Some(vec![0xDE, 0xAD]),
             timestamp_ms: 1500,
         };
-        store.upsert_gateway_desired_state(&desired).await.unwrap();
+        store.append_gateway_desired_state(&desired).await.unwrap();
 
         let published_before = publisher.sends.lock().await.len();
 
@@ -4956,7 +4957,7 @@ mod tests {
             rotation_payload: Some(vec![0xDE, 0xAD]),
             timestamp_ms: 1500,
         };
-        store.upsert_gateway_desired_state(&desired).await.unwrap();
+        store.append_gateway_desired_state(&desired).await.unwrap();
 
         let published_before = publisher.sends.lock().await.len();
 
@@ -5169,7 +5170,7 @@ mod tests {
 
         // Seed gateway desired state with a rotation payload
         store
-            .upsert_gateway_desired_state(&GatewayDesiredStateRow {
+            .append_gateway_desired_state(&GatewayDesiredStateRow {
                 gateway_id: "a1b2c3d4".to_string(),
                 row_key: "state".to_string(),
                 rotation_payload: Some(rotation_payload.clone()),
@@ -5223,6 +5224,28 @@ mod tests {
                 .map(|d| d.rotation_payload.is_none())
                 .unwrap_or(true),
             "rotation_payload should be cleared after epoch increment"
+        );
+
+        // Append-only: both the original SPA row and the cleared row must exist
+        // with distinct RowKeys (the original is preserved, not overwritten).
+        let all_rows = store.gateway_desired_states.lock().await;
+        let rows = all_rows.get("a1b2c3d4").expect("rows must exist");
+        assert_eq!(
+            rows.len(),
+            2,
+            "append-only: original + cleared row expected"
+        );
+        assert_ne!(
+            rows[0].row_key, rows[1].row_key,
+            "appended row must have a distinct RowKey"
+        );
+        assert!(
+            rows[0].rotation_payload.is_some(),
+            "original SPA row must be preserved with rotation_payload"
+        );
+        assert!(
+            rows[1].rotation_payload.is_none(),
+            "appended cleared row must have rotation_payload = None"
         );
     }
 

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -312,9 +312,10 @@ pub trait HandlerStore: Send + Sync {
         gateway_id: &str,
     ) -> Result<Option<GatewayDesiredStateRow>, HandlerError>;
 
-    /// Append gateway desired-state row (for clearing rotation_payload after
-    /// epoch increment). Appends a new row with a unique RowKey; never
-    /// overwrites existing rows.
+    /// Append gateway desired-state row (for clearing `rotation_payload` after
+    /// epoch increment). The caller must provide a unique `RowKey` (e.g. via
+    /// `next_history_row_key()`). The store inserts the row without overwriting
+    /// or replacing existing rows.
     async fn append_gateway_desired_state(
         &self,
         row: &GatewayDesiredStateRow,

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -600,8 +600,13 @@ rewriting the payload.
 
 The handler clears `rotation_payload` after observing a gateway ACTUAL_STATE row
 whose `master_key_epoch` has incremented relative to the previously stored
-gateway row. This makes the DESIRED_STATE relay one-shot while still relying on
-gateway-reported convergence.
+gateway row. Clearing is performed by appending a **new** row to the
+`desiredstate` table (with a fresh `next_history_row_key()` RowKey and
+`rotation_payload: None`) rather than overwriting the original SPA-written row.
+The `load_gateway_desired_state` reader returns `$top=1` from the partition, so
+the newly appended row (which sorts first due to the inverted-timestamp RowKey)
+is picked up as the latest state. This preserves the original SPA-written row
+for audit purposes while making the DESIRED_STATE relay one-shot.
 
 ### 9.5  Salt management and gateway DESIRED_STATE construction
 

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -472,12 +472,16 @@ The handler MUST relay rotation payloads from the SPA to the gateway via the
 `DESIRED_STATE` field `rotation_payload` (CBOR key 28 inside desired-state map
 key 4). The handler does not originate, inspect, or modify rotation payloads.
 After the gateway reports a new `master_key_epoch` in `ACTUAL_STATE`, the
-handler MUST clear `rotation_payload` from `DESIRED_STATE`.
+handler MUST clear `rotation_payload` by appending a new row to the
+`desiredstate` table with `rotation_payload` set to `None` and a fresh
+history `RowKey`. The handler MUST NOT overwrite or replace the original
+SPA-written row.
 
 **Acceptance criteria:**
 
 1. `rotation_payload` is relayed unmodified.
 2. `rotation_payload` is cleared after the gateway reports an incremented epoch.
+3. Clearing appends a new row; the original SPA-written row is preserved.
 
 ---
 
@@ -509,12 +513,15 @@ The handler MUST construct gateway `DESIRED_STATE` with
 `desired_state` map it MUST use CBOR keys 15 for `channel`, 21 for `salt`, 22
 for `kdf_params`, 28 for `rotation_payload`, and 29 for `recovered_psks`.
 Gateway `DESIRED_STATE` is written to the `desiredstate` Azure Table with
-`PartitionKey = "g:" + gateway_id_hex`.
+`PartitionKey = "g:" + gateway_id_hex`. All handler writes to the
+`desiredstate` table MUST be append-only (new rows with unique history
+`RowKey`s), never upserts or replacements.
 
 **Acceptance criteria:**
 
 1. Gateway `DESIRED_STATE` uses the correct CBOR key numbers.
 2. The `PartitionKey` uses the `"g:"` prefix.
+3. Handler writes to the `desiredstate` table are append-only.
 
 ---
 

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -436,6 +436,9 @@ divergence publication instead of treating that redelivery as permanently stale.
    than the pre-rotation epoch.
 4. Assert: subsequent gateway `DESIRED_STATE` messages omit `rotation_payload`
    or encode it as cleared/null according to the table representation.
+5. Assert: the original SPA-written desired-state row is preserved (not
+   overwritten). The clearing operation appends a new row with a distinct
+   `RowKey`.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #1097

Converts the gateway `desiredstate` Azure Table write path from **upsert** (`insert_or_replace`) to **append-only** (`insert` with fresh `RowKey`), preserving original SPA-written rows for audit purposes.

## Changes

### Specifications (3 files)
- **`azure-handler-requirements.md`** — AZH-0603 AC3: clearing appends a new row; original preserved. AZH-0605 AC3: handler writes are append-only.
- **`azure-handler-design.md`** — §9.4: clarified that clearing means appending a new row with `next_history_row_key()` RowKey and `rotation_payload: None`.
- **`azure-handler-validation.md`** — T-AZH-0603 step 5: verify original SPA row is preserved with distinct RowKey.

### Implementation (`crates/sonde-azure-handler/src/lib.rs`)
- **Trait**: `upsert_gateway_desired_state` → `append_gateway_desired_state`
- **Azure Table impl**: `insert_or_replace` → `table.insert()` (conflict-safe)
- **Call site**: fresh `next_history_row_key(msg.timestamp_ms)` instead of reusing existing `row_key`
- **MemoryStore**: `HashMap<String, GatewayDesiredStateRow>` → `HashMap<String, Vec<...>>`, load returns smallest RowKey (matches Azure `top=1`)
- **Tests**: 4 mock stubs + 2 call sites renamed; T-AZH-0603 gains append-only assertion (2 rows, distinct RowKeys)

## Testing

All 98 `sonde-azure-handler` tests pass. Clippy and fmt clean.