### PR TITLE
fix: fleet-scoped KDF salt for disaster recovery

### DIFF
--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -149,6 +149,19 @@ pub struct GatewayDesiredStateRow {
     pub timestamp_ms: u64,
 }
 
+/// Fleet-scoped KDF row in the `desiredstate` table (§4.3.1).
+///
+/// Stores the authoritative salt and KDF params for master key derivation.
+/// Read by the SPA during key rotation; written by the handler whenever a
+/// gateway reports a non-null salt that differs from the current fleet salt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetKdfRow {
+    pub row_key: String,
+    pub salt: Vec<u8>,
+    pub kdf_params_json: Option<String>,
+    pub timestamp_ms: u64,
+}
+
 impl ActualStateRow {
     fn from_message(message: &ActualStateMessage) -> Result<Self, HandlerError> {
         Ok(Self {
@@ -325,6 +338,12 @@ pub trait HandlerStore: Send + Sync {
         &self,
         row: &GatewayDesiredStateRow,
     ) -> Result<(), HandlerError>;
+
+    /// Load the latest fleet-scoped KDF row (§4.3.1).
+    async fn load_fleet_kdf(&self) -> Result<Option<FleetKdfRow>, HandlerError>;
+
+    /// Append a fleet-scoped KDF row (§4.3.1).
+    async fn append_fleet_kdf(&self, row: &FleetKdfRow) -> Result<(), HandlerError>;
 }
 
 #[async_trait]
@@ -625,6 +644,36 @@ where
         } else {
             None
         };
+
+        // Fleet KDF update (§4.3.1): append fleet-scoped KDF row when
+        // gateway reports a non-null salt that differs from the current fleet
+        // salt or KDF params. This survives gateway identity changes during
+        // disaster recovery.
+        if let Some(ref gw_salt) = msg.salt {
+            let fleet_kdf = self.store.load_fleet_kdf().await?;
+            let should_append = match fleet_kdf.as_ref() {
+                Some(current) => {
+                    // Skip if this message is older than the current fleet row.
+                    if current.timestamp_ms > msg.timestamp_ms {
+                        false
+                    } else {
+                        // Append if salt or kdf_params changed.
+                        current.salt != *gw_salt
+                            || current.kdf_params_json != gw_row.kdf_params_json
+                    }
+                }
+                None => true, // No fleet row exists yet.
+            };
+            if should_append {
+                let fleet_row = FleetKdfRow {
+                    row_key: next_history_row_key(msg.timestamp_ms)?,
+                    salt: gw_salt.clone(),
+                    kdf_params_json: gw_row.kdf_params_json.clone(),
+                    timestamp_ms: msg.timestamp_ms,
+                };
+                self.store.append_fleet_kdf(&fleet_row).await?;
+            }
+        }
 
         // Construct gateway DESIRED_STATE if there's anything to send.
         let has_content =
@@ -1355,6 +1404,55 @@ impl HandlerStore for AzureTablesStore {
             })?;
         Ok(())
     }
+
+    async fn load_fleet_kdf(&self) -> Result<Option<FleetKdfRow>, HandlerError> {
+        let mut stream = self
+            .desired_state_table
+            .query()
+            .filter(partition_filter("fleet"))
+            .top(1)
+            .into_stream::<FleetKdfEntity>();
+        match stream.next().await {
+            Some(Ok(response)) => response
+                .entities
+                .into_iter()
+                .next()
+                .map(|e| {
+                    let salt = base64::engine::general_purpose::STANDARD
+                        .decode(&e.salt)
+                        .map_err(|err| {
+                            HandlerError::Store(format!("decode fleet salt base64 failed: {err}"))
+                        })?;
+                    Ok(FleetKdfRow {
+                        row_key: e.row_key,
+                        salt,
+                        kdf_params_json: e.kdf_params_json,
+                        timestamp_ms: e.timestamp_ms,
+                    })
+                })
+                .transpose(),
+            Some(Err(e)) => Err(HandlerError::Store(format!(
+                "query fleet KDF row failed: {e}"
+            ))),
+            None => Ok(None),
+        }
+    }
+
+    async fn append_fleet_kdf(&self, row: &FleetKdfRow) -> Result<(), HandlerError> {
+        let entity = FleetKdfEntity {
+            partition_key: "fleet".to_string(),
+            row_key: row.row_key.clone(),
+            salt: base64::engine::general_purpose::STANDARD.encode(&row.salt),
+            kdf_params_json: row.kdf_params_json.clone(),
+            timestamp_ms: row.timestamp_ms,
+        };
+        self.desired_state_table
+            .insert::<_, FleetKdfEntity>(&entity)
+            .map_err(|e| HandlerError::Store(format!("prepare fleet KDF insert failed: {e}")))?
+            .await
+            .map_err(|e| HandlerError::Store(format!("append fleet KDF row failed: {e}")))?;
+        Ok(())
+    }
 }
 
 const STORAGE_QUEUE_API_VERSION: &str = "2024-11-04";
@@ -1519,6 +1617,23 @@ struct GatewayDesiredStateEntity {
     row_key: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     rotation_payload: Option<String>,
+    #[serde(
+        deserialize_with = "deserialize_u64_flexible",
+        default = "default_zero_u64"
+    )]
+    timestamp_ms: u64,
+}
+
+/// Fleet-scoped KDF entity for Azure Table (§4.3.1).
+#[derive(Debug, Deserialize, Serialize, Clone)]
+struct FleetKdfEntity {
+    #[serde(rename = "PartitionKey")]
+    partition_key: String,
+    #[serde(rename = "RowKey")]
+    row_key: String,
+    salt: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    kdf_params_json: Option<String>,
     #[serde(
         deserialize_with = "deserialize_u64_flexible",
         default = "default_zero_u64"
@@ -2560,6 +2675,7 @@ mod tests {
         sensor_data_rows: Mutex<Vec<SensorDataRow>>,
         gateway_actual_states: Mutex<HashMap<String, Vec<GatewayActualStateRow>>>,
         gateway_desired_states: Mutex<HashMap<String, Vec<GatewayDesiredStateRow>>>,
+        fleet_kdf_rows: Mutex<Vec<FleetKdfRow>>,
     }
 
     impl MemoryStore {
@@ -2753,6 +2869,21 @@ mod tests {
                 .push(row.clone());
             Ok(())
         }
+
+        async fn load_fleet_kdf(&self) -> Result<Option<FleetKdfRow>, HandlerError> {
+            Ok(self
+                .fleet_kdf_rows
+                .lock()
+                .await
+                .iter()
+                .min_by_key(|r| &r.row_key)
+                .cloned())
+        }
+
+        async fn append_fleet_kdf(&self, row: &FleetKdfRow) -> Result<(), HandlerError> {
+            self.fleet_kdf_rows.lock().await.push(row.clone());
+            Ok(())
+        }
     }
 
     #[derive(Default)]
@@ -2882,6 +3013,14 @@ mod tests {
         ) -> Result<(), HandlerError> {
             Ok(())
         }
+
+        async fn load_fleet_kdf(&self) -> Result<Option<FleetKdfRow>, HandlerError> {
+            Ok(None)
+        }
+
+        async fn append_fleet_kdf(&self, _row: &FleetKdfRow) -> Result<(), HandlerError> {
+            Ok(())
+        }
     }
 
     struct SameTimestampDifferentLatestStore {
@@ -2958,6 +3097,14 @@ mod tests {
             &self,
             _row: &GatewayDesiredStateRow,
         ) -> Result<(), HandlerError> {
+            Ok(())
+        }
+
+        async fn load_fleet_kdf(&self) -> Result<Option<FleetKdfRow>, HandlerError> {
+            Ok(None)
+        }
+
+        async fn append_fleet_kdf(&self, _row: &FleetKdfRow) -> Result<(), HandlerError> {
             Ok(())
         }
     }
@@ -3037,6 +3184,14 @@ mod tests {
             &self,
             _row: &GatewayDesiredStateRow,
         ) -> Result<(), HandlerError> {
+            Ok(())
+        }
+
+        async fn load_fleet_kdf(&self) -> Result<Option<FleetKdfRow>, HandlerError> {
+            Ok(None)
+        }
+
+        async fn append_fleet_kdf(&self, _row: &FleetKdfRow) -> Result<(), HandlerError> {
             Ok(())
         }
     }
@@ -4298,6 +4453,12 @@ mod tests {
             ) -> Result<(), HandlerError> {
                 Ok(())
             }
+            async fn load_fleet_kdf(&self) -> Result<Option<FleetKdfRow>, HandlerError> {
+                Ok(None)
+            }
+            async fn append_fleet_kdf(&self, _: &FleetKdfRow) -> Result<(), HandlerError> {
+                Ok(())
+            }
         }
 
         let store = Arc::new(FailingProgramStore);
@@ -5410,6 +5571,182 @@ mod tests {
         assert!(sends.is_empty(), "no DESIRED_STATE for gateway with salt");
     }
 
+    // --- T-AZH-2004: Fleet-scoped KDF storage (disaster recovery) ---
+    #[tokio::test]
+    async fn t_azh_2004_fleet_kdf_storage() {
+        let store = Arc::new(MemoryStore::default());
+        let publisher = Arc::new(RecordingPublisher::default());
+        let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
+
+        let master_key_id = vec![0xAAu8; 16];
+        let salt_a = vec![0xAAu8; 16];
+        let kdf_a = (131072, 4, 2); // m_cost, t_cost, p_cost
+
+        // Step 1: Gateway A reports salt + kdf_params — fleet KDF row created.
+        let payload1 = encode_gateway_actual_state_msg_with_kdf(
+            "aa110011",
+            1000,
+            6,
+            &master_key_id,
+            1,
+            &[0x55u8; 32],
+            Some(&salt_a),
+            Some(kdf_a),
+            false,
+        );
+        handler.handle_payload(&payload1).await.unwrap();
+
+        // Step 2: Verify fleet KDF row exists with salt_a and kdf_params.
+        let fleet = store.load_fleet_kdf().await.unwrap();
+        assert!(fleet.is_some(), "fleet KDF row should exist");
+        let fleet = fleet.unwrap();
+        assert_eq!(fleet.salt, salt_a);
+        assert!(
+            fleet.kdf_params_json.is_some(),
+            "fleet KDF row should have kdf_params"
+        );
+        let params: serde_json::Value =
+            serde_json::from_str(fleet.kdf_params_json.as_ref().unwrap()).unwrap();
+        assert_eq!(params["m_cost"], 131072);
+        assert_eq!(params["t_cost"], 4);
+        assert_eq!(params["p_cost"], 2);
+
+        // Step 3: Gateway A reports same salt + params again — no duplicate row.
+        let payload2 = encode_gateway_actual_state_msg_with_kdf(
+            "aa110011",
+            2000,
+            6,
+            &master_key_id,
+            1,
+            &[0x55u8; 32],
+            Some(&salt_a),
+            Some(kdf_a),
+            false,
+        );
+        handler.handle_payload(&payload2).await.unwrap();
+        let fleet_rows_count = store.fleet_kdf_rows.lock().await.len();
+        assert_eq!(
+            fleet_rows_count, 1,
+            "same salt+params should not create duplicate fleet row"
+        );
+
+        // Step 4-5: Gateway B reports different salt + params — new fleet row appended.
+        let salt_b = vec![0xBBu8; 16];
+        let kdf_b = (65536, 3, 1);
+        let payload3 = encode_gateway_actual_state_msg_with_kdf(
+            "bb220022",
+            3000,
+            6,
+            &master_key_id,
+            1,
+            &[0x55u8; 32],
+            Some(&salt_b),
+            Some(kdf_b),
+            false,
+        );
+        handler.handle_payload(&payload3).await.unwrap();
+        let fleet_rows_count = store.fleet_kdf_rows.lock().await.len();
+        assert_eq!(
+            fleet_rows_count, 2,
+            "different salt should create new fleet row"
+        );
+
+        // Step 6: Latest fleet salt is salt_b with kdf_b params (latest-wins).
+        let fleet = store.load_fleet_kdf().await.unwrap().unwrap();
+        assert_eq!(fleet.salt, salt_b, "latest fleet salt should be salt_b");
+        let params: serde_json::Value =
+            serde_json::from_str(fleet.kdf_params_json.as_ref().unwrap()).unwrap();
+        assert_eq!(params["m_cost"], 65536);
+        assert_eq!(params["t_cost"], 3);
+        assert_eq!(params["p_cost"], 1);
+
+        // Step 7-8: Gateway C reports null salt — no fleet update.
+        let payload4 = encode_gateway_actual_state_msg(
+            "cc330033",
+            4000,
+            6,
+            &master_key_id,
+            1,
+            &[0x55u8; 32],
+            None,
+            false,
+        );
+        handler.handle_payload(&payload4).await.unwrap();
+        let fleet_rows_count = store.fleet_kdf_rows.lock().await.len();
+        assert_eq!(fleet_rows_count, 2, "null salt should not create fleet row");
+
+        // Step 9: DESIRED_STATE relay unchanged — fleet salt NOT injected.
+        // Gateway C has null salt and no previous ACTUAL_STATE for this gateway_id.
+        // No per-gateway desired state row exists, so no DESIRED_STATE is published
+        // (fleet KDF row does NOT inject into DESIRED_STATE per §4.3.1).
+        // The only send should have been from step 7-8's AZH-0604 logic using
+        // the previous row (none for gw-c), so no desired_salt.
+        // Check that fleet salt was NOT injected into any DESIRED_STATE.
+        let sends = publisher.sends.lock().await;
+        for (_, payload) in sends.iter() {
+            let decoded: Value = ciborium::from_reader(&payload[..]).unwrap();
+            let map = decoded.as_map().unwrap();
+            if let Some(desired_state_val) = map_get(map, 4) {
+                let desired_map = desired_state_val.as_map().unwrap();
+                // If salt is present in DESIRED_STATE, it must come from per-gateway
+                // previous row, not fleet salt.
+                if let Some(salt_val) = map_get(desired_map, 21) {
+                    assert_ne!(
+                        salt_val.as_bytes().unwrap(),
+                        &salt_b,
+                        "fleet salt should NOT appear in DESIRED_STATE"
+                    );
+                }
+            }
+        }
+        drop(sends);
+
+        // Step 10: Stale message does not update fleet KDF.
+        let salt_c = vec![0xCCu8; 16];
+        let stale_payload = encode_gateway_actual_state_msg(
+            "dd440044",
+            500, // timestamp older than fleet row (3000)
+            6,
+            &master_key_id,
+            1,
+            &[0x55u8; 32],
+            Some(&salt_c),
+            false,
+        );
+        handler.handle_payload(&stale_payload).await.unwrap();
+        let fleet = store.load_fleet_kdf().await.unwrap().unwrap();
+        assert_eq!(
+            fleet.salt, salt_b,
+            "stale message should not update fleet salt"
+        );
+
+        // Bonus: same salt but different kdf_params triggers update.
+        let kdf_c = (262144, 5, 4);
+        let payload5 = encode_gateway_actual_state_msg_with_kdf(
+            "ee550055",
+            5000,
+            6,
+            &master_key_id,
+            1,
+            &[0x55u8; 32],
+            Some(&salt_b), // same salt as fleet
+            Some(kdf_c),   // different params
+            false,
+        );
+        handler.handle_payload(&payload5).await.unwrap();
+        let fleet_rows_count = store.fleet_kdf_rows.lock().await.len();
+        assert_eq!(
+            fleet_rows_count, 3,
+            "same salt but different params should create new fleet row"
+        );
+        let fleet = store.load_fleet_kdf().await.unwrap().unwrap();
+        let params: serde_json::Value =
+            serde_json::from_str(fleet.kdf_params_json.as_ref().unwrap()).unwrap();
+        assert_eq!(params["m_cost"], 262144);
+        assert_eq!(params["t_cost"], 5);
+        assert_eq!(params["p_cost"], 4);
+    }
+
     // --- T-AZH-0605: No phone escrow rows ---
     #[tokio::test]
     async fn t_azh_0605_phone_actual_state_ignored() {
@@ -5493,6 +5830,50 @@ mod tests {
         match salt {
             Some(s) => pairs.push(map_entry(21, Value::Bytes(s.to_vec()))),
             None => pairs.push(map_entry(21, Value::Null)),
+        }
+        pairs.push(map_entry(27, Value::Bool(rotation_in_progress)));
+        let value = Value::Map(pairs);
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&value, &mut bytes).unwrap();
+        bytes
+    }
+
+    /// Encode gateway ACTUAL_STATE with KDF params (CBOR key 22).
+    #[allow(clippy::too_many_arguments)]
+    fn encode_gateway_actual_state_msg_with_kdf(
+        entity_id: &str,
+        timestamp_ms: u64,
+        channel: u64,
+        master_key_id: &[u8],
+        master_key_epoch: u64,
+        x25519_public_key: &[u8],
+        salt: Option<&[u8]>,
+        kdf_params: Option<(u64, u64, u64)>, // (m_cost, t_cost, p_cost)
+        rotation_in_progress: bool,
+    ) -> Vec<u8> {
+        let mut pairs = vec![
+            map_entry(1, Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
+            map_entry(2, Value::Text("gateway".to_string())),
+            map_entry(3, Value::Text(entity_id.to_string())),
+            map_entry(9, Value::Integer(timestamp_ms.into())),
+            map_entry(15, Value::Integer(channel.into())),
+            map_entry(16, Value::Bytes(master_key_id.to_vec())),
+            map_entry(17, Value::Integer(master_key_epoch.into())),
+            map_entry(18, Value::Bytes(x25519_public_key.to_vec())),
+        ];
+        match salt {
+            Some(s) => pairs.push(map_entry(21, Value::Bytes(s.to_vec()))),
+            None => pairs.push(map_entry(21, Value::Null)),
+        }
+        if let Some((m, t, p)) = kdf_params {
+            pairs.push(map_entry(
+                22,
+                Value::Map(vec![
+                    map_entry(1, Value::Integer(m.into())),
+                    map_entry(2, Value::Integer(t.into())),
+                    map_entry(3, Value::Integer(p.into())),
+                ]),
+            ));
         }
         pairs.push(map_entry(27, Value::Bool(rotation_in_progress)));
         let value = Value::Map(pairs);

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -623,6 +623,33 @@ handler includes the stored salt only if the gateway reports `salt = null`.
 If the gateway reports a non-null salt, the handler preserves that value in the
 gateway row and does not override it via DESIRED_STATE.
 
+#### 9.5.1  Fleet-scoped KDF state (disaster recovery)
+
+To survive gateway identity changes, the handler maintains a fleet-scoped
+KDF row in the `desiredstate` table:
+
+- `PartitionKey = "fleet"`, `RowKey` = reverse-timestamp via
+  `next_history_row_key()`.
+- The row carries both `salt` (base64-encoded binary) and `kdf_params_json`
+  (JSON string).
+- When a gateway reports a non-null salt in ACTUAL_STATE, the handler appends
+  a fleet KDF row **only if** the reported salt differs from the current fleet
+  salt (or no fleet row exists yet). This prevents unbounded row accumulation.
+  The existing stale-message guards (pre-append and post-append timestamp
+  checks) apply: a stale gateway report does not update the fleet row.
+- Loading uses the same `$top=1` latest-row query as
+  `load_gateway_desired_state`.
+
+The fleet KDF row does **not** affect gateway DESIRED_STATE construction.
+DESIRED_STATE relay continues to use the gateway's own desired state record
+(unchanged). The fleet KDF row is consumed exclusively by the SPA during key
+rotation: the SPA reads the latest fleet salt and KDF params for
+`Argon2id(passphrase, salt, kdf_params)` master key derivation.
+
+Fleet-scoped `desiredstate` rows (`PartitionKey = "fleet"`) are
+handler-internal. The SPA reads them for rotation but filters gateway
+desired-state rows by `PartitionKey` starting with `"g:"`.
+
 Gateway DESIRED_STATE uses:
 
 - `entity_kind = "gateway"`

--- a/docs/evolve-962-specification.md
+++ b/docs/evolve-962-specification.md
@@ -648,6 +648,50 @@ Salt conflict resolution: the handler stores whatever the gateway reports
 (gateway is authoritative for its own salt). The handler includes its
 stored salt in DESIRED_STATE only for gateways that report `salt = null`.
 
+#### 4.3.1  Fleet-scoped salt and KDF params (disaster recovery)
+
+To survive gateway identity changes during disaster recovery, the handler
+maintains a **fleet-scoped KDF row** in the `desiredstate` table:
+
+- `PartitionKey = "fleet"`, `RowKey` = reverse-timestamp via
+  `next_history_row_key()` (same append-only scheme as other desired state
+  rows).
+- The row carries both `salt` (base64-encoded binary) and `kdf_params_json`
+  (JSON string) — both are required for correct `Argon2id` master key
+  re-derivation.
+- When a gateway reports a non-null salt in ACTUAL_STATE, the handler
+  appends a fleet KDF row **only if** the reported salt differs from the
+  current fleet salt (or no fleet row exists yet). This prevents unbounded
+  row accumulation from repeated identical reports. The stale-message
+  guards (pre-append and post-append timestamp checks) that protect
+  gateway ACTUAL_STATE rows also apply: a stale gateway report that
+  fails stale checks does not update the fleet row.
+- Loading uses the same `$top=1` latest-row query as other desired state
+  lookups.
+
+The fleet KDF row does **not** affect gateway DESIRED_STATE construction.
+DESIRED_STATE relay continues to use the gateway's own desired state
+record (unchanged). The fleet KDF row is consumed exclusively by the SPA
+during key rotation (see §9): the SPA reads the latest fleet salt and
+KDF params from the `desiredstate` table and uses them for
+`Argon2id(passphrase, salt, kdf_params)` master key derivation. This
+ensures a replacement gateway (new `gateway_id` after DB loss) can
+receive a correctly derived master key via the rotation payload, even
+though the handler has no per-gateway salt history for the new identity.
+
+Fleet-scoped `desiredstate` rows (`PartitionKey = "fleet"`) are
+handler-internal. The SPA reads them for rotation but MUST NOT treat
+them as gateway desired-state rows (SPA filters gateway rows by
+`PartitionKey` starting with `"g:"`).
+
+**Limitation — concurrent rotation race:** If two gateways both have
+`salt = null` and an admin rotates both simultaneously, each generates a
+different salt. Both rotations succeed (the master key is delivered
+directly in the rotation payload). Both gateways append fleet KDF rows;
+the latest writer's salt becomes the fleet salt. The admin must
+re-rotate one gateway to converge on the fleet salt. No automated
+indication of this condition is provided.
+
 ### 4.4  Rotation payload relay
 
 The handler does not originate or modify rotation payloads. The SPA
@@ -1124,6 +1168,38 @@ identity loading failure.
 
 ---
 
+### T-AZH-2004  Fleet-scoped KDF storage (disaster recovery)
+
+**Covers:** §4.3.1
+**Method:** Integration test
+
+**Steps:**
+1. Send gateway ACTUAL_STATE from gateway A with `salt = [0xAA; 16]`
+   and `kdf_params = {m: 131072, t: 4, p: 2}`.
+2. Verify a fleet KDF row is appended in the `desiredstate` table
+   (`PartitionKey = "fleet"`) carrying both salt and kdf_params.
+3. Verify that gateway A reporting the same salt again does **not** append
+   a duplicate fleet KDF row (deduplication check).
+4. Send gateway ACTUAL_STATE from gateway B (different `gateway_id`)
+   with `salt = [0xBB; 16]` and `kdf_params = {m: 65536, t: 3, p: 1}`.
+5. Verify a new fleet KDF row is appended with the updated values.
+6. Load the latest fleet KDF row — verify it returns `[0xBB; 16]` and the
+   updated kdf_params (latest-wins, not `[0xAA; 16]`).
+7. Send gateway ACTUAL_STATE from gateway C with `salt = null`.
+8. Verify no fleet KDF row is appended (null salt does not update fleet).
+9. Verify the existing DESIRED_STATE relay for gateway C is **unchanged**:
+   the handler uses the per-gateway desired state record (not fleet salt)
+   for DESIRED_STATE construction.
+10. Send a stale gateway ACTUAL_STATE (older timestamp than the latest
+    fleet KDF row) from gateway D with a different salt `[0xCC; 16]`.
+    Verify no fleet KDF row is appended (stale-message guard).
+
+**Pass criteria:** Fleet KDF rows are append-only, latest-wins,
+deduplicated, and stale-guarded; null salt does not update fleet;
+DESIRED_STATE relay behavior is unchanged.
+
+---
+
 ## 9  Design Changes — Web UI (SPA)
 
 The SPA rotation flow is fully specified in the web-ui spec trifecta:
@@ -1144,8 +1220,12 @@ The SPA performs master key rotation via the following flow:
    the locally-computed fingerprint and prompt operator to verify against
    the modem display.
 3. Prompt for rotation code (from modem display) and passphrase.
-4. Derive new master key: `Argon2id(passphrase, salt, kdf_params)` using
-   a WASM Argon2id implementation.
+4. Read the **fleet salt and KDF params** from the latest fleet KDF row
+   in the `desiredstate` table (`PartitionKey = "fleet"`, `$top=1`).
+   If no fleet KDF row exists (first rotation), generate a new random
+   16-byte salt and use default KDF params (`m=65536, t=3, p=1`).
+   Derive new master key: `Argon2id(passphrase, fleet_salt, kdf_params)`
+   using a WASM Argon2id implementation.
 5. Construct `RotationPayloadV1` (§2.6.1) using browser-side cryptography:
    X25519 key exchange via `noble-curves`, HKDF-SHA-256 and AES-256-GCM
    via Web Crypto API.

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -637,8 +637,9 @@ against the gateway actual-state row.
   4. Submit button
 - The `Rotate Key` button toggles the form's visibility. When expanded, the
   form appears below the gateway status fields within the same card panel.
-- Displays the current salt from gateway ACTUAL_STATE, or a `first rotation`
-  indicator when no salt exists yet.
+- Displays the current fleet salt from the latest fleet KDF row in the
+  `desiredstate` table (`PartitionKey = "fleet"`, `$top=1`), or a `first
+  rotation` indicator when no fleet KDF row exists yet.
 - Shows a progress indicator during Argon2id key derivation because the WASM
   KDF may take ~1–3 seconds.
 - After successful submission, the form displays "Rotation submitted" and
@@ -681,6 +682,11 @@ against the gateway actual-state row.
 - Gateway DESIRED_STATE `PartitionKey` is `"g:" + gateway_id_hex`
 - Gateway DESIRED_STATE `RowKey` uses the same reverse-timestamp format as node
   desired state rows
+- Fleet KDF read (for key rotation):
+  `GET /desiredstate?$filter=PartitionKey eq 'fleet'&$top=1`
+  Returns the latest fleet KDF row carrying `salt` and `kdf_params_json`.
+  Used only during key rotation to obtain the authoritative salt and KDF
+  parameters for master key derivation.
 
 ### 13.5 Dashboard Filtering
 

--- a/docs/web-ui-requirements.md
+++ b/docs/web-ui-requirements.md
@@ -1151,8 +1151,9 @@ collapsible rotation form within the card. The form shows (1) the BIP-39
 fingerprint with instructions to verify it against the modem, (2) a rotation
 code input limited to 6 characters and normalized to uppercase `[A-Z0-9]`,
 (3) a masked passphrase input that requires either at least 20 characters or
-6 space-separated words, (4) the current salt from the gateway ACTUAL_STATE
-or a `first rotation` indicator if the salt is null, and (5) a confirmation
+6 space-separated words, (4) the current fleet salt from the latest fleet KDF
+row in the `desiredstate` table (`PartitionKey = "fleet"`)
+or a `first rotation` indicator if no fleet KDF row exists, and (5) a confirmation
 action. If the browser lacks the required rotation crypto capabilities, the
 button MUST be disabled with a tooltip explaining the requirement.
 
@@ -1173,6 +1174,8 @@ resumes when the form collapses.
 3. Unsupported browsers show the action as disabled with an explanatory message.
 4. After submission the form shows a success message and collapses.
 5. Dashboard auto-refresh is paused while the rotation form is expanded.
+6. When a fleet KDF row exists, the form displays the fleet salt; when no fleet
+   KDF row exists, the form shows a `first rotation` indicator.
 
 ---
 
@@ -1185,17 +1188,19 @@ resumes when the form collapses.
 **Description:**
 The SPA MUST derive the new master key using
 `Argon2id(passphrase, salt, kdf_params)` via a WASM Argon2id implementation
-(e.g., `argon2-browser`). The default KDF parameters for the first rotation are
-`m_cost=65536`, `t_cost=3`, and `p_cost=1`. If the gateway ACTUAL_STATE
-includes `kdf_params`, the SPA MUST use those parameters instead. Passphrase and
-derived key material MUST be cleared from JavaScript variables after use on a
-best-effort basis.
+(e.g., `argon2-browser`). The SPA reads the salt and KDF params from the latest
+fleet KDF row in the `desiredstate` table (`PartitionKey = "fleet"`, `$top=1`).
+If no fleet KDF row exists (first rotation), the SPA generates a new random
+16-byte salt and uses default KDF parameters (`m_cost=65536`, `t_cost=3`,
+`p_cost=1`). Passphrase and derived key material MUST be cleared from JavaScript
+variables after use on a best-effort basis.
 
 **Acceptance criteria:**
 
 1. The derived key matches the gateway's expected output for the same inputs.
-2. `kdf_params` from ACTUAL_STATE are used when present.
-3. Key material is cleared after use on a best-effort basis.
+2. `salt` and `kdf_params` from the latest fleet KDF row are used when present.
+3. When no fleet KDF row exists, a new random salt and default KDF params are used.
+4. Key material is cleared after use on a best-effort basis.
 
 ---
 

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -104,8 +104,8 @@ and verifies one or more acceptance criteria.
 | WEB-0901 | T-WEB-0901, T-WEB-0901b, T-WEB-0901c |
 | WEB-0902 | T-WEB-0902, T-WEB-0902b |
 | WEB-1001 | T-WEB-1001, T-WEB-1001b, T-WEB-1001c, T-WEB-1001d |
-| WEB-1002 | T-WEB-1002, T-WEB-1002b, T-WEB-1002c, T-WEB-1002d, T-WEB-1002e |
-| WEB-1003 | T-WEB-1003, T-WEB-1003b |
+| WEB-1002 | T-WEB-1002, T-WEB-1002b, T-WEB-1002c, T-WEB-1002d, T-WEB-1002e, T-WEB-1002f |
+| WEB-1003 | T-WEB-1003, T-WEB-1003b, T-WEB-1003c |
 | WEB-1004 | T-WEB-1004 |
 | WEB-1005 | T-WEB-1005 |
 | WEB-1006 | ~~T-WEB-1006, T-WEB-1006b~~ (retired — Issue #1092) |
@@ -349,8 +349,10 @@ and verifies one or more acceptance criteria.
 | T-WEB-1002c | WEB-1002 | Rotation is disabled on unsupported browsers | Manual | Planned |
 | T-WEB-1002d | WEB-1002 | After submission, form shows success message and collapses (no inline polling) | Manual | Planned |
 | T-WEB-1002e | WEB-1002 | Dashboard auto-refresh is paused while rotation form is expanded | Manual | Planned |
+| T-WEB-1002f | WEB-1002 | Rotation form displays fleet salt from fleet KDF row, or `first rotation` indicator when no fleet row exists | Manual | Planned |
 | T-WEB-1003 | WEB-1003 | Argon2id key derivation produces the correct output | Unit (JS) | Planned |
-| T-WEB-1003b | WEB-1003 | KDF params from ACTUAL_STATE are used when present | Unit (JS) | Planned |
+| T-WEB-1003b | WEB-1003 | Salt and KDF params from fleet KDF row are used when present | Unit (JS) | Planned |
+| T-WEB-1003c | WEB-1003 | First rotation fallback: when no fleet KDF row exists, a new random salt and default KDF params are used | Unit (JS) | Planned |
 | T-WEB-1004 | WEB-1004 | `RotationPayloadV1` construction matches the specified binary format | Unit (JS) | Planned |
 | T-WEB-1005 | WEB-1005 | DESIRED_STATE row is created with the correct gateway `PartitionKey` and includes `submitted_epoch` | Integration | Planned |
 | T-WEB-1006 | WEB-1006 | ~~Successful rotation is detected via `master_key_epoch` polling~~ **Retired** (Issue #1092) | — | Retired |


### PR DESCRIPTION
## Summary

Fixes #1108 — KDF salt lost when gateway identity changes during disaster recovery, causing master key mismatch and data loss.

## Root Cause

Salt was stored only per-\gateway_id\ in \ActualState\. When a gateway lost its DB and restarted with a new identity, the old salt was orphaned. The SPA would generate a new salt during key rotation, producing a different master key and making escrowed PSKs unrecoverable.

## Solution

Store KDF salt and params at **fleet scope** in the \desiredstate\ table (\PartitionKey = \"fleet\"\). The SPA reads the fleet salt during key rotation instead of the gateway's \ACTUAL_STATE\ salt.

### Handler changes
- \FleetKdfRow\ struct and \load_fleet_kdf\/\ppend_fleet_kdf\ on \HandlerStore\
- When a gateway reports non-null salt in ACTUAL_STATE, append a fleet KDF row if salt or \kdf_params\ differ (append-only, latest-wins, deduplicated, stale-guarded)
- DESIRED_STATE relay is **unchanged** — fleet salt is NOT injected

### Spec changes
- evolve-962 §4.3.1, §9 step 4, T-AZH-2004
- azure-handler-design §9.5.1
- web-ui-design §13.2, §13.4
- web-ui-requirements WEB-1002, WEB-1003
- web-ui-validation T-WEB-1002f, T-WEB-1003b, T-WEB-1003c

## Test coverage
- \	_azh_2004_fleet_kdf_storage\: fleet row creation, dedup, latest-wins with params verification, null-salt skip, DESIRED_STATE unchanged, stale-message guard, params-only change trigger

## Artifacts changed
| File | Change |
|------|--------|
| \crates/sonde-azure-handler/src/lib.rs\ | Fleet KDF storage, trait, test |
| \docs/evolve-962-specification.md\ | §4.3.1, §9, T-AZH-2004 |
| \docs/azure-handler-design.md\ | §9.5.1 |
| \docs/web-ui-design.md\ | §13.2, §13.4 |
| \docs/web-ui-requirements.md\ | WEB-1002, WEB-1003 |
| \docs/web-ui-validation.md\ | T-WEB-1002f, T-WEB-1003b, T-WEB-1003c |