### PR TITLE
Remove dead upsertEntity function from SPA

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -1116,20 +1116,6 @@ async function insertEntity(tableName, entity) {
   });
 }
 
-async function upsertEntity(tableName, partitionKey, rowKey, entity) {
-  const token = await getToken();
-  return fetchJson(entityUrl(tableName, partitionKey, rowKey), {
-    method: 'PUT',
-    headers: {
-      Accept: 'application/json;odata=nometadata',
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-      'x-ms-version': '2019-02-02',
-    },
-    body: JSON.stringify(entity),
-  });
-}
-
 async function listPrograms() {
   return sortByDateDesc(await queryTable(CONFIG.programsTable, "PartitionKey eq 'program'"), 'created_at');
 }


### PR DESCRIPTION
## Summary

Remove the dead `upsertEntity()` function from `deploy/web-ui/app.js`.

## Problem

The SPA defined an `upsertEntity()` function (HTTP PUT / Azure Table InsertOrReplace) that was **never called**. All SPA writes correctly use `insertEntity()` (HTTP POST). The dead code was a footgun: a future contributor could call it by mistake, silently breaking the append-only invariant on Azure Storage tables.

## Changes

- Deleted `upsertEntity()` function (13 lines) from `deploy/web-ui/app.js`
- Verified zero callers exist across the codebase

## Traceability

- **Requirement**: Issue #1099 — remove dead code to prevent accidental misuse
- **Specification impact**: None — no spec docs reference this function
- **Behavioral impact**: None — function was never called

## Acceptance Criteria

- [x] Delete the `upsertEntity` function from `app.js`
- [x] Verify no callers exist (confirmed: zero references)

Closes #1099