### PR TITLE
fix: enforce append-only semantics on Programs table (AZH-0800)

### DIFF
--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -2663,9 +2663,7 @@ mod tests {
             let key = hex::encode(&row.program_hash);
             let mut map = self.program_images.lock().await;
             // Insert-only / first-writer-wins (AZH-0800 AC-4).
-            if !map.contains_key(&key) {
-                map.insert(key, row.clone());
-            }
+            map.entry(key).or_insert_with(|| row.clone());
             self.stored_program_rows.lock().await.push(row.clone());
             Ok(())
         }

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -283,6 +283,11 @@ pub trait HandlerStore: Send + Sync {
         &self,
         program_hash: &[u8],
     ) -> Result<Option<ProgramImageRow>, HandlerError>;
+    /// Insert a program image row into the `Programs` table (AZH-0800).
+    ///
+    /// Uses insert-only (append) semantics with first-writer-wins: if a row
+    /// with the same `program_hash` already exists the call succeeds as a
+    /// no-op and the original row is preserved unchanged.
     async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), HandlerError>;
     /// Append a row to the `SensorData` table for a `GW-0813` message (AZH-0500).
     async fn append_sensor_data(&self, row: &SensorDataRow) -> Result<(), HandlerError>;
@@ -444,7 +449,8 @@ where
                                 node_id = %actual_state.entity_id,
                                 "program row has no elf_image (legacy row); \
                                  DESIRED_STATE will omit inline ELF — \
-                                 re-ingest the program to populate elf_image"
+                                 delete the legacy Programs row and re-ingest \
+                                 the program to populate elf_image"
                             );
                         }
                     } else {
@@ -1016,6 +1022,16 @@ fn is_legacy_not_found(e: &LegacyAzureError) -> bool {
     )
 }
 
+fn is_legacy_conflict(e: &LegacyAzureError) -> bool {
+    matches!(
+        e.kind(),
+        LegacyAzureErrorKind::HttpResponse {
+            status: LegacyStatusCode::Conflict,
+            error_code,
+        } if error_code.as_deref() == Some("EntityAlreadyExists")
+    )
+}
+
 #[async_trait]
 impl HandlerStore for AzureTablesStore {
     async fn append_actual_state(&self, row: &ActualStateRow) -> Result<(), HandlerError> {
@@ -1117,10 +1133,9 @@ impl HandlerStore for AzureTablesStore {
     }
 
     async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), HandlerError> {
-        let row_key = hex::encode(&row.program_hash);
         let entity = ProgramImageEntity {
             partition_key: "program".to_string(),
-            row_key: row_key.clone(),
+            row_key: hex::encode(&row.program_hash),
             cbor_image: base64::engine::general_purpose::STANDARD.encode(&row.cbor_image),
             elf_image: Some(base64::engine::general_purpose::STANDARD.encode(&row.elf_image)),
             source_filename: row.source_filename.clone(),
@@ -1129,16 +1144,19 @@ impl HandlerStore for AzureTablesStore {
             verification_profile: Some(row.verification_profile.clone()),
             created_at: Some(row.created_at.clone()),
         };
-        let entity_client = self
+        match self
             .programs_table
-            .partition_key_client("program")
-            .entity_client(row_key);
-        entity_client
-            .insert_or_replace(entity)
-            .map_err(|e| HandlerError::Store(format!("prepare program-image upsert failed: {e}")))?
+            .insert::<_, ProgramImageEntity>(&entity)
+            .map_err(|e| HandlerError::Store(format!("prepare program-image insert failed: {e}")))?
             .await
-            .map_err(|e| HandlerError::Store(format!("upsert program-image row failed: {e}")))?;
-        Ok(())
+        {
+            Ok(_) => Ok(()),
+            // Entity already exists — treat as no-op (AZH-0800 AC-2).
+            Err(e) if is_legacy_conflict(&e) => Ok(()),
+            Err(e) => Err(HandlerError::Store(format!(
+                "insert program-image row failed: {e}"
+            ))),
+        }
     }
 
     async fn append_sensor_data(&self, row: &SensorDataRow) -> Result<(), HandlerError> {
@@ -2642,10 +2660,12 @@ mod tests {
         }
 
         async fn store_program_image(&self, row: &ProgramImageRow) -> Result<(), HandlerError> {
-            self.program_images
-                .lock()
-                .await
-                .insert(hex::encode(&row.program_hash), row.clone());
+            let key = hex::encode(&row.program_hash);
+            let mut map = self.program_images.lock().await;
+            // Insert-only / first-writer-wins (AZH-0800 AC-4).
+            if !map.contains_key(&key) {
+                map.insert(key, row.clone());
+            }
             self.stored_program_rows.lock().await.push(row.clone());
             Ok(())
         }
@@ -4130,6 +4150,7 @@ mod tests {
         assert!(err.message.contains("verification_profile"));
     }
 
+    // T-AZH-0800: Program image storage is append-only (first-writer-wins).
     #[tokio::test]
     async fn program_ingest_is_idempotent() {
         let (store, handler) = make_ingest_handler();
@@ -4137,6 +4158,17 @@ mod tests {
         let body = make_ingest_body(&elf, Some("v1.o"), Some(1), None);
 
         let resp1 = handler.handle_program_ingest(&body).await.unwrap();
+
+        // Capture original created_at.
+        let hash_bytes = hex::decode(&resp1.program_hash).unwrap();
+        let original_created_at = store
+            .load_program_image(&hash_bytes)
+            .await
+            .unwrap()
+            .unwrap()
+            .created_at
+            .clone();
+
         let body2 = make_ingest_body(&elf, Some("v2.o"), Some(2), None);
         let resp2 = handler.handle_program_ingest(&body2).await.unwrap();
 
@@ -4144,9 +4176,65 @@ mod tests {
         assert_eq!(resp1.program_hash, resp2.program_hash);
 
         // Stored image is still valid.
-        let hash_bytes = hex::decode(&resp1.program_hash).unwrap();
-        let stored = store.load_program_image(&hash_bytes).await.unwrap();
-        assert!(stored.is_some());
+        let stored = store
+            .load_program_image(&hash_bytes)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // First-writer-wins: the original row's metadata is preserved (AZH-0800).
+        assert_eq!(stored.source_filename.as_deref(), Some("v1.o"));
+        assert_eq!(stored.abi_version, Some(1));
+        assert_eq!(
+            stored.created_at, original_created_at,
+            "original created_at preserved"
+        );
+    }
+
+    // T-AZH-0800a: Duplicate program hash returns success without overwrite.
+    #[tokio::test]
+    async fn store_program_image_duplicate_hash_preserves_original() {
+        let store = MemoryStore::default();
+        let hash = vec![0x42u8; 32];
+        let row1 = ProgramImageRow {
+            program_hash: hash.clone(),
+            cbor_image: vec![1, 2, 3],
+            elf_image: vec![4, 5, 6],
+            source_filename: Some("first.o".to_string()),
+            abi_version: Some(1),
+            size_bytes: 3,
+            verification_profile: "resident".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        let row2 = ProgramImageRow {
+            program_hash: hash.clone(),
+            cbor_image: vec![1, 2, 3],
+            elf_image: vec![4, 5, 6],
+            source_filename: Some("second.o".to_string()),
+            abi_version: Some(2),
+            size_bytes: 3,
+            verification_profile: "resident".to_string(),
+            created_at: "2026-06-01T00:00:00Z".to_string(),
+        };
+
+        store.store_program_image(&row1).await.unwrap();
+        store.store_program_image(&row2).await.unwrap();
+
+        let loaded = store.load_program_image(&hash).await.unwrap().unwrap();
+        assert_eq!(
+            loaded.created_at, "2026-01-01T00:00:00Z",
+            "original created_at preserved"
+        );
+        assert_eq!(
+            loaded.source_filename.as_deref(),
+            Some("first.o"),
+            "original metadata preserved"
+        );
+        assert_eq!(
+            loaded.abi_version,
+            Some(1),
+            "original abi_version preserved"
+        );
     }
 
     #[tokio::test]

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -157,7 +157,7 @@ The design uses four Azure Tables:
 1. **`ActualNodeState`** — append-only actual-state history keyed for latest-per-node queries.
 2. **`DesiredNodeState`** — append-only desired-state history keyed for latest-per-node queries.
 3. **`SensorData`** — append-only sensor data history (§6.1).
-4. **`Programs`** — BPF program image store, upserted by `ProgramIngest` (§8).
+4. **`Programs`** — BPF program image store, append-only, written by `ProgramIngest` (§8).
 
 ### 4.1  `ActualNodeState` schema
 
@@ -249,8 +249,11 @@ Each row uses:
 | `verification_profile` | `String` | `"resident"` or `"ephemeral"`. |
 | `created_at` | `String` | ISO 8601 UTC timestamp of ingestion. |
 
-Programs are upserted (insert-or-replace) keyed by `program_hash`. Re-ingesting
-the same ELF overwrites the existing row.
+Programs are inserted (append-only) keyed by `program_hash`. Re-ingesting the
+same ELF is a no-op — the existing row is preserved unchanged. Since
+`program_hash` is SHA-256 of the CBOR image, identical content always produces
+the same hash. First-writer-wins: the response may echo the new request's
+metadata, but the stored row retains original values.
 
 ---
 
@@ -296,8 +299,9 @@ For each node-scoped `GW-0812`, the handler performs the following sequence:
       at key 7, and `abi_version` at key 8. If the program row exists but
       `elf_image` is absent (legacy row ingested before ELF storage was added),
       omit key 5 and log a warning; the gateway will reject the message if it
-      does not already have the program locally. Programs must be re-ingested
-      through `ProgramIngest` to populate the `elf_image` column.
+      does not already have the program locally. To populate `elf_image`,
+      delete the legacy row from the `Programs` table and re-ingest the
+      program.
 12. Publish that payload to the downstream queue.
 
 `ephemeral_program_hash` is intentionally omitted in v1. The gateway connector
@@ -495,10 +499,13 @@ code embedded in the Azure Functions output binding envelope:
 
 ### 8.5  Storage
 
-On successful verification the handler upserts one row in the `Programs` table
+On successful verification the handler inserts one row in the `Programs` table
 (§4.4) containing both the CBOR-encoded program image and the original ELF
-binary. The ELF is retained so the reconciliation path (§5 step 11) can embed
-it in downstream `GW-0811` messages without requiring a separate ELF store.
+binary. If the row already exists (duplicate `program_hash`), the insert is
+treated as a successful no-op — only an entity-already-exists conflict is
+suppressed; other errors propagate. The ELF is retained so the reconciliation
+path (§5 step 11) can embed it in downstream `GW-0811` messages without
+requiring a separate ELF store.
 
 ---
 

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -544,3 +544,27 @@ header into Azure Table Storage responses that lack one, using the SDK's
    `"Windows-Azure-Table/1.0 Microsoft-HTTPAPI/2.0"`.
 2. When the `Server` header is already present, it is not modified.
 3. The workaround is removable when the upstream SDK fix lands.
+
+### AZH-0800  Append-only program image storage
+
+**Priority:** Must
+**Source:** Issue #1098
+
+**Description:**
+The `Programs` table MUST use insert-only (append) semantics, consistent
+with the audit-trail guarantees of the other Azure Tables
+(`ActualNodeState`, `DesiredNodeState`, `SensorData`). The handler MUST
+NOT use insert-or-replace on the `Programs` table.
+
+**Acceptance criteria:**
+
+1. `store_program_image` uses `insert` (not `insert_or_replace`).
+2. If a row with the same `program_hash` RowKey already exists
+   (Azure Table entity-already-exists conflict), the operation succeeds
+   as a no-op — the original row is preserved unchanged.
+3. The `HandlerStore` trait documents insert-only, first-writer-wins
+   semantics for `store_program_image`.
+4. Test mocks enforce insert-only: existing entries are not overwritten.
+5. Legacy rows missing `elf_image` require manual deletion before
+   re-ingest can populate the column; the re-ingest-to-repair path
+   is removed from the design.

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -492,3 +492,27 @@ divergence publication instead of treating that redelivery as permanently stale.
 2. Send a request through the policy chain.
 3. Assert: the returned response contains a `Server` header with value
    `"OriginalServer/1.0"` (unmodified).
+
+### T-AZH-0800  Program image storage is append-only
+
+**Validates:** AZH-0800 (AC-1, AC-3, AC-4)
+
+**Procedure:**
+1. Create a `MemoryStore` instance.
+2. Ingest a program ELF via `handle_program_ingest`.
+3. Assert: `store_program_image` was called and the row is persisted.
+4. Ingest the same ELF again.
+5. Assert: the operation succeeds (no error).
+6. Assert: the original row's `created_at` timestamp is unchanged.
+
+### T-AZH-0800a  Duplicate program hash returns success without overwrite
+
+**Validates:** AZH-0800 (AC-2)
+
+**Procedure:**
+1. Call `store_program_image` with a valid `ProgramImageRow`.
+2. Call `store_program_image` again with the same `program_hash`
+   but a different `created_at`.
+3. Assert: the second call returns `Ok(())`.
+4. Assert: loading the program by hash returns the original row
+   (first `created_at` preserved).


### PR DESCRIPTION
## Summary

Replaces `insert_or_replace` with `insert` in `store_program_image` so the `Programs` Azure Table uses append-only semantics, matching `ActualNodeState`, `DesiredNodeState`, and `SensorData`.

Duplicate `program_hash` inserts (HTTP 409 `EntityAlreadyExists`) are treated as a no-op - the original row is preserved unchanged (first-writer-wins).

## Requirement

**AZH-0800** - Append-only program image storage (Issue #1098)

## Changes

### Specifications (3 files)
- `azure-handler-requirements.md`: Added AZH-0800
- `azure-handler-design.md`: Updated section 4 table list, section 4.4 schema, section 5 step 11 (legacy `elf_image` repair), section 8.5 storage
- `azure-handler-validation.md`: Added T-AZH-0800 and T-AZH-0800a

### Code (`crates/sonde-azure-handler/src/lib.rs`)
- `store_program_image`: `insert` + `EntityAlreadyExists` conflict = no-op
- New `is_legacy_conflict` helper (matches `EntityAlreadyExists` only)
- `HandlerStore` trait doc comment: insert-only, first-writer-wins contract
- `MemoryStore` mock: insert-only with `contains_key` guard
- Legacy `elf_image` warning: updated to say "delete the legacy row and re-ingest"
- Enhanced `program_ingest_is_idempotent` test (T-AZH-0800)
- New `store_program_image_duplicate_hash_preserves_original` test (T-AZH-0800a)

## Traceability

| Requirement | Design | Validation | Code |
|-------------|--------|------------|------|
| AZH-0800 AC-1 | section 4.4, 8.5 | T-AZH-0800 | `store_program_image` uses `insert` |
| AZH-0800 AC-2 | section 4.4 | T-AZH-0800a | `is_legacy_conflict` -> `Ok(())` |
| AZH-0800 AC-3 | section 4.4 | T-AZH-0800 | `HandlerStore` trait doc |
| AZH-0800 AC-4 | section 4.4 | T-AZH-0800 | `MemoryStore` `contains_key` guard |
| AZH-0800 AC-5 | section 5 step 11 | - | Warning text updated |

## Testing

All 99 `sonde-azure-handler` tests pass. Zero `insert_or_replace` calls remain in Rust code.

Closes #1098
