### PR TITLE
feat(web-ui): add gateway convergence badge and inline rotation form

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -226,6 +226,7 @@ const APP = {
   refreshToken: 0,
   viewMessage: null,
   sensorChart: null,
+  rotationFormOpen: null, // gateway ID when rotation form is expanded (WEB-1002)
 };
 
 const contentEl = document.getElementById('content');
@@ -362,10 +363,49 @@ function filterGatewayRows(rows) {
   return rows.filter((r) => isGatewayPartitionKey(r.PartitionKey));
 }
 
-async function renderGatewayStatusCard(gatewayRows) {
+// Gateway convergence logic (WEB-1009).
+// Returns true if the gateway's actual state diverges from desired state.
+function computeGatewayDivergence(actual, desired) {
+  if (!desired) return false;
+
+  // Rotation payload pending: desired has rotation_payload AND gateway has not
+  // consumed it (rotation_in_progress is not true AND epoch has not advanced
+  // past submitted_epoch).
+  if (desired.rotation_payload) {
+    const actualEpoch = Number(actual.master_key_epoch) || 0;
+    const submittedEpoch = Number(desired.submitted_epoch) || 0;
+    if (actual.rotation_in_progress !== true && actualEpoch <= submittedEpoch) {
+      return true;
+    }
+  }
+
+  // Channel mismatch.
+  if (desired.channel != null) {
+    const desiredCh = Number(desired.channel);
+    const actualCh = Number(actual.channel);
+    if (!Number.isNaN(desiredCh) && desiredCh !== actualCh) return true;
+  }
+
+  // Salt pending adoption (set-if-absent): diverged only when actual has no salt.
+  if (desired.salt != null && !actual.salt) return true;
+
+  // KDF params pending adoption (set-if-absent): diverged only when actual has
+  // no KDF params. Field name in Azure Tables is kdf_params_json.
+  const desiredHasKdf = desired.kdf_params != null || desired.kdf_params_json != null;
+  const actualHasKdf = actual.kdf_params != null || actual.kdf_params_json != null;
+  if (desiredHasKdf && !actualHasKdf) return true;
+
+  return false;
+}
+
+async function renderGatewayStatusCard(gatewayRows, gatewayDesiredRows) {
   if (!gatewayRows || gatewayRows.length === 0) {
     return '<div class="panel stack"><h2>Gateway Status</h2><p class="muted">No gateway connected.</p></div>';
   }
+
+  const desiredByPartition = new Map(
+    (gatewayDesiredRows || []).map((row) => [row.PartitionKey, row])
+  );
 
   let cardsHtml = '';
   for (const gw of gatewayRows) {
@@ -394,14 +434,23 @@ async function renderGatewayStatusCard(gatewayRows) {
     const modemVersion = gw.modem_firmware_version || '—';
     const channel = gw.channel ?? '—';
 
+    // Gateway convergence badge (WEB-1009).
+    const desired = desiredByPartition.get(gw.PartitionKey);
+    const diverged = computeGatewayDivergence(gw, desired);
+    const badgeHtml = `<span class="badge ${diverged ? 'warning' : 'success'}">${diverged ? 'Diverged' : 'Aligned'}</span>`;
+
     const rotationDisabled = !hasRotationCrypto();
     const rotateBtn = rotationDisabled
       ? '<button class="secondary" disabled title="Browser lacks required crypto capabilities (Web Crypto + WebAssembly)">Rotate Key</button>'
       : `<button class="secondary rotate-key-btn" data-gateway-id="${escapeHtml(gwId)}">Rotate Key</button>`;
 
+    const saltStatusText = gw.salt ? 'Current salt loaded' : 'First rotation (no salt)';
+    const formExpanded = APP.rotationFormOpen === gwId;
+    const formStyle = formExpanded ? '' : ' style="display:none"';
+
     cardsHtml += `
-      <div class="panel stack">
-        <h2>Gateway ${escapeHtml(gwId.slice(0, 8))}…</h2>
+      <div class="panel stack" data-gateway-card="${escapeHtml(gwId)}">
+        <h2>Gateway ${escapeHtml(gwId.slice(0, 8))}… ${badgeHtml}</h2>
         <div class="kv-grid">
           <div class="kv"><strong>Fingerprint</strong> ${fingerprintHtml}</div>
           <div class="kv"><strong>Epoch</strong> ${escapeHtml(epoch)}</div>
@@ -413,6 +462,26 @@ async function renderGatewayStatusCard(gatewayRows) {
           <div class="kv"><strong>Channel</strong> ${escapeHtml(channel)}</div>
         </div>
         ${rotateBtn}
+        <div class="rotation-form-container" data-gateway-form="${escapeHtml(gwId)}"${formStyle}>
+          <hr>
+          <p><strong>Step 1:</strong> Verify the fingerprint above matches the modem display.</p>
+          <form class="rotation-form form-grid" data-gateway-id="${escapeHtml(gwId)}">
+            <label>Rotation Code (from modem)
+              <input name="rotationCode" type="text" maxlength="6" pattern="[A-Za-z0-9]{6}"
+                placeholder="ABC123" autocomplete="off" style="text-transform:uppercase" required>
+            </label>
+            <label>Passphrase (≥20 chars or 6+ words)
+              <input name="passphrase" type="password"
+                placeholder="Enter passphrase…" required>
+            </label>
+            <p class="muted small">${escapeHtml(saltStatusText)}</p>
+            <div class="rotation-status" data-gateway-status="${escapeHtml(gwId)}"></div>
+            <div style="display:flex;gap:0.5rem">
+              <button type="submit" class="primary rotation-submit-btn">Rotate</button>
+              <button type="button" class="secondary rotation-cancel-btn" data-gateway-id="${escapeHtml(gwId)}">Cancel</button>
+            </div>
+          </form>
+        </div>
       </div>
     `;
   }
@@ -434,117 +503,103 @@ function hasRotationCrypto() {
   }
 }
 
-// 8b. Rotation modal (WEB-1002–WEB-1008)
-function showRotationModal(gatewayRow) {
-  const gwId = gatewayRow.PartitionKey?.replace('g:', '') || '';
-  const saltStatus = gatewayRow.salt ? 'Current salt loaded' : 'First rotation (no salt)';
-  const epoch = Number(gatewayRow.master_key_epoch) || 0;
+// 8b. Inline rotation form (WEB-1002, WEB-1009)
+// Toggles the inline rotation form within a gateway card and pauses
+// auto-refresh while the form is open to prevent DOM replacement.
+function toggleRotationForm(gwId) {
+  const container = document.querySelector(`.rotation-form-container[data-gateway-form="${gwId}"]`);
+  if (!container) return;
 
-  // Compute fingerprint synchronously (already loaded wordlist by now).
-  let fingerprintText = 'Unable to compute fingerprint';
-  const pubKeyRaw = gatewayRow.x25519_public_key
-    ? base64ToBytes(gatewayRow.x25519_public_key)
-    : null;
-
-  const modalHtml = `
-    <div class="overlay" id="rotation-overlay" role="dialog" aria-modal="true" aria-label="Rotate Master Key">
-      <div class="modal" style="max-width:480px">
-        <h2>Rotate Master Key</h2>
-        <p><strong>Step 1:</strong> Verify the fingerprint below matches the modem display.</p>
-        <div id="rotation-fingerprint" class="alert" style="word-break:break-all">Computing…</div>
-        <form id="rotation-form" class="form-grid">
-          <label>Rotation Code (from modem)
-            <input name="rotationCode" type="text" maxlength="6" pattern="[A-Za-z0-9]{6}"
-              placeholder="ABC123" autocomplete="off" style="text-transform:uppercase" required>
-          </label>
-          <label>Passphrase (≥20 chars or 6+ words)
-            <input name="passphrase" type="password"
-              placeholder="Enter passphrase…" required>
-          </label>
-          <p class="muted small">${escapeHtml(saltStatus)}</p>
-          <div id="rotation-status"></div>
-          <div style="display:flex;gap:0.5rem">
-            <button type="submit" class="primary" id="rotation-submit-btn">Rotate</button>
-            <button type="button" class="secondary" id="rotation-cancel-btn">Cancel</button>
-          </div>
-        </form>
-      </div>
-    </div>
-  `;
-
-  let overlay = document.getElementById('rotation-overlay');
-  if (overlay) overlay.remove();
-  document.body.insertAdjacentHTML('beforeend', modalHtml);
-
-  // Compute fingerprint async, update display.
-  if (pubKeyRaw && pubKeyRaw.length === 32) {
-    computeBip39Fingerprint(pubKeyRaw).then((words) => {
-      const el = document.getElementById('rotation-fingerprint');
-      if (el && words) {
-        el.innerHTML = `<code>${words.map(escapeHtml).join(' ')}</code>`;
-      } else if (el) {
-        el.textContent = fingerprintText;
-      }
-    });
+  const isOpen = container.style.display !== 'none';
+  if (isOpen) {
+    closeRotationForm(gwId);
   } else {
-    const el = document.getElementById('rotation-fingerprint');
-    if (el) el.textContent = 'Fingerprint unavailable (missing or invalid public key)';
+    // Close any other open rotation form first.
+    for (const el of document.querySelectorAll('.rotation-form-container')) {
+      el.style.display = 'none';
+    }
+    container.style.display = '';
+    APP.rotationFormOpen = gwId;
+    // Pause auto-refresh while form is open.
+    clearRefresh();
+    // Focus the first input.
+    container.querySelector('input')?.focus();
+  }
+}
+
+// Idempotent close — safe to call from timeout even if user already closed.
+function closeRotationForm(gwId) {
+  if (APP.rotationFormOpen !== gwId) return;
+  const container = document.querySelector(`.rotation-form-container[data-gateway-form="${gwId}"]`);
+  if (container) container.style.display = 'none';
+  APP.rotationFormOpen = null;
+  // Resume auto-refresh (WEB-1002 AC#5).
+  setAutoRefresh(async () => {
+    if (APP.activeTab === 'dashboard') await renderDashboard();
+  });
+}
+
+// Attaches event handlers for rotation forms and buttons after dashboard
+// DOM is inserted. Called from renderDashboard().
+function attachRotationFormHandlers(gatewayRows) {
+  // Rotate Key button toggles inline form.
+  for (const btn of document.querySelectorAll('.rotate-key-btn')) {
+    btn.addEventListener('click', () => {
+      toggleRotationForm(btn.dataset.gatewayId);
+    });
   }
 
-  document.getElementById('rotation-cancel-btn')?.addEventListener('click', () => {
-    document.getElementById('rotation-overlay')?.remove();
-  });
+  // Cancel button collapses the form.
+  for (const btn of document.querySelectorAll('.rotation-cancel-btn')) {
+    btn.addEventListener('click', () => {
+      toggleRotationForm(btn.dataset.gatewayId);
+    });
+  }
 
-  // Escape to close
-  const rotationOverlay = document.getElementById('rotation-overlay');
-  rotationOverlay?.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') rotationOverlay.remove();
-  });
-  // Click outside modal to close
-  rotationOverlay?.addEventListener('click', (e) => {
-    if (e.target === rotationOverlay) rotationOverlay.remove();
-  });
-  // Focus the first input
-  rotationOverlay?.querySelector('input')?.focus();
+  // Submit handler for each rotation form.
+  for (const form of document.querySelectorAll('.rotation-form')) {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const gwId = form.dataset.gatewayId;
+      const gwRow = gatewayRows.find(
+        (r) => (r.PartitionKey?.replace('g:', '') || '') === gwId
+      );
+      if (!gwRow) return;
 
-  document.getElementById('rotation-form')?.addEventListener('submit', async (event) => {
-    event.preventDefault();
-    const form = event.target;
-    const code = (form.rotationCode?.value || '').toUpperCase().trim();
-    const passphrase = form.passphrase?.value || '';
-    const statusEl = document.getElementById('rotation-status');
-    const submitBtn = document.getElementById('rotation-submit-btn');
+      const code = (form.rotationCode?.value || '').toUpperCase().trim();
+      const passphrase = form.passphrase?.value || '';
+      const statusEl = document.querySelector(`.rotation-status[data-gateway-status="${gwId}"]`);
+      const submitBtn = form.querySelector('.rotation-submit-btn');
 
-    if (!/^[A-Z0-9]{6}$/.test(code)) {
-      if (statusEl) statusEl.innerHTML = '<div class="alert error">Rotation code must be 6 alphanumeric characters.</div>';
-      return;
-    }
-    if (passphrase.length < 20 && passphrase.split(/\s+/).filter((w) => w).length < 6) {
-      if (statusEl) statusEl.innerHTML = '<div class="alert error">Passphrase must be ≥20 characters or 6+ space-separated words.</div>';
-      return;
-    }
-
-    if (submitBtn) submitBtn.disabled = true;
-    if (statusEl) statusEl.innerHTML = '<p class="muted">Deriving key (Argon2id)… this may take a few seconds.</p>';
-
-    try {
-      const payload = await buildRotationPayload(gatewayRow, code, passphrase);
-      if (statusEl) statusEl.innerHTML = '<p class="muted">Submitting rotation…</p>';
-      await submitRotationPayload(gwId, payload);
-      if (statusEl) statusEl.innerHTML = '<p class="muted">Rotation submitted. Polling for confirmation…</p>';
-      const success = await pollRotationResult(gwId, epoch);
-      if (success) {
-        if (statusEl) statusEl.innerHTML = '<div class="alert success">Rotation complete! New epoch active.</div>';
-      } else {
-        if (statusEl) statusEl.innerHTML = '<div class="alert error">Rotation may still be in progress — check gateway status.</div>';
+      if (!/^[A-Z0-9]{6}$/.test(code)) {
+        if (statusEl) statusEl.innerHTML = '<div class="alert error">Rotation code must be 6 alphanumeric characters.</div>';
+        return;
       }
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (statusEl) statusEl.innerHTML = `<div class="alert error">${escapeHtml(msg)}</div>`;
-    } finally {
-      if (submitBtn) submitBtn.disabled = false;
-    }
-  });
+      if (passphrase.length < 20 && passphrase.split(/\s+/).filter((w) => w).length < 6) {
+        if (statusEl) statusEl.innerHTML = '<div class="alert error">Passphrase must be ≥20 characters or 6+ space-separated words.</div>';
+        return;
+      }
+
+      if (submitBtn) submitBtn.disabled = true;
+      if (statusEl) statusEl.innerHTML = '<p class="muted">Deriving key (Argon2id)… this may take a few seconds.</p>';
+
+      const epoch = Number(gwRow.master_key_epoch) || 0;
+
+      try {
+        const payload = await buildRotationPayload(gwRow, code, passphrase);
+        if (statusEl) statusEl.innerHTML = '<p class="muted">Submitting rotation…</p>';
+        await submitRotationPayload(gwId, payload, epoch);
+        if (statusEl) statusEl.innerHTML = '<div class="alert success">Rotation submitted.</div>';
+        // Collapse form after short delay to show success message.
+        setTimeout(() => closeRotationForm(gwId), 1500);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (statusEl) statusEl.innerHTML = `<div class="alert error">${escapeHtml(msg)}</div>`;
+      } finally {
+        if (submitBtn) submitBtn.disabled = false;
+      }
+    });
+  }
 }
 
 async function buildRotationPayload(gatewayRow, rotationCode, passphrase) {
@@ -712,7 +767,7 @@ function encodeCborUintEntry(parts, key, value) {
   }
 }
 
-async function submitRotationPayload(gwId, payloadBytes) {
+async function submitRotationPayload(gwId, payloadBytes, epoch) {
   const partitionKey = `g:${gwId}`;
   const nowMs = Date.now();
   const rowKey = desiredRowKey(nowMs);
@@ -728,29 +783,12 @@ async function submitRotationPayload(gwId, payloadBytes) {
     RowKey: rowKey,
     rotation_payload: b64Payload,
     'rotation_payload@odata.type': 'Edm.Binary',
+    submitted_epoch: String(epoch),
+    'submitted_epoch@odata.type': 'Edm.Int64',
     timestamp_ms: String(nowMs),
     'timestamp_ms@odata.type': 'Edm.Int64',
   };
   await insertEntity(CONFIG.desiredStateTable, entity);
-}
-
-async function pollRotationResult(gwId, originalEpoch) {
-  const maxAttempts = 24; // 5s × 24 = 120s
-  for (let i = 0; i < maxAttempts; i++) {
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-    try {
-      const filter = `PartitionKey eq 'g:${gwId}'`;
-      const rows = await queryTable(CONFIG.actualStateTable, filter, { top: 1 });
-      if (rows.length > 0) {
-        const currentEpoch = Number(rows[0].master_key_epoch) || 0;
-        if (currentEpoch > originalEpoch) return true;
-        if (rows[0].rotation_in_progress === false && currentEpoch === originalEpoch && i > 2) {
-          return false; // rotation_in_progress went back to false without epoch change
-        }
-      }
-    } catch { /* retry */ }
-  }
-  return false;
 }
 
 function showViewMessage(kind, text) {
@@ -1149,9 +1187,14 @@ async function renderDashboard() {
       queryTable(CONFIG.desiredStateTable, ''),
     ]);
 
+    // If user opened rotation form while we were fetching, skip DOM
+    // replacement to preserve form state (WEB-1002 AC#5).
+    if (APP.rotationFormOpen) return;
+
     // Separate gateway and node rows (WEB-1001).
     const gatewayRows = latestByPartition(filterGatewayRows(actualRows));
-    const gatewayCardHtml = await renderGatewayStatusCard(gatewayRows);
+    const gatewayDesiredRows = latestByPartition(filterGatewayRows(desiredRows));
+    const gatewayCardHtml = await renderGatewayStatusCard(gatewayRows, gatewayDesiredRows);
 
     const latestActual = latestByPartition(filterNodeRows(actualRows)).sort((left, right) => String(left.node_id || '').localeCompare(String(right.node_id || '')));
     const desiredByPartition = new Map(latestByPartition(filterNodeRows(desiredRows)).map((row) => [row.PartitionKey, row]));
@@ -1206,25 +1249,20 @@ async function renderDashboard() {
       </div>
     `);
 
-    // Attach rotation button click handlers
-    for (const btn of document.querySelectorAll('.rotate-key-btn')) {
-      btn.addEventListener('click', () => {
-        const gwIdForBtn = btn.dataset.gatewayId;
-        const gwRow = gatewayRows.find(
-          (r) => (r.PartitionKey?.replace('g:', '') || '') === gwIdForBtn
-        );
-        if (gwRow) showRotationModal(gwRow);
-      });
-    }
+    // Attach inline rotation form handlers (WEB-1002, WEB-1009).
+    attachRotationFormHandlers(gatewayRows);
   } catch (error) {
     renderError('Dashboard', error);
   }
 
-  setAutoRefresh(async () => {
-    if (APP.activeTab === 'dashboard') {
-      await renderDashboard();
-    }
-  });
+  // Only set auto-refresh if rotation form is not open (WEB-1002 AC#5).
+  if (!APP.rotationFormOpen) {
+    setAutoRefresh(async () => {
+      if (APP.activeTab === 'dashboard') {
+        await renderDashboard();
+      }
+    });
+  }
 }
 
 // 5. Desired State Tab

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -515,16 +515,19 @@ function hasRotationCrypto() {
 function toggleRotationForm(gwId) {
   const container = document.querySelector(`.rotation-form-container[data-gateway-form="${gwId}"]`);
   if (!container) return;
-  // Block close while submission is in flight.
-  if (container.dataset.submitting === '1') return;
+  // Block any toggle while any form has an in-flight submission.
+  if (document.querySelector('.rotation-form-container[data-submitting="1"]')) return;
 
   const isOpen = container.style.display !== 'none';
   if (isOpen) {
     closeRotationForm(gwId);
   } else {
-    // Close any other open rotation form first.
-    for (const el of document.querySelectorAll('.rotation-form-container')) {
-      el.style.display = 'none';
+    // Close the currently-open form (if any) before opening the new one.
+    if (APP.rotationFormOpen) {
+      const prev = document.querySelector(
+        `.rotation-form-container[data-gateway-form="${APP.rotationFormOpen}"]`
+      );
+      if (prev) prev.style.display = 'none';
     }
     container.style.display = '';
     APP.rotationFormOpen = gwId;

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -376,12 +376,13 @@ function computeGatewayDivergence(actual, desired) {
       // Gateway is actively processing — not diverged for this condition.
     } else {
       const submittedEpoch = Number(desired.submitted_epoch);
-      if (Number.isNaN(submittedEpoch)) {
-        // Legacy row without submitted_epoch — treat as diverged.
-        return true;
+      if (!Number.isNaN(submittedEpoch)) {
+        // New-style row with submitted_epoch — compare epochs.
+        const actualEpoch = Number(actual.master_key_epoch) || 0;
+        if (actualEpoch <= submittedEpoch) return true;
       }
-      const actualEpoch = Number(actual.master_key_epoch) || 0;
-      if (actualEpoch <= submittedEpoch) return true;
+      // Legacy row without submitted_epoch — cannot determine convergence,
+      // skip to avoid permanent false Diverged after gateway consumes it.
     }
   }
 
@@ -542,7 +543,12 @@ function toggleRotationForm(gwId) {
 function closeRotationForm(gwId) {
   if (APP.rotationFormOpen !== gwId) return;
   const container = document.querySelector(`.rotation-form-container[data-gateway-form="${gwId}"]`);
-  if (container) container.style.display = 'none';
+  if (container) {
+    // Clear sensitive fields so passphrase doesn't linger in hidden DOM.
+    const form = container.querySelector('.rotation-form');
+    if (form) form.reset();
+    container.style.display = 'none';
+  }
   APP.rotationFormOpen = null;
   // Resume auto-refresh only if still on the dashboard tab (WEB-1002 AC#5).
   if (APP.activeTab === 'dashboard') {

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -1189,7 +1189,15 @@ async function renderDashboard() {
 
     // If user opened rotation form while we were fetching, skip DOM
     // replacement to preserve form state (WEB-1002 AC#5).
-    if (APP.rotationFormOpen) return;
+    // Only skip if the form container is still in the DOM (not stale from a tab switch).
+    if (APP.rotationFormOpen) {
+      const formStillPresent = document.querySelector(
+        `.rotation-form-container[data-gateway-form="${APP.rotationFormOpen}"]`
+      );
+      if (formStillPresent) return;
+      // Stale flag — user navigated away and back; clear and continue.
+      APP.rotationFormOpen = null;
+    }
 
     // Separate gateway and node rows (WEB-1001).
     const gatewayRows = latestByPartition(filterGatewayRows(actualRows));

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -533,10 +533,12 @@ function closeRotationForm(gwId) {
   const container = document.querySelector(`.rotation-form-container[data-gateway-form="${gwId}"]`);
   if (container) container.style.display = 'none';
   APP.rotationFormOpen = null;
-  // Resume auto-refresh (WEB-1002 AC#5).
-  setAutoRefresh(async () => {
-    if (APP.activeTab === 'dashboard') await renderDashboard();
-  });
+  // Resume auto-refresh only if still on the dashboard tab (WEB-1002 AC#5).
+  if (APP.activeTab === 'dashboard') {
+    setAutoRefresh(async () => {
+      if (APP.activeTab === 'dashboard') await renderDashboard();
+    });
+  }
 }
 
 // Attaches event handlers for rotation forms and buttons after dashboard
@@ -1179,6 +1181,18 @@ async function renderDashboard() {
     return;
   }
 
+  // If rotation form is open and still in the DOM, skip the entire render
+  // to preserve form state (WEB-1002 AC#5). Must run before the loading
+  // renderCard() call which would destroy the form.
+  if (APP.rotationFormOpen) {
+    const formStillPresent = document.querySelector(
+      `.rotation-form-container[data-gateway-form="${APP.rotationFormOpen}"]`
+    );
+    if (formStillPresent) return;
+    // Stale flag — user navigated away and back; clear and continue.
+    APP.rotationFormOpen = null;
+  }
+
   renderCard('Dashboard', '<p class="muted">Loading dashboard…</p>');
 
   try {
@@ -1186,18 +1200,6 @@ async function renderDashboard() {
       queryTable(CONFIG.actualStateTable, ''),
       queryTable(CONFIG.desiredStateTable, ''),
     ]);
-
-    // If user opened rotation form while we were fetching, skip DOM
-    // replacement to preserve form state (WEB-1002 AC#5).
-    // Only skip if the form container is still in the DOM (not stale from a tab switch).
-    if (APP.rotationFormOpen) {
-      const formStillPresent = document.querySelector(
-        `.rotation-form-container[data-gateway-form="${APP.rotationFormOpen}"]`
-      );
-      if (formStillPresent) return;
-      // Stale flag — user navigated away and back; clear and continue.
-      APP.rotationFormOpen = null;
-    }
 
     // Separate gateway and node rows (WEB-1001).
     const gatewayRows = latestByPartition(filterGatewayRows(actualRows));

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -372,10 +372,16 @@ function computeGatewayDivergence(actual, desired) {
   // consumed it (rotation_in_progress is not true AND epoch has not advanced
   // past submitted_epoch).
   if (desired.rotation_payload) {
-    const actualEpoch = Number(actual.master_key_epoch) || 0;
-    const submittedEpoch = Number(desired.submitted_epoch) || 0;
-    if (actual.rotation_in_progress !== true && actualEpoch <= submittedEpoch) {
-      return true;
+    if (actual.rotation_in_progress === true) {
+      // Gateway is actively processing — not diverged for this condition.
+    } else {
+      const submittedEpoch = Number(desired.submitted_epoch);
+      if (Number.isNaN(submittedEpoch)) {
+        // Legacy row without submitted_epoch — treat as diverged.
+        return true;
+      }
+      const actualEpoch = Number(actual.master_key_epoch) || 0;
+      if (actualEpoch <= submittedEpoch) return true;
     }
   }
 
@@ -509,6 +515,8 @@ function hasRotationCrypto() {
 function toggleRotationForm(gwId) {
   const container = document.querySelector(`.rotation-form-container[data-gateway-form="${gwId}"]`);
   if (!container) return;
+  // Block close while submission is in flight.
+  if (container.dataset.submitting === '1') return;
 
   const isOpen = container.style.display !== 'none';
   if (isOpen) {
@@ -582,7 +590,12 @@ function attachRotationFormHandlers(gatewayRows) {
         return;
       }
 
+      const formContainer = document.querySelector(`.rotation-form-container[data-gateway-form="${gwId}"]`);
+      const cancelBtn = formContainer?.querySelector('.rotation-cancel-btn');
+
       if (submitBtn) submitBtn.disabled = true;
+      if (cancelBtn) cancelBtn.disabled = true;
+      if (formContainer) formContainer.dataset.submitting = '1';
       if (statusEl) statusEl.innerHTML = '<p class="muted">Deriving key (Argon2id)… this may take a few seconds.</p>';
 
       const epoch = Number(gwRow.master_key_epoch) || 0;
@@ -599,6 +612,8 @@ function attachRotationFormHandlers(gatewayRows) {
         if (statusEl) statusEl.innerHTML = `<div class="alert error">${escapeHtml(msg)}</div>`;
       } finally {
         if (submitBtn) submitBtn.disabled = false;
+        if (cancelBtn) cancelBtn.disabled = false;
+        if (formContainer) delete formContainer.dataset.submitting;
       }
     });
   }

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -528,7 +528,7 @@ function toggleRotationForm(gwId) {
       const prev = document.querySelector(
         `.rotation-form-container[data-gateway-form="${APP.rotationFormOpen}"]`
       );
-      if (prev) prev.style.display = 'none';
+      if (prev) resetAndHideFormContainer(prev);
     }
     container.style.display = '';
     APP.rotationFormOpen = gwId;
@@ -539,16 +539,20 @@ function toggleRotationForm(gwId) {
   }
 }
 
+// Resets form inputs, clears status messages, and hides a form container.
+function resetAndHideFormContainer(container) {
+  const form = container.querySelector('.rotation-form');
+  if (form) form.reset();
+  const status = container.querySelector('.rotation-status');
+  if (status) status.innerHTML = '';
+  container.style.display = 'none';
+}
+
 // Idempotent close — safe to call from timeout even if user already closed.
 function closeRotationForm(gwId) {
   if (APP.rotationFormOpen !== gwId) return;
   const container = document.querySelector(`.rotation-form-container[data-gateway-form="${gwId}"]`);
-  if (container) {
-    // Clear sensitive fields so passphrase doesn't linger in hidden DOM.
-    const form = container.querySelector('.rotation-form');
-    if (form) form.reset();
-    container.style.display = 'none';
-  }
+  if (container) resetAndHideFormContainer(container);
   APP.rotationFormOpen = null;
   // Resume auto-refresh only if still on the dashboard tab (WEB-1002 AC#5).
   if (APP.activeTab === 'dashboard') {

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -620,9 +620,9 @@ against the gateway actual-state row.
    rotation payload — a mismatched desired `salt` against an existing
    actual `salt` is a no-op by gateway design (set-if-absent semantics)
    and does NOT flag divergence.
-4. **KDF params pending adoption:** Desired `kdf_params` is non-null AND
-   actual `kdf_params` is null/absent. Same set-if-absent semantics as
-   salt.
+4. **KDF params pending adoption:** Desired `kdf_params`/`kdf_params_json` is
+   non-null AND actual `kdf_params_json` is null/absent. Same set-if-absent
+   semantics as salt.
 
 **No desired row:** If no gateway desired-state row exists, the gateway is
 "Aligned" (no pending changes — same as unmanaged nodes in §4).

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -574,10 +574,12 @@ rendering in the popup:
 ### 13.1 Gateway Status Card
 
 - Reads the `actualstate` table for rows whose `PartitionKey` starts with `g:`.
+- Cross-references the `desiredstate` table for gateway rows (`PartitionKey`
+  starting with `g:`) to compute a convergence badge (see §13.1.1).
 - Renders a dedicated gateway status card above the node table, showing the
   BIP-39 fingerprint, `master_key_epoch`, `master_key_id`, salt status,
-  `rotation_in_progress`, `gateway_version`, `modem_firmware_version`, and
-  `channel`.
+  `rotation_in_progress`, `gateway_version`, `modem_firmware_version`,
+  `channel`, and an **Aligned / Diverged** convergence badge.
 - **Fingerprint computation is local:** The SPA MUST compute the 6-word BIP-39
   fingerprint from `x25519_public_key` using SHA-256 + 66-bit extraction +
   BIP-39 wordlist lookup. The SPA MUST NOT use the `fingerprint_words` field
@@ -589,18 +591,63 @@ rendering in the popup:
   take first 66 bits → split into 6 × 11-bit indices → map to BIP-39 words.
 - Uses the same MSAL.js bearer token acquisition path as node `actualstate`
   queries.
+- The `renderGatewayStatusCard` function receives both gateway actual-state
+  rows and gateway desired-state rows (filtered via `filterGatewayRows`).
 
-### 13.2 Rotation Modal
+#### 13.1.1 Gateway Convergence Rules
 
-- Multi-step modal flow:
+Gateway convergence mirrors the node divergence pattern (§4) but uses
+gateway-specific fields. The convergence badge is computed per gateway by
+comparing the latest gateway desired-state row (from `desiredstate`, filtered
+by `PartitionKey` starting with `g:`, deduplicated via `latestByPartition`)
+against the gateway actual-state row.
+
+**Divergence conditions** (any true → "Diverged"):
+
+1. **Rotation payload pending:** The desired row has a non-null
+   `rotation_payload` AND the actual `rotation_in_progress` is not `true`
+   AND `actual.master_key_epoch <= desired.submitted_epoch`.
+   - The `submitted_epoch` field is stored in the desired-state row at
+     submission time (see §13.4). This enables precise comparison without
+     timestamp heuristics.
+   - Once `rotation_in_progress` becomes `true` or
+     `actual.master_key_epoch > desired.submitted_epoch`, the rotation is
+     considered consumed and this condition clears.
+2. **Channel mismatch:** Desired `channel` is non-null and differs from
+   actual `channel`.
+3. **Salt pending adoption:** Desired `salt` is non-null AND actual `salt`
+   is null/absent. Once the gateway has a salt, it is immutable except via
+   rotation payload — a mismatched desired `salt` against an existing
+   actual `salt` is a no-op by gateway design (set-if-absent semantics)
+   and does NOT flag divergence.
+4. **KDF params pending adoption:** Desired `kdf_params` is non-null AND
+   actual `kdf_params` is null/absent. Same set-if-absent semantics as
+   salt.
+
+**No desired row:** If no gateway desired-state row exists, the gateway is
+"Aligned" (no pending changes — same as unmanaged nodes in §4).
+
+### 13.2 Rotation Form
+
+- Inline collapsible form within the gateway status card (replaces the
+  previous modal dialog):
   1. Fingerprint verification against the modem
   2. Rotation code input (`text`, 6 chars, auto-uppercase)
   3. Passphrase input (`password` field)
-  4. Final confirmation before submission
+  4. Submit button
+- The `Rotate Key` button toggles the form's visibility. When expanded, the
+  form appears below the gateway status fields within the same card panel.
 - Displays the current salt from gateway ACTUAL_STATE, or a `first rotation`
   indicator when no salt exists yet.
-- Shows a progress bar during Argon2id key derivation because the WASM KDF may
-  take ~1–3 seconds.
+- Shows a progress indicator during Argon2id key derivation because the WASM
+  KDF may take ~1–3 seconds.
+- After successful submission, the form displays "Rotation submitted" and
+  collapses. No inline polling is performed — the convergence badge
+  (§13.1.1) reflects rotation status via the dashboard auto-refresh cycle.
+- Dashboard auto-refresh (§4, WEB-0103) is paused while the rotation form
+  is expanded or a submission is in progress. This prevents DOM replacement
+  from destroying form state or interrupting Argon2id key derivation.
+  Auto-refresh resumes when the form collapses.
 
 ### 13.3 Crypto Pipeline
 
@@ -628,6 +675,9 @@ rendering in the popup:
   `GET /actualstate?$filter=PartitionKey ge 'g:' and PartitionKey lt 'g;'`
 - DESIRED_STATE write:
   `POST /desiredstate` with `rotation_payload` serialized as `Edm.Binary`
+  and `submitted_epoch` as `Edm.Int64` (set to the gateway's current
+  `master_key_epoch` at submission time, for convergence tracking per
+  §13.1.1)
 - Gateway DESIRED_STATE `PartitionKey` is `"g:" + gateway_id_hex`
 - Gateway DESIRED_STATE `RowKey` uses the same reverse-timestamp format as node
   desired state rows
@@ -660,4 +710,5 @@ rendering in the popup:
 
 | Date | Author | Description |
 |------|--------|-------------|
+| 2026-05-29 | Issue #1092 | Added §13.1.1 gateway convergence rules. Replaced §13.2 rotation modal with inline form. Added convergence badge to §13.1. |
 | 2026-05-19 | Trifecta remediation (#1012) | Added §12 (cross-cutting concerns: HTML escaping, MSAL hash routing, popup detection). Fixed §10.2 downsample cap to 500 points per series. |

--- a/docs/web-ui-requirements.md
+++ b/docs/web-ui-requirements.md
@@ -1101,7 +1101,7 @@ initialization to avoid unnecessary API calls and rendering.
 ### WEB-1001  Gateway Status Display
 
 **Priority:** Must
-**Source:** Issue #962
+**Source:** Issue #962, Issue #1092
 **Confidence:** High
 
 **Description:**
@@ -1112,6 +1112,10 @@ gateway partition using `latestByPartition`. The card MUST
 show the BIP-39 fingerprint (6 words), `master_key_epoch`, `master_key_id`
 (hex), `rotation_in_progress`, salt status (present/absent),
 `gateway_version`, `modem_firmware_version`, and `channel`.
+
+The gateway status card MUST also display a convergence badge (Aligned /
+Diverged) by cross-referencing the `desiredstate` table for gateway rows
+(`PartitionKey` starting with `"g:"`). See WEB-1009 for convergence rules.
 
 **Critical:** The BIP-39 fingerprint MUST be computed locally in the SPA
 from the `x25519_public_key` field — NOT read from the Azure-stored
@@ -1131,31 +1135,44 @@ NOT appear in the node table or node dropdown.
    read from the stored `fingerprint_words` field.
 3. The gateway ACTUAL_STATE row is not shown in the node table.
 4. Node dropdowns exclude gateway entities.
+5. The gateway status card shows an Aligned/Diverged convergence badge.
 
 ---
 
 ### WEB-1002  Key Rotation Initiation
 
 **Priority:** Must
-**Source:** Issue #962
+**Source:** Issue #962, Issue #1092
 **Confidence:** High
 
 **Description:**
-A `Rotate Key` button on the gateway status card MUST open a modal that shows
-(1) the BIP-39 fingerprint with instructions to verify it against the modem,
-(2) a rotation code input limited to 6 characters and normalized to uppercase
-`[A-Z0-9]`, (3) a masked passphrase input that requires either at least 20
-characters or 6 space-separated words, (4) the current salt from the gateway
-ACTUAL_STATE or a `first rotation` indicator if the salt is null, and (5) a
-confirmation action. If the browser lacks the required rotation crypto
-capabilities, the button MUST be disabled with a tooltip explaining the
-requirement.
+A `Rotate Key` button on the gateway status card MUST toggle an inline
+collapsible rotation form within the card. The form shows (1) the BIP-39
+fingerprint with instructions to verify it against the modem, (2) a rotation
+code input limited to 6 characters and normalized to uppercase `[A-Z0-9]`,
+(3) a masked passphrase input that requires either at least 20 characters or
+6 space-separated words, (4) the current salt from the gateway ACTUAL_STATE
+or a `first rotation` indicator if the salt is null, and (5) a confirmation
+action. If the browser lacks the required rotation crypto capabilities, the
+button MUST be disabled with a tooltip explaining the requirement.
+
+After submission the form displays a brief confirmation message (e.g.,
+"Rotation submitted") and collapses. No inline polling is performed — the
+gateway convergence badge (WEB-1009) reflects pending rotation status via
+the normal dashboard auto-refresh cycle.
+
+The dashboard auto-refresh (WEB-0103) MUST be paused while the rotation
+form is expanded or a submission is in progress, to prevent DOM replacement
+from destroying form state or interrupting key derivation. Auto-refresh
+resumes when the form collapses.
 
 **Acceptance criteria:**
 
-1. The modal validates rotation code format as 6 characters from `[A-Z0-9]`.
-2. The modal validates the passphrase length requirement.
+1. The inline form validates rotation code format as 6 characters from `[A-Z0-9]`.
+2. The inline form validates the passphrase length requirement.
 3. Unsupported browsers show the action as disabled with an explanatory message.
+4. After submission the form shows a success message and collapses.
+5. Dashboard auto-refresh is paused while the rotation form is expanded.
 
 ---
 
@@ -1220,35 +1237,40 @@ The SPA MUST write the rotation payload into the gateway's DESIRED_STATE row in
 the `desiredstate` Azure Table. The row MUST use
 `PartitionKey = "g:" + gateway_id_hex`, a reverse-timestamp `RowKey` using the
 same format as node desired state rows, and a `rotation_payload` entity property
-encoded as binary data for the Azure Table REST API.
+encoded as binary data for the Azure Table REST API. The row MUST also include a
+`submitted_epoch` property (Edm.Int64) set to the gateway's current
+`master_key_epoch` at the time of submission, to enable convergence tracking
+(WEB-1009).
 
 **Acceptance criteria:**
 
 1. A DESIRED_STATE row is created in the `desiredstate` table.
 2. The `PartitionKey` uses the `g:` gateway prefix.
+3. The row includes `submitted_epoch` matching the current `master_key_epoch`.
 
 ---
 
 ### WEB-1006  Rotation Status Monitoring
 
-**Priority:** Must
+**Priority:** ~~Must~~ **Retired** (Issue #1092)
 **Source:** Issue #962
 **Confidence:** High
 
 **Description:**
-After submitting a rotation payload, the SPA MUST poll the latest gateway
-ACTUAL_STATE row (the first row returned by a `$top=1` partition query on the
-gateway's partition key) every 5 seconds for up to 120 seconds and watch for
-`master_key_epoch` to increment. On success, the SPA MUST display `Rotation complete` with the new
-epoch. On timeout, it MUST display `Rotation may still be in progress — check gateway status.`
-If `rotation_in_progress` transitions from false to false without an epoch
-change, the SPA MUST display `Rotation failed`.
+~~After submitting a rotation payload, the SPA MUST poll the latest gateway
+ACTUAL_STATE row every 5 seconds for up to 120 seconds and watch for
+`master_key_epoch` to increment.~~
+
+**Retired:** Replaced by WEB-1009 (gateway convergence badge). Rotation
+status is now reflected by the Aligned/Diverged badge on the gateway status
+card, updated via the dashboard auto-refresh cycle (WEB-0103). No dedicated
+inline polling is performed.
 
 **Acceptance criteria:**
 
-1. Success is detected within the 120-second polling window.
-2. Timeout is handled gracefully.
-3. A progress indicator is shown while polling.
+1. ~~Success is detected within the 120-second polling window.~~ Retired.
+2. ~~Timeout is handled gracefully.~~ Retired.
+3. ~~A progress indicator is shown while polling.~~ Retired.
 
 ---
 
@@ -1293,6 +1315,71 @@ zeros on a best-effort basis.
 1. No key material is stored in browser storage.
 2. Only `rotation_payload` is written to Azure.
 3. Key variables are cleared after use on a best-effort basis.
+
+---
+
+### WEB-1009  Gateway Convergence Display
+
+**Priority:** Must
+**Source:** Issue #1092
+**Confidence:** High
+
+**Description:**
+The gateway status card (WEB-1001) MUST display an Aligned / Diverged
+convergence badge by cross-referencing gateway desired-state rows in the
+`desiredstate` Azure Table (`PartitionKey` starting with `"g:"`) against
+the gateway ACTUAL_STATE row.
+
+The convergence check compares the following fields:
+- **`rotation_payload`:** Diverged if the latest desired-state row has a
+  non-null `rotation_payload` AND the actual `rotation_in_progress` is
+  `false` AND `master_key_epoch` has not advanced past the epoch at which
+  the rotation was submitted. The SPA MUST store the current
+  `master_key_epoch` as `submitted_epoch` (Edm.Int64) in the desired-state
+  row when submitting a rotation payload. Divergence condition:
+  `desired.rotation_payload != null AND actual.rotation_in_progress !== true
+  AND actual.master_key_epoch <= desired.submitted_epoch`. Once
+  `rotation_in_progress` is `true` or `master_key_epoch >
+  desired.submitted_epoch`, the rotation is considered consumed.
+- **`channel`:** Diverged if the desired `channel` is non-null and differs
+  from actual `channel`.
+- **`salt`:** Diverged only when the gateway has no local salt (actual
+  `salt` is null/absent) AND the desired `salt` is non-null. Once the
+  gateway has a salt, it is immutable except via rotation payload — a
+  mismatched desired `salt` against an existing actual `salt` is a no-op
+  by gateway design and does NOT flag divergence.
+- **`kdf_params`:** Diverged only when the gateway has no local KDF params
+  (actual `kdf_params` is null/absent) AND the desired `kdf_params` is
+  non-null. Same set-if-absent semantics as `salt`.
+
+`recovered_psks` is excluded from convergence — it is a background queue
+not visible to the operator.
+
+If no gateway desired-state row exists, the gateway is "Aligned" (no
+pending changes).
+
+The badge uses the same CSS classes as the node convergence badge (`badge
+success` for Aligned, `badge warning` for Diverged).
+
+**Acceptance criteria:**
+
+1. Gateway with no desired-state row shows "Aligned."
+2. Gateway with a pending `rotation_payload` (not yet consumed, i.e.,
+   `actual.master_key_epoch <= desired.submitted_epoch` and
+   `rotation_in_progress` is false) shows "Diverged."
+3. Gateway where `rotation_in_progress` is `true` or
+   `master_key_epoch > submitted_epoch` shows "Aligned" (rotation
+   consumed).
+4. Gateway with desired `channel` differing from actual shows "Diverged."
+5. Gateway with desired `salt` when actual `salt` is absent shows
+   "Diverged."
+6. Gateway with desired `salt` when actual `salt` already exists (even if
+   different) shows "Aligned" (set-if-absent semantics).
+7. Gateway with desired `kdf_params` when actual is absent shows
+   "Diverged."
+8. Gateway with desired `kdf_params` when actual already exists shows
+   "Aligned" (set-if-absent semantics).
+9. Badge uses the same CSS styling as the node convergence badge.
 
 ---
 

--- a/docs/web-ui-requirements.md
+++ b/docs/web-ui-requirements.md
@@ -1349,8 +1349,9 @@ The convergence check compares the following fields:
   mismatched desired `salt` against an existing actual `salt` is a no-op
   by gateway design and does NOT flag divergence.
 - **`kdf_params`:** Diverged only when the gateway has no local KDF params
-  (actual `kdf_params` is null/absent) AND the desired `kdf_params` is
-  non-null. Same set-if-absent semantics as `salt`.
+  (actual `kdf_params_json` is null/absent) AND the desired
+  `kdf_params`/`kdf_params_json` is non-null. Same set-if-absent semantics
+  as `salt`.
 
 `recovered_psks` is excluded from convergence — it is a background queue
 not visible to the operator.

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -103,14 +103,15 @@ and verifies one or more acceptance criteria.
 | WEB-0806 | T-WEB-0803, T-WEB-0803b, T-WEB-0803c, T-WEB-0803d, T-WEB-0803d2, T-WEB-0803e, T-WEB-0803f, T-WEB-0803g |
 | WEB-0901 | T-WEB-0901, T-WEB-0901b, T-WEB-0901c |
 | WEB-0902 | T-WEB-0902, T-WEB-0902b |
-| WEB-1001 | T-WEB-1001, T-WEB-1001b, T-WEB-1001c |
-| WEB-1002 | T-WEB-1002, T-WEB-1002b, T-WEB-1002c |
+| WEB-1001 | T-WEB-1001, T-WEB-1001b, T-WEB-1001c, T-WEB-1001d |
+| WEB-1002 | T-WEB-1002, T-WEB-1002b, T-WEB-1002c, T-WEB-1002d, T-WEB-1002e |
 | WEB-1003 | T-WEB-1003, T-WEB-1003b |
 | WEB-1004 | T-WEB-1004 |
 | WEB-1005 | T-WEB-1005 |
-| WEB-1006 | T-WEB-1006, T-WEB-1006b |
+| WEB-1006 | ~~T-WEB-1006, T-WEB-1006b~~ (retired — Issue #1092) |
 | WEB-1007 | T-WEB-1007, T-WEB-1007b |
 | WEB-1008 | T-WEB-1008 |
+| WEB-1009 | T-WEB-1009, T-WEB-1009b, T-WEB-1009c, T-WEB-1009d, T-WEB-1009e, T-WEB-1009f, T-WEB-1009g, T-WEB-1009h, T-WEB-1009i, T-WEB-1009j, T-WEB-1009k |
 | WEB-CC-01 | T-WEB-CC-01, T-WEB-CC-01b |
 | WEB-CC-02 | T-WEB-CC-02, T-WEB-CC-02b |
 | WEB-CC-03 | T-WEB-CC-03, T-WEB-CC-03b |
@@ -339,21 +340,35 @@ and verifies one or more acceptance criteria.
 
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
-| T-WEB-1001 | WEB-1001 | Gateway status card displays all required fields | Manual/E2E | Planned |
+| T-WEB-1001 | WEB-1001 | Gateway status card displays all required fields including convergence badge | Manual/E2E | Planned |
 | T-WEB-1001b | WEB-1001 | Gateway row is not shown in the node table | Manual | Planned |
 | T-WEB-1001c | WEB-1001 | Fingerprint computed locally from x25519_public_key, not read from stored fingerprint_words | Unit JS | Planned |
-| T-WEB-1002 | WEB-1002 | Rotation modal opens and validates inputs | Manual | Planned |
+| T-WEB-1001d | WEB-1001 | Gateway status card shows convergence badge (Aligned or Diverged) | Manual/E2E | Planned |
+| T-WEB-1002 | WEB-1002 | Inline rotation form opens within gateway card and validates inputs | Manual | Planned |
 | T-WEB-1002b | WEB-1002 | Rotation code input is normalized to uppercase | Manual | Planned |
 | T-WEB-1002c | WEB-1002 | Rotation is disabled on unsupported browsers | Manual | Planned |
+| T-WEB-1002d | WEB-1002 | After submission, form shows success message and collapses (no inline polling) | Manual | Planned |
+| T-WEB-1002e | WEB-1002 | Dashboard auto-refresh is paused while rotation form is expanded | Manual | Planned |
 | T-WEB-1003 | WEB-1003 | Argon2id key derivation produces the correct output | Unit (JS) | Planned |
 | T-WEB-1003b | WEB-1003 | KDF params from ACTUAL_STATE are used when present | Unit (JS) | Planned |
 | T-WEB-1004 | WEB-1004 | `RotationPayloadV1` construction matches the specified binary format | Unit (JS) | Planned |
-| T-WEB-1005 | WEB-1005 | DESIRED_STATE row is created with the correct gateway `PartitionKey` | Integration | Planned |
-| T-WEB-1006 | WEB-1006 | Successful rotation is detected via `master_key_epoch` polling using a `$top=1` partition query to select the latest row | Manual/E2E | Planned |
-| T-WEB-1006b | WEB-1006 | Rotation timeout is handled gracefully | Manual | Planned |
+| T-WEB-1005 | WEB-1005 | DESIRED_STATE row is created with the correct gateway `PartitionKey` and includes `submitted_epoch` | Integration | Planned |
+| T-WEB-1006 | WEB-1006 | ~~Successful rotation is detected via `master_key_epoch` polling~~ **Retired** (Issue #1092) | — | Retired |
+| T-WEB-1006b | WEB-1006 | ~~Rotation timeout is handled gracefully~~ **Retired** (Issue #1092) | — | Retired |
 | T-WEB-1007 | WEB-1007 | Gateway ACTUAL_STATE is read from the Azure Table using latest-row selection (not `RowKey='state'`) | Integration | Planned |
 | T-WEB-1007b | WEB-1007 | Missing gateway row shows a `No gateway connected` message | Manual | Planned |
 | T-WEB-1008 | WEB-1008 | No key material is written to browser storage | Manual | Planned |
+| T-WEB-1009 | WEB-1009 | Gateway with no desired-state row shows "Aligned" | Manual/E2E | Planned |
+| T-WEB-1009b | WEB-1009 | Gateway with pending `rotation_payload` (`actual.master_key_epoch <= desired.submitted_epoch` and `rotation_in_progress` false) shows "Diverged" | Manual/E2E | Planned |
+| T-WEB-1009c | WEB-1009 | Gateway with `rotation_in_progress` true shows "Aligned" (rotation consumed) | Manual/E2E | Planned |
+| T-WEB-1009d | WEB-1009 | Gateway with desired `channel` differing from actual shows "Diverged" | Manual/E2E | Planned |
+| T-WEB-1009e | WEB-1009 | Gateway with desired `salt` when actual `salt` is absent shows "Diverged" | Manual/E2E | Planned |
+| T-WEB-1009f | WEB-1009 | Gateway with desired `salt` when actual `salt` already exists shows "Aligned" (set-if-absent) | Manual/E2E | Planned |
+| T-WEB-1009g | WEB-1009 | Gateway with desired `kdf_params` when actual is absent shows "Diverged" | Manual/E2E | Planned |
+| T-WEB-1009h | WEB-1009 | Gateway with desired `kdf_params` when actual already exists shows "Aligned" (set-if-absent) | Manual/E2E | Planned |
+| T-WEB-1009i | WEB-1009 | Badge uses same CSS classes as node convergence badge (`badge success`/`badge warning`) | Manual | Planned |
+| T-WEB-1009j | WEB-1009 | Gateway with `master_key_epoch > submitted_epoch` shows "Aligned" (rotation consumed via epoch advance) | Manual/E2E | Planned |
+| T-WEB-1009k | WEB-1009 | Matched channel, salt, kdf_params (desired == actual) shows "Aligned" | Manual/E2E | Planned |
 
 ---
 
@@ -364,6 +379,7 @@ and verifies one or more acceptance criteria.
 | Authentication failure blocks all functionality | High | Medium | P1 | T-WEB-0501–0509 |
 | Program ingest rejects valid ELF or accepts invalid | High | Low | P1 | T-WEB-0301–0308 |
 | Divergence indicator shows wrong status | Medium | Medium | P2 | T-WEB-0104–0108 |
+| Gateway convergence badge shows wrong status | Medium | Medium | P2 | T-WEB-1009–1009k |
 | Environment switching leaves stale tokens | Medium | Medium | P2 | T-WEB-0803 |
 | Rotation key derivation timeout (Argon2id WASM slow on mobile) | Medium | Medium | P2 | T-WEB-1003 |
 | XSS from unescaped user/server data | High | Low | P1 | T-WEB-CC-02 |
@@ -383,5 +399,6 @@ and verifies one or more acceptance criteria.
 
 | Date | Author | Description |
 |------|--------|-------------|
+| 2026-05-29 | Issue #1092 | Added T-WEB-1009 through T-WEB-1009g for gateway convergence. Updated T-WEB-1001/1002 for badge and inline form. Retired T-WEB-1006/1006b. |
 | 2026-05-19 | Spec extraction (automated) | Restructured with sections, traceability matrix, risk prioritization. Added references to web-ui-requirements.md. |
 | 2026-05-19 | Trifecta remediation (#1012) | Added ~35 fine-grained test cases to cover all acceptance criteria individually. Updated traceability matrix. |

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -399,6 +399,6 @@ and verifies one or more acceptance criteria.
 
 | Date | Author | Description |
 |------|--------|-------------|
-| 2026-05-29 | Issue #1092 | Added T-WEB-1009 through T-WEB-1009g for gateway convergence. Updated T-WEB-1001/1002 for badge and inline form. Retired T-WEB-1006/1006b. |
+| 2026-05-29 | Issue #1092 | Added T-WEB-1009 through T-WEB-1009k for gateway convergence. Updated T-WEB-1001/1002 for badge and inline form. Retired T-WEB-1006/1006b. |
 | 2026-05-19 | Spec extraction (automated) | Restructured with sections, traceability matrix, risk prioritization. Added references to web-ui-requirements.md. |
 | 2026-05-19 | Trifecta remediation (#1012) | Added ~35 fine-grained test cases to cover all acceptance criteria individually. Updated traceability matrix. |


### PR DESCRIPTION
## Summary

Add an **Aligned/Diverged** badge to each gateway status card and replace the rotation modal with an inline collapsible form. Closes #1092.

## Changes

### Specifications (docs/)
- **WEB-1001**: Added convergence badge acceptance criterion (AC#5)
- **WEB-1002**: Modal → inline collapsible form with auto-refresh pause (AC#4-5)
- **WEB-1005**: \submitted_epoch\ stored as \Edm.Int64\ in desired-state writes
- **WEB-1006**: Retired — \pollRotationResult\ removed; convergence badge replaces inline polling
- **WEB-1009** (new): 9 acceptance criteria for gateway convergence badge
- **Design §13.1/§13.1.1/§13.2/§13.4**: Badge rendering, 4 divergence rules, inline form, \submitted_epoch\
- **Validation**: 11 new test cases (T-WEB-1009 through T-WEB-1009k), retired T-WEB-1006/1006b

### Implementation (\deploy/web-ui/app.js\)
- \computeGatewayDivergence(actual, desired)\ — 4 convergence rules:
  1. \otation_payload\ pending + \ctualEpoch <= submittedEpoch\
  2. \channel\ mismatch (normalized with \Number()\)
  3. \salt\ set-if-absent (diverged only when actual absent)
  4. \kdf_params\/\kdf_params_json\ set-if-absent
- \enderGatewayStatusCard()\ receives desired rows, renders badge + inline form
- \	oggleRotationForm()\ / \closeRotationForm()\ manage visibility + auto-refresh pause
- \submitRotationPayload()\ now stores \submitted_epoch\
- Removed \showRotationModal()\ and \pollRotationResult()\
- In-flight render guard: skips DOM replacement if form opened during async fetch

## Audit trail
- Spec audit: PASS (2 blocking findings fixed before approval)
- Implementation audit: PASS (in-flight race guard + idempotent close added)
