### PR TITLE
feat: plumb modem firmware version and commit through gateway ACTUAL_STATE

### DIFF
--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -2008,10 +2008,6 @@ async fn run_gateway(
 
 // ── ACTUAL_STATE emission helpers (GW-2003, §23.14) ──────────────────────────
 
-/// Emit a full gateway ACTUAL_STATE by reading all required fields from storage.
-///
-/// Used for the initial startup emission (§23.11 step 9a) where the identity
-/// is already loaded.
 /// Modem firmware metadata extracted from the MODEM_READY handshake.
 /// Shared between the reconnect loop and the ACTUAL_STATE re-emission task.
 #[derive(Clone, Default)]
@@ -2020,6 +2016,10 @@ struct ModemMetadata {
     firmware_commit: Option<String>,
 }
 
+/// Emit a full gateway ACTUAL_STATE by reading all required fields from storage.
+///
+/// Used for the initial startup emission (§23.11 step 9a) where the identity
+/// is already loaded.
 async fn emit_gateway_actual_state_from_storage(
     event_hub: &sonde_gateway::ConnectorEventHub,
     storage: &SqliteStorage,

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1212,6 +1212,10 @@ async fn run_gateway(
         info!("rotation engine started");
     }
 
+    // Shared modem firmware metadata — updated after each successful modem
+    // handshake and cleared on disconnect (Issue #1096).
+    let modem_metadata = Arc::new(std::sync::Mutex::new(ModemMetadata::default()));
+
     // 9a. Emit initial gateway ACTUAL_STATE (§23.11 step 9a, GW-2003).
     {
         let identity = storage
@@ -1224,6 +1228,7 @@ async fn run_gateway(
             &storage,
             &identity,
             &gateway,
+            &modem_metadata,
         )
         .await?;
         info!("initial gateway ACTUAL_STATE emitted");
@@ -1236,6 +1241,7 @@ async fn run_gateway(
                 &storage,
                 &identity,
                 &gateway,
+                &modem_metadata,
             )
             .await?;
             info!("re-emitted ACTUAL_STATE after resumed rotation completion");
@@ -1251,6 +1257,7 @@ async fn run_gateway(
         let reemit_event_hub = gateway.connector_event_hub();
         let reemit_gateway = Arc::clone(&gateway);
         let missing_hints_notify = gateway.missing_hints_notify();
+        let reemit_modem_metadata = Arc::clone(&modem_metadata);
 
         tokio::spawn(async move {
             /// Debounce interval for missing key hint-triggered re-emission.
@@ -1277,6 +1284,7 @@ async fn run_gateway(
                             &reemit_event_hub,
                             &reemit_storage,
                             &reemit_gateway,
+                            &reemit_modem_metadata,
                         ).await {
                             error!("failed to re-emit ACTUAL_STATE on rotation complete: {e}");
                         }
@@ -1287,6 +1295,7 @@ async fn run_gateway(
                             &reemit_event_hub,
                             &reemit_storage,
                             &reemit_gateway,
+                            &reemit_modem_metadata,
                         ).await {
                             error!("failed to re-emit ACTUAL_STATE on state change: {e}");
                         }
@@ -1307,6 +1316,7 @@ async fn run_gateway(
                             &reemit_event_hub,
                             &reemit_storage,
                             &reemit_gateway,
+                            &reemit_modem_metadata,
                         ).await {
                             error!("failed to re-emit ACTUAL_STATE on heartbeat: {e}");
                         }
@@ -1323,6 +1333,7 @@ async fn run_gateway(
                             &reemit_event_hub,
                             &reemit_storage,
                             &reemit_gateway,
+                            &reemit_modem_metadata,
                         ).await {
                             error!("failed to re-emit ACTUAL_STATE on missing hints: {e}");
                         }
@@ -1406,6 +1417,9 @@ async fn run_gateway(
                                 the gateway will retry automatically",
                     "modem startup failed"
                 );
+                // Clear stale modem metadata on handshake failure.
+                *modem_metadata.lock().unwrap_or_else(|e| e.into_inner()) =
+                    ModemMetadata::default();
                 info!("retrying in {}s…", backoff.as_secs());
                 tokio::time::sleep(backoff).await;
                 backoff = (backoff * 2).min(MAX_BACKOFF);
@@ -1413,6 +1427,16 @@ async fn run_gateway(
             }
         };
         info!(channel = channel_for_transport, "modem transport ready");
+
+        // Update shared modem metadata after successful handshake (Issue #1096).
+        {
+            let mut meta = modem_metadata.lock().unwrap_or_else(|e| e.into_inner());
+            *meta = ModemMetadata {
+                firmware_version: Some(transport.modem_firmware_version().to_string()),
+                firmware_commit: transport.modem_firmware_commit().map(|s| s.to_string()),
+            };
+        }
+
         let warm_reboot_notify = transport.warm_reboot_notify();
         let warm_reboot_flag = transport.warm_reboot_flag();
         if let Err(e) = send_gateway_version_banner(&transport).await {
@@ -1425,6 +1449,8 @@ async fn run_gateway(
             let immediate_reconnect = warm_reboot_flag.load(std::sync::atomic::Ordering::Acquire);
             transport.abort_reader_and_wait().await;
             drop(transport);
+            // Clear modem metadata on transport failure.
+            *modem_metadata.lock().unwrap_or_else(|e| e.into_inner()) = ModemMetadata::default();
             if immediate_reconnect {
                 info!(
                     "modem warm reboot detected during banner transfer — reconnecting immediately"
@@ -1437,6 +1463,21 @@ async fn run_gateway(
             continue;
         }
         backoff = Duration::from_secs(1); // reset on success
+
+        // Re-emit ACTUAL_STATE with populated modem metadata after
+        // successful modem handshake (GW-2003 AC-9, Issue #1096).
+        if let Err(e) = reemit_gateway_actual_state(
+            &gateway.connector_event_hub(),
+            &storage,
+            &gateway,
+            &modem_metadata,
+        )
+        .await
+        {
+            error!("failed to re-emit ACTUAL_STATE after modem handshake: {e}");
+        } else {
+            info!("re-emitted ACTUAL_STATE after modem handshake");
+        }
 
         // Re-create the admin service and spawn a fresh gRPC server on each
         // reconnect iteration to bind to the new transport reference.
@@ -1938,6 +1979,20 @@ async fn run_gateway(
         // GW-1301: log modem disconnecting before reconnect attempt.
         info!("modem disconnecting");
 
+        // Clear stale modem metadata on disconnect and re-emit ACTUAL_STATE
+        // so the connector cache reflects the absence of a modem.
+        *modem_metadata.lock().unwrap_or_else(|e| e.into_inner()) = ModemMetadata::default();
+        if let Err(e) = reemit_gateway_actual_state(
+            &gateway.connector_event_hub(),
+            &storage,
+            &gateway,
+            &modem_metadata,
+        )
+        .await
+        {
+            error!("failed to re-emit ACTUAL_STATE after modem disconnect: {e}");
+        }
+
         // Transport disconnected — retry after backoff (GW-1103, GW-1301).
         info!(
             backoff_s = backoff.as_secs(),
@@ -1957,11 +2012,20 @@ async fn run_gateway(
 ///
 /// Used for the initial startup emission (§23.11 step 9a) where the identity
 /// is already loaded.
+/// Modem firmware metadata extracted from the MODEM_READY handshake.
+/// Shared between the reconnect loop and the ACTUAL_STATE re-emission task.
+#[derive(Clone, Default)]
+struct ModemMetadata {
+    firmware_version: Option<String>,
+    firmware_commit: Option<String>,
+}
+
 async fn emit_gateway_actual_state_from_storage(
     event_hub: &sonde_gateway::ConnectorEventHub,
     storage: &SqliteStorage,
     identity: &sonde_gateway::GatewayIdentity,
     gateway: &Gateway,
+    modem_metadata: &std::sync::Mutex<ModemMetadata>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let entity_id: String = identity
         .gateway_id()
@@ -2042,6 +2106,11 @@ async fn emit_gateway_actual_state_from_storage(
         .unwrap_or("unknown")
         .to_string();
 
+    let modem_meta = modem_metadata
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+
     event_hub.emit_gateway_actual_state(
         entity_id,
         channel,
@@ -2054,8 +2123,8 @@ async fn emit_gateway_actual_state_from_storage(
         kdf_params,
         gateway_version,
         gateway_commit,
-        None, // modem_firmware_version — not yet available at this point
-        None, // modem_firmware_commit
+        modem_meta.firmware_version,
+        modem_meta.firmware_commit,
         rotation_in_progress,
     );
 
@@ -2069,13 +2138,15 @@ async fn reemit_gateway_actual_state(
     event_hub: &sonde_gateway::ConnectorEventHub,
     storage: &SqliteStorage,
     gateway: &Gateway,
+    modem_metadata: &std::sync::Mutex<ModemMetadata>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let identity = storage
         .load_gateway_identity()
         .await?
         .ok_or("gateway identity missing for ACTUAL_STATE re-emission")?;
 
-    emit_gateway_actual_state_from_storage(event_hub, storage, &identity, gateway).await
+    emit_gateway_actual_state_from_storage(event_hub, storage, &identity, gateway, modem_metadata)
+        .await
 }
 
 // ── Windows NT service implementation ────────────────────────────────────────
@@ -2426,6 +2497,7 @@ mod tests {
                 &encode_modem_frame(&ModemMessage::ModemReady(ModemReady {
                     firmware_version: [1, 0, 0, 0],
                     mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+                    firmware_commit: [0x42u8; 8],
                 }))
                 .unwrap(),
             )

--- a/crates/sonde-gateway/src/modem.rs
+++ b/crates/sonde-gateway/src/modem.rs
@@ -116,6 +116,11 @@ pub struct UsbEspNowTransport {
     display_send_lock: Mutex<()>,
     next_display_transfer_id: AtomicU8,
     modem_mac: [u8; 6],
+    /// Modem firmware version formatted as "major.minor.patch".
+    modem_firmware_version: String,
+    /// Modem firmware commit as 16-char hex, or `None` if the modem's
+    /// 8-byte commit field was all zeros (commit unavailable at build time).
+    modem_firmware_commit: Option<String>,
     reader_handle: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
     warm_reboot_notify: Arc<tokio::sync::Notify>,
     warm_reboot_flag: Arc<std::sync::atomic::AtomicBool>,
@@ -276,18 +281,33 @@ impl UsbEspNowTransport {
         let startup_result = async {
             let modem_ready = Self::reset_and_wait(Arc::clone(&writer), ready_rx).await?;
             let modem_mac = modem_ready.mac_address;
+            let fw = modem_ready.firmware_version;
+            let commit_bytes = modem_ready.firmware_commit;
             info!(
-                firmware = ?modem_ready.firmware_version,
+                firmware = ?fw,
                 mac = ?modem_mac,
+                commit = ?commit_bytes,
                 "modem ready"
             );
             Self::set_channel(Arc::clone(&writer), channel, ack_rx).await?;
-            Ok::<_, TransportError>(modem_mac)
+
+            // Format version as "major.minor.patch" (build byte intentionally omitted).
+            let modem_firmware_version = format!("{}.{}.{}", fw[0], fw[1], fw[2]);
+
+            // All-zero commit means the hash was unavailable at build time → None.
+            let modem_firmware_commit = if commit_bytes == [0u8; 8] {
+                None
+            } else {
+                let hex: String = commit_bytes.iter().map(|b| format!("{b:02x}")).collect();
+                Some(hex)
+            };
+
+            Ok::<_, TransportError>((modem_mac, modem_firmware_version, modem_firmware_commit))
         }
         .await;
 
         match startup_result {
-            Ok(modem_mac) => {
+            Ok((modem_mac, modem_firmware_version, modem_firmware_commit)) => {
                 let reader_handle = guard.0.take().expect("guard still holds handle");
                 Ok(Self {
                     writer,
@@ -300,6 +320,8 @@ impl UsbEspNowTransport {
                     display_send_lock: Mutex::new(()),
                     next_display_transfer_id: AtomicU8::new(0),
                     modem_mac,
+                    modem_firmware_version,
+                    modem_firmware_commit,
                     reader_handle: std::sync::Mutex::new(Some(reader_handle)),
                     warm_reboot_notify,
                     warm_reboot_flag,
@@ -315,6 +337,17 @@ impl UsbEspNowTransport {
     /// Return the modem's MAC address reported during startup.
     pub fn modem_mac(&self) -> &[u8; 6] {
         &self.modem_mac
+    }
+
+    /// Return the modem firmware version as "major.minor.patch".
+    pub fn modem_firmware_version(&self) -> &str {
+        &self.modem_firmware_version
+    }
+
+    /// Return the modem firmware commit as a 16-char hex string, or `None`
+    /// if the modem's commit field was all zeros.
+    pub fn modem_firmware_commit(&self) -> Option<&str> {
+        self.modem_firmware_commit.as_deref()
     }
 
     /// Return a clone of the warm-reboot notification primitive.
@@ -1170,6 +1203,7 @@ mod tests {
         let ready = ModemMessage::ModemReady(ModemReady {
             firmware_version: [1, 2, 3, 4],
             mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+            firmware_commit: [0x42u8; 8],
         });
         let frame = encode_modem_frame(&ready).unwrap();
         server.write_all(&frame).await.unwrap();

--- a/crates/sonde-gateway/tests/ble_pairing.rs
+++ b/crates/sonde-gateway/tests/ble_pairing.rs
@@ -464,6 +464,7 @@ async fn modem_startup(server: &mut DuplexStream, channel: u8) {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [1, 0, 0, 0],
         mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0x42u8; 8],
     });
     server
         .write_all(&encode_modem_frame(&ready).unwrap())

--- a/crates/sonde-gateway/tests/common/mod.rs
+++ b/crates/sonde-gateway/tests/common/mod.rs
@@ -85,6 +85,7 @@ pub async fn modem_startup(server: &mut DuplexStream, channel: u8) {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [1, 0, 0, 0],
         mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0x42u8; 8],
     });
     server
         .write_all(&encode_modem_frame(&ready).unwrap())

--- a/crates/sonde-gateway/tests/modem_transport.rs
+++ b/crates/sonde-gateway/tests/modem_transport.rs
@@ -49,6 +49,7 @@ async fn do_startup_handshake(server: &mut DuplexStream, channel: u8) {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [1, 0, 0, 0],
         mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0x42u8; 8],
     });
     server
         .write_all(&encode_modem_frame(&ready).unwrap())
@@ -243,6 +244,7 @@ async fn t1103_startup_sequence() {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [2, 0, 0, 1],
         mac_address: [0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01],
+        firmware_commit: [0x42u8; 8],
     });
     server
         .write_all(&encode_modem_frame(&ready).unwrap())
@@ -589,6 +591,7 @@ async fn gw1101_set_channel_ack_timeout() {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [1, 0, 0, 0],
         mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0x42u8; 8],
     });
     server
         .write_all(&encode_modem_frame(&ready).unwrap())
@@ -671,6 +674,7 @@ async fn gw1103_error_recovery_full_restart() {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [1, 0, 0, 0],
         mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0x42u8; 8],
     });
     server2
         .write_all(&encode_modem_frame(&ready).unwrap())
@@ -799,6 +803,7 @@ async fn t1104d_unexpected_modem_ready_fires_warm_reboot_notify() {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [1, 0, 0, 0],
         mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0x42u8; 8],
     });
     server
         .write_all(&encode_modem_frame(&ready).unwrap())
@@ -863,6 +868,7 @@ async fn t1104e_warm_reboot_recovery_uses_persisted_channel() {
         let ready = ModemMessage::ModemReady(ModemReady {
             firmware_version: [1, 0, 0, 0],
             mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+            firmware_commit: [0x42u8; 8],
         });
         server1
             .write_all(&encode_modem_frame(&ready).unwrap())
@@ -889,6 +895,7 @@ async fn t1104e_warm_reboot_recovery_uses_persisted_channel() {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [1, 0, 0, 0],
         mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0x42u8; 8],
     });
     server1
         .write_all(&encode_modem_frame(&ready).unwrap())
@@ -934,6 +941,7 @@ async fn t1104e_warm_reboot_recovery_uses_persisted_channel() {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [1, 0, 0, 0],
         mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0x42u8; 8],
     });
     server2
         .write_all(&encode_modem_frame(&ready).unwrap())
@@ -958,4 +966,89 @@ async fn t1104e_warm_reboot_recovery_uses_persisted_channel() {
     }
 
     let _transport2 = transport2_handle.await.unwrap();
+}
+
+// ─── T-2016 / T-2016a: Modem firmware metadata in transport ─────────
+
+/// T-2016: After a successful handshake with a non-zero firmware_commit,
+/// the transport exposes the version as "major.minor.patch" and the commit
+/// as a 16-char lowercase hex string.
+#[tokio::test]
+#[traced_test]
+async fn modem_firmware_metadata_nonzero_commit() {
+    let (client, mut server) = duplex(4096);
+    let mut decoder = FrameDecoder::new();
+    let mut buf = [0u8; 4096];
+
+    let transport_handle = tokio::spawn(async move { UsbEspNowTransport::new(client, 1).await });
+
+    // 1. RESET
+    let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+    assert!(matches!(msg, ModemMessage::Reset));
+
+    // 2. MODEM_READY with specific version and commit
+    let ready = ModemMessage::ModemReady(ModemReady {
+        firmware_version: [0, 1, 2, 0],
+        mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x23, 0x45, 0x67],
+    });
+    server
+        .write_all(&encode_modem_frame(&ready).unwrap())
+        .await
+        .unwrap();
+
+    // 3. SET_CHANNEL → ACK
+    let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+    let ch = match msg {
+        ModemMessage::SetChannel(ch) => ch,
+        other => panic!("expected SetChannel, got {other:?}"),
+    };
+    server
+        .write_all(&encode_modem_frame(&ModemMessage::SetChannelAck(ch)).unwrap())
+        .await
+        .unwrap();
+
+    let transport = transport_handle.await.unwrap().unwrap();
+
+    assert_eq!(transport.modem_firmware_version(), "0.1.2");
+    assert_eq!(transport.modem_firmware_commit(), Some("deadbeef01234567"));
+}
+
+/// T-2016a: All-zero firmware_commit in MODEM_READY yields None.
+#[tokio::test]
+#[traced_test]
+async fn modem_firmware_metadata_zero_commit() {
+    let (client, mut server) = duplex(4096);
+    let mut decoder = FrameDecoder::new();
+    let mut buf = [0u8; 4096];
+
+    let transport_handle = tokio::spawn(async move { UsbEspNowTransport::new(client, 1).await });
+
+    let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+    assert!(matches!(msg, ModemMessage::Reset));
+
+    let ready = ModemMessage::ModemReady(ModemReady {
+        firmware_version: [3, 5, 7, 0],
+        mac_address: [0x11, 0x22, 0x33, 0x44, 0x55, 0x66],
+        firmware_commit: [0u8; 8],
+    });
+    server
+        .write_all(&encode_modem_frame(&ready).unwrap())
+        .await
+        .unwrap();
+
+    let msg = read_next_message(&mut server, &mut decoder, &mut buf).await;
+    let ch = match msg {
+        ModemMessage::SetChannel(ch) => ch,
+        other => panic!("expected SetChannel, got {other:?}"),
+    };
+    server
+        .write_all(&encode_modem_frame(&ModemMessage::SetChannelAck(ch)).unwrap())
+        .await
+        .unwrap();
+
+    let transport = transport_handle.await.unwrap().unwrap();
+
+    assert_eq!(transport.modem_firmware_version(), "3.5.7");
+    assert_eq!(transport.modem_firmware_commit(), None);
 }

--- a/crates/sonde-gateway/tests/phase2d.rs
+++ b/crates/sonde-gateway/tests/phase2d.rs
@@ -56,6 +56,7 @@ async fn do_startup_handshake(server: &mut DuplexStream) -> u8 {
     let ready = ModemMessage::ModemReady(ModemReady {
         firmware_version: [1, 2, 3, 4],
         mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+        firmware_commit: [0x42u8; 8],
     });
     let frame = encode_modem_frame(&ready).unwrap();
     server.write_all(&frame).await.unwrap();

--- a/crates/sonde-modem/build.rs
+++ b/crates/sonde-modem/build.rs
@@ -15,18 +15,29 @@ fn main() {
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| {
             std::process::Command::new("git")
-                .args(["rev-parse", "--short", "HEAD"])
+                .args(["rev-parse", "HEAD"])
                 .output()
                 .ok()
                 .filter(|o| o.status.success())
                 .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
                 .unwrap_or_else(|| "unknown".to_string())
         });
-    // Normalise to a short hash (7 chars) for readable log output and
-    // consistency between CI (full SHA from github.sha) and local builds
-    // (short SHA from `git rev-parse --short`).  Also guards against
-    // newlines corrupting the `cargo:rustc-env` directive.
-    let commit: String = raw.chars().take(7).collect();
+    // Keep the full hex hash so the firmware can extract the first 8 raw
+    // bytes (16 hex chars) for the MODEM_READY `firmware_commit` field.
+    // Validate that every character is hex-safe; replace with "unknown"
+    // otherwise to avoid corrupting the `cargo:rustc-env` directive.
+    let commit: String = if raw.chars().all(|c| c.is_ascii_hexdigit()) {
+        if raw.len() < 16 {
+            println!(
+                "cargo:warning=SONDE_GIT_COMMIT is only {} hex chars; \
+                 firmware_commit will be all-zero (need >= 16 for 8-byte field)",
+                raw.len()
+            );
+        }
+        raw
+    } else {
+        "unknown".to_string()
+    };
     println!("cargo:rustc-env=SONDE_GIT_COMMIT={commit}");
     println!("cargo:rerun-if-env-changed=SONDE_GIT_COMMIT");
 

--- a/crates/sonde-modem/src/bridge.rs
+++ b/crates/sonde-modem/src/bridge.rs
@@ -60,6 +60,40 @@ const FIRMWARE_VERSION: [u8; 4] = [
     0,
 ];
 
+/// Decode the first 8 bytes (16 hex chars) of a hex commit string into raw bytes.
+/// Returns all zeros if the input is too short, not valid hex, or "unknown".
+const fn decode_firmware_commit(hex: &[u8]) -> [u8; 8] {
+    if hex.len() < 16 {
+        return [0u8; 8];
+    }
+    let mut out = [0u8; 8];
+    let mut i = 0;
+    while i < 8 {
+        let hi = hex_nibble(hex[i * 2]);
+        let lo = hex_nibble(hex[i * 2 + 1]);
+        if hi == 0xFF || lo == 0xFF {
+            return [0u8; 8];
+        }
+        out[i] = (hi << 4) | lo;
+        i += 1;
+    }
+    out
+}
+
+/// Convert a single ASCII hex char to its 4-bit value, or 0xFF on invalid input.
+const fn hex_nibble(c: u8) -> u8 {
+    match c {
+        b'0'..=b'9' => c - b'0',
+        b'a'..=b'f' => c - b'a' + 10,
+        b'A'..=b'F' => c - b'A' + 10,
+        _ => 0xFF,
+    }
+}
+
+/// First 8 bytes of the build's git commit SHA, decoded from
+/// `SONDE_GIT_COMMIT`. All zeros if the commit hash is unavailable.
+const FIRMWARE_COMMIT: [u8; 8] = decode_firmware_commit(env!("SONDE_GIT_COMMIT").as_bytes());
+
 /// Maximum number of received radio frames forwarded per `poll()` call.
 /// Prevents starvation of serial decode and other poll() work under
 /// sustained RX burst traffic.
@@ -536,15 +570,22 @@ impl<S: SerialPort, R: Radio, B: Ble, Btn: ButtonPoll, D: Display> Bridge<S, R, 
         let msg = ModemMessage::ModemReady(ModemReady {
             firmware_version: FIRMWARE_VERSION,
             mac_address: mac,
+            firmware_commit: FIRMWARE_COMMIT,
         });
         self.send_msg(&msg);
+        let commit_hex = env!("SONDE_GIT_COMMIT");
+        let short_commit = if commit_hex.len() >= 7 {
+            &commit_hex[..7]
+        } else {
+            commit_hex
+        };
         info!(
             "sent MODEM_READY (fw={}.{}.{}.{}, commit={}, mac={:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X})",
             FIRMWARE_VERSION[0],
             FIRMWARE_VERSION[1],
             FIRMWARE_VERSION[2],
             FIRMWARE_VERSION[3],
-            env!("SONDE_GIT_COMMIT"),
+            short_commit,
             mac[0],
             mac[1],
             mac[2],
@@ -1098,6 +1139,7 @@ mod tests {
             ModemMessage::ModemReady(mr) => {
                 assert_eq!(mr.firmware_version, FIRMWARE_VERSION);
                 assert_eq!(mr.mac_address, [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+                assert_eq!(mr.firmware_commit, FIRMWARE_COMMIT);
             }
             _ => panic!("expected ModemReady"),
         }

--- a/crates/sonde-protocol/src/modem.rs
+++ b/crates/sonde-protocol/src/modem.rs
@@ -126,7 +126,10 @@ pub const MODEM_ERR_UNKNOWN: u8 = 0xFF;
 // -- Body sizes for fixed-layout messages --
 
 /// MODEM_READY body: firmware_version (4B) + mac_address (6B).
-pub const MODEM_READY_BODY_SIZE: usize = 4 + MAC_SIZE; // 10
+pub const MODEM_READY_BODY_SIZE: usize = 4 + MAC_SIZE + FIRMWARE_COMMIT_SIZE; // 18
+
+/// Size of the firmware commit hash field in MODEM_READY (first 8 bytes of SHA-1).
+pub const FIRMWARE_COMMIT_SIZE: usize = 8;
 
 /// STATUS body: channel (1B) + uptime_s (4B) + tx_count (4B) + rx_count (4B) + tx_fail_count (4B).
 pub const STATUS_BODY_SIZE: usize = 1 + 4 + 4 + 4 + 4; // 17
@@ -347,6 +350,9 @@ pub struct SendFrame {
 pub struct ModemReady {
     pub firmware_version: [u8; 4],
     pub mac_address: [u8; MAC_SIZE],
+    /// First 8 bytes of the firmware build's git commit SHA-1.
+    /// All zeros if the commit hash was unavailable at build time.
+    pub firmware_commit: [u8; FIRMWARE_COMMIT_SIZE],
 }
 
 /// RECV_FRAME (Modem → Gateway): an inbound ESP-NOW frame.
@@ -544,6 +550,7 @@ fn encode_body(msg: &ModemMessage) -> Result<(u8, Vec<u8>), ModemCodecError> {
             let mut body = Vec::with_capacity(MODEM_READY_BODY_SIZE);
             body.extend_from_slice(&mr.firmware_version);
             body.extend_from_slice(&mr.mac_address);
+            body.extend_from_slice(&mr.firmware_commit);
             Ok((MODEM_MSG_MODEM_READY, body))
         }
         ModemMessage::RecvFrame(rf) => {
@@ -838,9 +845,13 @@ fn decode_typed_message(msg_type: u8, body: &[u8]) -> Result<ModemMessage, Modem
             firmware_version.copy_from_slice(&body[..4]);
             let mut mac_address = [0u8; MAC_SIZE];
             mac_address.copy_from_slice(&body[4..4 + MAC_SIZE]);
+            let mut firmware_commit = [0u8; FIRMWARE_COMMIT_SIZE];
+            firmware_commit
+                .copy_from_slice(&body[4 + MAC_SIZE..4 + MAC_SIZE + FIRMWARE_COMMIT_SIZE]);
             Ok(ModemMessage::ModemReady(ModemReady {
                 firmware_version,
                 mac_address,
+                firmware_commit,
             }))
         }
 
@@ -1228,6 +1239,7 @@ mod tests {
         let msg = ModemMessage::ModemReady(ModemReady {
             firmware_version: [1, 0, 3, 7],
             mac_address: [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC],
+            firmware_commit: [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x23, 0x45, 0x67],
         });
         let frame = encode_modem_frame(&msg).unwrap();
         let (decoded, _) = decode_modem_frame(&frame).unwrap();
@@ -1348,13 +1360,14 @@ mod tests {
         let msg = ModemMessage::ModemReady(ModemReady {
             firmware_version: [1, 2, 3, 4],
             mac_address: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
+            firmware_commit: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
         });
         let frame = encode_modem_frame(&msg).unwrap();
-        // LEN = 11 (TYPE + 10 bytes body) → 0x00 0x0B
+        // LEN = 19 (TYPE + 18 bytes body) → 0x00 0x13
         assert_eq!(frame[0], 0x00);
-        assert_eq!(frame[1], 0x0B);
+        assert_eq!(frame[1], 0x13);
         assert_eq!(frame[2], MODEM_MSG_MODEM_READY);
-        assert_eq!(frame.len(), 2 + 11); // LEN field + len value
+        assert_eq!(frame.len(), 2 + 19); // LEN field + len value
     }
 
     // -- Error handling tests --

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -135,6 +135,10 @@ pub struct UsbEspNowTransport {
     recv_rx: mpsc::Receiver<(Vec<u8>, PeerAddress)>,
     /// Modem's MAC address (from MODEM_READY).
     modem_mac: [u8; 6],
+    /// Modem firmware version (from MODEM_READY), formatted as "major.minor.patch".
+    modem_firmware_version: Option<String>,
+    /// Modem firmware commit (from MODEM_READY), 16-char lowercase hex, or None if all-zero.
+    modem_firmware_commit: Option<String>,
 }
 ```
 
@@ -144,7 +148,7 @@ pub struct UsbEspNowTransport {
 2. Start the serial reader task (it demultiplexes all incoming frames, including `MODEM_READY` and `SET_CHANNEL_ACK`, and routes them to the appropriate pending futures).
 3. Send `RESET`.
 4. Wait for `MODEM_READY` (timeout: 5 seconds, up to 3 retries).
-5. Extract `firmware_version` and `mac_address` from `MODEM_READY`; log both.
+5. Extract `firmware_version`, `mac_address`, and `firmware_commit` from `MODEM_READY`; log all three. Format `firmware_version` as `"major.minor.patch"` (omitting the build byte) and store as `modem_firmware_version`. Decode the 8-byte `firmware_commit` as lowercase hex; if all-zero, store `None`; otherwise store `Some(hex_string)` as `modem_firmware_commit`.
 6. Send `SET_CHANNEL` with the persisted channel from the database (GW-0808). If no channel is persisted yet, seed the database with the CLI `--channel` value and use that.
 7. Wait for `SET_CHANNEL_ACK` (timeout: 2 seconds).
 8. Start the health monitor task.
@@ -2184,6 +2188,14 @@ step 9a is inline.
    notifications during the debounce window reset the timer to coalesce
    concurrent hint arrivals.
 
+5. `modem_ready_rx` — receives modem metadata (`modem_firmware_version`,
+   `modem_firmware_commit`) from the modem handshake task after
+   `MODEM_READY` is successfully parsed. Re-emit immediately with
+   populated modem fields. The gateway's `emit_gateway_actual_state()`
+   reads `modem_firmware_version` and `modem_firmware_commit` from the
+   transport (or a shared state holder) so re-emissions after the modem
+   handshake always include the modem fields.
+
 **Re-emission procedure:**
 
 On each trigger, the task:
@@ -2193,7 +2205,11 @@ On each trigger, the task:
    `kdf_salt`, `kdf_params_json` from `gateway_config`.
 4. Drains `missing_key_hints` from the gateway engine's tracker.
 5. Checks `storage.read_pending_rotation()` to determine `rotation_in_progress`.
-6. Calls `emit_gateway_actual_state()` on the connector event hub.
+6. Reads `modem_firmware_version` and `modem_firmware_commit` from the
+   transport or shared modem state. These are `None` before the modem
+   handshake completes, and `Some(...)` afterwards (with `modem_firmware_commit`
+   being `None` if the modem's 8-byte commit field was all-zero).
+7. Calls `emit_gateway_actual_state()` on the connector event hub.
 
 **Hint notification mechanism:**
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2646,6 +2646,10 @@ heartbeat interval (default 900 seconds).
    pending desired state. The heartbeat schedule is process-local (resets
    on gateway restart), independent of event-driven emissions, and does
    not require an attached connector subscriber.
+9. Re-emitted after modem handshake completes (`MODEM_READY` received)
+   with `modem_firmware_version` and `modem_firmware_commit` populated
+   from the handshake. The initial startup emission MAY have these
+   fields as null if the modem has not yet connected.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4259,6 +4259,49 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-2016  Modem handshake triggers ACTUAL_STATE re-emission with version/commit
+
+**Traces to:** GW-2003 (AC-1, AC-9), Issue #1096
+
+**Steps:**
+1. Start gateway with identity and master key (no modem connected yet).
+2. Connect a mock connector consumer.
+3. Consume the initial startup ACTUAL_STATE.
+4. Verify `modem_firmware_version` (CBOR key 25) is null in the initial emission.
+5. Verify `modem_firmware_commit` (CBOR key 26) is null in the initial emission.
+6. Connect a modem (or inject a `MODEM_READY` with `firmware_version` = `[0, 1, 2, 0]`,
+   `mac_address` = 6 non-zero bytes, `firmware_commit` = 8 non-zero bytes).
+7. Verify gateway re-emits ACTUAL_STATE after the modem handshake completes.
+8. Verify `modem_firmware_version` (key 25) is the formatted semver string
+   (e.g., `"0.1.2"`).
+9. Verify `modem_firmware_commit` (key 26) is the 16-character lowercase hex
+   string of the 8-byte `firmware_commit` from the modem.
+
+**Expected:**
+1. Initial ACTUAL_STATE has null modem fields.
+2. After modem handshake, ACTUAL_STATE is re-emitted with populated modem fields.
+
+---
+
+### T-2016a  All-zero firmware_commit yields null modem_firmware_commit
+
+**Traces to:** GW-2003 (AC-1, AC-9), Issue #1096
+
+**Steps:**
+1. Start gateway with identity and master key.
+2. Connect a mock connector consumer.
+3. Consume the initial startup ACTUAL_STATE.
+4. Inject a `MODEM_READY` with `firmware_version` = `[0, 1, 2, 0]`,
+   `mac_address` = 6 non-zero bytes, `firmware_commit` = 8 zero bytes.
+5. Verify gateway re-emits ACTUAL_STATE after the modem handshake.
+6. Verify `modem_firmware_version` (key 25) is `"0.1.2"`.
+7. Verify `modem_firmware_commit` (key 26) is null (not `"0000000000000000"`).
+
+**Expected:**
+1. All-zero firmware commit from modem yields null `modem_firmware_commit`.
+
+---
+
 ### T-2002  Gateway DESIRED_STATE channel change
 
 **Traces to:** GW-2004 (AC-1)
@@ -4717,7 +4760,7 @@ by existing handler tests.
 | GW-2000 | T-2001 |
 | GW-2001 | T-2000 |
 | GW-2002 | T-2003 |
-| GW-2003 | T-2001, T-2011, T-2012, T-2013, T-2014 |
+| GW-2003 | T-2001, T-2011, T-2012, T-2013, T-2014, T-2016, T-2016a |
 | GW-2004 | T-2002 |
 | GW-2005 | T-2001, T-2006c |
 | GW-2006 | T-2004, T-2004a |

--- a/docs/modem-design.md
+++ b/docs/modem-design.md
@@ -395,15 +395,15 @@ This separation is critical: the USB-CDC port (GPIO19/20) carries the binary mod
 
 ### 14.0a  Build-time commit SHA injection
 
-The build script (`build.rs`) captures the current git commit SHA at compile time and injects it as the `SONDE_GIT_COMMIT` environment variable via `cargo:rustc-env`. The firmware logs the short SHA (first 7 characters) in the boot banner and in the diagnostic log line emitted when `MODEM_READY` is sent. The `MODEM_READY` protocol payload itself is unchanged (`firmware_version` + `mac_address`).
+The build script (`build.rs`) captures the current git commit SHA at compile time and injects it as the `SONDE_GIT_COMMIT` environment variable via `cargo:rustc-env`. The firmware logs the short SHA (first 7 characters) in the boot banner and in the diagnostic log line emitted when `MODEM_READY` is sent. The `MODEM_READY` protocol payload includes the first 8 bytes of the full commit SHA-1 in the `firmware_commit` field, enabling the gateway to plumb it through ACTUAL_STATE to the web UI and companion (see modem-protocol.md §4.3 and Issue #1096).
 
 **Resolution order:**
 
 1. If the `SONDE_GIT_COMMIT` environment variable is set (CI sets this from `github.sha`), use that value.
-2. Otherwise, run `git rev-parse --short HEAD` to obtain the local commit.
+2. Otherwise, run `git rev-parse HEAD` to obtain the full local commit hash.
 3. If neither is available (e.g., building outside a git repository), fall back to the string `"unknown"`.
 
-Empty values are ignored, and the selected value is normalized to the first 7 characters before injection. The short SHA provides firmware traceability with negligible binary size impact and no runtime overhead — the value is baked into the binary at compile time via `env!()` and requires no runtime git access.
+Empty values are ignored. For the `MODEM_READY` `firmware_commit` field, the first 8 bytes (16 hex characters) of the full SHA-1 are decoded to binary and included in the payload. When the commit is `"unknown"` or otherwise non-hex, all 8 bytes are set to zero. For diagnostic logging, the selected value is normalized to the first 7 characters for the short SHA display. The commit hash provides firmware traceability with negligible binary size impact and no runtime overhead — the value is baked into the binary at compile time via `env!()` and requires no runtime git access.
 
 ### 14.1  Dual-port setup
 

--- a/docs/modem-protocol.md
+++ b/docs/modem-protocol.md
@@ -67,8 +67,8 @@ The maximum body size of 1024 bytes is retained so protocol extensions can carry
 If the gateway opens a serial port mid-stream (e.g., after a modem reset or hot-plug), it may land in the middle of a frame. Recovery procedure:
 
 1. Gateway sends `RESET` (TYPE = 0x01, empty body).
-2. Modem firmware resets its receive-side framing parser on any `RESET` command and then sends a `MODEM_READY` frame (`LEN` = 0x00 0x0B, `TYPE` = 0x81, 10-byte body).
-3. After sending `RESET`, the gateway MUST discard received bytes until it observes a valid `MODEM_READY` frame: a two-byte big-endian length of 11 (`0x00 0x0B`), followed by `TYPE` = `0x81`, followed by exactly 10 bytes of body (`firmware_version` + `mac_address`). This deterministic framing pattern allows the gateway to resynchronize even if the `RESET` was sent mid-frame.
+2. Modem firmware resets its receive-side framing parser on any `RESET` command and then sends a `MODEM_READY` frame (`LEN` = 0x00 0x13, `TYPE` = 0x81, 18-byte body).
+3. After sending `RESET`, the gateway MUST discard received bytes until it observes a valid `MODEM_READY` frame: a two-byte big-endian length of 19 (`0x00 0x13`), followed by `TYPE` = `0x81`, followed by exactly 18 bytes of body (`firmware_version` + `mac_address` + `firmware_commit`). This deterministic framing pattern allows the gateway to resynchronize even if the `RESET` was sent mid-frame.
 
 ---
 
@@ -152,18 +152,19 @@ The modem MUST respond with `SET_CHANNEL_ACK` (§4.5) after the channel change t
 
 Sent when the modem has completed initialization and is ready to send and receive ESP-NOW frames. The gateway MUST wait for this message before sending any other commands.
 
-The `MODEM_READY` body contains two fields: a 4-byte big-endian `firmware_version` (encoded as major.minor.patch.build, one byte each, derived from the crate's `CARGO_PKG_VERSION` at compile time) followed by the 6-byte `mac_address` (the modem's own WiFi MAC).
+The `MODEM_READY` body contains three fields: a 4-byte big-endian `firmware_version` (encoded as major.minor.patch.build, one byte each, derived from the crate's `CARGO_PKG_VERSION` at compile time), followed by the 6-byte `mac_address` (the modem's own WiFi MAC), followed by an 8-byte `firmware_commit` (the first 8 bytes of the build-time git commit SHA-1 hash, or all zeros if the commit is unavailable).
 
 ```
-┌────────────────────────┬──────────────────┐
-│  firmware_version (4B) │  mac_address (6B)│
-└────────────────────────┴──────────────────┘
+┌────────────────────────┬──────────────────┬──────────────────────┐
+│  firmware_version (4B) │  mac_address (6B)│  firmware_commit (8B)│
+└────────────────────────┴──────────────────┴──────────────────────┘
 ```
 
 | Field | Type | Size | Description |
 |-------|------|------|-------------|
 | `firmware_version` | Unsigned integer | 4 bytes, big-endian | Modem firmware version (semantic: major.minor.patch.build, one byte each). |
 | `mac_address` | Bytes | 6 bytes | The modem's own WiFi MAC address (the source address for all transmitted ESP-NOW frames). |
+| `firmware_commit` | Bytes | 8 bytes | First 8 bytes of the build-time git commit SHA-1 hash. All zeros if unavailable (e.g., built outside a git repository). The gateway formats this as a 16-character lowercase hex string for ACTUAL_STATE. |
 
 This message is sent:
 - On power-up / USB enumeration (within 2 seconds).
@@ -474,7 +475,7 @@ The `EVENT_BUTTON` body is a single 1-byte `button_type` field.
 
 The gateway MUST always send `RESET` when opening the serial port, regardless of whether the modem was just powered on or was already running. This ensures deterministic state.
 
-The startup sequence is: (1) gateway opens the serial port and immediately sends `RESET`; (2) the modem performs initialization and sends `MODEM_READY` (containing its firmware version and MAC address); (3) the gateway sends `SET_CHANNEL` with the desired WiFi channel; (4) the modem applies the channel and responds with `SET_CHANNEL_ACK`; then normal operation begins.
+The startup sequence is: (1) gateway opens the serial port and immediately sends `RESET`; (2) the modem performs initialization and sends `MODEM_READY` (containing its firmware version, MAC address, and firmware commit); (3) the gateway sends `SET_CHANNEL` with the desired WiFi channel; (4) the modem applies the channel and responds with `SET_CHANNEL_ACK`; then normal operation begins.
 
 ```
 Gateway                          Modem
@@ -698,7 +699,11 @@ However, the reliable display-transfer subprotocol (`DISPLAY_FRAME_BEGIN`, `DISP
 
 ### 8.2  Version detection
 
-The `firmware_version` field in `MODEM_READY` allows the gateway to detect the modem firmware version and adjust behavior if needed (e.g., skip `SCAN_CHANNELS` if the modem predates that feature).
+The `firmware_version` field in `MODEM_READY` allows the gateway to detect the modem firmware version and adjust behavior if needed (e.g., skip `SCAN_CHANNELS` if the modem predates that feature). The `firmware_commit` field provides build-level traceability for diagnostics and the web UI.
+
+### 8.2a  MODEM_READY payload size change (Issue #1096)
+
+The `MODEM_READY` payload was extended from 10 bytes to 18 bytes to include the `firmware_commit` field. The gateway's synchronization recovery (§2.3) expects the new 18-byte body size. **Gateway and modem firmware must be upgraded together** — an older modem sending a 10-byte `MODEM_READY` will fail the gateway's resync pattern. No version negotiation mechanism exists for the serial protocol; both endpoints must agree on the frame layout.
 
 ### 8.3  Reserved type ranges
 

--- a/docs/modem-requirements.md
+++ b/docs/modem-requirements.md
@@ -110,6 +110,22 @@ The modem firmware MUST send `MODEM_READY` within 2 seconds of USB enumeration.
 
 ---
 
+### MD-0105  Firmware commit in MODEM_READY
+
+**Priority:** Must
+**Source:** modem-protocol.md §4.3, Issue #1096
+
+**Description:**
+The modem firmware MUST include the first 8 bytes of the build-time git commit SHA-1 hash in the `firmware_commit` field of `MODEM_READY`. The commit hash is captured at compile time via `build.rs` (see §14.0a of modem-design.md). If the commit hash is unavailable (e.g., built outside a git repository), the field MUST be all zeros.
+
+**Acceptance criteria:**
+
+1. `MODEM_READY` body is 18 bytes (4B version + 6B MAC + 8B commit).
+2. `firmware_commit` contains the first 8 bytes of the git commit SHA-1 when built inside a git repository.
+3. `firmware_commit` is all zeros when built outside a git repository or when the commit is otherwise unavailable.
+
+---
+
 ## 4  ESP-NOW interface
 
 ### MD-0200  ESP-NOW initialization

--- a/docs/modem-validation.md
+++ b/docs/modem-validation.md
@@ -59,14 +59,17 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 
 ### T-0101  MODEM_READY on boot
 
-**Validates:** MD-0104
+**Validates:** MD-0104, MD-0105
 
 **Procedure:**
 1. Open the modem's serial port.
 2. Wait up to 2 seconds for a `MODEM_READY` message.
 3. Assert: `MODEM_READY` is received within 2 seconds.
-4. Assert: `firmware_version` is a valid 4-byte value.
-5. Assert: `mac_address` is a valid 6-byte MAC (not all zeros).
+4. Assert: `MODEM_READY` body is exactly 18 bytes.
+5. Assert: `firmware_version` is a valid 4-byte value.
+6. Assert: `mac_address` is a valid 6-byte MAC (not all zeros).
+7. Assert: `firmware_commit` is 8 bytes. When built inside a git repository,
+   at least one byte is non-zero.
 
 > **Implementation note:** The current `device_tests.rs` implementation (`t0101_modem_ready_after_reset`) verifies field values but does not assert the 2-second timing constraint from MD-0104. A future update should record `Instant::now()` before `reset_and_wait()` and assert `elapsed <= Duration::from_secs(2)` on return.
 
@@ -292,14 +295,16 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 
 ### T-0303  MODEM_READY after RESET
 
-**Validates:** MD-0300, MD-0104
+**Validates:** MD-0300, MD-0104, MD-0105
 
 **Procedure:**
 1. Send `RESET`.
 2. Assert: `MODEM_READY` is received within 2 seconds.
-3. Send `RESET` again.
-4. Assert: `MODEM_READY` is received within 2 seconds.
-5. Repeat 5 times to confirm stability.
+3. Assert: `MODEM_READY` body is exactly 18 bytes (4B version + 6B MAC + 8B commit).
+4. Send `RESET` again.
+5. Assert: `MODEM_READY` is received within 2 seconds.
+6. Assert: `firmware_commit` is identical across both resets (same build).
+7. Repeat 5 times to confirm stability.
 
 ---
 
@@ -1426,7 +1431,7 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 | ID | Title | Validates |
 |----|-------|-----------|
 | T-0100 | USB-CDC device enumeration | MD-0100 |
-| T-0101 | MODEM_READY on boot | MD-0104 |
+| T-0101 | MODEM_READY on boot | MD-0104, MD-0105 |
 | T-0102 | Serial framing — valid frame and max length | MD-0101, MD-0102 |
 | T-0103 | Serial framing — oversized len | MD-0101, MD-0102 |
 | T-0104 | Unknown message type | MD-0103 |
@@ -1441,7 +1446,7 @@ For tests that do not require real radio hardware, a PTY pair replaces the USB-C
 | T-0300 | RESET clears state | MD-0300 |
 | T-0301 | USB-CDC serial link drop and reconnection | MD-0301 |
 | T-0302 | Status counter accuracy | MD-0303 |
-| T-0303 | MODEM_READY after RESET | MD-0300, MD-0104 |
+| T-0303 | MODEM_READY after RESET | MD-0300, MD-0104, MD-0105 |
 | T-0304 | Watchdog triggers on stalled main loop | MD-0302 |
 | T-0400 | SEND_FRAME with body too short | MD-0208 |
 | T-0401 | SET_CHANNEL with invalid channel | MD-0209 |


### PR DESCRIPTION
## Summary

Extends the modem serial protocol's MODEM_READY frame to include the firmware git commit hash, wires both version and commit through the gateway's ACTUAL_STATE emission, and re-emits ACTUAL_STATE after modem handshake completes.

Closes #1096

## Changes

### Protocol (sonde-protocol)
- MODEM_READY body size: 10 → 18 bytes (+8-byte `firmware_commit` field)
- `ModemReady` struct gains `firmware_commit: [u8; 8]` with updated encode/decode

### Modem (sonde-modem)
- `build.rs`: captures full `git rev-parse HEAD`, validates hex, warns if too short for 8-byte extraction
- `bridge.rs`: const hex decoder embeds `FIRMWARE_COMMIT` at compile time; `send_modem_ready()` includes commit field

### Gateway (sonde-gateway)
- `modem.rs`: `UsbEspNowTransport` stores parsed `modem_firmware_version` ("major.minor.patch") and `modem_firmware_commit` (16-char hex or `None` when all-zero)
- `gateway.rs`: new `ModemMetadata` struct behind `Arc<Mutex<>>`; ACTUAL_STATE re-emitted after modem handshake (GW-2003 AC-9) and after disconnect (clears stale cache)

### Specifications (7 docs)
- **modem-protocol.md**: §4.3 extended field table + diagram, §2.3 sync recovery size, §5.1 startup, §8.2a backward compat note
- **modem-requirements.md**: added MD-0105 (commit hash in MODEM_READY)
- **modem-design.md**: §14.0a updated to reflect commit in protocol payload
- **modem-validation.md**: updated T-0101, T-0303, traceability
- **gateway-requirements.md**: added AC-9 to GW-2003
- **gateway-design.md**: struct fields, §23.14 trigger, re-emission procedure
- **gateway-validation.md**: added T-2016 (re-emission), T-2016a (all-zero → null)

### Tests
- 2 new transport-level tests: `modem_firmware_metadata_nonzero_commit`, `modem_firmware_metadata_zero_commit`
- Updated `ModemReady` construction in 4 existing test files (11 sites)

## Breaking Change

This is a **breaking protocol change**: the MODEM_READY frame size increases from 10 to 18 bytes. Both modem firmware and gateway must be upgraded together. Documented in §8.2a of modem-protocol.md.

## Verification

- `cargo build --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅
- `cargo fmt --all` ✅
