### PR TITLE
Simplify KDF: deterministic master_key_id, client-side-only salt/KDF

### DIFF
--- a/crates/sonde-admin/src/main.rs
+++ b/crates/sonde-admin/src/main.rs
@@ -915,23 +915,11 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
             KeyAction::Status => {
                 let state = client.get_gateway_state().await?;
                 if json {
-                    let mut obj = serde_json::json!({
+                    print_json(&serde_json::json!({
                         "master_key_epoch": state.master_key_epoch,
                         "master_key_id": hex::encode(&state.master_key_id),
                         "rotation_in_progress": state.rotation_in_progress,
-                        "salt": state.salt.as_ref().map(hex::encode),
-                    });
-                    if let Some(kdf) = &state.kdf_params {
-                        obj["kdf_params"] = serde_json::json!({
-                            "m_cost": kdf.m_cost,
-                            "t_cost": kdf.t_cost,
-                            "p_cost": kdf.p_cost,
-                            "kdf_version": kdf.kdf_version,
-                        });
-                    } else {
-                        obj["kdf_params"] = serde_json::Value::Null;
-                    }
-                    print_json(&obj)?;
+                    }))?;
                 } else {
                     println!("Master key epoch:      {}", state.master_key_epoch);
                     println!(
@@ -939,19 +927,6 @@ async fn run(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn std::err
                         hex::encode(&state.master_key_id)
                     );
                     println!("Rotation in progress:  {}", state.rotation_in_progress);
-                    match &state.salt {
-                        Some(s) => println!("Salt:                  {}", hex::encode(s)),
-                        None => println!("Salt:                  (not set)"),
-                    }
-                    match &state.kdf_params {
-                        Some(kdf) => {
-                            println!(
-                                "KDF params:            m={}, t={}, p={}, version={}",
-                                kdf.m_cost, kdf.t_cost, kdf.p_cost, kdf.kdf_version,
-                            );
-                        }
-                        None => println!("KDF params:            (not set)"),
-                    }
                 }
             }
             KeyAction::Rotate => {
@@ -967,13 +942,6 @@ fn print_json(value: &impl serde::Serialize) -> Result<(), serde_json::Error> {
     println!("{}", serde_json::to_string_pretty(value)?);
     Ok(())
 }
-
-/// Default Argon2id parameters used when the gateway has no stored KDF params
-/// (i.e. first rotation). Per `admin-design.md` §11.3.
-const DEFAULT_KDF_M_COST: u32 = 65536;
-const DEFAULT_KDF_T_COST: u32 = 3;
-const DEFAULT_KDF_P_COST: u32 = 1;
-const DEFAULT_KDF_VERSION: u32 = 1;
 
 /// Validate a rotation passphrase per ADMIN-0900.
 ///
@@ -994,16 +962,12 @@ fn validate_passphrase(passphrase: &str) -> Result<(), String> {
 /// Build a `RotationPayloadV1` binary envelope per `evolve-962-specification.md` §2.6.1.
 ///
 /// Returns the serialized payload suitable for `SubmitRotation`.
-#[allow(clippy::too_many_arguments)]
 fn build_rotation_payload(
     gw_x25519_public: &[u8; 32],
     gateway_id_raw: &[u8; 16],
     master_key_epoch: u64,
     new_master_key: &[u8; 32],
     rotation_code: &str,
-    new_master_key_id: &[u8; 16],
-    salt: Option<&[u8; 16]>,
-    kdf_params: Option<(u32, u32, u32, u32)>,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     use aes_gcm::aead::{Aead, OsRng};
     use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
@@ -1037,15 +1001,9 @@ fn build_rotation_payload(
     hkdf.expand(&info, &mut *aes_key)
         .map_err(|_| "HKDF expand failed")?;
 
-    // Encode CBOR plaintext map with integer keys 1–5, deterministic ordering.
+    // Encode CBOR plaintext map with integer keys 1–2, deterministic ordering.
     // Wrapped in Zeroizing because it contains new_master_key in the clear.
-    let plaintext = Zeroizing::new(encode_rotation_plaintext(
-        new_master_key,
-        rotation_code,
-        new_master_key_id,
-        salt,
-        kdf_params,
-    ));
+    let plaintext = Zeroizing::new(encode_rotation_plaintext(new_master_key, rotation_code));
 
     // Encrypt with AES-256-GCM.
     // AAD: gateway_id_raw || master_key_epoch_be64
@@ -1078,17 +1036,11 @@ fn build_rotation_payload(
 ///
 /// Deterministic CBOR encoding per RFC 8949 §4.2: integer keys in ascending
 /// order, minimal-length encoding.
-fn encode_rotation_plaintext(
-    new_master_key: &[u8; 32],
-    rotation_code: &str,
-    new_master_key_id: &[u8; 16],
-    salt: Option<&[u8; 16]>,
-    kdf_params: Option<(u32, u32, u32, u32)>,
-) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(128);
+fn encode_rotation_plaintext(new_master_key: &[u8; 32], rotation_code: &str) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(64);
 
-    // CBOR map with 5 entries: A5
-    buf.push(0xA5);
+    // CBOR map with 2 entries: A2
+    buf.push(0xA2);
 
     // Key 1: new_master_key (bstr, 32 bytes)
     buf.push(0x01);
@@ -1100,42 +1052,11 @@ fn encode_rotation_plaintext(
     buf.push(0x02);
     cbor_encode_tstr(&mut buf, rotation_code);
 
-    // Key 3: new_master_key_id (bstr, 16 bytes)
-    buf.push(0x03);
-    buf.push(0x50); // bytes(16)
-    buf.extend_from_slice(new_master_key_id);
-
-    // Key 4: salt (bstr 16 bytes or null)
-    buf.push(0x04);
-    match salt {
-        Some(s) => {
-            buf.push(0x50); // bytes(16)
-            buf.extend_from_slice(s);
-        }
-        None => buf.push(0xF6), // null
-    }
-
-    // Key 5: kdf_params (map or null)
-    buf.push(0x05);
-    match kdf_params {
-        Some((m_cost, t_cost, p_cost, kdf_version)) => {
-            buf.push(0xA4); // map(4)
-            buf.push(0x01);
-            cbor_encode_uint(&mut buf, m_cost as u64);
-            buf.push(0x02);
-            cbor_encode_uint(&mut buf, t_cost as u64);
-            buf.push(0x03);
-            cbor_encode_uint(&mut buf, p_cost as u64);
-            buf.push(0x04);
-            cbor_encode_uint(&mut buf, kdf_version as u64);
-        }
-        None => buf.push(0xF6), // null
-    }
-
     buf
 }
 
 /// Encode a CBOR unsigned integer in minimal form.
+#[cfg(test)]
 fn cbor_encode_uint(buf: &mut Vec<u8>, value: u64) {
     if value < 24 {
         buf.push(value as u8);
@@ -1194,17 +1115,12 @@ async fn key_rotate(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn s
         )
         .into());
     }
-    if state.master_key_id.len() != 16 {
+    if state.master_key_id.len() != 32 {
         return Err(format!(
-            "master_key_id has unexpected length: {} (expected 16)",
+            "master_key_id has unexpected length: {} (expected 32)",
             state.master_key_id.len()
         )
         .into());
-    }
-    if let Some(ref salt) = state.salt {
-        if salt.len() != 16 {
-            return Err(format!("salt has unexpected length: {} (expected 16)", salt.len()).into());
-        }
     }
 
     // Step 2: Display fingerprint and prompt for confirmation.
@@ -1232,30 +1148,25 @@ async fn key_rotate(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn s
     );
     validate_passphrase(&passphrase)?;
 
-    // Step 5: Select KDF parameters.
-    let (m_cost, t_cost, p_cost, kdf_version) = match &state.kdf_params {
-        Some(kdf) => (kdf.m_cost, kdf.t_cost, kdf.p_cost, kdf.kdf_version),
-        None => (
-            DEFAULT_KDF_M_COST,
-            DEFAULT_KDF_T_COST,
-            DEFAULT_KDF_P_COST,
-            DEFAULT_KDF_VERSION,
-        ),
-    };
+    // Step 5: Prompt for deployment label.
+    eprint!("Deployment label: ");
+    let mut stderr = std::io::stderr();
+    std::io::Write::flush(&mut stderr)?;
+    let mut deployment_label = String::new();
+    std::io::stdin().read_line(&mut deployment_label)?;
+    let deployment_label = deployment_label.trim();
+    if deployment_label.is_empty() {
+        return Err("deployment label must not be empty".into());
+    }
 
-    // Step 6: Select or generate salt.
-    let (salt_bytes, include_salt_in_payload) = match &state.salt {
-        Some(s) => {
-            let mut arr = [0u8; 16];
-            arr.copy_from_slice(s);
-            (arr, false)
-        }
-        None => {
-            let mut arr = [0u8; 16];
-            getrandom::fill(&mut arr).map_err(|e| format!("failed to generate salt: {e}"))?;
-            (arr, true)
-        }
-    };
+    // Step 6: Derive the KDF salt from the deployment label and use fixed v1 params.
+    use sha2::{Digest, Sha256};
+    let salt_input = format!("sonde-kdf-v1:{deployment_label}");
+    let salt_hash = Sha256::digest(salt_input.as_bytes());
+    let salt: [u8; 16] = salt_hash[..16].try_into().expect("SHA-256 is 32 bytes");
+    let m_cost = 65536u32;
+    let t_cost = 3u32;
+    let p_cost = 1u32;
 
     // Step 7: Derive new master key with Argon2id.
     let argon2_params = argon2::Params::new(m_cost, t_cost, p_cost, Some(32))
@@ -1267,28 +1178,12 @@ async fn key_rotate(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn s
     );
     let mut new_master_key = Zeroizing::new([0u8; 32]);
     argon2
-        .hash_password_into(passphrase.as_bytes(), &salt_bytes, &mut *new_master_key)
+        .hash_password_into(passphrase.as_bytes(), &salt, &mut *new_master_key)
         .map_err(|e| format!("Argon2id key derivation failed: {e}"))?;
 
-    // Step 8: Generate random new_master_key_id.
-    let mut new_master_key_id = [0u8; 16];
-    getrandom::fill(&mut new_master_key_id)
-        .map_err(|e| format!("failed to generate new_master_key_id: {e}"))?;
-
-    // Step 9: Build RotationPayloadV1.
+    // Step 8: Build RotationPayloadV1.
     let gateway_id_raw: [u8; 16] = state.gateway_id[..16].try_into().unwrap();
     let gw_x25519_public: [u8; 32] = state.x25519_public_key[..32].try_into().unwrap();
-
-    let payload_salt = if include_salt_in_payload {
-        Some(&salt_bytes)
-    } else {
-        None
-    };
-    let payload_kdf = if state.kdf_params.is_none() {
-        Some((m_cost, t_cost, p_cost, kdf_version))
-    } else {
-        None
-    };
 
     let rotation_payload = build_rotation_payload(
         &gw_x25519_public,
@@ -1296,18 +1191,15 @@ async fn key_rotate(client: &mut AdminClient, cli: &Cli) -> Result<(), Box<dyn s
         state.master_key_epoch,
         &new_master_key,
         &rotation_code,
-        &new_master_key_id,
-        payload_salt,
-        payload_kdf,
     )?;
 
-    // Step 10: Submit rotation.
+    // Step 9: Submit rotation.
     let resp = client.submit_rotation(rotation_payload).await?;
     if !resp.accepted {
         return Err(format!("rotation rejected: {}", resp.error).into());
     }
 
-    // Step 11: Poll until master_key_epoch increments or timeout.
+    // Step 10: Poll until master_key_epoch increments or timeout.
     let original_epoch = state.master_key_epoch;
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
     loop {
@@ -1491,38 +1383,15 @@ mod tests {
     #[test]
     fn cbor_plaintext_round_trip_structure() {
         let master_key = [0x42u8; 32];
-        let key_id = [0xABu8; 16];
-        let salt = [0xCDu8; 16];
 
-        let plaintext = encode_rotation_plaintext(
-            &master_key,
-            "ABC123",
-            &key_id,
-            Some(&salt),
-            Some((65536, 3, 1, 1)),
-        );
+        let plaintext = encode_rotation_plaintext(&master_key, "ABC123");
 
-        // Must start with A5 (map of 5 entries).
-        assert_eq!(plaintext[0], 0xA5);
+        // Must start with A2 (map of 2 entries).
+        assert_eq!(plaintext[0], 0xA2);
         // Key 1 follows.
         assert_eq!(plaintext[1], 0x01);
-    }
-
-    #[test]
-    fn cbor_plaintext_null_salt_and_params() {
-        let master_key = [0x42u8; 32];
-        let key_id = [0xABu8; 16];
-
-        let plaintext = encode_rotation_plaintext(&master_key, "XYZ789", &key_id, None, None);
-
-        // Must start with A5 (map of 5 entries).
-        assert_eq!(plaintext[0], 0xA5);
-        // Salt (key 4) and kdf_params (key 5) should be null (0xF6).
-        // Find the null values by scanning for key 4 and key 5.
-        let pos4 = plaintext.windows(2).position(|w| w == [0x04, 0xF6]);
-        assert!(pos4.is_some(), "key 4 should be followed by null");
-        let pos5 = plaintext.windows(2).position(|w| w == [0x05, 0xF6]);
-        assert!(pos5.is_some(), "key 5 should be followed by null");
+        // Key 2 must be present.
+        assert!(plaintext.contains(&0x02));
     }
 
     // ── CBOR uint encoding ──────────────────────────────────────────────

--- a/crates/sonde-admin/tests/integration.rs
+++ b/crates/sonde-admin/tests/integration.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use tokio::sync::RwLock;
 
+use sha2::Digest;
 use sonde_admin::grpc_client::AdminClient;
 use sonde_gateway::admin::AdminService;
 use sonde_gateway::engine::PendingCommand;
@@ -855,12 +856,12 @@ async fn seed_gateway_identity(storage: &Arc<InMemoryStorage>) -> GatewayIdentit
     let identity = GatewayIdentity::from_parts(seed, gateway_id);
     storage.store_gateway_identity(&identity).await.unwrap();
 
-    // Master key ID: deterministic 16-byte hex value.
+    let master_key = [0x42u8; 32];
+    let master_key_id = sha2::Sha256::digest(master_key);
     storage
-        .set_config("master_key_id", &hex::encode([0xAA; 16]))
+        .set_config("master_key_id", &hex::encode(master_key_id))
         .await
         .unwrap();
-    // Master key epoch starts at 1.
     storage.set_config("master_key_epoch", "1").await.unwrap();
 
     identity
@@ -912,16 +913,12 @@ async fn start_server_with_rotation(
 
 /// Build a rotation payload for testing. Mirrors the logic in `main.rs`
 /// `build_rotation_payload()` without requiring it to be public.
-#[allow(clippy::too_many_arguments)]
 fn build_test_rotation_payload(
     gw_x25519_public: &[u8; 32],
     gateway_id_raw: &[u8; 16],
     master_key_epoch: u64,
     new_master_key: &[u8; 32],
     rotation_code: &str,
-    new_master_key_id: &[u8; 16],
-    salt: Option<&[u8; 16]>,
-    kdf_params: Option<(u32, u32, u32, u32)>,
 ) -> Vec<u8> {
     use aes_gcm::aead::{Aead, OsRng};
     use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
@@ -944,9 +941,9 @@ fn build_test_rotation_payload(
     let mut aes_key = [0u8; 32];
     hkdf.expand(&info, &mut aes_key).unwrap();
 
-    // Deterministic CBOR: 5-entry map with integer keys 1–5.
-    let mut plaintext = Vec::with_capacity(128);
-    plaintext.push(0xA5); // map(5)
+    // Deterministic CBOR: 2-entry map with integer keys 1–2.
+    let mut plaintext = Vec::with_capacity(64);
+    plaintext.push(0xA2); // map(2)
                           // key 1: new_master_key (bstr 32)
     plaintext.push(0x01);
     plaintext.push(0x58);
@@ -962,40 +959,6 @@ fn build_test_rotation_payload(
         plaintext.push(code_bytes.len() as u8);
     }
     plaintext.extend_from_slice(code_bytes);
-    // key 3: new_master_key_id (bstr 16)
-    plaintext.push(0x03);
-    plaintext.push(0x50);
-    plaintext.extend_from_slice(new_master_key_id);
-    // key 4: salt or null
-    plaintext.push(0x04);
-    if let Some(s) = salt {
-        plaintext.push(0x50);
-        plaintext.extend_from_slice(s);
-    } else {
-        plaintext.push(0xF6); // null
-    }
-    // key 5: kdf_params or null
-    plaintext.push(0x05);
-    if let Some((m, t, p, v)) = kdf_params {
-        plaintext.push(0xA4); // map(4)
-        for (key, val) in [(1u8, m), (2, t), (3, p), (4, v)] {
-            plaintext.push(key);
-            if val < 24 {
-                plaintext.push(val as u8);
-            } else if val <= 0xFF {
-                plaintext.push(0x18);
-                plaintext.push(val as u8);
-            } else if val <= 0xFFFF {
-                plaintext.push(0x19);
-                plaintext.extend_from_slice(&(val as u16).to_be_bytes());
-            } else {
-                plaintext.push(0x1A);
-                plaintext.extend_from_slice(&val.to_be_bytes());
-            }
-        }
-    } else {
-        plaintext.push(0xF6); // null
-    }
 
     let cipher = Aes256Gcm::new((&aes_key).into());
     let mut nonce_bytes = [0u8; 12];
@@ -1074,25 +1037,22 @@ async fn key_fingerprint_returns_six_words() {
     assert_eq!(parsed["fingerprint_words"].as_array().unwrap().len(), 6);
 }
 
-/// T-0904: `key status` returns epoch, master_key_id, rotation_in_progress, and
-/// optional salt/kdf_params.
+/// T-0904: `key status` returns epoch, master_key_id, and rotation_in_progress.
 #[tokio::test(flavor = "multi_thread")]
 async fn key_status_shows_all_fields() {
-    let (endpoint, storage, _identity, _rx) =
+    let (endpoint, _storage, _identity, _rx) =
         start_server_with_rotation("key_status_shows_all_fields").await;
+    let expected_master_key_id = hex::encode(sha2::Sha256::digest([0x42u8; 32]));
 
-    // Seed optional KDF fields.
-    storage
-        .set_config("kdf_salt", &hex::encode([0xBB; 16]))
-        .await
-        .unwrap();
-    storage
-        .set_config(
-            "kdf_params_json",
-            r#"{"m_cost":65536,"t_cost":3,"p_cost":1,"kdf_version":1}"#,
-        )
-        .await
-        .unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
+        .args(["--socket", &endpoint, "key", "status"])
+        .output()
+        .expect("failed to run sonde-admin key status");
+    assert!(output.status.success(), "CLI key status should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Master key epoch:      1"));
+    assert!(stdout.contains(&expected_master_key_id));
+    assert!(stdout.contains("Rotation in progress:  false"));
 
     let json_output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
         .args(["--socket", &endpoint, "--format", "json", "key", "status"])
@@ -1100,7 +1060,7 @@ async fn key_status_shows_all_fields() {
         .expect("failed to run sonde-admin key status");
     assert!(
         json_output.status.success(),
-        "CLI key status should succeed"
+        "CLI key status JSON should succeed"
     );
 
     let parsed: serde_json::Value =
@@ -1108,20 +1068,15 @@ async fn key_status_shows_all_fields() {
             .expect("stdout must be valid JSON");
 
     assert_eq!(parsed["master_key_epoch"], 1);
-    assert_eq!(parsed["master_key_id"], hex::encode([0xAA; 16]));
+    assert_eq!(parsed["master_key_id"], expected_master_key_id);
     assert_eq!(parsed["rotation_in_progress"], false);
-    assert_eq!(parsed["salt"], hex::encode([0xBB; 16]));
-    assert_eq!(parsed["kdf_params"]["m_cost"], 65536);
-    assert_eq!(parsed["kdf_params"]["t_cost"], 3);
-    assert_eq!(parsed["kdf_params"]["p_cost"], 1);
-    assert_eq!(parsed["kdf_params"]["kdf_version"], 1);
 }
 
-/// T-0904 supplement: `key status` with no salt/kdf_params shows null.
+/// T-0904 supplement: `key status` exposes only current key metadata fields.
 #[tokio::test(flavor = "multi_thread")]
-async fn key_status_no_salt_shows_null() {
+async fn key_status_omits_legacy_fields() {
     let (endpoint, _storage, _identity, _rx) =
-        start_server_with_rotation("key_status_no_salt_shows_null").await;
+        start_server_with_rotation("key_status_omits_legacy_fields").await;
 
     let json_output = Command::new(env!("CARGO_BIN_EXE_sonde-admin"))
         .args(["--socket", &endpoint, "--format", "json", "key", "status"])
@@ -1132,11 +1087,15 @@ async fn key_status_no_salt_shows_null() {
     let parsed: serde_json::Value =
         serde_json::from_str(&String::from_utf8_lossy(&json_output.stdout))
             .expect("stdout must be valid JSON");
-    assert!(parsed["salt"].is_null(), "salt should be null when absent");
-    assert!(
-        parsed["kdf_params"].is_null(),
-        "kdf_params should be null when absent"
+    let object = parsed.as_object().expect("status JSON must be an object");
+    assert_eq!(
+        object.len(),
+        3,
+        "status JSON should expose only current fields"
     );
+    assert!(object.contains_key("master_key_epoch"));
+    assert!(object.contains_key("master_key_id"));
+    assert!(object.contains_key("rotation_in_progress"));
 }
 
 /// T-0900: `key rotate` happy path — submit a valid rotation payload to the
@@ -1175,9 +1134,6 @@ async fn key_rotate_submit_accepted() {
         state.master_key_epoch,
         &[0x42u8; 32],
         "TESTCODE",
-        &[0xCC; 16],
-        Some(&[0xDD; 16]),
-        Some((65536, 3, 1, 1)),
     );
 
     let resp = client.submit_rotation(payload).await.unwrap();
@@ -1214,9 +1170,6 @@ async fn key_rotate_rejected_by_engine() {
         state.master_key_epoch,
         &[0x42u8; 32],
         "WRONGCODE",
-        &[0xCC; 16],
-        Some(&[0xDD; 16]),
-        Some((65536, 3, 1, 1)),
     );
 
     let resp = client.submit_rotation(payload).await.unwrap();

--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -104,7 +104,7 @@ pub struct ActualStateRow {
     pub encrypted_psk: Option<Vec<u8>>,
     /// Node PSK escrow: key_hint for recovery lookup (AZH-0601).
     pub escrow_key_hint: Option<u64>,
-    /// Node PSK escrow: master_key_id (AZH-0601, 16 bytes).
+    /// Node PSK escrow: master_key_id (AZH-0601, 32 bytes).
     pub master_key_id: Option<Vec<u8>>,
 }
 
@@ -122,8 +122,6 @@ pub struct GatewayActualStateRow {
     pub x25519_public_key: Option<Vec<u8>>,
     pub fingerprint_words: Option<String>,
     pub missing_key_hints: Option<String>,
-    pub salt: Option<Vec<u8>>,
-    pub kdf_params_json: Option<String>,
     pub gateway_version: Option<String>,
     pub gateway_commit: Option<String>,
     pub modem_firmware_version: Option<String>,
@@ -220,11 +218,11 @@ pub struct ActualStateMessage {
     pub encrypted_psk: Option<Vec<u8>>,
     /// Node escrow: key_hint (CBOR key 13, u16).
     pub escrow_key_hint: Option<u16>,
-    /// Node escrow: master_key_id (CBOR key 14, 16 bytes).
+    /// Node escrow: master_key_id (CBOR key 14, 32 bytes).
     pub node_master_key_id: Option<Vec<u8>>,
     /// Gateway: channel (CBOR key 15).
     pub channel: Option<u32>,
-    /// Gateway: master_key_id (CBOR key 16, 16 bytes).
+    /// Gateway: master_key_id (CBOR key 16, 32 bytes).
     pub gateway_master_key_id: Option<Vec<u8>>,
     /// Gateway: master_key_epoch (CBOR key 17).
     pub master_key_epoch: Option<u64>,
@@ -234,10 +232,6 @@ pub struct ActualStateMessage {
     pub fingerprint_words: Option<Vec<String>>,
     /// Gateway: missing key_hints (CBOR key 20).
     pub missing_key_hints: Option<Vec<u64>>,
-    /// Gateway: KDF salt (CBOR key 21, 16 bytes).
-    pub salt: Option<Vec<u8>>,
-    /// Gateway: KDF params JSON (CBOR key 22).
-    pub kdf_params: Option<serde_json::Value>,
     /// Gateway: gateway binary version (CBOR key 23).
     pub gateway_version: Option<String>,
     /// Gateway: gateway binary commit (CBOR key 24).
@@ -536,13 +530,6 @@ where
             .map(serde_json::to_string)
             .transpose()
             .map_err(|e| HandlerError::Decode(format!("serialize missing_key_hints: {e}")))?;
-        let kdf_params_json = msg
-            .kdf_params
-            .as_ref()
-            .map(serde_json::to_string)
-            .transpose()
-            .map_err(|e| HandlerError::Decode(format!("serialize kdf_params: {e}")))?;
-
         let gw_row = GatewayActualStateRow {
             gateway_id: gateway_id.clone(),
             row_key: next_history_row_key(msg.timestamp_ms)?,
@@ -553,8 +540,6 @@ where
             x25519_public_key: msg.x25519_public_key.clone(),
             fingerprint_words,
             missing_key_hints: missing_key_hints_json,
-            salt: msg.salt.clone(),
-            kdf_params_json,
             gateway_version: msg.gateway_version.clone(),
             gateway_commit: msg.gateway_commit.clone(),
             modem_firmware_version: msg.modem_firmware_version.clone(),
@@ -618,22 +603,12 @@ where
             gw_desired.and_then(|d| d.rotation_payload)
         };
 
-        // Salt management (AZH-0604): include stored salt in DESIRED_STATE only
-        // when gateway reports salt = null.
-        let desired_salt = if msg.salt.is_none() {
-            previous.as_ref().and_then(|p| p.salt.clone())
-        } else {
-            None
-        };
-
         // Construct gateway DESIRED_STATE if there's anything to send.
-        let has_content =
-            !recovered_psks.is_empty() || rotation_payload.is_some() || desired_salt.is_some();
+        let has_content = !recovered_psks.is_empty() || rotation_payload.is_some();
 
         if has_content {
             let desired = encode_gateway_desired_state(
                 gateway_id,
-                desired_salt.as_deref(),
                 rotation_payload.as_deref(),
                 &recovered_psks,
             )?;
@@ -1187,11 +1162,6 @@ impl HandlerStore for AzureTablesStore {
                 .as_ref()
                 .map(|b| base64::engine::general_purpose::STANDARD.encode(b)),
             master_key_epoch: row.master_key_epoch.map(|e| e as i64),
-            salt: row
-                .salt
-                .as_ref()
-                .map(|b| base64::engine::general_purpose::STANDARD.encode(b)),
-            kdf_params_json: row.kdf_params_json.clone(),
             gateway_version: row.gateway_version.clone(),
             gateway_commit: row.gateway_commit.clone(),
             modem_firmware_version: row.modem_firmware_version.clone(),
@@ -1453,7 +1423,7 @@ struct ActualStateEntity {
         deserialize_with = "deserialize_optional_u64_flexible"
     )]
     key_hint: Option<u64>,
-    /// Node PSK escrow: base64-encoded master_key_id (AZH-0601).
+    /// Node PSK escrow: base64-encoded 32-byte master_key_id (AZH-0601).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     master_key_id: Option<String>,
 }
@@ -1473,6 +1443,7 @@ struct GatewayActualStateEntity {
         deserialize_with = "deserialize_optional_i64_flexible"
     )]
     channel: Option<i64>,
+    /// Gateway: base64-encoded 32-byte master_key_id.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     master_key_id: Option<String>,
     #[serde(
@@ -1481,10 +1452,6 @@ struct GatewayActualStateEntity {
         deserialize_with = "deserialize_optional_i64_flexible"
     )]
     master_key_epoch: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    salt: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    kdf_params_json: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     gateway_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -1902,21 +1869,19 @@ fn decode_connector_message(bytes: &[u8]) -> Result<ConnectorMessage, HandlerErr
                 // Node escrow fields (keys 12–14)
                 encrypted_psk: optional_fixed_bytes_field(&map, 12, 60, "encrypted_psk")?,
                 escrow_key_hint: optional_u16_field(&map, 13, "escrow_key_hint")?,
-                node_master_key_id: optional_fixed_bytes_field(&map, 14, 16, "node_master_key_id")?,
+                node_master_key_id: optional_fixed_bytes_field(&map, 14, 32, "node_master_key_id")?,
                 // Gateway-scoped fields (keys 15–27)
                 channel: optional_u32_field(&map, 15, "channel")?,
                 gateway_master_key_id: optional_fixed_bytes_field(
                     &map,
                     16,
-                    16,
+                    32,
                     "gateway_master_key_id",
                 )?,
                 master_key_epoch: optional_u64_field(&map, 17, "master_key_epoch")?,
                 x25519_public_key: optional_fixed_bytes_field(&map, 18, 32, "x25519_public_key")?,
                 fingerprint_words: decode_optional_string_array(&map, 19)?,
                 missing_key_hints: decode_optional_uint_array(&map, 20)?,
-                salt: optional_fixed_bytes_field(&map, 21, 16, "salt")?,
-                kdf_params: decode_optional_kdf_params(&map, 22)?,
                 gateway_version: optional_text_field(&map, 23, "gateway_version")?,
                 gateway_commit: optional_text_field(&map, 24, "gateway_commit")?,
                 modem_firmware_version: optional_text_field(&map, 25, "modem_firmware_version")?,
@@ -1975,16 +1940,10 @@ pub(crate) fn encode_desired_state(
 /// Encode a gateway DESIRED_STATE connector message (AZH-0605).
 fn encode_gateway_desired_state(
     gateway_id: &str,
-    salt: Option<&[u8]>,
     rotation_payload: Option<&[u8]>,
     recovered_psks: &[NodeEscrowRecord],
 ) -> Result<Vec<u8>, HandlerError> {
     let mut desired_state_entries = Vec::new();
-
-    // Salt (CBOR key 21) — only when gateway has no local salt.
-    if let Some(s) = salt {
-        desired_state_entries.push(map_entry(21, Value::Bytes(s.to_vec())));
-    }
 
     // Rotation payload (CBOR key 28) — opaque relay.
     if let Some(rp) = rotation_payload {
@@ -2111,12 +2070,6 @@ fn gateway_entity_to_row(
             .map_err(|e| HandlerError::Store(format!("decode gw x25519_public_key: {e}")))?,
         fingerprint_words: e.fingerprint_words,
         missing_key_hints: e.missing_key_hints,
-        salt: e
-            .salt
-            .map(|s| base64::engine::general_purpose::STANDARD.decode(s))
-            .transpose()
-            .map_err(|e| HandlerError::Store(format!("decode gw salt: {e}")))?,
-        kdf_params_json: e.kdf_params_json,
         gateway_version: e.gateway_version,
         gateway_commit: e.gateway_commit,
         modem_firmware_version: e.modem_firmware_version,
@@ -2411,39 +2364,6 @@ fn decode_optional_uint_array(
         }
         Some(_) => Err(HandlerError::Decode(
             "`missing_key_hints` must be an array or null".to_string(),
-        )),
-    }
-}
-
-fn decode_optional_kdf_params(
-    map: &[(Value, Value)],
-    key: u64,
-) -> Result<Option<serde_json::Value>, HandlerError> {
-    match map_get(map, key) {
-        Some(Value::Null) | None => Ok(None),
-        Some(Value::Map(entries)) => {
-            let mut json_map = serde_json::Map::new();
-            for (k, v) in entries {
-                if let Some(ki) = k.as_integer().and_then(|i| u64::try_from(i).ok()) {
-                    let key_name = match ki {
-                        1 => "m_cost",
-                        2 => "t_cost",
-                        3 => "p_cost",
-                        4 => "kdf_version",
-                        _ => continue,
-                    };
-                    if let Some(val) = v.as_integer().and_then(|i| u64::try_from(i).ok()) {
-                        json_map.insert(
-                            key_name.to_string(),
-                            serde_json::Value::Number(serde_json::Number::from(val)),
-                        );
-                    }
-                }
-            }
-            Ok(Some(serde_json::Value::Object(json_map)))
-        }
-        Some(_) => Err(HandlerError::Decode(
-            "`kdf_params` must be a map or null".to_string(),
         )),
     }
 }
@@ -4732,7 +4652,7 @@ mod tests {
             map_entry(3, Value::Text("abcdef01".to_string())),
             map_entry(9, Value::Integer(1234u64.into())),
             map_entry(15, Value::Integer(6u64.into())),
-            map_entry(16, Value::Bytes(vec![0x42u8; 16])),
+            map_entry(16, Value::Bytes(vec![0x42u8; 32])),
             map_entry(17, Value::Integer(3u64.into())),
             map_entry(18, Value::Bytes(vec![0x55u8; 32])),
             map_entry(27, Value::Bool(false)),
@@ -4800,10 +4720,9 @@ mod tests {
             "aabb0011",
             1000,
             6,
-            &[0x42u8; 16],
+            &[0x42u8; 32],
             1,
             &[0x55u8; 32],
-            Some(&[0xAA; 16]),
             false,
         );
         handler.handle_payload(&payload1).await.unwrap();
@@ -4824,10 +4743,9 @@ mod tests {
             "aabb0011",
             2000,
             11,
-            &[0x42u8; 16],
+            &[0x42u8; 32],
             2,
             &[0x55u8; 32],
-            Some(&[0xAA; 16]),
             false,
         );
         handler.handle_payload(&payload2).await.unwrap();
@@ -4877,8 +4795,6 @@ mod tests {
             x25519_public_key: None,
             fingerprint_words: None,
             missing_key_hints: None,
-            salt: None,
-            kdf_params_json: None,
             gateway_version: None,
             gateway_commit: None,
             modem_firmware_version: None,
@@ -4913,8 +4829,6 @@ mod tests {
             x25519_public_key: None,
             fingerprint_words: None,
             missing_key_hints: None,
-            salt: None,
-            kdf_params_json: None,
             gateway_version: None,
             gateway_commit: None,
             modem_firmware_version: None,
@@ -4950,10 +4864,9 @@ mod tests {
             "aabb0011",
             2000,
             6,
-            &[0x42u8; 16],
+            &[0x42u8; 32],
             2,
             &[0x55u8; 32],
-            Some(&[0xAA; 16]),
             false,
         );
         handler.handle_payload(&payload_new).await.unwrap();
@@ -4975,10 +4888,9 @@ mod tests {
             "aabb0011",
             1000,
             6,
-            &[0x42u8; 16],
+            &[0x42u8; 32],
             1,
             &[0x55u8; 32],
-            Some(&[0xAA; 16]),
             false,
         );
         handler.handle_payload(&payload_stale).await.unwrap();
@@ -5021,8 +4933,6 @@ mod tests {
             x25519_public_key: None,
             fingerprint_words: None,
             missing_key_hints: None,
-            salt: None,
-            kdf_params_json: None,
             gateway_version: None,
             gateway_commit: None,
             modem_firmware_version: None,
@@ -5055,10 +4965,9 @@ mod tests {
             "aabb0011",
             1000,
             6,
-            &[0x42u8; 16],
+            &[0x42u8; 32],
             1,
             &[0x55u8; 32],
-            Some(&[0xAA; 16]),
             false,
         );
         handler.handle_payload(&payload_stale).await.unwrap();
@@ -5107,7 +5016,7 @@ mod tests {
         let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
 
         let psk_blob = vec![0xBBu8; 60];
-        let master_key_id = vec![0xCCu8; 16];
+        let master_key_id = vec![0xCCu8; 32];
         let value = Value::Map(vec![
             map_entry(1, Value::Integer(MSG_TYPE_ACTUAL_STATE.into())),
             map_entry(2, Value::Text("node".to_string())),
@@ -5141,7 +5050,7 @@ mod tests {
         let publisher = Arc::new(RecordingPublisher::default());
         let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
 
-        let master_key_id = vec![0xAAu8; 16];
+        let master_key_id = vec![0xAAu8; 32];
         let psk_blob = vec![0xBBu8; 60];
 
         // Store a node with escrow fields
@@ -5173,7 +5082,6 @@ mod tests {
             &master_key_id,
             1,
             &[0x55u8; 32],
-            None,
             false,
             &[42],
         );
@@ -5201,8 +5109,8 @@ mod tests {
         let publisher = Arc::new(RecordingPublisher::default());
         let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
 
-        let node_mkid = vec![0xAAu8; 16];
-        let gateway_mkid = vec![0xFFu8; 16]; // Different!
+        let node_mkid = vec![0xAAu8; 32];
+        let gateway_mkid = vec![0xFFu8; 32]; // Different!
 
         store
             .append_actual_state(&ActualStateRow {
@@ -5231,7 +5139,6 @@ mod tests {
             &gateway_mkid,
             1,
             &[0x55u8; 32],
-            None,
             false,
             &[42],
         );
@@ -5252,7 +5159,7 @@ mod tests {
         let publisher = Arc::new(RecordingPublisher::default());
         let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
 
-        let master_key_id = vec![0xAAu8; 16];
+        let master_key_id = vec![0xAAu8; 32];
         let rotation_payload = vec![0x01, 0x02, 0x03, 0x04];
 
         // Seed gateway desired state with a rotation payload
@@ -5274,7 +5181,6 @@ mod tests {
             &master_key_id,
             1,
             &[0x55u8; 32],
-            None,
             false,
         );
         handler.handle_payload(&payload1).await.unwrap();
@@ -5298,7 +5204,6 @@ mod tests {
             &master_key_id,
             2,
             &[0x55u8; 32],
-            None,
             false,
         );
         handler.handle_payload(&payload2).await.unwrap();
@@ -5336,80 +5241,6 @@ mod tests {
         );
     }
 
-    // --- T-AZH-0604: Salt management ---
-    #[tokio::test]
-    async fn t_azh_0604_salt_included_when_gateway_has_none() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
-
-        let master_key_id = vec![0xAAu8; 16];
-        let stored_salt = vec![0xDDu8; 16];
-
-        // First: deliver gateway state WITH salt to store it
-        let payload1 = encode_gateway_actual_state_msg(
-            "a1b2c3d4",
-            1000,
-            6,
-            &master_key_id,
-            1,
-            &[0x55u8; 32],
-            Some(&stored_salt),
-            false,
-        );
-        handler.handle_payload(&payload1).await.unwrap();
-        publisher.sends.lock().await.clear();
-
-        // Second: deliver gateway state WITHOUT salt
-        let payload2 = encode_gateway_actual_state_msg(
-            "a1b2c3d4",
-            2000,
-            6,
-            &master_key_id,
-            1,
-            &[0x55u8; 32],
-            None,
-            false,
-        );
-        handler.handle_payload(&payload2).await.unwrap();
-
-        // DESIRED_STATE should include the stored salt
-        let sends = publisher.sends.lock().await;
-        assert_eq!(sends.len(), 1);
-        let decoded: Value = ciborium::from_reader(&sends[0].1[..]).unwrap();
-        let map = decoded.as_map().unwrap();
-        let desired_state = map_get(map, 4).unwrap().as_map().unwrap();
-        let salt_val = map_get(desired_state, 21).unwrap();
-        assert_eq!(salt_val.as_bytes().unwrap(), &stored_salt);
-    }
-
-    // --- T-AZH-0604: Salt NOT overridden when gateway has salt ---
-    #[tokio::test]
-    async fn t_azh_0604_salt_not_overridden_when_gateway_has_salt() {
-        let store = Arc::new(MemoryStore::default());
-        let publisher = Arc::new(RecordingPublisher::default());
-        let handler = AzureHandler::new(Arc::clone(&store), Arc::clone(&publisher), "downstream");
-
-        let master_key_id = vec![0xAAu8; 16];
-        let salt = vec![0xEEu8; 16];
-
-        let payload = encode_gateway_actual_state_msg(
-            "a1b2c3d4",
-            1000,
-            6,
-            &master_key_id,
-            1,
-            &[0x55u8; 32],
-            Some(&salt),
-            false,
-        );
-        handler.handle_payload(&payload).await.unwrap();
-
-        // No DESIRED_STATE should be published since gateway already has salt
-        let sends = publisher.sends.lock().await;
-        assert!(sends.is_empty(), "no DESIRED_STATE for gateway with salt");
-    }
-
     // --- T-AZH-0605: No phone escrow rows ---
     #[tokio::test]
     async fn t_azh_0605_phone_actual_state_ignored() {
@@ -5441,7 +5272,6 @@ mod tests {
         master_key_id: &[u8],
         master_key_epoch: u64,
         x25519_public_key: &[u8],
-        salt: Option<&[u8]>,
         rotation_in_progress: bool,
     ) -> Vec<u8> {
         encode_gateway_actual_state_msg_with_hints(
@@ -5451,7 +5281,6 @@ mod tests {
             master_key_id,
             master_key_epoch,
             x25519_public_key,
-            salt,
             rotation_in_progress,
             &[],
         )
@@ -5465,7 +5294,6 @@ mod tests {
         master_key_id: &[u8],
         master_key_epoch: u64,
         x25519_public_key: &[u8],
-        salt: Option<&[u8]>,
         rotation_in_progress: bool,
         missing_key_hints: &[u64],
     ) -> Vec<u8> {
@@ -5489,10 +5317,6 @@ mod tests {
                         .collect(),
                 ),
             ));
-        }
-        match salt {
-            Some(s) => pairs.push(map_entry(21, Value::Bytes(s.to_vec()))),
-            None => pairs.push(map_entry(21, Value::Null)),
         }
         pairs.push(map_entry(27, Value::Bool(rotation_in_progress)));
         let value = Value::Map(pairs);

--- a/crates/sonde-gateway/src/admin.rs
+++ b/crates/sonde-gateway/src/admin.rs
@@ -24,16 +24,6 @@ use crate::session::SessionManager;
 use crate::storage::{HandlerRecord, Storage};
 use crate::transient_display::{show_modem_display_message, ActiveDisplayState};
 
-/// JSON-deserializable KDF parameters (stored in gateway_config).
-#[derive(serde::Deserialize)]
-struct KdfParamsJson {
-    m_cost: u32,
-    t_cost: u32,
-    p_cost: u32,
-    #[serde(alias = "version")]
-    kdf_version: u32,
-}
-
 /// Channel type for rotation payload submission with oneshot response.
 pub type RotationSubmitChannel =
     tokio::sync::mpsc::UnboundedSender<(Vec<u8>, tokio::sync::oneshot::Sender<Result<(), String>>)>;
@@ -1260,9 +1250,8 @@ impl GatewayAdmin for AdminService {
     /// Return the gateway's current state for key management operations.
     ///
     /// Provides the X25519 public key, BIP-39 fingerprint, master key
-    /// identification, salt, KDF params, and rotation status needed by
-    /// the admin CLI `key rotate`, `key fingerprint`, and `key status`
-    /// commands.
+    /// identification, and rotation status needed by the admin CLI
+    /// `key rotate`, `key fingerprint`, and `key status` commands.
     async fn get_gateway_state(
         &self,
         _request: Request<Empty>,
@@ -1286,9 +1275,9 @@ impl GatewayAdmin for AdminService {
             .ok_or_else(|| Status::not_found("master key not initialized"))?;
         let master_key_id = hex::decode(&master_key_id_hex)
             .map_err(|e| Status::internal(format!("invalid master_key_id hex: {e}")))?;
-        if master_key_id.len() != 16 {
+        if master_key_id.len() != 32 {
             return Err(Status::internal(format!(
-                "master_key_id has wrong length: {} (expected 16)",
+                "master_key_id has wrong length: {} (expected 32)",
                 master_key_id.len()
             )));
         }
@@ -1326,47 +1315,6 @@ impl GatewayAdmin for AdminService {
             None => 1,
         };
 
-        // Salt — error if stored but malformed, None if absent.
-        let salt = match self
-            .storage
-            .get_config("kdf_salt")
-            .await
-            .map_err(storage_err)?
-        {
-            Some(s) => {
-                let bytes = hex::decode(&s)
-                    .map_err(|e| Status::internal(format!("invalid kdf_salt hex: {e}")))?;
-                if bytes.len() != 16 {
-                    return Err(Status::internal(format!(
-                        "kdf_salt has wrong length: {} (expected 16)",
-                        bytes.len()
-                    )));
-                }
-                Some(bytes)
-            }
-            None => None,
-        };
-
-        // KDF params — error if stored but malformed, None if absent.
-        let kdf_params = match self
-            .storage
-            .get_config("kdf_params_json")
-            .await
-            .map_err(storage_err)?
-        {
-            Some(json) => {
-                let p: KdfParamsJson = serde_json::from_str(&json)
-                    .map_err(|e| Status::internal(format!("invalid kdf_params_json: {e}")))?;
-                Some(KdfParameters {
-                    m_cost: p.m_cost,
-                    t_cost: p.t_cost,
-                    p_cost: p.p_cost,
-                    kdf_version: p.kdf_version,
-                })
-            }
-            None => None,
-        };
-
         // Check for active rotation via the `pending_rotation_phase` config key.
         // This key is set by the rotation engine when a rotation begins and
         // cleared on commit. When the engine wiring lands, this will reflect
@@ -1386,8 +1334,8 @@ impl GatewayAdmin for AdminService {
             x25519_public_key: x25519_public.as_bytes().to_vec(),
             fingerprint_words: fp.iter().map(|w| w.to_string()).collect(),
             rotation_in_progress,
-            salt,
-            kdf_params,
+            salt: None,
+            kdf_params: None,
             gateway_version: env!("CARGO_PKG_VERSION").to_string(),
             gateway_commit: option_env!("SONDE_GIT_COMMIT")
                 .unwrap_or("unknown")

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1028,6 +1028,8 @@ async fn run_gateway(
     //     comment retained for section numbering continuity).
 
     // 2e. Load/generate master_key_id and master_key_epoch (§23.11 step 2c).
+    // init_master_key_id() uses the storage-internal master key, which
+    // reflects any swap performed by crash recovery in step 2a.
     let (master_key_id, master_key_epoch) = storage.init_master_key_id().await?;
     info!(
         master_key_id = %hex::encode(master_key_id),
@@ -2033,7 +2035,19 @@ async fn emit_gateway_actual_state_from_storage(
         .map(|b| format!("{b:02x}"))
         .collect();
 
-    let (mk_id, mk_epoch) = storage.init_master_key_id().await?;
+    let mk_id_hex = storage
+        .get_config("master_key_id")
+        .await?
+        .ok_or("master key not initialized")?;
+    let mk_id_vec =
+        hex::decode(&mk_id_hex).map_err(|e| format!("invalid master_key_id hex: {e}"))?;
+    let mk_id: [u8; 32] = mk_id_vec.as_slice().try_into().map_err(|_| {
+        format!(
+            "master_key_id has wrong length: {} (expected 32)",
+            mk_id_vec.len()
+        )
+    })?;
+    let mk_epoch = storage.get_master_key_epoch().await?;
 
     let (_, x25519_public) = identity
         .to_x25519()
@@ -2047,49 +2061,6 @@ async fn emit_gateway_actual_state_from_storage(
         Some(s) => s.parse().unwrap_or(1),
         None => 1,
     };
-
-    let salt: Option<Vec<u8>> = match storage.get_config("kdf_salt").await? {
-        Some(s) => {
-            let bytes = hex::decode(&s).map_err(|e| format!("invalid kdf_salt hex: {e}"))?;
-            if bytes.len() == 16 {
-                Some(bytes)
-            } else {
-                warn!(
-                    expected = 16,
-                    actual = bytes.len(),
-                    "kdf_salt in storage has invalid length — treating as absent"
-                );
-                None
-            }
-        }
-        None => None,
-    };
-
-    let kdf_params: Option<sonde_gateway::connector::KdfParams> =
-        match storage.get_config("kdf_params_json").await? {
-            Some(json) => {
-                #[derive(serde::Deserialize)]
-                struct Kdf {
-                    m_cost: u32,
-                    t_cost: u32,
-                    p_cost: u32,
-                    kdf_version: u32,
-                }
-                match serde_json::from_str::<Kdf>(&json) {
-                    Ok(p) => Some(sonde_gateway::connector::KdfParams {
-                        m_cost: p.m_cost,
-                        t_cost: p.t_cost,
-                        p_cost: p.p_cost,
-                        kdf_version: p.kdf_version,
-                    }),
-                    Err(e) => {
-                        warn!("invalid kdf_params_json in storage: {e}");
-                        None
-                    }
-                }
-            }
-            None => None,
-        };
 
     let missing_key_hints = gateway.drain_missing_hints().await;
 
@@ -2119,8 +2090,6 @@ async fn emit_gateway_actual_state_from_storage(
         *x25519_public.as_bytes(),
         fingerprint_words,
         missing_key_hints,
-        salt,
-        kdf_params,
         gateway_version,
         gateway_commit,
         modem_meta.firmware_version,

--- a/crates/sonde-gateway/src/bin/gateway.rs
+++ b/crates/sonde-gateway/src/bin/gateway.rs
@@ -1281,7 +1281,8 @@ async fn run_gateway(
                 tokio::select! {
                     biased;
                     Some(_notification) = rotation_complete_rx.recv() => {
-                        info!("rotation complete — re-emitting gateway ACTUAL_STATE");
+                        info!("rotation complete — refreshing cached master_key_id and re-emitting gateway ACTUAL_STATE");
+                        reemit_gateway.refresh_cached_master_key_id().await;
                         if let Err(e) = reemit_gateway_actual_state(
                             &reemit_event_hub,
                             &reemit_storage,

--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -25,10 +25,6 @@ pub struct GatewayDesiredState {
     pub entity_id: String,
     /// Desired ESP-NOW channel (CBOR key 15).
     pub channel: Option<u32>,
-    /// KDF salt from cloud (CBOR key 21, 16 bytes).
-    pub salt: Option<Vec<u8>>,
-    /// KDF parameters from cloud (CBOR key 22).
-    pub kdf_params: Option<KdfParams>,
     /// X25519-encrypted rotation payload (CBOR key 28).
     pub rotation_payload: Option<Vec<u8>>,
     /// Recovered PSK records for missing nodes (CBOR key 29).
@@ -44,7 +40,7 @@ pub struct RecoveredPskRecord {
     pub key_hint: u16,
     /// Encrypted PSK blob (60 bytes).
     pub encrypted_psk: Vec<u8>,
-    /// Opaque master key ID (16 bytes).
+    /// `SHA-256(master_key)` identifier (32 bytes).
     pub master_key_id: Vec<u8>,
 }
 
@@ -103,7 +99,7 @@ enum ConnectorOutboundMessage {
         encrypted_psk_escrow: Option<Vec<u8>>,
         /// Key hint (u16) for Azure recovery lookup, CBOR key 13.
         escrow_key_hint: Option<u16>,
-        /// Opaque master key ID (16 bytes) that encrypted this PSK, CBOR key 14.
+        /// `SHA-256(master_key)` identifier (32 bytes) that encrypted this PSK, CBOR key 14.
         master_key_id: Option<Vec<u8>>,
         /// Modem-measured RSSI (dBm) of the node's WAKE frame, CBOR key 28.
         wake_rssi_dbm: Option<i8>,
@@ -134,27 +130,16 @@ pub struct GatewayActualStateData {
     pub entity_id: String,
     pub timestamp_ms: u64,
     pub channel: u32,
-    pub master_key_id: [u8; 16],
+    pub master_key_id: [u8; 32],
     pub master_key_epoch: u64,
     pub x25519_public_key: [u8; 32],
     pub fingerprint_words: [String; 6],
     pub missing_key_hints: Vec<u16>,
-    pub salt: Option<Vec<u8>>,
-    pub kdf_params: Option<KdfParams>,
     pub gateway_version: String,
     pub gateway_commit: String,
     pub modem_firmware_version: Option<String>,
     pub modem_firmware_commit: Option<String>,
     pub rotation_in_progress: bool,
-}
-
-/// KDF parameters for Argon2id.
-#[derive(Clone, Debug)]
-pub struct KdfParams {
-    pub m_cost: u32,
-    pub t_cost: u32,
-    pub p_cost: u32,
-    pub kdf_version: u32,
 }
 
 impl ConnectorOutboundMessage {
@@ -312,25 +297,6 @@ impl ConnectorOutboundMessage {
                         ),
                     ),
                 ];
-                pairs.push(map_entry(
-                    21,
-                    match data.salt {
-                        Some(ref s) => Value::Bytes(s.clone()),
-                        None => Value::Null,
-                    },
-                ));
-                pairs.push(map_entry(
-                    22,
-                    match data.kdf_params {
-                        Some(ref kdf) => Value::Map(vec![
-                            map_entry(1, Value::Integer((kdf.m_cost as u64).into())),
-                            map_entry(2, Value::Integer((kdf.t_cost as u64).into())),
-                            map_entry(3, Value::Integer((kdf.p_cost as u64).into())),
-                            map_entry(4, Value::Integer((kdf.kdf_version as u64).into())),
-                        ]),
-                        None => Value::Null,
-                    },
-                ));
                 pairs.push(map_entry(23, Value::Text(data.gateway_version.clone())));
                 pairs.push(map_entry(24, Value::Text(data.gateway_commit.clone())));
                 pairs.push(map_entry(
@@ -450,11 +416,11 @@ impl ConnectorEventHub {
                     );
                     (None, None, None)
                 } else if let (Some(key_hint), Some(key_id)) = (escrow_key_hint, master_key_id) {
-                    if key_id.len() != 16 {
+                    if key_id.len() != 32 {
                         error!(
                             node_id = %node_id,
                             len = key_id.len(),
-                            "dropping escrow: master_key_id must be 16 bytes"
+                            "dropping escrow: master_key_id must be 32 bytes"
                         );
                         (None, None, None)
                     } else {
@@ -496,13 +462,11 @@ impl ConnectorEventHub {
         &self,
         entity_id: String,
         channel: u32,
-        master_key_id: [u8; 16],
+        master_key_id: [u8; 32],
         master_key_epoch: u64,
         x25519_public_key: [u8; 32],
         fingerprint_words: [String; 6],
         missing_key_hints: Vec<u16>,
-        salt: Option<Vec<u8>>,
-        kdf_params: Option<KdfParams>,
         gateway_version: String,
         gateway_commit: String,
         modem_firmware_version: Option<String>,
@@ -518,8 +482,6 @@ impl ConnectorEventHub {
             x25519_public_key,
             fingerprint_words,
             missing_key_hints,
-            salt,
-            kdf_params,
             gateway_version,
             gateway_commit,
             modem_firmware_version,
@@ -725,24 +687,12 @@ impl ConnectorService {
             ));
         }
         let channel = optional_u32_field(desired_state, 15, "channel")?;
-        let salt = optional_bytes_field(desired_state, 21, "salt")?;
-        if let Some(ref s) = salt {
-            if s.len() != 16 {
-                return Err(format!(
-                    "gateway DESIRED_STATE salt must be 16 bytes, got {}",
-                    s.len()
-                ));
-            }
-        }
-        let kdf_params = parse_optional_kdf_params(desired_state, 22)?;
         let rotation_payload = optional_bytes_field(desired_state, 28, "rotation_payload")?;
         let recovered_psks = parse_optional_recovered_psks(desired_state, 29)?;
 
         let gw_ds = GatewayDesiredState {
             entity_id: entity_id.to_owned(),
             channel,
-            salt,
-            kdf_params,
             rotation_payload,
             recovered_psks,
         };
@@ -1124,11 +1074,6 @@ fn required_u64(map: &[(Value, Value)], key: u64, field: &str) -> Result<u64, St
         })
 }
 
-fn required_u32(map: &[(Value, Value)], key: u64, field: &str) -> Result<u32, String> {
-    let v = required_u64(map, key, field)?;
-    u32::try_from(v).map_err(|_| format!("`{field}` exceeds u32::MAX ({v})"))
-}
-
 fn required_text(map: &[(Value, Value)], key: u64, field: &str) -> Result<String, String> {
     map_get(map, key)
         .ok_or_else(|| format!("missing `{field}`"))
@@ -1204,29 +1149,6 @@ fn optional_text_field(
     }
 }
 
-/// Parse optional KDF params from a CBOR map field.
-fn parse_optional_kdf_params(
-    map: &[(Value, Value)],
-    key: u64,
-) -> Result<Option<KdfParams>, String> {
-    match map_get(map, key) {
-        Some(Value::Map(kdf_map)) => {
-            let m_cost = required_u32(kdf_map, 1, "m_cost")?;
-            let t_cost = required_u32(kdf_map, 2, "t_cost")?;
-            let p_cost = required_u32(kdf_map, 3, "p_cost")?;
-            let kdf_version = required_u32(kdf_map, 4, "kdf_version")?;
-            Ok(Some(KdfParams {
-                m_cost,
-                t_cost,
-                p_cost,
-                kdf_version,
-            }))
-        }
-        Some(Value::Null) | None => Ok(None),
-        Some(_) => Err("kdf_params must be a map or null".to_string()),
-    }
-}
-
 /// Parse optional recovered PSK records from a CBOR array field.
 fn parse_optional_recovered_psks(
     map: &[(Value, Value)],
@@ -1263,9 +1185,9 @@ fn parse_optional_recovered_psks(
                             4,
                             &format!("recovered_psks[{i}].master_key_id"),
                         )?;
-                        if master_key_id.len() != 16 {
+                        if master_key_id.len() != 32 {
                             return Err(format!(
-                                "recovered_psks[{i}].master_key_id must be 16 bytes, got {}",
+                                "recovered_psks[{i}].master_key_id must be 32 bytes, got {}",
                                 master_key_id.len()
                             ));
                         }
@@ -1394,7 +1316,7 @@ mod tests {
         hub.emit_gateway_actual_state(
             "aabbccdd11223344aabbccdd11223344".to_string(),
             1,
-            [0x42u8; 16],
+            [0x42u8; 32],
             1,
             [0x55u8; 32],
             [
@@ -1406,8 +1328,6 @@ mod tests {
                 "absent".to_string(),
             ],
             vec![],
-            None,
-            None,
             "0.8.0".to_string(),
             "abc123".to_string(),
             None,

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -337,7 +337,7 @@ pub struct Gateway {
     /// Cached master_key_id for pending_recovery lookups (GW-2009).
     /// Loaded once at `set_sqlite_storage` time to avoid calling
     /// `init_master_key_id` on the per-frame path.
-    cached_master_key_id: Option<[u8; 16]>,
+    cached_master_key_id: Option<[u8; 32]>,
 }
 
 impl Gateway {

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -335,9 +335,10 @@ pub struct Gateway {
     /// Typed storage reference for pending_recovery access (GW-2009).
     sqlite_storage: Option<Arc<SqliteStorage>>,
     /// Cached master_key_id for pending_recovery lookups (GW-2009).
-    /// Loaded once at `set_sqlite_storage` time to avoid calling
-    /// `init_master_key_id` on the per-frame path.
-    cached_master_key_id: Option<[u8; 32]>,
+    /// Initialised at `set_sqlite_storage` time and refreshed after rotation
+    /// completes, so `try_recovery_auth` does not call `init_master_key_id`
+    /// on the per-frame path.
+    cached_master_key_id: RwLock<Option<[u8; 32]>>,
 }
 
 impl Gateway {
@@ -357,7 +358,7 @@ impl Gateway {
             missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
             missing_hints_notify: Arc::new(tokio::sync::Notify::new()),
             sqlite_storage: None,
-            cached_master_key_id: None,
+            cached_master_key_id: RwLock::new(None),
         }
     }
 
@@ -388,7 +389,7 @@ impl Gateway {
             missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
             missing_hints_notify: Arc::new(tokio::sync::Notify::new()),
             sqlite_storage: None,
-            cached_master_key_id: None,
+            cached_master_key_id: RwLock::new(None),
         }
     }
 
@@ -412,7 +413,7 @@ impl Gateway {
             missing_hint_tracker: Arc::new(RwLock::new(MissingKeyHintTracker::new())),
             missing_hints_notify: Arc::new(tokio::sync::Notify::new()),
             sqlite_storage: None,
-            cached_master_key_id: None,
+            cached_master_key_id: RwLock::new(None),
         }
     }
 
@@ -451,7 +452,7 @@ impl Gateway {
     pub async fn set_sqlite_storage(&mut self, storage: Arc<SqliteStorage>) {
         match storage.init_master_key_id().await {
             Ok((kid, _)) => {
-                self.cached_master_key_id = Some(kid);
+                *self.cached_master_key_id.write().await = Some(kid);
             }
             Err(e) => {
                 warn!("failed to cache master_key_id during gateway init: {e}");
@@ -459,6 +460,25 @@ impl Gateway {
             }
         }
         self.sqlite_storage = Some(storage);
+    }
+
+    /// Refresh the cached `master_key_id` from storage.
+    ///
+    /// Must be called after rotation completes so that `try_recovery_auth`
+    /// filters `pending_recovery` candidates against the new key identity.
+    pub async fn refresh_cached_master_key_id(&self) {
+        let sqlite = match &self.sqlite_storage {
+            Some(s) => s,
+            None => return,
+        };
+        match sqlite.init_master_key_id().await {
+            Ok((kid, _)) => {
+                *self.cached_master_key_id.write().await = Some(kid);
+            }
+            Err(e) => {
+                warn!("failed to refresh cached master_key_id after rotation: {e}");
+            }
+        }
     }
 
     /// Drain accumulated unknown `key_hint` values for ACTUAL_STATE emission.
@@ -581,7 +601,7 @@ impl Gateway {
         };
 
         // Use cached master_key_id for pre-filtering candidates.
-        let current_key_id = match self.cached_master_key_id {
+        let current_key_id = match *self.cached_master_key_id.read().await {
             Some(kid) => kid,
             None => {
                 warn!(key_hint, "no cached master_key_id — recovery unavailable");

--- a/crates/sonde-gateway/src/rotation.rs
+++ b/crates/sonde-gateway/src/rotation.rs
@@ -43,8 +43,6 @@ pub enum RotationError {
     RateLimited,
     /// New master key has wrong length.
     InvalidKeyLength(usize),
-    /// New master key ID has wrong length.
-    InvalidKeyIdLength(usize),
     /// CBOR plaintext parse error.
     PlaintextParse(String),
     /// Internal error.
@@ -68,9 +66,6 @@ impl std::fmt::Display for RotationError {
             Self::InvalidKeyLength(len) => {
                 write!(f, "new_master_key must be 32 bytes, got {len}")
             }
-            Self::InvalidKeyIdLength(len) => {
-                write!(f, "new_master_key_id must be 16 bytes, got {len}")
-            }
             Self::PlaintextParse(msg) => write!(f, "rotation plaintext parse error: {msg}"),
             Self::Internal(msg) => write!(f, "rotation internal error: {msg}"),
         }
@@ -85,21 +80,6 @@ pub struct DecryptedRotation {
     pub new_master_key: Zeroizing<[u8; 32]>,
     /// 6-character rotation code from modem display.
     pub rotation_code: String,
-    /// Random 16-byte ID for the new key.
-    pub new_master_key_id: [u8; 16],
-    /// KDF salt (included on first rotation).
-    pub salt: Option<Vec<u8>>,
-    /// KDF parameters.
-    pub kdf_params: Option<KdfParamsPayload>,
-}
-
-/// KDF parameters from the rotation payload.
-#[derive(Clone, Debug)]
-pub struct KdfParamsPayload {
-    pub m_cost: u32,
-    pub t_cost: u32,
-    pub p_cost: u32,
-    pub kdf_version: u32,
 }
 
 /// Decrypt and validate a RotationPayloadV1 (evolve-962 §2.6.1).
@@ -176,7 +156,8 @@ pub fn decrypt_rotation_payload(
             .map_err(|_| RotationError::DecryptionFailed)?,
     );
 
-    // Parse CBOR plaintext: {1: new_master_key, 2: rotation_code, 3: new_master_key_id, 4: salt, 5: kdf_params}
+    // Parse CBOR plaintext: {1: new_master_key, 2: rotation_code}
+    // Keys 3-5 are RESERVED (previously new_master_key_id, salt, kdf_params).
     parse_rotation_plaintext(&plaintext)
 }
 
@@ -215,26 +196,11 @@ fn parse_rotation_plaintext(plaintext: &[u8]) -> Result<DecryptedRotation, Rotat
         )));
     }
 
-    // Key 3: new_master_key_id (bstr, 16 bytes)
-    let new_id_bytes = get_bytes(&map, 3, "new_master_key_id")?;
-    if new_id_bytes.len() != 16 {
-        return Err(RotationError::InvalidKeyIdLength(new_id_bytes.len()));
-    }
-    let mut new_master_key_id = [0u8; 16];
-    new_master_key_id.copy_from_slice(&new_id_bytes);
-
-    // Key 4: salt (bstr/null, optional — 16 bytes when present)
-    let salt = get_optional_bytes_strict(&map, 4, "salt", Some(16))?;
-
-    // Key 5: kdf_params (map/null, optional)
-    let kdf_params = get_optional_kdf_params(&map, 5)?;
+    // Keys 3-5 (new_master_key_id, salt, kdf_params) are RESERVED and ignored.
 
     Ok(DecryptedRotation {
         new_master_key,
         rotation_code,
-        new_master_key_id,
-        salt,
-        kdf_params,
     })
 }
 
@@ -272,80 +238,6 @@ fn get_text(
         ))),
         None => Err(RotationError::PlaintextParse(format!("missing `{field}`"))),
     }
-}
-
-fn get_optional_bytes_strict(
-    map: &[(ciborium::Value, ciborium::Value)],
-    key: u64,
-    field: &str,
-    expected_len: Option<usize>,
-) -> Result<Option<Vec<u8>>, RotationError> {
-    match get_value(map, key) {
-        Some(ciborium::Value::Bytes(b)) => {
-            if let Some(len) = expected_len {
-                if b.len() != len {
-                    return Err(RotationError::PlaintextParse(format!(
-                        "`{field}` must be {len} bytes, got {}",
-                        b.len()
-                    )));
-                }
-            }
-            Ok(Some(b.clone()))
-        }
-        Some(ciborium::Value::Null) | None => Ok(None),
-        Some(_) => Err(RotationError::PlaintextParse(format!(
-            "`{field}` must be bstr or null"
-        ))),
-    }
-}
-
-fn get_optional_kdf_params(
-    map: &[(ciborium::Value, ciborium::Value)],
-    key: u64,
-) -> Result<Option<KdfParamsPayload>, RotationError> {
-    match get_value(map, key) {
-        Some(ciborium::Value::Map(kdf_map)) => {
-            let m_cost = get_u32(kdf_map, 1, "m_cost")?;
-            let t_cost = get_u32(kdf_map, 2, "t_cost")?;
-            let p_cost = get_u32(kdf_map, 3, "p_cost")?;
-            let kdf_version = get_u32(kdf_map, 4, "kdf_version")?;
-            Ok(Some(KdfParamsPayload {
-                m_cost,
-                t_cost,
-                p_cost,
-                kdf_version,
-            }))
-        }
-        Some(ciborium::Value::Null) | None => Ok(None),
-        Some(_) => Err(RotationError::PlaintextParse(
-            "kdf_params must be a map or null".into(),
-        )),
-    }
-}
-
-fn get_u64(
-    map: &[(ciborium::Value, ciborium::Value)],
-    key: u64,
-    field: &str,
-) -> Result<u64, RotationError> {
-    match get_value(map, key) {
-        Some(ciborium::Value::Integer(i)) => u64::try_from(*i)
-            .map_err(|_| RotationError::PlaintextParse(format!("`{field}` out of range"))),
-        Some(_) => Err(RotationError::PlaintextParse(format!(
-            "`{field}` must be uint"
-        ))),
-        None => Err(RotationError::PlaintextParse(format!("missing `{field}`"))),
-    }
-}
-
-fn get_u32(
-    map: &[(ciborium::Value, ciborium::Value)],
-    key: u64,
-    field: &str,
-) -> Result<u32, RotationError> {
-    let v = get_u64(map, key, field)?;
-    u32::try_from(v)
-        .map_err(|_| RotationError::PlaintextParse(format!("`{field}` exceeds u32::MAX ({v})")))
 }
 
 /// Rate limiter for failed rotation attempts (GW-2006 validation rule 8).

--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 sonde contributors
 
-//! Master key rotation execution engine (GW-2006, GW-2007, GW-2008, GW-2013).
+//! Master key rotation execution engine (GW-2006, GW-2007, GW-2013).
 //!
 //! Coordinates the 8-step rotation pipeline and crash recovery, receiving
 //! rotation payloads from both gRPC (`SubmitRotation`) and DESIRED_STATE
 //! ingress channels.
-//!
-//! Also implements salt and KDF-params convergence (GW-2008, §23.13):
-//! adopt-if-absent semantics for values delivered via DESIRED_STATE.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use sha2::{Digest, Sha256};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info, warn};
 use zeroize::Zeroizing;
@@ -35,13 +33,12 @@ type RotationSubmitReceiver =
 /// so the gateway can emit a full gateway ACTUAL_STATE.
 #[derive(Debug, Clone)]
 pub struct RotationCompleteNotification {
-    pub new_master_key_id: [u8; 16],
+    pub new_master_key_id: [u8; 32],
     pub new_epoch: u64,
 }
 
-/// Notification sent when gateway state changes outside of rotation
-/// (e.g., salt/KDF params adoption from DESIRED_STATE). The gateway
-/// binary subscribes to trigger a full ACTUAL_STATE re-emission.
+/// Notification sent when gateway state changes outside of rotation.
+/// The gateway binary subscribes to trigger a full ACTUAL_STATE re-emission.
 #[derive(Debug, Clone)]
 pub struct GatewayStateChanged;
 
@@ -78,8 +75,8 @@ pub struct RotationEngine {
     /// binary subscribes to trigger a full gateway ACTUAL_STATE re-emission
     /// (which requires runtime state not available to this engine).
     rotation_complete_tx: Option<mpsc::UnboundedSender<RotationCompleteNotification>>,
-    /// Optional notification channel for non-rotation state changes (e.g.,
-    /// salt/KDF params adoption). Triggers gateway ACTUAL_STATE re-emission.
+    /// Optional notification channel for non-rotation state changes such as
+    /// channel convergence. Triggers gateway ACTUAL_STATE re-emission.
     state_changed_tx: Option<mpsc::UnboundedSender<GatewayStateChanged>>,
 }
 
@@ -119,11 +116,10 @@ impl RotationEngine {
         self
     }
 
-    /// Set the notification channel for non-rotation state changes (GW-2008).
+    /// Set the notification channel for non-rotation state changes.
     ///
-    /// When salt or KDF params are adopted from DESIRED_STATE, the engine
-    /// sends a [`GatewayStateChanged`] so the gateway can emit a full
-    /// ACTUAL_STATE reflecting the new values.
+    /// When the gateway state changes outside rotation, the engine sends a
+    /// [`GatewayStateChanged`] so the gateway can emit a full ACTUAL_STATE.
     pub fn with_state_changed_tx(mut self, tx: mpsc::UnboundedSender<GatewayStateChanged>) -> Self {
         self.state_changed_tx = Some(tx);
         self
@@ -153,8 +149,7 @@ impl RotationEngine {
     }
 
     /// Handle a full DESIRED_STATE message — process channel convergence (GW-2004),
-    /// rotation_payload if present, salt/KDF-params convergence (GW-2008),
-    /// and recovered_psks (GW-2009).
+    /// rotation_payload if present, and recovered_psks (GW-2009).
     async fn handle_desired_state(&mut self, state: GatewayDesiredState) {
         // Verify entity_id matches this gateway (defense-in-depth).
         let expected_id: String = self
@@ -182,9 +177,6 @@ impl RotationEngine {
             // Errors from DESIRED_STATE rotation are silently discarded per spec.
             let _ = self.handle_rotation_payload(payload, false).await;
         }
-
-        // Salt/KDF-params convergence (GW-2008, §23.13).
-        state_changed |= self.converge_salt_and_kdf(&state).await;
 
         if state_changed {
             if let Some(ref tx) = self.state_changed_tx {
@@ -251,69 +243,6 @@ impl RotationEngine {
         }
     }
 
-    /// Apply adopt-if-absent semantics for salt and KDF params (§23.13).
-    ///
-    /// Returns `true` if at least one value was adopted, signalling that
-    /// a gateway ACTUAL_STATE re-emission is warranted.
-    async fn converge_salt_and_kdf(&self, state: &GatewayDesiredState) -> bool {
-        let mut adopted = false;
-
-        // Salt convergence.
-        if let Some(ref desired_salt) = state.salt {
-            if desired_salt.len() != 16 {
-                warn!(
-                    len = desired_salt.len(),
-                    "ignoring DESIRED_STATE salt with invalid length (expected 16)"
-                );
-            } else {
-                match self
-                    .storage
-                    .set_config_if_absent("kdf_salt", &hex::encode(desired_salt))
-                    .await
-                {
-                    Ok(true) => {
-                        info!("adopted salt from DESIRED_STATE");
-                        adopted = true;
-                    }
-                    Ok(false) => {
-                        info!("ignoring DESIRED_STATE salt — local salt already set");
-                    }
-                    Err(e) => {
-                        error!(error = %e, "failed to adopt salt from DESIRED_STATE");
-                    }
-                }
-            }
-        }
-
-        // KDF params convergence.
-        if let Some(ref desired_kdf) = state.kdf_params {
-            let json = serde_json::json!({
-                "m_cost": desired_kdf.m_cost,
-                "t_cost": desired_kdf.t_cost,
-                "p_cost": desired_kdf.p_cost,
-                "kdf_version": desired_kdf.kdf_version,
-            });
-            match self
-                .storage
-                .set_config_if_absent("kdf_params_json", &json.to_string())
-                .await
-            {
-                Ok(true) => {
-                    info!("adopted KDF params from DESIRED_STATE");
-                    adopted = true;
-                }
-                Ok(false) => {
-                    info!("ignoring DESIRED_STATE kdf_params — local params already set");
-                }
-                Err(e) => {
-                    error!(error = %e, "failed to adopt KDF params from DESIRED_STATE");
-                }
-            }
-        }
-
-        adopted
-    }
-
     /// Process recovered PSK records from DESIRED_STATE (GW-2009).
     ///
     /// For each record, validates `master_key_id` against the gateway's current
@@ -330,7 +259,7 @@ impl RotationEngine {
 
         for rec in &records {
             // Validate master_key_id matches current key (§2.8 step 1a).
-            if rec.master_key_id != current_key_id {
+            if rec.master_key_id.as_slice() != current_key_id.as_slice() {
                 warn!(
                     node_id = %rec.node_id,
                     key_hint = rec.key_hint,
@@ -483,18 +412,16 @@ impl RotationEngine {
             let mk = self.storage.master_key();
             Zeroizing::new(**mk)
         };
+        let new_master_key_id: [u8; 32] = {
+            let key_ref: &[u8; 32] = &decrypted.new_master_key;
+            Sha256::digest(key_ref).into()
+        };
 
         info!(new_epoch, current_epoch, "starting master key rotation");
 
         // Step 4: Prepare — write pending_rotation + purge pending_recovery.
         self.storage
-            .write_pending_rotation(
-                &decrypted.new_master_key,
-                &decrypted.new_master_key_id,
-                new_epoch,
-                decrypted.salt.as_deref(),
-                decrypted.kdf_params.as_ref(),
-            )
+            .write_pending_rotation(&decrypted.new_master_key, &new_master_key_id, new_epoch)
             .await
             .map_err(|e| format!("prepare failed: {e}"))?;
 
@@ -507,10 +434,8 @@ impl RotationEngine {
             .execute_rotation_phases(
                 &old_key,
                 &decrypted.new_master_key,
-                &decrypted.new_master_key_id,
+                &new_master_key_id,
                 new_epoch,
-                decrypted.salt.as_deref(),
-                decrypted.kdf_params.as_ref(),
             )
             .await;
 
@@ -550,7 +475,7 @@ impl RotationEngine {
         info!(new_epoch, "master key rotation committed successfully");
 
         // Step 8: Emit updated ACTUAL_STATE.
-        self.emit_post_rotation_state(new_epoch, &decrypted.new_master_key_id)
+        self.emit_post_rotation_state(new_epoch, &new_master_key_id)
             .await;
 
         Ok(())
@@ -562,10 +487,8 @@ impl RotationEngine {
         &self,
         old_key: &[u8; 32],
         new_key: &[u8; 32],
-        new_key_id: &[u8; 16],
+        new_key_id: &[u8; 32],
         new_epoch: u64,
-        salt: Option<&[u8]>,
-        kdf_params: Option<&crate::rotation::KdfParamsPayload>,
     ) -> Result<(), String> {
         // Read current phase to support resume.
         let pending = self
@@ -616,7 +539,7 @@ impl RotationEngine {
 
         if pending.phase == "committing" {
             self.storage
-                .commit_rotation(new_key_id, new_epoch, salt, kdf_params)
+                .commit_rotation(new_key_id, new_epoch)
                 .await
                 .map_err(|e| format!("commit rotation: {e}"))?;
         }
@@ -629,7 +552,7 @@ impl RotationEngine {
         &self,
         old_key: &[u8; 32],
         new_key: &[u8; 32],
-        new_key_id: &[u8; 16],
+        new_key_id: &[u8; 32],
         new_epoch: u64,
     ) -> Result<(), String> {
         // Migrate node PSKs.
@@ -671,7 +594,7 @@ impl RotationEngine {
     /// ACTUAL_STATE (which requires runtime state like channel, version, fingerprint),
     /// sends a [`RotationCompleteNotification`] via the optional callback channel
     /// so the gateway binary can emit a full gateway ACTUAL_STATE.
-    async fn emit_post_rotation_state(&self, new_epoch: u64, new_key_id: &[u8; 16]) {
+    async fn emit_post_rotation_state(&self, new_epoch: u64, new_key_id: &[u8; 32]) {
         // Notify the gateway binary to emit a full gateway ACTUAL_STATE.
         if let Some(ref tx) = self.rotation_complete_tx {
             let _ = tx.send(RotationCompleteNotification {
@@ -887,25 +810,12 @@ impl RotationEngine {
             state_changed_tx: None,
         };
 
-        // Parse salt/kdf_params from the pending_rotation record for crash recovery.
-        let kdf_params = pending.kdf_params_json.as_deref().and_then(|json| {
-            let v: serde_json::Value = serde_json::from_str(json).ok()?;
-            Some(crate::rotation::KdfParamsPayload {
-                m_cost: u32::try_from(v["m_cost"].as_u64()?).ok()?,
-                t_cost: u32::try_from(v["t_cost"].as_u64()?).ok()?,
-                p_cost: u32::try_from(v["p_cost"].as_u64()?).ok()?,
-                kdf_version: u32::try_from(v["kdf_version"].as_u64()?).ok()?,
-            })
-        });
-
         let result = engine
             .execute_rotation_phases(
                 &old_key,
                 &new_key,
                 &pending.new_master_key_id,
                 pending.new_epoch,
-                pending.salt.as_deref(),
-                kdf_params.as_ref(),
             )
             .await;
 
@@ -975,272 +885,11 @@ mod tests {
 
         // After writing a pending_rotation, it should report in progress.
         store
-            .write_pending_rotation(&[0xAAu8; 32], &[0xBBu8; 16], 2, None, None)
+            .write_pending_rotation(&[0xAAu8; 32], &[0xBBu8; 32], 2)
             .await
             .unwrap();
         let in_progress = store.is_rotation_in_progress().await.unwrap();
         assert!(in_progress);
-    }
-
-    /// T-2007: Salt and KDF-params management (GW-2008).
-    ///
-    /// Steps 1–4, 6–7 from gateway-validation.md. Step 5 (rotation-path
-    /// salt update) is covered by the existing rotation tests.
-    #[tokio::test]
-    async fn test_t2007_salt_and_kdf_convergence() {
-        use crate::connector::KdfParams;
-
-        let master_key = Zeroizing::new([0x42u8; 32]);
-        let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
-
-        let (state_tx, mut state_rx) = mpsc::unbounded_channel::<GatewayStateChanged>();
-
-        // Build a minimal engine for testing convergence only.
-        let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
-        let (_ds_tx, desired_state_rx) = mpsc::unbounded_channel();
-        let identity = crate::gateway_identity::GatewayIdentity::generate().unwrap();
-        let eid = entity_id_for(&identity);
-        let event_hub = Arc::new(ConnectorEventHub::default());
-
-        let mut engine = RotationEngine::new(
-            Arc::clone(&store),
-            identity,
-            event_hub,
-            Arc::new(crate::key_provider::EnvKeyProvider::new(
-                "__SONDE_TEST_UNUSED__",
-            )),
-            grpc_rx,
-            desired_state_rx,
-        )
-        .with_state_changed_tx(state_tx);
-
-        // ── Step 1: No local salt or KDF params ──
-        assert!(store.get_config("kdf_salt").await.unwrap().is_none());
-        assert!(store.get_config("kdf_params_json").await.unwrap().is_none());
-
-        // ── Step 2: Deliver DESIRED_STATE with salt + KDF params → adopted ──
-        let salt_a = vec![0xAAu8; 16];
-        let kdf_a = KdfParams {
-            m_cost: 65536,
-            t_cost: 3,
-            p_cost: 1,
-            kdf_version: 1,
-        };
-        let ds = GatewayDesiredState {
-            entity_id: eid.clone(),
-            channel: None,
-            salt: Some(salt_a.clone()),
-            kdf_params: Some(kdf_a.clone()),
-            rotation_payload: None,
-            recovered_psks: None,
-        };
-        engine.handle_desired_state(ds).await;
-
-        // Verify adoption.
-        let stored_salt = store.get_config("kdf_salt").await.unwrap().unwrap();
-        assert_eq!(stored_salt, hex::encode(&salt_a));
-
-        let stored_kdf = store.get_config("kdf_params_json").await.unwrap().unwrap();
-        let kdf_val: serde_json::Value = serde_json::from_str(&stored_kdf).unwrap();
-        assert_eq!(kdf_val["m_cost"], 65536);
-        assert_eq!(kdf_val["t_cost"], 3);
-        assert_eq!(kdf_val["p_cost"], 1);
-        assert_eq!(kdf_val["kdf_version"], 1);
-
-        // ── Step 3: Verify notification was sent ──
-        let notif = state_rx.try_recv();
-        assert!(notif.is_ok(), "expected GatewayStateChanged after adoption");
-
-        // ── Step 4: Different salt + KDF → local wins ──
-        let salt_b = vec![0xBBu8; 16];
-        let kdf_b = KdfParams {
-            m_cost: 131072,
-            t_cost: 5,
-            p_cost: 2,
-            kdf_version: 2,
-        };
-        let ds2 = GatewayDesiredState {
-            entity_id: eid.clone(),
-            channel: None,
-            salt: Some(salt_b),
-            kdf_params: Some(kdf_b),
-            rotation_payload: None,
-            recovered_psks: None,
-        };
-        engine.handle_desired_state(ds2).await;
-
-        // Verify local values unchanged.
-        let stored_salt2 = store.get_config("kdf_salt").await.unwrap().unwrap();
-        assert_eq!(
-            stored_salt2,
-            hex::encode(&salt_a),
-            "local salt must not change"
-        );
-
-        let stored_kdf2 = store.get_config("kdf_params_json").await.unwrap().unwrap();
-        assert_eq!(stored_kdf2, stored_kdf, "local KDF params must not change");
-
-        // Verify NO notification sent (nothing adopted).
-        assert!(
-            state_rx.try_recv().is_err(),
-            "no GatewayStateChanged expected when local values already set"
-        );
-
-        // ── Step 6: Salt only (no KDF params) → salt evaluated, KDF unchanged ──
-        // Reset DB to test partial delivery with only salt already set.
-        // Salt already set above, so this should be a no-op for salt.
-        let ds3 = GatewayDesiredState {
-            entity_id: eid.clone(),
-            channel: None,
-            salt: Some(vec![0xCCu8; 16]),
-            kdf_params: None,
-            rotation_payload: None,
-            recovered_psks: None,
-        };
-        engine.handle_desired_state(ds3).await;
-
-        // Salt unchanged.
-        let stored_salt3 = store.get_config("kdf_salt").await.unwrap().unwrap();
-        assert_eq!(stored_salt3, hex::encode(&salt_a));
-        // KDF unchanged (not provided, not touched).
-        let stored_kdf3 = store.get_config("kdf_params_json").await.unwrap().unwrap();
-        assert_eq!(stored_kdf3, stored_kdf);
-        // No notification.
-        assert!(state_rx.try_recv().is_err());
-
-        // ── Step 7: KDF only (no salt) → KDF evaluated, salt unchanged ──
-        let ds4 = GatewayDesiredState {
-            entity_id: eid.clone(),
-            channel: None,
-            salt: None,
-            kdf_params: Some(KdfParams {
-                m_cost: 999,
-                t_cost: 999,
-                p_cost: 999,
-                kdf_version: 999,
-            }),
-            rotation_payload: None,
-            recovered_psks: None,
-        };
-        engine.handle_desired_state(ds4).await;
-
-        // Salt unchanged (not provided).
-        let stored_salt4 = store.get_config("kdf_salt").await.unwrap().unwrap();
-        assert_eq!(stored_salt4, hex::encode(&salt_a));
-        // KDF unchanged (local already set, ignore new values).
-        let stored_kdf4 = store.get_config("kdf_params_json").await.unwrap().unwrap();
-        assert_eq!(stored_kdf4, stored_kdf);
-        // No notification.
-        assert!(state_rx.try_recv().is_err());
-    }
-
-    /// Salt with invalid length is rejected before attempting adoption.
-    #[tokio::test]
-    async fn test_salt_invalid_length_rejected() {
-        let master_key = Zeroizing::new([0x42u8; 32]);
-        let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
-
-        let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
-        let (_ds_tx, desired_state_rx) = mpsc::unbounded_channel();
-        let identity = crate::gateway_identity::GatewayIdentity::generate().unwrap();
-        let eid = entity_id_for(&identity);
-        let event_hub = Arc::new(ConnectorEventHub::default());
-
-        let mut engine = RotationEngine::new(
-            Arc::clone(&store),
-            identity,
-            event_hub,
-            Arc::new(crate::key_provider::EnvKeyProvider::new(
-                "__SONDE_TEST_UNUSED__",
-            )),
-            grpc_rx,
-            desired_state_rx,
-        );
-
-        // Deliver salt with wrong length.
-        let ds = GatewayDesiredState {
-            entity_id: eid,
-            channel: None,
-            salt: Some(vec![0xAAu8; 8]), // 8 bytes, not 16
-            kdf_params: None,
-            rotation_payload: None,
-            recovered_psks: None,
-        };
-        engine.handle_desired_state(ds).await;
-
-        // Salt should not have been stored.
-        assert!(store.get_config("kdf_salt").await.unwrap().is_none());
-    }
-
-    /// Adopt-if-absent: salt adopted only on first DESIRED_STATE, not
-    /// overwritten by subsequent deliveries even from fresh engine instances.
-    #[tokio::test]
-    async fn test_salt_immutability_across_engine_restarts() {
-        let master_key = Zeroizing::new([0x42u8; 32]);
-        let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
-
-        let identity = crate::gateway_identity::GatewayIdentity::generate().unwrap();
-        let eid = entity_id_for(&identity);
-
-        // First engine instance: adopt salt.
-        {
-            let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
-            let (_ds_tx, desired_state_rx) = mpsc::unbounded_channel();
-            let event_hub = Arc::new(ConnectorEventHub::default());
-            let mut engine = RotationEngine::new(
-                Arc::clone(&store),
-                identity.clone(),
-                event_hub,
-                Arc::new(crate::key_provider::EnvKeyProvider::new(
-                    "__SONDE_TEST_UNUSED__",
-                )),
-                grpc_rx,
-                desired_state_rx,
-            );
-
-            let ds = GatewayDesiredState {
-                entity_id: eid.clone(),
-                channel: None,
-                salt: Some(vec![0x11u8; 16]),
-                kdf_params: None,
-                rotation_payload: None,
-                recovered_psks: None,
-            };
-            engine.handle_desired_state(ds).await;
-        }
-
-        let original_salt = store.get_config("kdf_salt").await.unwrap().unwrap();
-
-        // Second engine instance (simulates restart): try different salt.
-        {
-            let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
-            let (_ds_tx, desired_state_rx) = mpsc::unbounded_channel();
-            let event_hub = Arc::new(ConnectorEventHub::default());
-            let mut engine = RotationEngine::new(
-                Arc::clone(&store),
-                identity,
-                event_hub,
-                Arc::new(crate::key_provider::EnvKeyProvider::new(
-                    "__SONDE_TEST_UNUSED__",
-                )),
-                grpc_rx,
-                desired_state_rx,
-            );
-
-            let ds = GatewayDesiredState {
-                entity_id: eid.clone(),
-                channel: None,
-                salt: Some(vec![0x22u8; 16]),
-                kdf_params: None,
-                rotation_payload: None,
-                recovered_psks: None,
-            };
-            engine.handle_desired_state(ds).await;
-        }
-
-        // Salt unchanged.
-        let final_salt = store.get_config("kdf_salt").await.unwrap().unwrap();
-        assert_eq!(final_salt, original_salt);
     }
 
     /// Channel convergence (GW-2004 AC-1): switch when desired differs,
@@ -1274,8 +923,6 @@ mod tests {
         let ds = GatewayDesiredState {
             entity_id: eid.clone(),
             channel: Some(5),
-            salt: None,
-            kdf_params: None,
             rotation_payload: None,
             recovered_psks: None,
         };
@@ -1294,8 +941,6 @@ mod tests {
         let ds_same = GatewayDesiredState {
             entity_id: eid.clone(),
             channel: Some(5),
-            salt: None,
-            kdf_params: None,
             rotation_payload: None,
             recovered_psks: None,
         };
@@ -1309,8 +954,6 @@ mod tests {
         let ds_bad = GatewayDesiredState {
             entity_id: eid.clone(),
             channel: Some(0),
-            salt: None,
-            kdf_params: None,
             rotation_payload: None,
             recovered_psks: None,
         };
@@ -1325,8 +968,6 @@ mod tests {
         let ds_bad2 = GatewayDesiredState {
             entity_id: eid.clone(),
             channel: Some(15),
-            salt: None,
-            kdf_params: None,
             rotation_payload: None,
             recovered_psks: None,
         };

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1178,16 +1178,19 @@ impl SqliteStorage {
                 // Backfill/repair node rows. When master_key_id differs, the
                 // epoch is reset because it is scoped to the key identity —
                 // an epoch from a previous key has no meaning for the current one.
+                let epoch_i64 = i64::try_from(epoch).map_err(|_| {
+                    StorageError::Internal(format!("master_key_epoch {epoch} exceeds i64::MAX"))
+                })?;
                 tx.execute(
                     "UPDATE nodes SET master_key_id = ?1, master_key_epoch = ?2 \
                      WHERE master_key_id IS NULL OR master_key_id != ?1 OR master_key_epoch < ?2",
-                    params![master_key_id.as_slice(), epoch as i64],
+                    params![master_key_id.as_slice(), epoch_i64],
                 )
                 .map_err(map_err)?;
                 tx.execute(
                     "UPDATE phone_psks SET master_key_id = ?1, master_key_epoch = ?2 \
                      WHERE master_key_id IS NULL OR master_key_id != ?1 OR master_key_epoch < ?2",
-                    params![master_key_id.as_slice(), epoch as i64],
+                    params![master_key_id.as_slice(), epoch_i64],
                 )
                 .map_err(map_err)?;
                 tx.commit().map_err(map_err)?;

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -9,6 +9,7 @@ use aes_gcm::aead::{Aead, KeyInit, Payload};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use async_trait::async_trait;
 use rusqlite::{params, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
 use sonde_protocol::normalize_display_filename;
 use zeroize::Zeroizing;
 
@@ -656,16 +657,12 @@ struct RotationKeyState {
 pub struct PendingRotationRecord {
     /// New master key encrypted with the old key (60 bytes: nonce + ciphertext + tag).
     pub new_master_key_enc: Vec<u8>,
-    /// Random 16-byte ID for the new key.
-    pub new_master_key_id: [u8; 16],
+    /// SHA-256 of the new master key.
+    pub new_master_key_id: [u8; 32],
     /// Epoch for the new key (current_epoch + 1).
     pub new_epoch: u64,
     /// Current rotation phase.
     pub phase: String,
-    /// KDF salt from the rotation payload (persisted for crash recovery).
-    pub salt: Option<Vec<u8>>,
-    /// KDF params from the rotation payload, serialized as JSON.
-    pub kdf_params_json: Option<String>,
 }
 
 /// Node escrow metadata for ACTUAL_STATE re-emission after rotation.
@@ -1013,9 +1010,7 @@ impl SqliteStorage {
                     new_master_key_id  BLOB    NOT NULL,
                     new_epoch          INTEGER NOT NULL,
                     started_at         INTEGER NOT NULL,
-                    phase              TEXT    NOT NULL DEFAULT 'migrating_psks',
-                    salt               BLOB,
-                    kdf_params_json    TEXT
+                    phase              TEXT    NOT NULL DEFAULT 'migrating_psks'
                 )",
             )
             .map_err(|e| {
@@ -1076,9 +1071,9 @@ impl SqliteStorage {
                             "pending_rotation.new_epoch is negative: {epoch_raw}"
                         ))
                     })?;
-                    if id_vec.len() != 16 {
+                    if id_vec.len() != 32 {
                         return Err(StorageError::Internal(format!(
-                            "pending_rotation.new_master_key_id has wrong length: {} (expected 16)",
+                            "pending_rotation.new_master_key_id has wrong length: {} (expected 32)",
                             id_vec.len()
                         )));
                     }
@@ -1108,14 +1103,22 @@ impl SqliteStorage {
 
     /// Initialize master key identification on first startup (§2.9 step 2c).
     ///
-    /// If `master_key_id` and `master_key_epoch` are not yet in `gateway_config`,
-    /// generates a random 16-byte `master_key_id`, sets `master_key_epoch = 1`,
-    /// backfills all existing PSK records, and persists.
+    /// `master_key_id` is always derived locally as `SHA-256(master_key)`.
+    /// The digest is persisted in `gateway_config`, and existing PSK records are
+    /// backfilled or repaired if they still carry an older identifier.
     ///
     /// Returns `(master_key_id, master_key_epoch)`.
-    pub async fn init_master_key_id(&self) -> Result<([u8; 16], u64), StorageError> {
+    pub async fn init_master_key_id(&self) -> Result<([u8; 32], u64), StorageError> {
+        // Compute SHA-256(master_key) outside the closure to avoid moving
+        // raw key material into the (non-zeroizing) closure capture.
+        let mk = self.master_key();
+        let master_key_id: [u8; 32] = {
+            let key_ref: &[u8; 32] = &mk;
+            Sha256::digest(key_ref).into()
+        };
+        let master_key_id_hex = hex::encode(master_key_id);
+
         self.with_conn(move |conn| {
-            // Check if already initialized.
             let existing_id: Option<String> = conn
                 .query_row(
                     "SELECT value FROM gateway_config WHERE key = 'master_key_id'",
@@ -1124,106 +1127,71 @@ impl SqliteStorage {
                 )
                 .optional()
                 .map_err(map_err)?;
+            let epoch_str: Option<String> = conn
+                .query_row(
+                    "SELECT value FROM gateway_config WHERE key = 'master_key_epoch'",
+                    [],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(map_err)?;
 
-            if let Some(hex_id) = existing_id {
-                // Already initialized — load existing values.
-                let id_bytes = hex::decode(&hex_id).map_err(|e| {
-                    StorageError::Internal(format!("invalid master_key_id hex: {e}"))
-                })?;
-                if id_bytes.len() != 16 {
-                    return Err(StorageError::Internal(format!(
-                        "master_key_id has wrong length: {} (expected 16)",
-                        id_bytes.len()
-                    )));
-                }
-                let epoch_str: Option<String> = conn
-                    .query_row(
-                        "SELECT value FROM gateway_config WHERE key = 'master_key_epoch'",
-                        [],
-                        |row| row.get(0),
-                    )
-                    .optional()
-                    .map_err(map_err)?;
-                let epoch: u64 = match epoch_str {
-                    Some(s) => s.parse().map_err(|e| {
+            let epoch_missing = epoch_str.is_none();
+            let epoch: u64 = match epoch_str {
+                Some(ref s) => {
+                    let v: u64 = s.parse().map_err(|e| {
                         StorageError::Internal(format!("invalid master_key_epoch: {e}"))
-                    })?,
-                    None => {
-                        // Partially initialized DB — id exists but epoch missing.
-                        // Repair: set epoch=1 and backfill any rows still missing.
-                        let tx = conn.unchecked_transaction().map_err(map_err)?;
-                        tx.execute(
-                            "INSERT INTO gateway_config (key, value) VALUES ('master_key_epoch', '1') \
-                             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                            [],
-                        )
-                        .map_err(map_err)?;
-                        tx.execute(
-                            "UPDATE nodes SET master_key_id = ?1, master_key_epoch = 1 \
-                             WHERE master_key_id IS NULL OR master_key_epoch < 1",
-                            params![id_bytes.as_slice()],
-                        )
-                        .map_err(map_err)?;
-                        tx.execute(
-                            "UPDATE phone_psks SET master_key_id = ?1, master_key_epoch = 1 \
-                             WHERE master_key_id IS NULL OR master_key_epoch < 1",
-                            params![id_bytes.as_slice()],
-                        )
-                        .map_err(map_err)?;
-                        tx.commit().map_err(map_err)?;
+                    })?;
+                    // Epoch must be ≥ 1; treat 0 as invalid and repair.
+                    if v == 0 {
                         1
+                    } else {
+                        v
                     }
-                };
-                let mut arr = [0u8; 16];
-                arr.copy_from_slice(&id_bytes);
-                return Ok((arr, epoch));
-            }
-
-            // First startup — generate and backfill.
-            let mut master_key_id = [0u8; 16];
-            loop {
-                getrandom::fill(&mut master_key_id)
-                    .map_err(|e| StorageError::Internal(format!("master_key_id rng: {e}")))?;
-                if master_key_id != [0u8; 16] {
-                    break;
                 }
+                None => 1,
+            };
+
+            let stored_matches = existing_id
+                .as_deref()
+                .and_then(|hex_id| hex::decode(hex_id).ok())
+                .as_deref()
+                == Some(master_key_id.as_slice());
+            // Also repair if epoch was 0 (parsed as stored_epoch=0 → epoch=1).
+            let stored_epoch_zero = epoch_str.as_deref() == Some("0");
+            let needs_update = !stored_matches || epoch_missing || stored_epoch_zero;
+
+            if needs_update {
+                let tx = conn.unchecked_transaction().map_err(map_err)?;
+                tx.execute(
+                    "INSERT INTO gateway_config (key, value) VALUES ('master_key_id', ?1) \
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    params![master_key_id_hex],
+                )
+                .map_err(map_err)?;
+                tx.execute(
+                    "INSERT INTO gateway_config (key, value) VALUES ('master_key_epoch', ?1) \
+                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                    params![epoch.to_string()],
+                )
+                .map_err(map_err)?;
+                // Backfill/repair node rows. When master_key_id differs, the
+                // epoch is reset because it is scoped to the key identity —
+                // an epoch from a previous key has no meaning for the current one.
+                tx.execute(
+                    "UPDATE nodes SET master_key_id = ?1, master_key_epoch = ?2 \
+                     WHERE master_key_id IS NULL OR master_key_id != ?1 OR master_key_epoch < ?2",
+                    params![master_key_id.as_slice(), epoch as i64],
+                )
+                .map_err(map_err)?;
+                tx.execute(
+                    "UPDATE phone_psks SET master_key_id = ?1, master_key_epoch = ?2 \
+                     WHERE master_key_id IS NULL OR master_key_id != ?1 OR master_key_epoch < ?2",
+                    params![master_key_id.as_slice(), epoch as i64],
+                )
+                .map_err(map_err)?;
+                tx.commit().map_err(map_err)?;
             }
-            let epoch: u64 = 1;
-            let hex_id = hex::encode(master_key_id);
-
-            let tx = conn.unchecked_transaction().map_err(map_err)?;
-
-            // Persist master_key_id and master_key_epoch.
-            tx.execute(
-                "INSERT INTO gateway_config (key, value) VALUES ('master_key_id', ?1) \
-                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                params![hex_id],
-            )
-            .map_err(map_err)?;
-            tx.execute(
-                "INSERT INTO gateway_config (key, value) VALUES ('master_key_epoch', ?1) \
-                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                params![epoch.to_string()],
-            )
-            .map_err(map_err)?;
-
-            // Backfill nodes.
-            tx.execute(
-                "UPDATE nodes SET master_key_id = ?1, master_key_epoch = ?2 \
-                 WHERE master_key_id IS NULL",
-                params![master_key_id.as_slice(), epoch as i64],
-            )
-            .map_err(map_err)?;
-
-            // Backfill phone_psks.
-            tx.execute(
-                "UPDATE phone_psks SET master_key_id = ?1, master_key_epoch = ?2 \
-                 WHERE master_key_id IS NULL",
-                params![master_key_id.as_slice(), epoch as i64],
-            )
-            .map_err(map_err)?;
-
-            tx.commit().map_err(map_err)?;
 
             Ok((master_key_id, epoch))
         })
@@ -1270,16 +1238,13 @@ impl SqliteStorage {
     /// Write a pending_rotation record and purge pending_recovery (§2.6.2 step 4).
     ///
     /// The new master key is encrypted with the OLD master key for crash safety.
-    /// Salt and KDF params are persisted so crash recovery can apply them.
     /// This must be called within a single logical operation — the DB transaction
     /// ensures atomicity of both the insert and the purge.
     pub async fn write_pending_rotation(
         &self,
         new_master_key: &[u8; 32],
-        new_master_key_id: &[u8; 16],
+        new_master_key_id: &[u8; 32],
         new_epoch: u64,
-        salt: Option<&[u8]>,
-        kdf_params: Option<&crate::rotation::KdfParamsPayload>,
     ) -> Result<(), StorageError> {
         let mk = self.master_key();
         let new_key = Zeroizing::new(*new_master_key);
@@ -1307,17 +1272,6 @@ impl SqliteStorage {
             StorageError::Internal(format!("new_epoch {new_epoch} exceeds i64::MAX"))
         })?;
 
-        let salt_blob = salt.map(|s| s.to_vec());
-        let kdf_json = kdf_params.map(|p| {
-            serde_json::json!({
-                "m_cost": p.m_cost,
-                "t_cost": p.t_cost,
-                "p_cost": p.p_cost,
-                "kdf_version": p.kdf_version,
-            })
-            .to_string()
-        });
-
         self.with_conn(move |conn| {
             let tx = conn.unchecked_transaction().map_err(map_err)?;
 
@@ -1328,15 +1282,9 @@ impl SqliteStorage {
             // Insert pending_rotation record.
             tx.execute(
                 "INSERT INTO pending_rotation \
-                 (id, new_master_key_enc, new_master_key_id, new_epoch, started_at, phase, salt, kdf_params_json) \
-                 VALUES (1, ?1, ?2, ?3, strftime('%s', 'now'), 'migrating_psks', ?4, ?5)",
-                params![
-                    enc_blob,
-                    new_id.as_slice(),
-                    epoch_i64,
-                    salt_blob,
-                    kdf_json,
-                ],
+                 (id, new_master_key_enc, new_master_key_id, new_epoch, started_at, phase) \
+                 VALUES (1, ?1, ?2, ?3, strftime('%s', 'now'), 'migrating_psks')",
+                params![enc_blob, new_id.as_slice(), epoch_i64],
             )
             .map_err(map_err)?;
 
@@ -1352,37 +1300,21 @@ impl SqliteStorage {
         &self,
     ) -> Result<Option<PendingRotationRecord>, StorageError> {
         self.with_conn(|conn| {
-            let row: Option<(
-                Vec<u8>,
-                Vec<u8>,
-                i64,
-                String,
-                Option<Vec<u8>>,
-                Option<String>,
-            )> = conn
+            let row: Option<(Vec<u8>, Vec<u8>, i64, String)> = conn
                 .query_row(
-                    "SELECT new_master_key_enc, new_master_key_id, new_epoch, phase, \
-                     salt, kdf_params_json FROM pending_rotation WHERE id = 1",
+                    "SELECT new_master_key_enc, new_master_key_id, new_epoch, phase \
+                     FROM pending_rotation WHERE id = 1",
                     [],
-                    |row| {
-                        Ok((
-                            row.get(0)?,
-                            row.get(1)?,
-                            row.get(2)?,
-                            row.get(3)?,
-                            row.get(4)?,
-                            row.get(5)?,
-                        ))
-                    },
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
                 )
                 .optional()
                 .map_err(map_err)?;
             match row {
                 None => Ok(None),
-                Some((enc, id_vec, epoch_raw, phase, salt, kdf_params_json)) => {
-                    if id_vec.len() != 16 {
+                Some((enc, id_vec, epoch_raw, phase)) => {
+                    if id_vec.len() != 32 {
                         return Err(StorageError::Internal(format!(
-                            "pending_rotation.new_master_key_id has wrong length: {} (expected 16)",
+                            "pending_rotation.new_master_key_id has wrong length: {} (expected 32)",
                             id_vec.len()
                         )));
                     }
@@ -1391,15 +1323,13 @@ impl SqliteStorage {
                             "pending_rotation.new_epoch is negative: {epoch_raw}"
                         ))
                     })?;
-                    let mut new_master_key_id = [0u8; 16];
+                    let mut new_master_key_id = [0u8; 32];
                     new_master_key_id.copy_from_slice(&id_vec);
                     Ok(Some(PendingRotationRecord {
                         new_master_key_enc: enc,
                         new_master_key_id,
                         new_epoch,
                         phase,
-                        salt,
-                        kdf_params_json,
                     }))
                 }
             }
@@ -1453,7 +1383,7 @@ impl SqliteStorage {
         node_id: &str,
         old_key: &[u8; 32],
         new_key: &[u8; 32],
-        new_key_id: &[u8; 16],
+        new_key_id: &[u8; 32],
         new_epoch: u64,
     ) -> Result<(), StorageError> {
         let node_id = node_id.to_owned();
@@ -1522,7 +1452,7 @@ impl SqliteStorage {
         phone_id: u32,
         old_key: &[u8; 32],
         new_key: &[u8; 32],
-        new_key_id: &[u8; 16],
+        new_key_id: &[u8; 32],
         new_epoch: u64,
     ) -> Result<(), StorageError> {
         let old_key = Zeroizing::new(*old_key);
@@ -1607,7 +1537,6 @@ impl SqliteStorage {
     /// In a single transaction:
     /// - Promote `encrypted_seed_new` → `encrypted_seed`, clear `encrypted_seed_new`
     /// - Update `master_key_id` and `master_key_epoch` in `gateway_config`
-    /// - Store salt and KDF params if non-null
     /// - Generate new rotation code
     ///
     /// **Note (GW-2014):** `pending_rotation` is intentionally **not** deleted
@@ -1616,14 +1545,10 @@ impl SqliteStorage {
     /// [`delete_pending_rotation()`] after `write_master_key()` succeeds.
     pub async fn commit_rotation(
         &self,
-        new_key_id: &[u8; 16],
+        new_key_id: &[u8; 32],
         new_epoch: u64,
-        salt: Option<&[u8]>,
-        kdf_params: Option<&crate::rotation::KdfParamsPayload>,
     ) -> Result<String, StorageError> {
         let new_key_id = *new_key_id;
-        let salt = salt.map(|s| s.to_vec());
-        let kdf_params = kdf_params.cloned();
         let hex_id = hex::encode(new_key_id);
 
         self.with_conn(move |conn| {
@@ -1663,32 +1588,6 @@ impl SqliteStorage {
                 params![new_epoch.to_string()],
             )
             .map_err(map_err)?;
-
-            // Store salt if provided (key matches admin GetGatewayState reader).
-            if let Some(ref salt_bytes) = salt {
-                tx.execute(
-                    "INSERT INTO gateway_config (key, value) VALUES ('kdf_salt', ?1) \
-                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                    params![hex::encode(salt_bytes)],
-                )
-                .map_err(map_err)?;
-            }
-
-            // Store KDF params if provided (key matches admin GetGatewayState reader).
-            if let Some(ref params) = kdf_params {
-                let kdf_json = serde_json::json!({
-                    "m_cost": params.m_cost,
-                    "t_cost": params.t_cost,
-                    "p_cost": params.p_cost,
-                    "kdf_version": params.kdf_version,
-                });
-                tx.execute(
-                    "INSERT INTO gateway_config (key, value) VALUES ('kdf_params_json', ?1) \
-                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                    params![kdf_json.to_string()],
-                )
-                .map_err(map_err)?;
-            }
 
             // Generate new rotation code.
             let new_code = generate_rotation_code()?;
@@ -1870,7 +1769,7 @@ impl SqliteStorage {
         key_hint: u16,
         node_id: &str,
         encrypted_psk: &[u8],
-        master_key_id: &[u8; 16],
+        master_key_id: &[u8; 32],
         master_key_epoch: u64,
     ) -> Result<(), StorageError> {
         if encrypted_psk.len() != ENCRYPTED_PSK_LEN {
@@ -1949,7 +1848,7 @@ impl SqliteStorage {
     pub async fn lookup_pending_recovery_filtered(
         &self,
         key_hint: u16,
-        master_key_id: &[u8; 16],
+        master_key_id: &[u8; 32],
         max_candidates: u32,
     ) -> Result<Vec<PendingRecoveryRecord>, StorageError> {
         let mkid = *master_key_id;
@@ -4422,18 +4321,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_init_master_key_id_first_startup() {
-        let store = SqliteStorage::in_memory(Zeroizing::new([0x42u8; 32])).unwrap();
+        let store = SqliteStorage::in_memory(Zeroizing::new(TEST_MASTER_KEY_RAW)).unwrap();
         let (id, epoch) = store.init_master_key_id().await.unwrap();
+        let expected_id: [u8; 32] = Sha256::digest(TEST_MASTER_KEY_RAW).into();
         assert_eq!(epoch, 1);
-        assert_ne!(id, [0u8; 16], "master_key_id should be random, not zero");
+        assert_eq!(id, expected_id, "master_key_id must be SHA-256(master_key)");
+        assert_ne!(id, [0u8; 32], "master_key_id should not be zero");
     }
 
     #[tokio::test]
     async fn test_init_master_key_id_stable_across_calls() {
-        let store = SqliteStorage::in_memory(Zeroizing::new([0x42u8; 32])).unwrap();
+        let store = SqliteStorage::in_memory(Zeroizing::new(TEST_MASTER_KEY_RAW)).unwrap();
         let (id1, epoch1) = store.init_master_key_id().await.unwrap();
         let (id2, epoch2) = store.init_master_key_id().await.unwrap();
-        assert_eq!(id1, id2, "master_key_id must be stable");
+        assert_eq!(
+            id1, id2,
+            "master_key_id must be stable for the same master key"
+        );
         assert_eq!(epoch1, epoch2, "master_key_epoch must be stable");
     }
 
@@ -4462,7 +4366,7 @@ mod tests {
     #[tokio::test]
     async fn test_pending_recovery_insert_and_lookup() {
         let store = SqliteStorage::in_memory(Zeroizing::new([0x42u8; 32])).unwrap();
-        let mk_id = [0xAAu8; 16];
+        let mk_id = [0xAAu8; 32];
         let psk = [0xBBu8; 60];
         store
             .insert_pending_recovery(42, "node-1", &psk, &mk_id, 1)
@@ -4481,7 +4385,7 @@ mod tests {
     async fn test_pending_recovery_delete() {
         let store = SqliteStorage::in_memory(Zeroizing::new([0x42u8; 32])).unwrap();
         store
-            .insert_pending_recovery(42, "node-1", &[0xBBu8; 60], &[0xAAu8; 16], 1)
+            .insert_pending_recovery(42, "node-1", &[0xBBu8; 60], &[0xAAu8; 32], 1)
             .await
             .unwrap();
         store.delete_pending_recovery(42, "node-1").await.unwrap();
@@ -4493,11 +4397,11 @@ mod tests {
     async fn test_pending_recovery_purge() {
         let store = SqliteStorage::in_memory(Zeroizing::new([0x42u8; 32])).unwrap();
         store
-            .insert_pending_recovery(1, "n1", &[0xBBu8; 60], &[0xAAu8; 16], 1)
+            .insert_pending_recovery(1, "n1", &[0xBBu8; 60], &[0xAAu8; 32], 1)
             .await
             .unwrap();
         store
-            .insert_pending_recovery(2, "n2", &[0xCCu8; 60], &[0xAAu8; 16], 1)
+            .insert_pending_recovery(2, "n2", &[0xCCu8; 60], &[0xAAu8; 32], 1)
             .await
             .unwrap();
         let purged = store.purge_pending_recovery().await.unwrap();
@@ -4510,7 +4414,7 @@ mod tests {
     async fn test_pending_recovery_rejects_wrong_psk_length() {
         let store = SqliteStorage::in_memory(Zeroizing::new([0x42u8; 32])).unwrap();
         let result = store
-            .insert_pending_recovery(42, "node-1", &[0xBBu8; 30], &[0xAAu8; 16], 1)
+            .insert_pending_recovery(42, "node-1", &[0xBBu8; 30], &[0xAAu8; 32], 1)
             .await;
         assert!(result.is_err(), "should reject non-60-byte PSK blob");
     }
@@ -4519,7 +4423,7 @@ mod tests {
     async fn test_pending_recovery_expire() {
         let store = SqliteStorage::in_memory(Zeroizing::new([0x42u8; 32])).unwrap();
         store
-            .insert_pending_recovery(42, "node-old", &[0xBBu8; 60], &[0xAAu8; 16], 1)
+            .insert_pending_recovery(42, "node-old", &[0xBBu8; 60], &[0xAAu8; 32], 1)
             .await
             .unwrap();
         // Backdate the record by directly updating received_at.
@@ -4537,7 +4441,7 @@ mod tests {
             .unwrap();
         // Insert a fresh record.
         store
-            .insert_pending_recovery(43, "node-new", &[0xCCu8; 60], &[0xAAu8; 16], 1)
+            .insert_pending_recovery(43, "node-new", &[0xCCu8; 60], &[0xAAu8; 32], 1)
             .await
             .unwrap();
         // Expire records older than 24 hours (86400 seconds).

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1137,19 +1137,19 @@ impl SqliteStorage {
                 .map_err(map_err)?;
 
             let epoch_missing = epoch_str.is_none();
-            let epoch: u64 = match epoch_str {
+            let (epoch, stored_epoch_zero): (u64, bool) = match epoch_str {
                 Some(ref s) => {
                     let v: u64 = s.parse().map_err(|e| {
                         StorageError::Internal(format!("invalid master_key_epoch: {e}"))
                     })?;
                     // Epoch must be ≥ 1; treat 0 as invalid and repair.
                     if v == 0 {
-                        1
+                        (1, true)
                     } else {
-                        v
+                        (v, false)
                     }
                 }
-                None => 1,
+                None => (1, false),
             };
 
             let stored_matches = existing_id
@@ -1157,8 +1157,6 @@ impl SqliteStorage {
                 .and_then(|hex_id| hex::decode(hex_id).ok())
                 .as_deref()
                 == Some(master_key_id.as_slice());
-            // Also repair if epoch was 0 (parsed as stored_epoch=0 → epoch=1).
-            let stored_epoch_zero = epoch_str.as_deref() == Some("0");
             let needs_update = !stored_matches || epoch_missing || stored_epoch_zero;
 
             if needs_update {
@@ -1175,9 +1173,10 @@ impl SqliteStorage {
                     params![epoch.to_string()],
                 )
                 .map_err(map_err)?;
-                // Backfill/repair node rows. When master_key_id differs, the
-                // epoch is reset because it is scoped to the key identity —
-                // an epoch from a previous key has no meaning for the current one.
+                // Backfill/repair node rows. When master_key_id changes,
+                // epoch is set to the current key's epoch because epoch is
+                // scoped to key identity — a previous key's epoch value has
+                // no meaning for the current key.
                 let epoch_i64 = i64::try_from(epoch).map_err(|_| {
                     StorageError::Internal(format!("master_key_epoch {epoch} exceeds i64::MAX"))
                 })?;

--- a/crates/sonde-gateway/tests/escrow.rs
+++ b/crates/sonde-gateway/tests/escrow.rs
@@ -4,7 +4,7 @@
 //! Integration tests for PSK escrow, master key identification, and ACTUAL_STATE
 //! publication (GW-2001, GW-2003, GW-2004, GW-2005).
 //!
-//! Test IDs: T-2000, T-2001, T-2002, T-2006c, T-2011, T-2012, T-2013, T-2014.
+//! Test IDs: T-2000, T-2001, T-2002, T-2006c, T-2011, T-2012, T-2014.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 use zeroize::Zeroizing;
 
 use sonde_gateway::connector::{
-    ConnectorEventHub, ConnectorService, GatewayDesiredState, KdfParams, MSG_TYPE_ACTUAL_STATE,
+    ConnectorEventHub, ConnectorService, GatewayDesiredState, MSG_TYPE_ACTUAL_STATE,
     MSG_TYPE_DESIRED_STATE,
 };
 use sonde_gateway::engine::Gateway;
@@ -30,7 +30,7 @@ use sonde_gateway::RustCryptoSha256;
 use aes_gcm::aead::{Aead, KeyInit, Payload};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use hkdf::Hkdf;
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 use x25519_dalek::PublicKey as X25519PublicKey;
 
 // ── helpers ──────────────────────────────────────────────────────
@@ -59,9 +59,9 @@ impl sonde_gateway::key_provider::KeyProvider for NoopWritableKeyProvider {
     }
 }
 
-/// Create a test gateway with identity and storage, but do NOT call
-/// `init_master_key_id()` — the caller must do that after registering nodes
-/// so the backfill picks them up.
+/// Create a test gateway with identity and storage, but do NOT initialize the
+/// master key ID yet — the caller must do that after registering nodes so the
+/// backfill picks them up.
 async fn setup_test_storage() -> (Arc<SqliteStorage>, GatewayIdentity) {
     let master_key = Zeroizing::new([0x42u8; 32]);
     let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
@@ -77,7 +77,7 @@ async fn setup_test_storage() -> (Arc<SqliteStorage>, GatewayIdentity) {
 async fn setup_test_gateway() -> (
     Arc<SqliteStorage>,
     GatewayIdentity,
-    [u8; 16], // master_key_id
+    [u8; 32], // master_key_id
     u64,      // epoch
     String,   // rotation_code
 ) {
@@ -131,8 +131,6 @@ fn build_rotation_payload(
     current_epoch: u64,
     new_master_key: &[u8; 32],
     rotation_code: &str,
-    new_master_key_id: &[u8; 16],
-    salt: Option<&[u8; 16]>,
 ) -> Vec<u8> {
     let mut rng_bytes = [0u8; 32];
     getrandom::fill(&mut rng_bytes).unwrap();
@@ -151,7 +149,7 @@ fn build_rotation_payload(
     let mut derived_key = [0u8; 32];
     hk.expand(&info, &mut derived_key).unwrap();
 
-    let mut cbor_pairs: Vec<(Value, Value)> = vec![
+    let cbor_map = Value::Map(vec![
         (
             Value::Integer(1.into()),
             Value::Bytes(new_master_key.to_vec()),
@@ -160,18 +158,7 @@ fn build_rotation_payload(
             Value::Integer(2.into()),
             Value::Text(rotation_code.to_string()),
         ),
-        (
-            Value::Integer(3.into()),
-            Value::Bytes(new_master_key_id.to_vec()),
-        ),
-    ];
-    if let Some(s) = salt {
-        cbor_pairs.push((Value::Integer(4.into()), Value::Bytes(s.to_vec())));
-    } else {
-        cbor_pairs.push((Value::Integer(4.into()), Value::Null));
-    }
-    cbor_pairs.push((Value::Integer(5.into()), Value::Null));
-    let cbor_map = Value::Map(cbor_pairs);
+    ]);
     let mut plaintext = Vec::new();
     ciborium::into_writer(&cbor_map, &mut plaintext).unwrap();
 
@@ -289,7 +276,7 @@ fn map_get(map: &[(i128, Value)], key: i128) -> Option<&Value> {
 ///
 /// Verifies:
 /// 1. No `master_key_id` or `master_key_epoch` on fresh DB.
-/// 2. After `init_master_key_id()`, a random 16-byte ID and epoch=1 are set.
+/// 2. After `init_master_key_id(&[0x42u8; 32])`, `SHA-256(master_key)` and epoch=1 are set.
 /// 3. All existing PSK records are backfilled.
 /// 4. On restart (re-call), the same values are returned.
 #[tokio::test]
@@ -317,9 +304,10 @@ async fn test_t2000_master_key_identification() {
     // Step 3: Run init_master_key_id.
     let (key_id, epoch) = store.init_master_key_id().await.unwrap();
 
-    // Step 4: Verify master_key_id is 16 bytes, non-zero.
-    assert_eq!(key_id.len(), 16);
-    assert_ne!(key_id, [0u8; 16], "master_key_id must be non-zero");
+    // Step 4: Verify master_key_id is SHA-256(master_key).
+    let expected_key_id: [u8; 32] = Sha256::digest([0x42u8; 32]).into();
+    assert_eq!(key_id, expected_key_id);
+    assert_ne!(key_id, [0u8; 32], "master_key_id must be non-zero");
 
     // Step 5: Verify epoch = 1.
     assert_eq!(epoch, 1);
@@ -399,8 +387,6 @@ async fn test_t2001_gateway_actual_state_publication() {
         *x25519_public.as_bytes(),
         expected_fp.map(|s| s.to_string()),
         vec![], // missing_key_hints
-        None,   // salt
-        None,   // kdf_params
         "0.8.0".to_string(),
         "abc123".to_string(),
         None, // modem_firmware_version
@@ -686,8 +672,8 @@ async fn test_t2006c_phone_psks_not_escrowed() {
 
     // Step 3: Perform key rotation.
     let new_key = [0xAAu8; 32];
-    let new_id = [0xBBu8; 16];
-    let payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+    let new_id: [u8; 32] = Sha256::digest(new_key).into();
+    let payload = build_rotation_payload(&identity, epoch, &new_key, &code);
 
     let (_, grpc_rx) = mpsc::unbounded_channel();
     let (_, desired_state_rx) = mpsc::unbounded_channel();
@@ -771,43 +757,29 @@ async fn emit_gateway_actual_state_from_storage(
         .map(|b| format!("{b:02x}"))
         .collect();
 
-    let (mk_id, mk_epoch) = storage.init_master_key_id().await.unwrap();
+    let mk_id_hex = storage
+        .get_config("master_key_id")
+        .await
+        .unwrap()
+        .expect("master_key_id must exist before ACTUAL_STATE emission");
+    let mk_id_vec = hex::decode(&mk_id_hex).expect("master_key_id must be valid hex");
+    let mk_id: [u8; 32] = mk_id_vec
+        .as_slice()
+        .try_into()
+        .expect("master_key_id must be 32 bytes");
+    let mk_epoch = storage
+        .get_config("master_key_epoch")
+        .await
+        .unwrap()
+        .expect("master_key_epoch must exist before ACTUAL_STATE emission")
+        .parse::<u64>()
+        .expect("master_key_epoch must be a valid u64");
 
     let (_, x25519_public) = identity.to_x25519().unwrap();
 
     let sha = RustCryptoSha256;
     let fp = sonde_protocol::fingerprint::compute_fingerprint(x25519_public.as_bytes(), &sha);
     let fingerprint_words: [String; 6] = fp.map(|w| w.to_string());
-
-    let salt: Option<Vec<u8>> = storage.get_config("kdf_salt").await.unwrap().and_then(|s| {
-        let bytes = hex::decode(&s).ok()?;
-        if bytes.len() == 16 {
-            Some(bytes)
-        } else {
-            None
-        }
-    });
-
-    let kdf_params: Option<KdfParams> = storage
-        .get_config("kdf_params_json")
-        .await
-        .unwrap()
-        .and_then(|json| {
-            #[derive(serde::Deserialize)]
-            struct Kdf {
-                m_cost: u32,
-                t_cost: u32,
-                p_cost: u32,
-                kdf_version: u32,
-            }
-            let p: Kdf = serde_json::from_str(&json).ok()?;
-            Some(KdfParams {
-                m_cost: p.m_cost,
-                t_cost: p.t_cost,
-                p_cost: p.p_cost,
-                kdf_version: p.kdf_version,
-            })
-        });
 
     let missing_key_hints = gateway.drain_missing_hints().await;
 
@@ -819,8 +791,6 @@ async fn emit_gateway_actual_state_from_storage(
         *x25519_public.as_bytes(),
         fingerprint_words,
         missing_key_hints,
-        salt,
-        kdf_params,
         "0.8.0".to_string(),
         "test".to_string(),
         None,
@@ -899,15 +869,8 @@ async fn test_t2012_rotation_complete_triggers_reemission() {
 
     // Submit a valid rotation payload via gRPC channel.
     let new_master_key = [0x99u8; 32];
-    let new_master_key_id = [0xBBu8; 16];
-    let payload = build_rotation_payload(
-        &identity,
-        initial_epoch,
-        &new_master_key,
-        &rotation_code,
-        &new_master_key_id,
-        None,
-    );
+    let new_master_key_id: [u8; 32] = Sha256::digest(new_master_key).into();
+    let payload = build_rotation_payload(&identity, initial_epoch, &new_master_key, &rotation_code);
 
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     grpc_tx.send((payload, reply_tx)).unwrap();
@@ -944,156 +907,6 @@ async fn test_t2012_rotation_complete_triggers_reemission() {
         new_mk_epoch,
         (initial_epoch + 1) as i128,
         "master_key_epoch should increment after rotation"
-    );
-}
-
-// ── T-2013: Salt/KDF adoption triggers ACTUAL_STATE re-emission ──
-
-/// T-2013: Salt/KDF adoption triggers ACTUAL_STATE re-emission (GW-2003 AC-7).
-///
-/// Verifies:
-/// 1. Delivering a gateway DESIRED_STATE with salt and kdf_params triggers
-///    ACTUAL_STATE re-emission with the adopted values.
-/// 2. Delivering a second DESIRED_STATE with a different salt does NOT trigger
-///    another re-emission (salt is immutable once set).
-#[tokio::test]
-async fn test_t2013_salt_kdf_adoption_triggers_reemission() {
-    let (store, identity) = setup_test_storage().await;
-    let (_key_id, _epoch) = store.init_master_key_id().await.unwrap();
-    let _code = store.init_rotation_code().await.unwrap();
-
-    let event_hub = Arc::new(ConnectorEventHub::new(16));
-    let gateway = Arc::new(Gateway::new(
-        store.clone() as Arc<dyn Storage>,
-        Duration::from_secs(300),
-    ));
-
-    // Spawn connector.
-    let (mut client, _handle) =
-        spawn_connector(event_hub.clone(), store.clone() as Arc<dyn Storage>).await;
-
-    // Emit initial ACTUAL_STATE (salt = null).
-    emit_gateway_actual_state_from_storage(&event_hub, &store, &identity, &gateway).await;
-    let initial_frame = read_framed(&mut client).await;
-    let initial_map = decode_cbor_map(&initial_frame);
-    // Salt (key 21) should be null or absent.
-    let initial_salt = map_get(&initial_map, 21);
-    assert!(
-        initial_salt.is_none() || matches!(initial_salt, Some(Value::Null)),
-        "initial salt should be absent or null"
-    );
-    // KDF params (key 22) should be null or absent.
-    let initial_kdf = map_get(&initial_map, 22);
-    assert!(
-        initial_kdf.is_none() || matches!(initial_kdf, Some(Value::Null)),
-        "initial kdf_params should be absent or null"
-    );
-
-    // Set up rotation engine with state_changed_tx.
-    let (state_changed_tx, mut state_changed_rx) = mpsc::unbounded_channel();
-    let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
-    let (ds_tx, ds_rx) = mpsc::unbounded_channel::<GatewayDesiredState>();
-
-    let engine = RotationEngine::new(
-        store.clone(),
-        identity.clone(),
-        event_hub.clone(),
-        Arc::new(NoopWritableKeyProvider),
-        grpc_rx,
-        ds_rx,
-    )
-    .with_state_changed_tx(state_changed_tx);
-
-    // Spawn the rotation engine.
-    tokio::spawn(engine.run());
-
-    // Spawn re-emission loop for state_changed notifications.
-    let reemit_store = store.clone();
-    let reemit_hub = event_hub.clone();
-    let reemit_gw = Arc::clone(&gateway);
-    tokio::spawn(async move {
-        while let Some(_changed) = state_changed_rx.recv().await {
-            let id = reemit_store.load_gateway_identity().await.unwrap().unwrap();
-            emit_gateway_actual_state_from_storage(&reemit_hub, &reemit_store, &id, &reemit_gw)
-                .await;
-        }
-    });
-
-    // Deliver a DESIRED_STATE with salt and kdf_params via the ds channel.
-    let gateway_id_hex: String = identity
-        .gateway_id()
-        .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect();
-    let test_salt = [0xAA; 16];
-    ds_tx
-        .send(GatewayDesiredState {
-            entity_id: gateway_id_hex.clone(),
-            channel: None,
-            rotation_payload: None,
-            recovered_psks: None,
-            salt: Some(test_salt.to_vec()),
-            kdf_params: Some(KdfParams {
-                m_cost: 65536,
-                t_cost: 3,
-                p_cost: 1,
-                kdf_version: 0x13,
-            }),
-        })
-        .unwrap();
-
-    // Read the re-emitted ACTUAL_STATE.
-    let reemitted_frame = tokio::time::timeout(Duration::from_secs(2), read_framed(&mut client))
-        .await
-        .expect("ACTUAL_STATE should be re-emitted after salt adoption");
-    let reemitted_map = decode_cbor_map(&reemitted_frame);
-
-    // Verify salt (key 21) matches the adopted value.
-    let adopted_salt = match map_get(&reemitted_map, 21).unwrap() {
-        Value::Bytes(b) => b.clone(),
-        other => panic!("expected bytes salt, got {other:?}"),
-    };
-    assert_eq!(adopted_salt, test_salt.to_vec());
-
-    // Verify kdf_params (key 22) matches the adopted values.
-    let kdf_map = match map_get(&reemitted_map, 22).unwrap() {
-        Value::Map(pairs) => pairs.clone(),
-        other => panic!("expected map kdf_params, got {other:?}"),
-    };
-    let kdf_get = |key: i128| -> i128 {
-        kdf_map
-            .iter()
-            .find(|(k, _)| matches!(k, Value::Integer(i) if i128::from(*i) == key))
-            .map(|(_, v)| match v {
-                Value::Integer(i) => (*i).into(),
-                other => panic!("expected integer in kdf_params, got {other:?}"),
-            })
-            .unwrap()
-    };
-    assert_eq!(kdf_get(1), 65536, "m_cost");
-    assert_eq!(kdf_get(2), 3, "t_cost");
-    assert_eq!(kdf_get(3), 1, "p_cost");
-    assert_eq!(kdf_get(4), 0x13, "kdf_version");
-
-    // Step 5: Deliver another DESIRED_STATE with different salt.
-    let different_salt = [0xBB; 16];
-    ds_tx
-        .send(GatewayDesiredState {
-            entity_id: gateway_id_hex.clone(),
-            channel: None,
-            rotation_payload: None,
-            recovered_psks: None,
-            salt: Some(different_salt.to_vec()),
-            kdf_params: None,
-        })
-        .unwrap();
-
-    // Step 6: Verify ACTUAL_STATE is NOT re-emitted (salt is immutable).
-    let timeout_result =
-        tokio::time::timeout(Duration::from_millis(500), read_framed(&mut client)).await;
-    assert!(
-        timeout_result.is_err(),
-        "ACTUAL_STATE should NOT be re-emitted when salt is already set"
     );
 }
 

--- a/crates/sonde-gateway/tests/escrow.rs
+++ b/crates/sonde-gateway/tests/escrow.rs
@@ -276,7 +276,7 @@ fn map_get(map: &[(i128, Value)], key: i128) -> Option<&Value> {
 ///
 /// Verifies:
 /// 1. No `master_key_id` or `master_key_epoch` on fresh DB.
-/// 2. After `init_master_key_id(&[0x42u8; 32])`, `SHA-256(master_key)` and epoch=1 are set.
+/// 2. After `init_master_key_id()`, `SHA-256(master_key)` and epoch=1 are set.
 /// 3. All existing PSK records are backfilled.
 /// 4. On restart (re-call), the same values are returned.
 #[tokio::test]

--- a/crates/sonde-gateway/tests/node_recovery.rs
+++ b/crates/sonde-gateway/tests/node_recovery.rs
@@ -141,8 +141,6 @@ async fn test_t2006_declarative_node_recovery() {
     let desired_state = GatewayDesiredState {
         entity_id,
         channel: None,
-        salt: None,
-        kdf_params: None,
         rotation_payload: None,
         recovered_psks: Some(vec![RecoveredPskRecord {
             node_id: "recovered-node".to_string(),
@@ -312,8 +310,6 @@ async fn test_t2006b_mismatched_master_key_id_skipped() {
     let desired_state = GatewayDesiredState {
         entity_id,
         channel: None,
-        salt: None,
-        kdf_params: None,
         rotation_payload: None,
         recovered_psks: Some(vec![RecoveredPskRecord {
             node_id: "orphan-node".to_string(),

--- a/crates/sonde-gateway/tests/rotation.rs
+++ b/crates/sonde-gateway/tests/rotation.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use aes_gcm::aead::{Aead, KeyInit, Payload};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use hkdf::Hkdf;
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 use tokio::sync::{mpsc, oneshot};
 use x25519_dalek::PublicKey as X25519PublicKey;
 use zeroize::Zeroizing;
@@ -30,8 +30,6 @@ fn build_rotation_payload(
     current_epoch: u64,
     new_master_key: &[u8; 32],
     rotation_code: &str,
-    new_master_key_id: &[u8; 16],
-    salt: Option<&[u8; 16]>,
 ) -> Vec<u8> {
     // Generate ephemeral X25519 keypair.
     let mut rng_bytes = [0u8; 32];
@@ -56,8 +54,8 @@ fn build_rotation_payload(
     let mut derived_key = [0u8; 32];
     hk.expand(&info, &mut derived_key).unwrap();
 
-    // Build CBOR plaintext: {1: new_master_key, 2: rotation_code, 3: new_master_key_id, 4: salt, 5: null}
-    let mut cbor_pairs: Vec<(ciborium::Value, ciborium::Value)> = vec![
+    // Build CBOR plaintext: {1: new_master_key, 2: rotation_code}
+    let cbor_map = ciborium::Value::Map(vec![
         (
             ciborium::Value::Integer(1.into()),
             ciborium::Value::Bytes(new_master_key.to_vec()),
@@ -66,21 +64,7 @@ fn build_rotation_payload(
             ciborium::Value::Integer(2.into()),
             ciborium::Value::Text(rotation_code.to_string()),
         ),
-        (
-            ciborium::Value::Integer(3.into()),
-            ciborium::Value::Bytes(new_master_key_id.to_vec()),
-        ),
-    ];
-    if let Some(s) = salt {
-        cbor_pairs.push((
-            ciborium::Value::Integer(4.into()),
-            ciborium::Value::Bytes(s.to_vec()),
-        ));
-    } else {
-        cbor_pairs.push((ciborium::Value::Integer(4.into()), ciborium::Value::Null));
-    }
-    cbor_pairs.push((ciborium::Value::Integer(5.into()), ciborium::Value::Null));
-    let cbor_map = ciborium::Value::Map(cbor_pairs);
+    ]);
     let mut plaintext = Vec::new();
     ciborium::into_writer(&cbor_map, &mut plaintext).unwrap();
 
@@ -111,7 +95,7 @@ fn build_rotation_payload(
 async fn setup_test_gateway() -> (
     Arc<SqliteStorage>,
     GatewayIdentity,
-    [u8; 16], // master_key_id
+    [u8; 32], // master_key_id
     u64,      // epoch
     String,   // rotation_code
 ) {
@@ -213,11 +197,10 @@ async fn test_t2003_rotation_code_authentication() {
 
     // Build a payload with the WRONG rotation code.
     let new_key = [0xAAu8; 32];
-    let new_id = [0xBBu8; 16];
     let wrong_code = "ZZZZZZ";
     assert_ne!(wrong_code, code);
 
-    let payload = build_rotation_payload(&identity, epoch, &new_key, wrong_code, &new_id, None);
+    let payload = build_rotation_payload(&identity, epoch, &new_key, wrong_code);
 
     // Submit via the engine — should be rejected.
     let (_grpc_tx, grpc_rx) = mpsc::unbounded_channel();
@@ -238,7 +221,7 @@ async fn test_t2003_rotation_code_authentication() {
     assert!(result.unwrap_err().contains("rotation code does not match"));
 
     // Submit with the CORRECT rotation code — should succeed.
-    let payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+    let payload = build_rotation_payload(&identity, epoch, &new_key, &code);
 
     let (_grpc_tx2, grpc_rx2) = mpsc::unbounded_channel();
     let (_, desired_state_rx2) = mpsc::unbounded_channel();
@@ -290,8 +273,8 @@ async fn test_t2004_rotation_happy_path() {
 
     // Build and submit rotation.
     let new_key = [0xAAu8; 32];
-    let new_id = [0xBBu8; 16];
-    let payload = build_rotation_payload(&identity, old_epoch, &new_key, &code, &new_id, None);
+    let new_id: [u8; 32] = Sha256::digest(new_key).into();
+    let payload = build_rotation_payload(&identity, old_epoch, &new_key, &code);
 
     let (_, grpc_rx) = mpsc::unbounded_channel();
     let (_, desired_state_rx) = mpsc::unbounded_channel();
@@ -338,11 +321,9 @@ async fn test_t2004a_rotation_validation_failures() {
     let (store, identity, _, epoch, code) = setup_test_gateway().await;
 
     let new_key = [0xAAu8; 32];
-    let new_id = [0xBBu8; 16];
 
     // 1. Wrong epoch (build with epoch+1 — AAD won't match).
-    let wrong_epoch_payload =
-        build_rotation_payload(&identity, epoch + 1, &new_key, &code, &new_id, None);
+    let wrong_epoch_payload = build_rotation_payload(&identity, epoch + 1, &new_key, &code);
     let (_, grpc_rx) = mpsc::unbounded_channel();
     let (_, desired_state_rx) = mpsc::unbounded_channel();
     let event_hub = Arc::new(ConnectorEventHub::default());
@@ -360,8 +341,7 @@ async fn test_t2004a_rotation_validation_failures() {
     assert!(result.is_err(), "wrong epoch should be rejected");
 
     // 2. Wrong rotation code.
-    let wrong_code_payload =
-        build_rotation_payload(&identity, epoch, &new_key, "BADCOD", &new_id, None);
+    let wrong_code_payload = build_rotation_payload(&identity, epoch, &new_key, "BADCOD");
     let (_, grpc_rx) = mpsc::unbounded_channel();
     let (_, desired_state_rx) = mpsc::unbounded_channel();
     let event_hub = Arc::new(ConnectorEventHub::default());
@@ -379,7 +359,7 @@ async fn test_t2004a_rotation_validation_failures() {
     assert!(result.is_err(), "wrong code should be rejected");
 
     // 3. Corrupted ciphertext.
-    let mut corrupted = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+    let mut corrupted = build_rotation_payload(&identity, epoch, &new_key, &code);
     // Flip a byte in the ciphertext region.
     let last = corrupted.len() - 1;
     corrupted[last] ^= 0xFF;
@@ -398,7 +378,7 @@ async fn test_t2004a_rotation_validation_failures() {
     assert!(result.is_err(), "corrupted ciphertext should be rejected");
 
     // 4. Replay (submit valid, then replay — epoch already incremented).
-    let valid_payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+    let valid_payload = build_rotation_payload(&identity, epoch, &new_key, &code);
     let (_, grpc_rx) = mpsc::unbounded_channel();
     let (_, desired_state_rx) = mpsc::unbounded_channel();
     let event_hub = Arc::new(ConnectorEventHub::default());
@@ -439,18 +419,17 @@ async fn test_t2004b_concurrent_rotation_discard() {
     register_test_node(&store, "node-a", 100).await;
 
     let new_key = [0xAAu8; 32];
-    let new_id = [0xBBu8; 16];
+    let new_id: [u8; 32] = Sha256::digest(new_key).into();
 
     // Manually create a pending_rotation to simulate an in-progress rotation.
     store
-        .write_pending_rotation(&new_key, &new_id, epoch + 1, None, None)
+        .write_pending_rotation(&new_key, &new_id, epoch + 1)
         .await
         .unwrap();
     assert!(store.is_rotation_in_progress().await.unwrap());
 
     // Submit a second rotation payload — should be rejected.
-    let payload =
-        build_rotation_payload(&identity, epoch, &[0xCCu8; 32], &code, &[0xDDu8; 16], None);
+    let payload = build_rotation_payload(&identity, epoch, &[0xCCu8; 32], &code);
 
     let (_, grpc_rx) = mpsc::unbounded_channel();
     let (_, desired_state_rx) = mpsc::unbounded_channel();
@@ -505,12 +484,12 @@ async fn test_t2005_crash_safe_rotation() {
     // Build and submit rotation — manually execute only partial migration to
     // simulate a crash.
     let new_key = [0xAAu8; 32];
-    let new_id = [0xBBu8; 16];
+    let new_id: [u8; 32] = Sha256::digest(new_key).into();
     let new_epoch = epoch + 1;
 
     // Step 4: Prepare.
     store
-        .write_pending_rotation(&new_key, &new_id, new_epoch, None, None)
+        .write_pending_rotation(&new_key, &new_id, new_epoch)
         .await
         .unwrap();
 
@@ -566,8 +545,7 @@ async fn test_t2008_grpc_rotation_path() {
     register_test_node(&store, "node-a", 100).await;
 
     let new_key = [0xAAu8; 32];
-    let new_id = [0xBBu8; 16];
-    let payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+    let payload = build_rotation_payload(&identity, epoch, &new_key, &code);
 
     // Submit via gRPC channel.
     let (grpc_tx, grpc_rx) = mpsc::unbounded_channel();
@@ -623,7 +601,7 @@ async fn test_t2008_grpc_rotation_path() {
 async fn test_t2009_crash_recovery_all_phases() {
     let master_key = Zeroizing::new([0x42u8; 32]);
     let new_key = [0xAAu8; 32];
-    let new_id = [0xBBu8; 16];
+    let new_id: [u8; 32] = Sha256::digest(new_key).into();
 
     // Phase 1: Crash during migrating_psks (tested in T-2005).
 
@@ -639,7 +617,7 @@ async fn test_t2009_crash_recovery_all_phases() {
 
         // Prepare + migrate all PSKs + set phase to rewrapping_identity.
         store
-            .write_pending_rotation(&new_key, &new_id, new_epoch, None, None)
+            .write_pending_rotation(&new_key, &new_id, new_epoch)
             .await
             .unwrap();
         let nodes = store.list_unmigrated_node_ids(new_epoch).await.unwrap();
@@ -682,7 +660,7 @@ async fn test_t2009_crash_recovery_all_phases() {
 
         // Prepare + migrate + rewrap + set phase to committing.
         store
-            .write_pending_rotation(&new_key, &new_id, new_epoch, None, None)
+            .write_pending_rotation(&new_key, &new_id, new_epoch)
             .await
             .unwrap();
         let nodes = store.list_unmigrated_node_ids(new_epoch).await.unwrap();
@@ -722,7 +700,7 @@ async fn test_t2010_pending_recovery_purge() {
     register_test_node(&store, "node-a", 100).await;
 
     // Insert records into pending_recovery.
-    let fake_key_id = [0x11u8; 16];
+    let fake_key_id = [0x11u8; 32];
     store
         .insert_pending_recovery(500, "recovered-node", &[0xEEu8; 60], &fake_key_id, epoch)
         .await
@@ -734,8 +712,8 @@ async fn test_t2010_pending_recovery_purge() {
 
     // Initiate rotation.
     let new_key = [0xAAu8; 32];
-    let new_id = [0xBBu8; 16];
-    let payload = build_rotation_payload(&identity, epoch, &new_key, &code, &new_id, None);
+    let new_id: [u8; 32] = Sha256::digest(new_key).into();
+    let payload = build_rotation_payload(&identity, epoch, &new_key, &code);
 
     let (_, grpc_rx) = mpsc::unbounded_channel();
     let (_, desired_state_rx) = mpsc::unbounded_channel();

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -393,14 +393,7 @@ function computeGatewayDivergence(actual, desired) {
     if (!Number.isNaN(desiredCh) && desiredCh !== actualCh) return true;
   }
 
-  // Salt pending adoption (set-if-absent): diverged only when actual has no salt.
-  if (desired.salt != null && !actual.salt) return true;
-
-  // KDF params pending adoption (set-if-absent): diverged only when actual has
-  // no KDF params. Field name in Azure Tables is kdf_params_json.
-  const desiredHasKdf = desired.kdf_params != null || desired.kdf_params_json != null;
-  const actualHasKdf = actual.kdf_params != null || actual.kdf_params_json != null;
-  if (desiredHasKdf && !actualHasKdf) return true;
+  // Salt and KDF convergence retired (GW-2020, GW-2021).
 
   return false;
 }
@@ -436,7 +429,6 @@ async function renderGatewayStatusCard(gatewayRows, gatewayDesiredRows) {
       ? bytesToHex(mkidBytes)
       : '—';
     const rotInProgress = gw.rotation_in_progress === true ? 'Yes' : 'No';
-    const saltStatus = gw.salt ? 'Present' : 'Absent';
     const gwVersion = gw.gateway_version || '—';
     const modemVersion = gw.modem_firmware_version || '—';
     const channel = gw.channel ?? '—';
@@ -451,7 +443,6 @@ async function renderGatewayStatusCard(gatewayRows, gatewayDesiredRows) {
       ? '<button class="secondary" disabled title="Browser lacks required crypto capabilities (Web Crypto + WebAssembly)">Rotate Key</button>'
       : `<button class="secondary rotate-key-btn" data-gateway-id="${escapeHtml(gwId)}">Rotate Key</button>`;
 
-    const saltStatusText = gw.salt ? 'Current salt loaded' : 'First rotation (no salt)';
     const formExpanded = APP.rotationFormOpen === gwId;
     const formStyle = formExpanded ? '' : ' style="display:none"';
 
@@ -463,7 +454,6 @@ async function renderGatewayStatusCard(gatewayRows, gatewayDesiredRows) {
           <div class="kv"><strong>Epoch</strong> ${escapeHtml(epoch)}</div>
           <div class="kv"><strong>Master Key ID</strong> <code>${mkid === '—' ? '—' : escapeHtml(mkid.slice(0, 16)) + '…'}</code></div>
           <div class="kv"><strong>Rotation in progress</strong> ${escapeHtml(rotInProgress)}</div>
-          <div class="kv"><strong>Salt</strong> ${escapeHtml(saltStatus)}</div>
           <div class="kv"><strong>Gateway version</strong> ${escapeHtml(gwVersion)}</div>
           <div class="kv"><strong>Modem version</strong> ${escapeHtml(modemVersion)}</div>
           <div class="kv"><strong>Channel</strong> ${escapeHtml(channel)}</div>
@@ -481,7 +471,10 @@ async function renderGatewayStatusCard(gatewayRows, gatewayDesiredRows) {
               <input name="passphrase" type="password"
                 placeholder="Enter passphrase…" required>
             </label>
-            <p class="muted small">${escapeHtml(saltStatusText)}</p>
+            <label>Deployment Label
+              <input name="deploymentLabel" type="text"
+                placeholder="e.g. Alan's production deployment" required>
+            </label>
             <div class="rotation-status" data-gateway-status="${escapeHtml(gwId)}"></div>
             <div style="display:flex;gap:0.5rem">
               <button type="submit" class="primary rotation-submit-btn">Rotate</button>
@@ -591,6 +584,7 @@ function attachRotationFormHandlers(gatewayRows) {
 
       const code = (form.rotationCode?.value || '').toUpperCase().trim();
       const passphrase = form.passphrase?.value || '';
+      const deploymentLabel = (form.deploymentLabel?.value || '').trim();
       const statusEl = document.querySelector(`.rotation-status[data-gateway-status="${gwId}"]`);
       const submitBtn = form.querySelector('.rotation-submit-btn');
 
@@ -600,6 +594,10 @@ function attachRotationFormHandlers(gatewayRows) {
       }
       if (passphrase.length < 20 && passphrase.split(/\s+/).filter((w) => w).length < 6) {
         if (statusEl) statusEl.innerHTML = '<div class="alert error">Passphrase must be ≥20 characters or 6+ space-separated words.</div>';
+        return;
+      }
+      if (!deploymentLabel) {
+        if (statusEl) statusEl.innerHTML = '<div class="alert error">Deployment label must not be empty.</div>';
         return;
       }
 
@@ -614,7 +612,7 @@ function attachRotationFormHandlers(gatewayRows) {
       const epoch = Number(gwRow.master_key_epoch) || 0;
 
       try {
-        const payload = await buildRotationPayload(gwRow, code, passphrase);
+        const payload = await buildRotationPayload(gwRow, code, passphrase, deploymentLabel);
         if (statusEl) statusEl.innerHTML = '<p class="muted">Submitting rotation…</p>';
         await submitRotationPayload(gwId, payload, epoch);
         if (statusEl) statusEl.innerHTML = '<div class="alert success">Rotation submitted.</div>';
@@ -632,7 +630,7 @@ function attachRotationFormHandlers(gatewayRows) {
   }
 }
 
-async function buildRotationPayload(gatewayRow, rotationCode, passphrase) {
+async function buildRotationPayload(gatewayRow, rotationCode, passphrase, deploymentLabel) {
   const gwId = gatewayRow.PartitionKey?.replace('g:', '') || '';
   const gwIdBytes = hexToBytes(gwId);
   if (!gwIdBytes || gwIdBytes.length === 0) throw new Error('Invalid gateway_id');
@@ -644,26 +642,14 @@ async function buildRotationPayload(gatewayRow, rotationCode, passphrase) {
 
   const epoch = Number(gatewayRow.master_key_epoch) || 0;
 
-  // Parse KDF params
-  let mCost = 65536, tCost = 3, pCost = 1;
-  if (gatewayRow.kdf_params_json) {
-    try {
-      const kdf = JSON.parse(gatewayRow.kdf_params_json);
-      if (kdf.m_cost) mCost = kdf.m_cost;
-      if (kdf.t_cost) tCost = kdf.t_cost;
-      if (kdf.p_cost) pCost = kdf.p_cost;
-    } catch { /* use defaults */ }
-  }
+  // KDF v1: hardcoded Argon2id params (GW-2020)
+  const mCost = 65536, tCost = 3, pCost = 1;
 
-  // Determine salt: use gateway salt if present, otherwise generate for first rotation.
-  let salt;
-  if (gatewayRow.salt) {
-    salt = base64ToBytes(gatewayRow.salt);
-  } else {
-    salt = new Uint8Array(16);
-    crypto.getRandomValues(salt);
-  }
-  if (!salt || salt.length !== 16) throw new Error('Invalid salt');
+  // Derive salt from deployment label (GW-2021)
+  if (!deploymentLabel) throw new Error('Deployment label must not be empty');
+  const saltInput = new TextEncoder().encode('sonde-kdf-v1:' + deploymentLabel);
+  const saltHashBuf = await crypto.subtle.digest('SHA-256', saltInput);
+  const salt = new Uint8Array(saltHashBuf).slice(0, 16);
 
   // Derive master key via Argon2id (WEB-1003)
   if (typeof argon2 === 'undefined') {
@@ -680,12 +666,7 @@ async function buildRotationPayload(gatewayRow, rotationCode, passphrase) {
   });
   const newMasterKey = new Uint8Array(argonResult.hash);
 
-  // Generate new master_key_id (16 random bytes)
-  const newMasterKeyId = new Uint8Array(16);
-  crypto.getRandomValues(newMasterKeyId);
-
-  // KDF params to include in plaintext
-  const kdfParams = { m_cost: mCost, t_cost: tCost, p_cost: pCost, kdf_version: 1 };
+  // master_key_id is derived by gateway as SHA-256(master_key) — not included in payload.
 
   // X25519 key exchange (WEB-1004)
   if (typeof nobleEd25519 === 'undefined' && typeof noble_curves_x25519 === 'undefined') {
@@ -716,8 +697,9 @@ async function buildRotationPayload(gatewayRow, rotationCode, passphrase) {
   );
   const aesKey = new Uint8Array(derivedBits);
 
-  // CBOR plaintext: {1: new_master_key, 2: rotation_code, 3: new_master_key_id, 4: salt, 5: kdf_params}
-  const plaintext = encodeCborRotationPlaintext(newMasterKey, rotationCode, newMasterKeyId, salt, kdfParams);
+  // CBOR plaintext: {1: new_master_key, 2: rotation_code}
+  // Keys 3-5 are RESERVED (previously new_master_key_id, salt, kdf_params).
+  const plaintext = encodeCborRotationPlaintext(newMasterKey, rotationCode);
 
   // AES-256-GCM encryption
   const nonce = new Uint8Array(12);
@@ -750,12 +732,13 @@ async function buildRotationPayload(gatewayRow, rotationCode, passphrase) {
   return result;
 }
 
-function encodeCborRotationPlaintext(masterKey, rotationCode, masterKeyId, salt, kdfParams) {
+function encodeCborRotationPlaintext(masterKey, rotationCode) {
   // Minimal deterministic CBOR encoder for the rotation plaintext map.
-  // Map with 5 entries: {1: bstr, 2: tstr, 3: bstr, 4: bstr, 5: map}
+  // Map with 2 entries: {1: bstr, 2: tstr}
+  // Keys 3-5 are RESERVED (previously new_master_key_id, salt, kdf_params).
   const parts = [];
-  // CBOR map header (5 items)
-  parts.push(0xa5);
+  // CBOR map header (2 items)
+  parts.push(0xa2);
   // Key 1: new_master_key (bstr 32)
   parts.push(0x01);
   parts.push(0x58, 0x20); // bstr(32)
@@ -765,36 +748,7 @@ function encodeCborRotationPlaintext(masterKey, rotationCode, masterKeyId, salt,
   const codeBytes = new TextEncoder().encode(rotationCode);
   parts.push(0x60 + codeBytes.length);
   for (let i = 0; i < codeBytes.length; i++) parts.push(codeBytes[i]);
-  // Key 3: new_master_key_id (bstr 16)
-  parts.push(0x03);
-  parts.push(0x50); // bstr(16)
-  for (let i = 0; i < masterKeyId.length; i++) parts.push(masterKeyId[i]);
-  // Key 4: salt (bstr 16)
-  parts.push(0x04);
-  parts.push(0x50); // bstr(16)
-  for (let i = 0; i < salt.length; i++) parts.push(salt[i]);
-  // Key 5: kdf_params (map with 4 entries)
-  parts.push(0x05);
-  parts.push(0xa4);
-  // {1: m_cost, 2: t_cost, 3: p_cost, 4: kdf_version}
-  encodeCborUintEntry(parts, 1, kdfParams.m_cost);
-  encodeCborUintEntry(parts, 2, kdfParams.t_cost);
-  encodeCborUintEntry(parts, 3, kdfParams.p_cost);
-  encodeCborUintEntry(parts, 4, kdfParams.kdf_version || 1);
   return new Uint8Array(parts);
-}
-
-function encodeCborUintEntry(parts, key, value) {
-  parts.push(key); // key (0-23 fits in 1 byte)
-  if (value < 24) {
-    parts.push(value);
-  } else if (value < 256) {
-    parts.push(0x18, value);
-  } else if (value < 65536) {
-    parts.push(0x19, (value >>> 8) & 0xff, value & 0xff);
-  } else {
-    parts.push(0x1a, (value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff);
-  }
 }
 
 async function submitRotationPayload(gwId, payloadBytes, epoch) {

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -622,6 +622,9 @@ function attachRotationFormHandlers(gatewayRows) {
         const msg = error instanceof Error ? error.message : String(error);
         if (statusEl) statusEl.innerHTML = `<div class="alert error">${escapeHtml(msg)}</div>`;
       } finally {
+        // Best-effort: clear passphrase and deployment label from DOM inputs.
+        if (form.passphrase) form.passphrase.value = '';
+        if (form.deploymentLabel) form.deploymentLabel.value = '';
         if (submitBtn) submitBtn.disabled = false;
         if (cancelBtn) cancelBtn.disabled = false;
         if (formContainer) delete formContainer.dataset.submitting;
@@ -633,7 +636,7 @@ function attachRotationFormHandlers(gatewayRows) {
 async function buildRotationPayload(gatewayRow, rotationCode, passphrase, deploymentLabel) {
   const gwId = gatewayRow.PartitionKey?.replace('g:', '') || '';
   const gwIdBytes = hexToBytes(gwId);
-  if (!gwIdBytes || gwIdBytes.length === 0) throw new Error('Invalid gateway_id');
+  if (!gwIdBytes || gwIdBytes.length !== 16) throw new Error('Invalid gateway_id (expected 16 bytes)');
 
   const pubKeyB64 = gatewayRow.x25519_public_key;
   if (!pubKeyB64) throw new Error('Gateway has no x25519_public_key');

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -609,7 +609,11 @@ function attachRotationFormHandlers(gatewayRows) {
       if (formContainer) formContainer.dataset.submitting = '1';
       if (statusEl) statusEl.innerHTML = '<p class="muted">Deriving key (Argon2id)… this may take a few seconds.</p>';
 
-      const epoch = Number(gwRow.master_key_epoch) || 0;
+      const epoch = Number(gwRow.master_key_epoch);
+      if (!Number.isSafeInteger(epoch) || epoch < 0) {
+        if (statusEl) statusEl.innerHTML = '<div class="alert error">Invalid or missing master_key_epoch in gateway row.</div>';
+        return;
+      }
 
       try {
         const payload = await buildRotationPayload(gwRow, code, passphrase, deploymentLabel);
@@ -643,7 +647,8 @@ async function buildRotationPayload(gatewayRow, rotationCode, passphrase, deploy
   const gwPubKey = base64ToBytes(pubKeyB64);
   if (!gwPubKey || gwPubKey.length !== 32) throw new Error('Invalid x25519_public_key');
 
-  const epoch = Number(gatewayRow.master_key_epoch) || 0;
+  const epoch = Number(gatewayRow.master_key_epoch);
+  if (!Number.isSafeInteger(epoch) || epoch < 0) throw new Error('Invalid master_key_epoch');
 
   // KDF v1: hardcoded Argon2id params (GW-2020)
   const mCost = 65536, tCost = 3, pCost = 1;

--- a/docs/admin-design.md
+++ b/docs/admin-design.md
@@ -379,8 +379,8 @@ gateway ACTUAL_STATE from the local gateway admin API.
 
 - `key fingerprint` reads `fingerprint_words` and prints the 6-word BIP-39
   fingerprint.
-- `key status` reads and displays `master_key_epoch`, `master_key_id`,
-  `rotation_in_progress`, salt status, and `kdf_params`.
+- `key status` reads and displays `master_key_epoch`, `master_key_id`
+  (32-byte SHA-256 hex), and `rotation_in_progress`.
 - `key rotate` reads the current gateway ACTUAL_STATE before building the
   rotation payload, then calls `SubmitRotation` to send the serialized
   `RotationPayloadV1` binary blob to the gateway.
@@ -393,23 +393,20 @@ After `SubmitRotation`, `key rotate` polls `GetGatewayState` until
 The `key rotate` handler performs the following sequence:
 
 1. Call `GetGatewayState` and extract the gateway fingerprint,
-   `x25519_public_key`, `master_key_epoch`, salt, and `kdf_params`.
+   `x25519_public_key`, and `master_key_epoch`.
 2. Display the BIP-39 fingerprint and prompt the user to confirm that it
    matches the modem display before continuing.
 3. Prompt for the rotation code on stdin and normalize the input to uppercase
    `[A-Z0-9]` before payload construction.
 4. Prompt for the passphrase using masked terminal input. Reject any passphrase
    shorter than 20 characters and fewer than 6 words.
-5. Select Argon2id parameters from gateway ACTUAL_STATE `kdf_params`, or use
-   defaults `m=65536`, `t=3`, `p=1` when the gateway has no stored parameters.
-6. Use the salt from gateway ACTUAL_STATE when present. On first rotation, if
-   the gateway reports no salt, generate a new random salt and include it in
-   the payload.
-7. Derive the new master key with Argon2id.
-8. Generate a random 16-byte `new_master_key_id`.
-9. Build `RotationPayloadV1` and send it with `SubmitRotation`.
-10. Poll `GetGatewayState` until `master_key_epoch` increments, then report
-    success.
+5. Prompt for the deployment label. Reject empty labels.
+6. Derive salt = `SHA-256("sonde-kdf-v1:" || utf8(deployment_label))[0..16]`.
+7. Derive the new master key with Argon2id v1 (m_cost=65536, t_cost=3,
+   p_cost=1, output_len=32) using the passphrase and derived salt.
+8. Build `RotationPayloadV1` and send it with `SubmitRotation`.
+9. Poll `GetGatewayState` until `master_key_epoch` increments, then report
+   success.
 
 ### 11.4  `RotationPayloadV1` construction
 
@@ -423,8 +420,8 @@ DESIRED_STATE rotation delivery.
 4. Derive the AES-256-GCM content-encryption key with HKDF-SHA-256 using:
    - `salt = b"sonde-rotation-v1"`
    - `info = gateway_id_raw || current_master_key_epoch_be64`
-5. Encode the plaintext as `{new_master_key, rotation_code, new_master_key_id,
-   salt, kdf_params}`.
+5. Encode the plaintext as `{1: new_master_key, 2: rotation_code}`. Keys 3–5
+   are RESERVED.
 6. Encrypt the plaintext with AES-256-GCM and serialize the final
    `RotationPayloadV1` as `version || sender_ephemeral_public || nonce || ciphertext_and_tag`.
 

--- a/docs/admin-validation.md
+++ b/docs/admin-validation.md
@@ -1184,14 +1184,14 @@ registers a phone, revokes it with `--yes`, and asserts on stdout.
 
 **Procedure:**
 1. Start a gateway test harness with known values for `master_key_epoch`,
-   `master_key_id`, `rotation_in_progress`, salt, and `kdf_params`.
+   `master_key_id` (32-byte SHA-256), and `rotation_in_progress`.
 2. Invoke `sonde-admin key status --gateway-url <url>`.
 3. Assert: exit code is 0.
-4. Assert: stdout displays `master_key_epoch`, `master_key_id`,
-   `rotation_in_progress`, salt status, and `kdf_params`.
+4. Assert: stdout displays `master_key_epoch`, `master_key_id` (32-byte hex),
+   and `rotation_in_progress`. Salt and KDF params are NOT displayed.
 5. Assert: `rotation_in_progress` is rendered as `true` or `false`.
 
-**Expected:** The CLI shows `master_key_epoch`, `master_key_id`, `rotation_in_progress`, salt, and `kdf_params`.
+**Expected:** The CLI shows `master_key_epoch`, `master_key_id` (32-byte hex), and `rotation_in_progress`. Salt and KDF params are not shown.
 
 ---
 

--- a/docs/azure-handler-design.md
+++ b/docs/azure-handler-design.md
@@ -526,13 +526,11 @@ columns:
 | Column | Type | Applicable entity_kind | Description |
 |--------|------|------------------------|-------------|
 | `encrypted_psk` | `Binary`/null | node | Raw encrypted PSK blob stored with node ACTUAL_STATE. |
-| `master_key_id` | `Binary`/null | node, gateway | Opaque master key identifier used for escrow matching. |
+| `master_key_id` | `Binary`/null | node, gateway | 32-byte `SHA-256(master_key)` identifier used for escrow matching. |
 | `key_hint` | `Edm.Int64`/null | node | Recovery lookup hint for node PSKs. |
 | `x25519_public_key` | `Binary`/null | gateway | Gateway X25519 public key. |
 | `channel` | `Edm.Int64`/null | gateway | Current ESP-NOW channel. |
 | `master_key_epoch` | `Edm.Int64`/null | gateway | Current gateway master-key epoch. |
-| `salt` | `Binary`/null | gateway | Gateway-reported KDF salt. |
-| `kdf_params_json` | `String`/null | gateway | JSON encoding of KDF parameters. |
 | `gateway_version` | `String`/null | gateway | Gateway binary semver. |
 | `gateway_commit` | `String`/null | gateway | Gateway binary git commit. |
 | `modem_firmware_version` | `String`/null | gateway | Modem firmware semver. |
@@ -615,13 +613,10 @@ the newly appended row (which sorts first due to the inverted-timestamp RowKey)
 is picked up as the latest state. This preserves the original SPA-written row
 for audit purposes while making the DESIRED_STATE relay one-shot.
 
-### 9.5  Salt management and gateway DESIRED_STATE construction
+### 9.5  Gateway DESIRED_STATE construction — KDF fields retired
 
-The gateway is authoritative for salt. The handler stores whatever salt the
-gateway reports in ACTUAL_STATE. When constructing gateway DESIRED_STATE, the
-handler includes the stored salt only if the gateway reports `salt = null`.
-If the gateway reports a non-null salt, the handler preserves that value in the
-gateway row and does not override it via DESIRED_STATE.
+KDF parameters and salt are client-side concerns only (GW-2020, GW-2021).
+The handler does not store or relay salt or KDF parameters.
 
 Gateway DESIRED_STATE uses:
 
@@ -629,11 +624,7 @@ Gateway DESIRED_STATE uses:
 - `entity_id = hex(gateway_id)`
 - `PartitionKey = "g:" + gateway_id_hex` in the `desiredstate` table
 - CBOR key 15 for `channel`
-- CBOR key 21 for `salt`
-- CBOR key 22 for `kdf_params`
 - CBOR key 28 for `rotation_payload`
 - CBOR key 29 for `recovered_psks`
 
-These keys align the shared channel and salt/KDF fields with gateway
-ACTUAL_STATE while reserving keys 28 and 29 for DESIRED_STATE-only escrow
-payloads.
+Keys 21 (`salt`) and 22 (`kdf_params`) are RESERVED and not emitted.

--- a/docs/azure-handler-requirements.md
+++ b/docs/azure-handler-requirements.md
@@ -404,10 +404,10 @@ singleton), unless the incoming message's `timestamp_ms` is older than the
 previously stored latest row, in which case the handler MUST silently discard
 the stale message without appending. The handler MUST store all gateway-specific
 escrow and recovery fields:
-`x25519_public_key`, `channel`, `master_key_id`, `master_key_epoch`, `salt`,
-`kdf_params_json`, `gateway_version`, `gateway_commit`,
-`modem_firmware_version`, `modem_firmware_commit`,
-`missing_key_hints`, `fingerprint_words`, and `rotation_in_progress`.
+`x25519_public_key`, `channel`, `master_key_id`, `master_key_epoch`,
+`gateway_version`, `gateway_commit`, `modem_firmware_version`,
+`modem_firmware_commit`, `missing_key_hints`, `fingerprint_words`, and
+`rotation_in_progress`.
 
 The `load_gateway_actual_state` operation MUST return only the latest row per
 gateway (the row with the lexicographically smallest `RowKey` within the
@@ -485,20 +485,11 @@ SPA-written row.
 
 ---
 
-### AZH-0604  Salt management
+### AZH-0604  Salt management — RETIRED
 
-**Priority:** Must
-**Source:** Issue #962, [evolve-962-specification.md](evolve-962-specification.md) §4.3
-
-**Description:**
-Salt arrives in gateway `ACTUAL_STATE` and is stored in the gateway row. The
-gateway is authoritative for salt. The handler includes the stored salt in
-gateway `DESIRED_STATE` only for gateways that report `salt = null`.
-
-**Acceptance criteria:**
-
-1. Gateway-reported salt is stored.
-2. Salt is included in `DESIRED_STATE` only when the gateway has no local salt.
+**Status:** RETIRED
+**Reason:** KDF parameters and salt are client-side concerns only (GW-2020, GW-2021).
+The handler no longer stores or relays salt or KDF parameters.
 
 ---
 
@@ -510,9 +501,10 @@ gateway `DESIRED_STATE` only for gateways that report `salt = null`.
 **Description:**
 The handler MUST construct gateway `DESIRED_STATE` with
 `entity_kind = "gateway"` and `entity_id = hex(gateway_id)`. Inside the
-`desired_state` map it MUST use CBOR keys 15 for `channel`, 21 for `salt`, 22
-for `kdf_params`, 28 for `rotation_payload`, and 29 for `recovered_psks`.
-Gateway `DESIRED_STATE` is written to the `desiredstate` Azure Table with
+`desired_state` map it MUST use CBOR keys 15 for `channel`, 28 for
+`rotation_payload`, and 29 for `recovered_psks`. Keys 21 and 22 are RESERVED
+and MUST NOT be emitted. Gateway `DESIRED_STATE` is written to the
+`desiredstate` Azure Table with
 `PartitionKey = "g:" + gateway_id_hex`. All handler writes to the
 `desiredstate` table MUST be append-only (new rows with unique history
 `RowKey`s), never upserts or replacements.

--- a/docs/azure-handler-validation.md
+++ b/docs/azure-handler-validation.md
@@ -379,9 +379,9 @@ divergence publication instead of treating that redelivery as permanently stale.
 
 **Procedure:**
 1. Deliver a gateway `ACTUAL_STATE` message with `x25519_public_key`, `channel`,
-   `master_key_id`, `master_key_epoch`, `salt`, `kdf_params`,
-   `gateway_version`, `gateway_commit`, `modem_firmware_version`,
-   `modem_firmware_commit`, and `missing_key_hints` populated.
+   `master_key_id`, `master_key_epoch`, `gateway_version`,
+   `gateway_commit`, `modem_firmware_version`, `modem_firmware_commit`, and
+   `missing_key_hints` populated.
 2. Assert: one row is created in `actualstate` with `PartitionKey = "g:" + gateway_id_hex`
    and a reverse-timestamp history `RowKey`.
 3. Assert: all gateway-specific fields are stored in that row.
@@ -442,18 +442,10 @@ divergence publication instead of treating that redelivery as permanently stale.
 
 ---
 
-### T-AZH-0604  Salt management
+### T-AZH-0604  Salt management — RETIRED
 
-**Validates:** AZH-0604, AZH-0605
-
-**Procedure:**
-1. Deliver a gateway `ACTUAL_STATE` message with `salt = null` and a stored
-   cloud-side salt available for that gateway.
-2. Assert: the resulting gateway `DESIRED_STATE` includes the stored salt.
-3. Deliver a gateway `ACTUAL_STATE` message with `salt = X`.
-4. Assert: the handler stores `X` in the gateway row.
-5. Assert: subsequent gateway `DESIRED_STATE` does not override the gateway's
-   non-null salt with the cloud-side value.
+**Status:** RETIRED
+**Reason:** Salt management is retired (AZH-0604 RETIRED, GW-2020, GW-2021).
 
 ---
 

--- a/docs/evolve-962-specification.md
+++ b/docs/evolve-962-specification.md
@@ -21,8 +21,9 @@
 >   Salt and KDF parameters are now client-side concerns only.
 > - §2.6.1 rotation payload keys 3 (`new_master_key_id`), 4 (`salt`),
 >   5 (`kdf_params`) → RESERVED. Payload plaintext is now `{1: new_master_key, 2: rotation_code}`.
-> - `master_key_id` throughout → Changed from random 16 bytes to
+> - `master_key_id` contract changed throughout → From random 16 bytes to
 >   `SHA-256(master_key)` (32 bytes), derived locally by gateway.
+>   (Body text below still shows old 16-byte format.)
 > - GW-2008 (salt management) → RETIRED.
 > **Traceability:** Redesigns GW-2000–GW-2013, AZH-0600–AZH-0605,
 > ADMIN-0900–ADMIN-0902.

--- a/docs/evolve-962-specification.md
+++ b/docs/evolve-962-specification.md
@@ -13,6 +13,17 @@
 > **Scope:** Simplify escrow architecture — eliminate imperative connector
 > messages, unify gateway identity, add rotation-code authentication, treat
 > gateway as first-class ACTUAL_STATE/DESIRED_STATE entity.
+>
+> **Partially superseded:** The following sections of this document are
+> superseded by the KDF simplification change:
+> - §2.5 (salt/KDF convergence) → Replaced by GW-2020 (versioned KDF
+>   parameter sets) and GW-2021 (deployment-label salt derivation).
+>   Salt and KDF parameters are now client-side concerns only.
+> - §2.6.1 rotation payload keys 3 (`new_master_key_id`), 4 (`salt`),
+>   5 (`kdf_params`) → RESERVED. Payload plaintext is now `{1: new_master_key, 2: rotation_code}`.
+> - `master_key_id` throughout → Changed from random 16 bytes to
+>   `SHA-256(master_key)` (32 bytes), derived locally by gateway.
+> - GW-2008 (salt management) → RETIRED.
 > **Traceability:** Redesigns GW-2000–GW-2013, AZH-0600–AZH-0605,
 > ADMIN-0900–ADMIN-0902.
 

--- a/docs/gateway-companion-api.md
+++ b/docs/gateway-companion-api.md
@@ -167,10 +167,10 @@ deployment (e.g., during gateway replacement failover).
 | Field | CBOR key | Type | Description |
 |---|---|---|---|
 | `channel` | 15 | uint/null | Desired ESP-NOW channel. `null` means no channel change requested. |
-| `salt` | 21 | bstr (16 bytes)/null | KDF salt from cloud. Adopted by gateway only if it has no local salt. `null` means no salt provided. |
-| `kdf_params` | 22 | map/null | KDF parameters `{1: m_cost, 2: t_cost, 3: p_cost, 4: kdf_version}`. `null` means no params provided. |
+| *(reserved)* | 21 | — | RETIRED — previously KDF salt. |
+| *(reserved)* | 22 | — | RETIRED — previously KDF params. |
 | `rotation_payload` | 28 | bstr/null | X25519-encrypted `RotationPayloadV1` for master key rotation. `null` means no rotation requested. See `evolve-962-specification.md` §2.6.1 for format. |
-| `recovered_psks` | 29 | array/null | Array of recovered PSK records for missing nodes. Each record is a CBOR map: `{1: node_id (tstr), 2: key_hint (uint), 3: encrypted_psk (bstr), 4: master_key_id (bstr)}`. `null` means no recovery records. |
+| `recovered_psks` | 29 | array/null | Array of recovered PSK records for missing nodes. Each record is a CBOR map: `{1: node_id (tstr), 2: key_hint (uint), 3: encrypted_psk (bstr), 4: master_key_id (bstr, 32 bytes)}`. `null` means no recovery records. |
 
 #### 3.2.2  `desired_state` payload for `entity_kind = "node"`
 
@@ -218,15 +218,15 @@ state.
 | `schedule_interval_s` | 11 | uint/null | Latest node wake interval in seconds when applicable. |
 | `encrypted_psk` | 12 | bstr (60 bytes)/null | Encrypted PSK blob for node escrow. Node-scoped only; omit for gateway. |
 | `escrow_key_hint` | 13 | uint (0–65535)/null | `key_hint` (u16) for Azure recovery lookup. Node-scoped only. |
-| `master_key_id` | 14 | bstr (16 bytes)/null | Opaque master key ID that encrypted this node's PSK. Node-scoped only. |
+| `master_key_id` | 14 | bstr (32 bytes)/null | SHA-256(master_key) identifying which master key encrypted this node's PSK. Node-scoped only. |
 | `channel` | 15 | uint/null | ESP-NOW channel. Gateway-scoped only. |
-| `master_key_id` | 16 | bstr (16 bytes)/null | Gateway's current master key ID. Gateway-scoped only. |
+| `master_key_id` | 16 | bstr (32 bytes)/null | Gateway's current master key identifier = SHA-256(master_key). Gateway-scoped only. |
 | `master_key_epoch` | 17 | uint/null | Monotonic master key epoch. Gateway-scoped only. |
 | `x25519_public_key` | 18 | bstr (32 bytes)/null | X25519 public key derived from GatewayIdentity. Gateway-scoped only. |
 | `fingerprint_words` | 19 | array of tstr/null | 6-word BIP-39 fingerprint. Gateway-scoped only. |
 | `missing_key_hints` | 20 | array of uint/null | Unknown key_hints (one-shot, cleared after reporting). Gateway-scoped only. |
-| `salt` | 21 | bstr (16 bytes)/null | KDF salt. Gateway-scoped only. |
-| `kdf_params` | 22 | map/null | `{1: m_cost, 2: t_cost, 3: p_cost, 4: kdf_version}`. Gateway-scoped only. |
+| *(reserved)* | 21 | — | RETIRED — previously KDF salt. |
+| *(reserved)* | 22 | — | RETIRED — previously KDF params. |
 | `gateway_version` | 23 | tstr/null | Gateway binary semver. Gateway-scoped only. |
 | `gateway_commit` | 24 | tstr/null | Gateway binary git commit. Gateway-scoped only. |
 | `modem_firmware_version` | 25 | tstr/null | Modem firmware semver. Gateway-scoped only. |
@@ -235,8 +235,9 @@ state.
 | `wake_rssi_dbm` | 28 | int/null | Modem-measured receive RSSI (dBm) of the node's WAKE frame. Node-scoped only; null when the transport does not supply RSSI metadata. |
 
 **Key scoping:** Keys 4–8, 10–11, 28 are node-specific and MUST be omitted for
-`entity_kind = "gateway"`. Keys 12–14 are node escrow fields. Keys 15–27
-are gateway-specific and MUST be omitted for `entity_kind = "node"`. Key 9
+`entity_kind = "gateway"`. Keys 12–14 are node escrow fields. Keys 15–20,
+23–27 are gateway-specific and MUST be omitted for `entity_kind = "node"`.
+Keys 21–22 are RESERVED (retired) and MUST NOT be emitted. Key 9
 (`timestamp_ms`) is shared and required for all entity kinds. Decoders
 dispatch on `entity_kind` to interpret the correct keys.
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1889,8 +1889,8 @@ additional storage is needed.
 
 ### 23.2  Master key identification (GW-2001)
 
-Each PSK record carries an opaque `master_key_id` (BLOB, 16 bytes, random)
-and a monotonic `master_key_epoch` (INTEGER):
+Each PSK record carries `master_key_id` (BLOB, 32 bytes) and a monotonic
+`master_key_epoch` (INTEGER):
 
 ```sql
 ALTER TABLE nodes ADD COLUMN master_key_id BLOB;
@@ -1899,10 +1899,14 @@ ALTER TABLE phone_psks ADD COLUMN master_key_id BLOB;
 ALTER TABLE phone_psks ADD COLUMN master_key_epoch INTEGER NOT NULL DEFAULT 0;
 ```
 
-`master_key_id` is NOT a hash of the key — it is a random opaque identifier
-to avoid creating an offline passphrase verifier. On first startup, the
-gateway generates a random `master_key_id`, sets `master_key_epoch = 1`,
-backfills all records, and stores in `gateway_config`.
+`master_key_id = SHA-256(master_key)` (32 bytes). The gateway derives it
+deterministically from the loaded master key. On first startup, the gateway
+computes `master_key_id` from the `KeyProvider`-loaded key, sets
+`master_key_epoch = 1`, and backfills all records. After rotation,
+`master_key_id` is recomputed from the new key.
+
+SQL schema: `master_key_id BLOB` columns in `nodes` and `phone_psks` are
+32 bytes (SHA-256 digest).
 
 ### 23.3  Rotation code authentication (GW-2002)
 
@@ -1922,25 +1926,25 @@ The gateway becomes a first-class entity in the ACTUAL_STATE model.
 - `entity_kind = "gateway"`, `entity_id = hex(gateway_id)` (lowercase, no prefix).
 - Emitted on startup, connector reconnection, and state changes.
 
-| Field | CBOR key | Type |
-|-------|----------|------|
-| `msg_type` | 1 | uint (0x02) |
-| `entity_kind` | 2 | tstr ("gateway") |
-| `entity_id` | 3 | tstr (hex gateway_id) |
-| `timestamp_ms` | 9 | uint |
-| `channel` | 15 | uint |
-| `master_key_id` | 16 | bstr (16 bytes) |
-| `master_key_epoch` | 17 | uint |
-| `x25519_public_key` | 18 | bstr (32 bytes) |
-| `fingerprint_words` | 19 | array of tstr |
-| `missing_key_hints` | 20 | array of uint |
-| `salt` | 21 | bstr (16 bytes)/null |
-| `kdf_params` | 22 | map/null |
-| `gateway_version` | 23 | tstr |
-| `gateway_commit` | 24 | tstr |
-| `modem_firmware_version` | 25 | tstr/null |
-| `modem_firmware_commit` | 26 | tstr/null |
-| `rotation_in_progress` | 27 | bool |
+| Field | CBOR key | Type | Notes |
+|-------|----------|------|-------|
+| `msg_type` | 1 | uint (0x02) | |
+| `entity_kind` | 2 | tstr ("gateway") | |
+| `entity_id` | 3 | tstr (hex gateway_id) | |
+| `timestamp_ms` | 9 | uint | |
+| `channel` | 15 | uint | |
+| `master_key_id` | 16 | bstr (32 bytes) | |
+| `master_key_epoch` | 17 | uint | |
+| `x25519_public_key` | 18 | bstr (32 bytes) | |
+| `fingerprint_words` | 19 | array of tstr | |
+| `missing_key_hints` | 20 | array of uint | |
+| *(reserved)* | 21 | — | RETIRED — previously KDF salt |
+| *(reserved)* | 22 | — | RETIRED — previously KDF params |
+| `gateway_version` | 23 | tstr | |
+| `gateway_commit` | 24 | tstr | |
+| `modem_firmware_version` | 25 | tstr/null | |
+| `modem_firmware_commit` | 26 | tstr/null | |
+| `rotation_in_progress` | 27 | bool | |
 
 Node-specific keys 4–8, 10–11 MUST be omitted for gateway entities.
 
@@ -1948,16 +1952,16 @@ Node-specific keys 4–8, 10–11 MUST be omitted for gateway entities.
 
 Inside `desired_state` map (CBOR key 4):
 
-| Field | CBOR key | Type |
-|-------|----------|------|
-| `channel` | 15 | uint/null |
-| `salt` | 21 | bstr (16 bytes)/null |
-| `kdf_params` | 22 | map/null |
-| `rotation_payload` | 28 | bstr/null |
-| `recovered_psks` | 29 | array/null |
+| Field | CBOR key | Type | Notes |
+|-------|----------|------|-------|
+| `channel` | 15 | uint/null | |
+| *(reserved)* | 21 | — | RETIRED — previously KDF salt |
+| *(reserved)* | 22 | — | RETIRED — previously KDF params |
+| `rotation_payload` | 28 | bstr/null | |
+| `recovered_psks` | 29 | array/null | |
 
-Shared keys (15, 21, 22) align with ACTUAL_STATE. DESIRED-only fields use
-keys 28–29 to avoid collision with ACTUAL_STATE keys 23–27.
+Shared keys (15) align with ACTUAL_STATE. DESIRED-only fields use keys 28–29
+to avoid collision with ACTUAL_STATE keys 23–27.
 
 ### 23.6  Node ACTUAL_STATE escrow fields (GW-2005)
 
@@ -1965,7 +1969,7 @@ keys 28–29 to avoid collision with ACTUAL_STATE keys 23–27.
 |-------|----------|------|
 | `encrypted_psk` | 12 | bstr (60 bytes)/null |
 | `escrow_key_hint` | 13 | uint (0–65535)/null |
-| `master_key_id` | 14 | bstr (16 bytes)/null |
+| `master_key_id` | 14 | bstr (32 bytes)/null |
 
 `encrypted_psk` format: 12-byte nonce + 32-byte ciphertext + 16-byte GCM tag.
 Encrypted with `AES-256-GCM(master_key, nonce, psk, aad=node_id_utf8)`.
@@ -1981,7 +1985,7 @@ via ACTUAL_STATE.
 version(1) || sender_ephemeral_public(32) || nonce(12) || ciphertext_and_tag(var)
 ```
 
-Plaintext (CBOR): `{1: new_master_key, 2: rotation_code, 3: new_master_key_id, 4: salt, 5: kdf_params}`.
+Plaintext (CBOR): `{1: new_master_key, 2: rotation_code}`. Keys 3 (`new_master_key_id`), 4 (`salt`), 5 (`kdf_params`) are RESERVED. The gateway derives `master_key_id = SHA-256(new_master_key)` locally after decryption.
 
 Encryption: X25519(ephemeral, gw_public) → HKDF-SHA-256(shared, salt=b"sonde-rotation-v1",
 info=gateway_id_raw||epoch_be64) → AES-256-GCM(key, nonce, plaintext, aad=gateway_id_raw||epoch_be64).
@@ -1991,7 +1995,7 @@ info=gateway_id_raw||epoch_be64) → AES-256-GCM(key, nonce, plaintext, aad=gate
 1. **Prepare:** Write `pending_rotation`, purge `pending_recovery` (same transaction).
 2. **Migrate PSKs** (`migrating_psks`): Re-encrypt all `nodes` and `phone_psks` records.
 3. **Rewrap identity** (`rewrapping_identity`): Re-encrypt `GatewayIdentity` seed under new key into `encrypted_seed_new`.
-4. **Commit** (`committing`): Atomic transaction — promote `encrypted_seed_new`, update `master_key_id`/`epoch`, generate new rotation code. `pending_rotation` is **NOT** deleted in this transaction.
+4. **Commit** (`committing`): Atomic transaction — promote `encrypted_seed_new`, derive the new `master_key_id = SHA-256(new_master_key)`, update `master_key_id`/`epoch`, and generate a new rotation code. `pending_rotation` is **NOT** deleted in this transaction.
 5. **Persist key** (`persisting_key`): Write new master key to `KeyProvider` backend via `write_master_key`. On success, delete `pending_rotation`.
 
 **Key invariant:** During all pre-commit phases, original `encrypted_seed` remains usable with the old key. `GatewayIdentity` is always loadable on restart.
@@ -2136,36 +2140,20 @@ message SubmitRotationResponse { bool accepted = 1; string error = 2; }
 
 Both gRPC and DESIRED_STATE rotation paths converge on the same handler.
 
-### 23.13  Salt and KDF-params convergence (GW-2008)
+### 23.13  KDF and salt — client-side only (GW-2020, GW-2021)
 
-`RotationEngine::handle_desired_state()` applies adopt-if-absent semantics
-for salt and KDF parameters from gateway DESIRED_STATE, per evolve-962 §2.5.
+KDF parameters and salt are client-side concerns. The gateway does not
+store, adopt, or emit KDF-related state.
 
-**Convergence rules:**
+- **KDF v1:** Argon2id (m_cost=65536, t_cost=3, p_cost=1, output_len=32).
+  Hardcoded in admin CLI and SPA.
+- **Salt derivation:** `SHA-256("sonde-kdf-v1:" || utf8(deployment_label))[0..16]`.
+  Computed by client tools from a deployment label stored in client-side
+  configuration only.
 
-1. **Salt adoption:** If DESIRED_STATE contains `salt` (16 bytes),
-   atomically write via `set_config_if_absent("kdf_salt", hex::encode(salt))`
-   (`INSERT ... ON CONFLICT DO NOTHING`). If inserted → log at `info` level.
-2. **Salt immutability:** If `kdf_salt` already exists in `gateway_config` →
-   the atomic insert is a no-op. Log at `info` level that
-   local salt is retained.
-3. **KDF params adoption:** Same adopt-if-absent pattern for `kdf_params`.
-   Read `gateway_config` key `kdf_params_json`. If absent and DESIRED_STATE
-   contains `kdf_params` → serialize as JSON
-   (`{"m_cost":N,"t_cost":N,"p_cost":N,"kdf_version":N}`) and write via
-   `set_config_if_absent("kdf_params_json", json)` (atomic insert).
-4. **KDF params immutability:** If `kdf_params_json` already exists →
-   ignore DESIRED_STATE value.
-5. **ACTUAL_STATE re-emission:** After any successful adoption (salt or KDF
-   params), send a `GatewayStateChanged` notification via a dedicated
-   `state_changed_tx` channel (separate from the rotation-specific
-   `rotation_complete_tx`) to trigger an immediate gateway ACTUAL_STATE
-   re-emission so the cloud sees the adopted values promptly. If a write
-   fails, log the error and do not trigger re-emission for that field;
-   adoption will be retried on the next DESIRED_STATE delivery.
-6. **Rotation-path update:** Salt and KDF params can also be updated via
-   rotation payload delivery — already handled by `commit_rotation()` in
-   §23.7.
+The previous adopt-if-absent convergence for salt and KDF params
+(evolve-962 §2.5) is retired. Gateway DESIRED_STATE keys 21 and 22 are
+RESERVED and ignored if received.
 
 ### 23.14  ACTUAL_STATE re-emission task (GW-2003)
 
@@ -2179,8 +2167,8 @@ step 9a is inline.
 1. `rotation_complete_rx` — receives `RotationCompleteNotification` from
    `RotationEngine` after a successful rotation. Re-emit immediately.
 2. `state_changed_rx` — receives `GatewayStateChanged` from
-   `RotationEngine` after channel convergence, salt/KDF-params adoption,
-   or other non-rotation state changes. Re-emit immediately.
+   `RotationEngine` after channel convergence or other non-rotation state
+   changes. Re-emit immediately.
 3. `missing_hints_notify` — a `tokio::sync::Notify` signalled by the
    `Gateway` engine when `MissingKeyHintTracker::report()` accepts a new
    hint. On notification, start a 60-second debounce timer. If the timer
@@ -2201,8 +2189,8 @@ step 9a is inline.
 On each trigger, the task:
 1. Loads the current gateway identity from storage.
 2. Derives the X25519 public key and BIP-39 fingerprint.
-3. Reads `master_key_id`, `master_key_epoch`, `espnow_channel`,
-   `kdf_salt`, `kdf_params_json` from `gateway_config`.
+3. Reads `master_key_id`, `master_key_epoch`, `espnow_channel` from
+   `gateway_config`.
 4. Drains `missing_key_hints` from the gateway engine's tracker.
 5. Checks `storage.read_pending_rotation()` to determine `rotation_in_progress`.
 6. Reads `modem_firmware_version` and `modem_firmware_commit` from the

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2990,8 +2990,8 @@ Salt is derived from a deployment label chosen by the admin:
 (first 16 bytes of the SHA-256 digest).
 
 The deployment label is a human-readable UTF-8 string (e.g.,
-"Alan's production deployment"). It is stored only in client-side
-configuration (SPA environment settings). Neither the gateway, Azure
+"Alan's production deployment"). It is provided by the operator at
+rotation time in both the CLI and SPA. Neither the gateway, Azure
 handler, nor companion stores or transmits the deployment label.
 
 Label encoding: UTF-8 bytes with leading/trailing whitespace trimmed.

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2573,18 +2573,22 @@ generated or stored.
 **Source:** Issue #962 (supersedes evolve-887 GW-2005)
 
 **Description:**
-Each PSK record in `nodes` and `phone_psks` MUST carry an opaque
-`master_key_id` (BLOB, 16 bytes, random) and a monotonic
-`master_key_epoch` (INTEGER). On first startup, the gateway MUST generate
-a random 16-byte `master_key_id`, set `master_key_epoch = 1`, and
-backfill all existing PSK records.
+Each PSK record in `nodes` and `phone_psks` MUST carry a deterministic
+`master_key_id` (BLOB, 32 bytes) = `SHA-256(master_key)` and a monotonic
+`master_key_epoch` (INTEGER). The gateway MUST derive `master_key_id`
+locally from the loaded master key — it is never transmitted in rotation
+payloads or received from external sources. On first startup, the gateway
+MUST compute `master_key_id` from the `KeyProvider`-loaded key, set
+`master_key_epoch = 1`, and backfill all existing PSK records.
 
 **Acceptance criteria:**
 
-1. `master_key_id` is a random 16-byte value, NOT a hash of the key.
+1. `master_key_id` = `SHA-256(master_key)` (32 bytes), derived locally.
 2. `master_key_epoch` starts at 1 and is monotonically incremented.
-3. Existing PSK records are backfilled on first startup.
-4. Values are stable across restarts (not regenerated).
+3. On first startup AND after rotation, gateway recomputes `master_key_id`
+   from the current master key.
+4. Existing PSK records are backfilled on first startup.
+5. Values are stable across restarts (not regenerated).
 
 ---
 
@@ -2621,9 +2625,11 @@ connector.
 The gateway MUST emit its own ACTUAL_STATE with `entity_kind = "gateway"`
 and `entity_id = hex(gateway_id)` (lowercase hex, no `0x` prefix). Gateway
 ACTUAL_STATE MUST include: channel, master_key_id, master_key_epoch,
-x25519_public_key, fingerprint_words, missing_key_hints, salt, kdf_params,
+x25519_public_key, fingerprint_words, missing_key_hints,
 gateway_version, gateway_commit, modem_firmware_version, modem_firmware_commit,
 rotation_in_progress. Node-specific keys 4–8, 10–11 MUST be omitted.
+CBOR keys 21 (`salt`) and 22 (`kdf_params`) are RESERVED and MUST NOT
+be emitted.
 
 Gateway ACTUAL_STATE is emitted on startup, connector reconnection,
 whenever gateway state changes, and periodically at a compile-time
@@ -2640,7 +2646,7 @@ heartbeat interval (default 900 seconds).
 6. Re-emitted within 60 seconds when `MissingKeyHintTracker` accepts a
    previously-unseen `key_hint`, using a debounce window to coalesce
    concurrent arrivals.
-7. Re-emitted when salt or KDF params are adopted from DESIRED_STATE.
+7. *(Reserved — previously salt/KDF adoption trigger, now retired.)*
 8. Re-emitted periodically at a compile-time heartbeat interval (default
    900 seconds) to ensure the control-plane handler regularly evaluates
    pending desired state. The heartbeat schedule is process-local (resets
@@ -2661,21 +2667,20 @@ heartbeat interval (default 900 seconds).
 **Description:**
 The gateway MUST accept DESIRED_STATE with `entity_kind = "gateway"` and
 process the following fields from the `desired_state` map: `channel`
-(CBOR key 15), `salt` (key 21), `kdf_params` (key 22),
-`rotation_payload` (key 28), `recovered_psks` (key 29).
+(CBOR key 15), `rotation_payload` (key 28), `recovered_psks` (key 29).
+CBOR keys 21 (`salt`) and 22 (`kdf_params`) are RESERVED and MUST be
+ignored if received.
 
 **Convergence behavior:**
 - Channel: switch if different from current.
-- Salt/KDF params: adopt from DESIRED_STATE if no local salt; once set
-  locally, salt is immutable except via rotation payload.
 - Rotation payload: process if valid (see GW-2006).
 - Recovered PSKs: process each record (see GW-2009).
 
 **Acceptance criteria:**
 
 1. Gateway switches channel when DESIRED_STATE channel differs.
-2. Salt adopted when gateway has no local salt.
-3. Local salt not overwritten by DESIRED_STATE after first set.
+2. *(Reserved — previously salt adoption, now retired.)*
+3. *(Reserved — previously salt immutability, now retired.)*
 4. All DESIRED_STATE fields processed.
 
 ---
@@ -2688,7 +2693,7 @@ process the following fields from the `desired_state` map: `channel`
 **Description:**
 Node ACTUAL_STATE MUST include three escrow fields: `encrypted_psk`
 (CBOR key 12, bstr 60 bytes), `escrow_key_hint` (key 13, uint 0–65535),
-and `master_key_id` (key 14, bstr 16 bytes). Phone PSKs are NOT escrowed
+and `master_key_id` (key 14, bstr 32 bytes). Phone PSKs are NOT escrowed
 (phone ACTUAL_STATE is never emitted).
 
 Escrow fields are emitted on node registration, after key rotation, and
@@ -2709,8 +2714,11 @@ on connector reconnection.
 
 **Description:**
 The gateway MUST accept a `RotationPayloadV1` (via DESIRED_STATE key 28
-or gRPC `SubmitRotation`) containing a new master key, rotation code,
-and new master_key_id encrypted with X25519 + HKDF-SHA-256 + AES-256-GCM.
+or gRPC `SubmitRotation`) containing a new master key and rotation code,
+encrypted with X25519 + HKDF-SHA-256 + AES-256-GCM. The gateway MUST
+derive `master_key_id = SHA-256(new_master_key)` locally after
+decryption. CBOR plaintext keys 3 (`new_master_key_id`), 4 (`salt`),
+and 5 (`kdf_params`) are RESERVED and MUST be ignored if present.
 
 The gateway MUST: (1) decrypt using GatewayIdentity X25519 private key,
 (2) verify rotation code, (3) verify master_key_epoch via AAD,
@@ -2805,22 +2813,13 @@ provider write succeeds (or is determined unnecessary).
 
 ---
 
-### GW-2008  Salt management
+### GW-2008  Salt management — RETIRED
 
-**Priority:** Must
-**Source:** Issue #962 (supersedes evolve-887 GW-2008)
-
-**Description:**
-The gateway MUST adopt salt from DESIRED_STATE if it has no local salt.
-Once set, local salt is immutable except via rotation payload delivery.
-Salt MUST be included in gateway ACTUAL_STATE.
-
-**Acceptance criteria:**
-
-1. Salt adopted from DESIRED_STATE when gateway has no local salt.
-2. Existing local salt not overwritten by DESIRED_STATE.
-3. Salt updated via rotation payload.
-4. Salt reported in ACTUAL_STATE.
+**Status:** RETIRED
+**Reason:** KDF parameters and salt are now client-side concerns only.
+The gateway does not store, adopt, or emit KDF-related state.
+See GW-2020 (versioned KDF parameter sets) and GW-2021 (deployment-label
+salt derivation).
 
 ---
 
@@ -2953,6 +2952,60 @@ emitted and the payload is discarded.
 2. Rotation via DESIRED_STATE is discarded with a warning log when `is_writable()` returns `false`.
 3. No database mutations or cryptographic operations occur before the rejection.
 4. Writable providers (`file`, `dpapi`, `secret-service`) are not affected.
+
+---
+
+### GW-2020  Versioned KDF parameter sets
+
+**Priority:** Must
+**Source:** KDF simplification (supersedes evolve-962 §2.5 salt/KDF convergence)
+
+**Description:**
+KDF parameters are hardcoded, versioned constants known only to
+client-side tools (admin CLI, SPA). The gateway MUST NOT store or
+process KDF parameters.
+
+Version 1: `Argon2id(m_cost=65536, t_cost=3, p_cost=1, output_len=32)`.
+
+Version selection is implicit (v1 only for now). Future versions may
+add a selector in client tools without gateway changes.
+
+**Acceptance criteria:**
+
+1. No KDF parameters in gateway storage, ACTUAL_STATE, or DESIRED_STATE.
+2. Admin CLI and SPA use v1 parameters for key derivation.
+3. KDF version is not transmitted to the gateway.
+4. Argon2id output length is 32 bytes.
+
+---
+
+### GW-2021  Deployment-label salt derivation
+
+**Priority:** Must
+**Source:** KDF simplification (supersedes evolve-962 §2.5 salt/KDF convergence)
+
+**Description:**
+Salt is derived from a deployment label chosen by the admin:
+`salt = SHA-256("sonde-kdf-v1:" || utf8(deployment_label))[0..16]`
+(first 16 bytes of the SHA-256 digest).
+
+The deployment label is a human-readable UTF-8 string (e.g.,
+"Alan's production deployment"). It is stored only in client-side
+configuration (SPA environment settings). Neither the gateway, Azure
+handler, nor companion stores or transmits the deployment label.
+
+Label encoding: UTF-8 bytes with leading/trailing whitespace trimmed.
+No other normalization (no case-folding, no Unicode normalization).
+Empty labels (after trimming) MUST be rejected by client tools.
+
+**Acceptance criteria:**
+
+1. Salt is deterministically derived from the deployment label.
+2. No salt stored in gateway, Azure, or transmitted in any protocol message.
+3. Deployment label is a client-side-only concept.
+4. Different deployment labels produce different salts.
+5. Empty deployment labels are rejected by both CLI and SPA.
+6. Label bytes are UTF-8 with leading/trailing whitespace trimmed; no other normalization.
 
 ---
 
@@ -3097,10 +3150,12 @@ emitted and the payload is discarded.
 | GW-2005 | Node ACTUAL_STATE escrow fields | Must |
 | GW-2006 | Master key rotation | Must |
 | GW-2007 | Crash-safe key rotation | Must |
-| GW-2008 | Salt management | Must |
+| GW-2008 | Salt management | RETIRED |
 | GW-2009 | Declarative node recovery | Must |
 | GW-2010 | Rotation code display on modem | Must |
 | GW-2011 | Fingerprint computation | Must |
 | GW-2012 | gRPC rotation API | Must |
 | GW-2013 | Pending recovery purge on rotation | Must |
 | GW-2014 | Rotation blocked for non-writable key providers | Must |
+| GW-2020 | Versioned KDF parameter sets | Must |
+| GW-2021 | Deployment-label salt derivation | Must |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4223,19 +4223,19 @@ A configurable stub handler process (or in-process mock) that:
 
 ### T-2000  Master key identification — first startup
 
-**Traces to:** GW-2001 (AC-1, AC-2, AC-3, AC-4)
+**Traces to:** GW-2001 (AC-1, AC-2, AC-3, AC-4, AC-5)
 
 **Steps:**
 1. Create `SqliteStorage` with a master key.
 2. Verify no `master_key_id` or `master_key_epoch` in `gateway_config`.
 3. Run startup initialization.
-4. Verify `master_key_id` is a random 16-byte value (non-zero).
+4. Verify `master_key_id` = `SHA-256(master_key)` (32 bytes).
 5. Verify `master_key_epoch = 1`.
 6. Verify all existing PSK records have `master_key_id` and `master_key_epoch` backfilled.
 7. Restart — verify same values are loaded (not regenerated).
 
 **Expected:**
-1. Stable `master_key_id` across restarts; epoch = 1; all records backfilled.
+1. Stable `master_key_id` = SHA-256(master_key) across restarts; epoch = 1; all records backfilled.
 
 ---
 
@@ -4342,15 +4342,18 @@ A configurable stub handler process (or in-process mock) that:
 1. Start gateway with 3 registered nodes, 1 phone PSK, and a writable
    `FileKeyProvider` (using a temp key file).
 2. Record old `master_key_id` and `master_key_epoch`.
-3. Submit valid rotation payload via DESIRED_STATE.
+3. Submit valid rotation payload via DESIRED_STATE (payload contains only
+   `{1: new_master_key, 2: rotation_code}` — no master_key_id, salt, or
+   KDF params in payload).
 4. Verify all PSK records (nodes and phone_psks) updated with new
-   `master_key_id` and `master_key_epoch = old_epoch + 1`.
+   `master_key_id = SHA-256(new_master_key)` (32 bytes) and
+   `master_key_epoch = old_epoch + 1`.
 5. Verify old master key no longer decrypts any PSK record.
 6. Verify new master key decrypts all PSK records.
-7. Verify updated gateway ACTUAL_STATE: new epoch, new id,
-   `rotation_in_progress = false`.
+7. Verify updated gateway ACTUAL_STATE: new epoch, new id =
+   SHA-256(new_key), `rotation_in_progress = false`.
 8. Verify node ACTUAL_STATE re-emitted with new `encrypted_psk`
-   and `master_key_id`.
+   and `master_key_id` (32 bytes).
 9. Verify the key file on disk contains the new master key (hex-encoded).
 10. Verify `pending_rotation` table is empty.
 11. Stop the gateway.  Reload the key from the key file and re-open the
@@ -4502,27 +4505,12 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
-### T-2007  Salt and KDF-params management
+### T-2007  Salt and KDF-params management — RETIRED
 
-**Traces to:** GW-2008 (AC-1, AC-2, AC-3, AC-4)
-
-**Steps:**
-1. Start gateway with no local salt or KDF params — verify `salt = null`
-   and `kdf_params = null` in ACTUAL_STATE.
-2. Deliver DESIRED_STATE with salt and KDF params — verify gateway adopts
-   both.
-3. Verify subsequent ACTUAL_STATE reports the adopted salt and KDF params.
-4. Deliver DESIRED_STATE with a different salt and different KDF params —
-   verify gateway keeps its existing values (local wins once set).
-5. Perform rotation with salt in payload — verify salt updated.
-6. Deliver DESIRED_STATE with salt but no KDF params — verify only salt is
-   evaluated (KDF params unchanged).
-7. Deliver DESIRED_STATE with KDF params but no salt — verify only KDF
-   params is evaluated (salt unchanged).
-
-**Expected:**
-1. Salt and KDF-params adoption and immutability semantics correct.
-2. Partial DESIRED_STATE (only salt or only KDF params) handled independently.
+**Status:** RETIRED
+**Reason:** Salt and KDF parameters are client-side concerns only
+(GW-2008 RETIRED, GW-2020, GW-2021). The gateway does not store, adopt,
+or emit KDF-related state.
 
 ---
 
@@ -4627,23 +4615,11 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
-### T-2013  Salt/KDF adoption triggers ACTUAL_STATE re-emission
+### T-2013  Salt/KDF adoption triggers ACTUAL_STATE re-emission — RETIRED
 
-**Traces to:** GW-2003 (AC-7)
-
-**Steps:**
-1. Start gateway with no local salt or KDF params.
-2. Connect a connector consumer and verify initial ACTUAL_STATE
-   (salt = null, kdf_params = null).
-3. Deliver a gateway DESIRED_STATE with `salt` (16 bytes) and `kdf_params`.
-4. Verify gateway ACTUAL_STATE re-emitted with the adopted `salt` and
-   `kdf_params` values.
-5. Deliver another DESIRED_STATE with different salt.
-6. Verify ACTUAL_STATE is NOT re-emitted (local salt is immutable).
-
-**Expected:**
-1. First adoption triggers ACTUAL_STATE re-emission with new values.
-2. Subsequent DESIRED_STATE with different salt does not trigger re-emission.
+**Status:** RETIRED
+**Reason:** Salt and KDF adoption is retired (GW-2008 RETIRED, GW-2020,
+GW-2021). No salt/KDF-related state changes trigger re-emission.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -512,18 +512,24 @@ Direct ESP-NOW pairing (without BLE intermediary) was considered and rejected �
 
 ```
 passphrase + salt ──► Argon2id ──► master_key (32 bytes)
-                                      │
-                              ┌───────┴────────┐
-                              ▼                ▼
-                    Encrypt(PSK_node1)  Encrypt(PSK_node2) ...
-                              │                │
-                              ▼                ▼
-                       Azure ACTUAL_STATE   (encrypted blobs)
+   (client-side only)                    │
+                                 ┌───────┼────────┐
+                                 │       │        │
+                                 ▼       ▼        ▼
+                      SHA-256 ──► master_key_id (32 bytes)
+                               Encrypt(PSK_node1)  Encrypt(PSK_node2) ...
+
+salt = SHA-256("sonde-kdf-v1:" || deployment_label)[0..16]
+KDF v1: Argon2id(m=65536, t=3, p=1, output=32)
 ```
 
 The master key encrypts all PSK records (nodes and phone_psks) at rest.
-The master key itself is derived from a passphrase via Argon2id and is
-never stored in Azure — only opaque encrypted PSK blobs transit the cloud.
+The master key is derived from a passphrase via Argon2id entirely on the
+client side (admin CLI or SPA). Neither salt, KDF parameters, nor the
+deployment label are transmitted to or stored by the gateway or Azure — only
+the derived master key reaches the gateway via the encrypted rotation payload,
+and only opaque encrypted PSK blobs transit the cloud. `master_key_id =
+SHA-256(master_key)` is derived locally by the gateway.
 
 ### 10.2  Master key delivery
 
@@ -536,7 +542,7 @@ Admin ──► Argon2id(passphrase, salt) ──► new_master_key
                                                 │
                                    ┌────────────┘
                                    ▼
-                    {new_key, rotation_code, new_key_id, salt, kdf}
+                    {new_key, rotation_code}
                                    │
                         ──► DESIRED_STATE ──► Gateway
                                                 │
@@ -558,7 +564,8 @@ Admin ──► Argon2id(passphrase, salt) ──► new_master_key
 | Azure compromise → PSK disclosure | PSKs encrypted with master key; key never in Azure | None (AES-256-GCM) |
 | Azure compromise → forced key rotation | Rotation requires rotation_code from modem display; attacker cannot read physical display | Requires physical access to modem |
 | Azure MITM on public key | BIP-39 fingerprint computed locally by SPA from `x25519_public_key`, NOT read from Azure-stored `fingerprint_words`. Admin verifies SPA-computed fingerprint against modem display (66-bit work factor). A compromised Azure cannot substitute a rogue key with pre-matched words. | Targeted collision requires ~2^66 operations |
-| Offline passphrase brute-force | Argon2id (64 MiB memory-hard); `master_key_id` is opaque random (NOT a hash of key) — no offline verifier in cloud | Computationally infeasible without direct gateway access |
+| Offline passphrase brute-force | Argon2id (64 MiB memory-hard); `master_key_id = SHA-256(master_key)` is a public verifier but encrypted PSK blobs already provide a faster AEAD trial-decryption oracle. Argon2id dominates the cost of passphrase guessing. KDF parameters and deployment label not stored in Azure. | Computationally infeasible without direct gateway access |
+| Cross-gateway key linkability | `master_key_id = SHA-256(master_key)` is deterministic — same passphrase + label → same ID visible to Azure | Accepted; shared label implies single deployment by design |
 | `key_hint` amplification (radio→cloud) | Rate limiting: 1 hint per `key_hint` per 60 seconds; max 256 dedup entries (LRU) | Bounded amplification factor |
 | Fake recovered PSKs from cloud | Provisional `pending_recovery` table; promoted only after successful frame authentication | Bogus records expire after 24h |
 | Rotation crash → split-brain keys | Two-key window + `pending_rotation` record + per-record `master_key_epoch` | Auto-recoverable on restart |
@@ -578,6 +585,6 @@ The rotation code provides physical-presence authentication:
 ### 10.5  Escrow trust model
 
 - **PSK blobs are opaque to the cloud.** The Azure handler stores and returns encrypted blobs without inspection.
-- **No offline passphrase verifier.** `master_key_id` is a random opaque identifier, not a hash of the key material.
+- **No additional offline passphrase verifier beyond existing AEAD oracle.** `master_key_id = SHA-256(master_key)` is technically a verifier, but encrypted PSK blobs already provide a strictly faster trial-decryption oracle. The incremental risk is zero. KDF parameters and salt are not stored in Azure.
 - **Recovery is trial-based.** Recovered PSKs are placed in `pending_recovery` and only promoted after successful frame authentication.
 - **Phone PSKs are not escrowed.** This is a scoping decision; the protocol supports phone escrow without modification.

--- a/docs/web-ui-requirements.md
+++ b/docs/web-ui-requirements.md
@@ -1110,7 +1110,7 @@ gateway's ACTUAL_STATE row in the `actualstate` Azure Table
 (`PartitionKey` starting with `"g:"`). The SPA selects the latest row per
 gateway partition using `latestByPartition`. The card MUST
 show the BIP-39 fingerprint (6 words), `master_key_epoch`, `master_key_id`
-(hex), `rotation_in_progress`, salt status (present/absent),
+(32-byte SHA-256 hex), `rotation_in_progress`,
 `gateway_version`, `modem_firmware_version`, and `channel`.
 
 The gateway status card MUST also display a convergence badge (Aligned /
@@ -1151,8 +1151,8 @@ collapsible rotation form within the card. The form shows (1) the BIP-39
 fingerprint with instructions to verify it against the modem, (2) a rotation
 code input limited to 6 characters and normalized to uppercase `[A-Z0-9]`,
 (3) a masked passphrase input that requires either at least 20 characters or
-6 space-separated words, (4) the current salt from the gateway ACTUAL_STATE
-or a `first rotation` indicator if the salt is null, and (5) a confirmation
+6 space-separated words, (4) a deployment label input field where the admin
+enters the label used to derive salt deterministically, and (5) a confirmation
 action. If the browser lacks the required rotation crypto capabilities, the
 button MUST be disabled with a tooltip explaining the requirement.
 
@@ -1183,18 +1183,18 @@ resumes when the form collapses.
 **Confidence:** High
 
 **Description:**
-The SPA MUST derive the new master key using
-`Argon2id(passphrase, salt, kdf_params)` via a WASM Argon2id implementation
-(e.g., `argon2-browser`). The default KDF parameters for the first rotation are
-`m_cost=65536`, `t_cost=3`, and `p_cost=1`. If the gateway ACTUAL_STATE
-includes `kdf_params`, the SPA MUST use those parameters instead. Passphrase and
-derived key material MUST be cleared from JavaScript variables after use on a
-best-effort basis.
+The SPA MUST derive the new master key using Argon2id with hardcoded KDF v1
+parameters (`m_cost=65536`, `t_cost=3`, `p_cost=1`, `output_len=32`) via a
+WASM Argon2id implementation (e.g., `argon2-browser`). Salt is derived from
+the deployment label: `SHA-256("sonde-kdf-v1:" || utf8(deployment_label))[0..16]`.
+The SPA MUST NOT read KDF parameters or salt from gateway ACTUAL_STATE.
+Passphrase and derived key material MUST be cleared from JavaScript variables
+after use on a best-effort basis.
 
 **Acceptance criteria:**
 
 1. The derived key matches the gateway's expected output for the same inputs.
-2. `kdf_params` from ACTUAL_STATE are used when present.
+2. Hardcoded KDF v1 parameters are always used.
 3. Key material is cleared after use on a best-effort basis.
 
 ---
@@ -1213,8 +1213,8 @@ CDN-loaded `noble-curves` implementation; shared secret
 using `shared_secret`, `hkdf_salt = b"sonde-rotation-v1"`, and
 `info = gateway_id_raw || current_master_key_epoch_be64`; a random 12-byte nonce
 from `crypto.getRandomValues()`; CBOR plaintext map
-`{1: new_master_key, 2: rotation_code, 3: new_master_key_id, 4: salt, 5: kdf_params}`;
-AES-256-GCM ciphertext using the derived key, nonce, and
+`{1: new_master_key, 2: rotation_code}`. CBOR keys 3–5 are RESERVED and MUST
+NOT be included; AES-256-GCM ciphertext using the derived key, nonce, and
 `aad = gateway_id_raw || current_master_key_epoch_be64`; and final output
 `version || ephemeral_public || nonce || ciphertext_and_tag`.
 
@@ -1343,15 +1343,8 @@ The convergence check compares the following fields:
   desired.submitted_epoch`, the rotation is considered consumed.
 - **`channel`:** Diverged if the desired `channel` is non-null and differs
   from actual `channel`.
-- **`salt`:** Diverged only when the gateway has no local salt (actual
-  `salt` is null/absent) AND the desired `salt` is non-null. Once the
-  gateway has a salt, it is immutable except via rotation payload — a
-  mismatched desired `salt` against an existing actual `salt` is a no-op
-  by gateway design and does NOT flag divergence.
-- **`kdf_params`:** Diverged only when the gateway has no local KDF params
-  (actual `kdf_params_json` is null/absent) AND the desired
-  `kdf_params`/`kdf_params_json` is non-null. Same set-if-absent semantics
-  as `salt`.
+- **`salt`:** *(Retired — no longer tracked for convergence.)*
+- **`kdf_params`:** *(Retired — no longer tracked for convergence.)*
 
 `recovered_psks` is excluded from convergence — it is a background queue
 not visible to the operator.
@@ -1372,14 +1365,10 @@ success` for Aligned, `badge warning` for Diverged).
    `master_key_epoch > submitted_epoch` shows "Aligned" (rotation
    consumed).
 4. Gateway with desired `channel` differing from actual shows "Diverged."
-5. Gateway with desired `salt` when actual `salt` is absent shows
-   "Diverged."
-6. Gateway with desired `salt` when actual `salt` already exists (even if
-   different) shows "Aligned" (set-if-absent semantics).
-7. Gateway with desired `kdf_params` when actual is absent shows
-   "Diverged."
-8. Gateway with desired `kdf_params` when actual already exists shows
-   "Aligned" (set-if-absent semantics).
+5. *(Reserved — previously salt divergence, now retired.)*
+6. *(Reserved — previously salt alignment, now retired.)*
+7. *(Reserved — previously KDF params divergence, now retired.)*
+8. *(Reserved — previously KDF params alignment, now retired.)*
 9. Badge uses the same CSS styling as the node convergence badge.
 
 ---


### PR DESCRIPTION
Simplify KDF: deterministic `master_key_id`, client-side-only salt/KDF

Remove salt and KDF parameters from gateway storage, wire protocol
(ACTUAL/DESIRED STATE CBOR keys 21/22), rotation payload (CBOR keys
3/4/5), and Azure Tables. KDF is now a client-side-only concern:

- `master_key_id` = `SHA-256(master_key)` (32 bytes, deterministic)
  instead of random 16 bytes. Eliminates transmitting it in rotation
  payloads; gateway derives it locally after decryption.

- KDF v1 (Argon2id m=65536 t=3 p=1) is hardcoded in client tools
  (admin CLI, web SPA). No KDF parameters are stored or transmitted.

- Salt is derived deterministically from a deployment label:
  `SHA-256("sonde-kdf-v1:" || utf8(label))[0..16]`.
  The label is stored only in the SPA environment config.

- Rotation payload plaintext simplified to `{1: new_master_key,
  2: rotation_code}`. Keys 3-5 are RESERVED (not reused).

- CBOR keys 21/22 in ACTUAL/DESIRED STATE are RESERVED (retired).

- Cross-gateway linkability (same passphrase+label produces the same
  `master_key_id` visible to Azure) is accepted and documented in
  `security.md`.

- Fix: use post-recovery master key (not stale pre-recovery capture)
  when deriving `master_key_id` during gateway startup.

- `master_key_epoch` is unchanged (crash recovery, dual-key processing).

This is a clean-break change — no migration needed (no production
gateways exist).

Spec: GW-2001, GW-2003, GW-2004, GW-2005, GW-2006, GW-2008 (RETIRE),
GW-2020 (NEW), GW-2021 (NEW), AZH-0600, AZH-0604 (RETIRE), AZH-0605,
WEB-1001-1004, WEB-1009.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
