### PR TITLE
Log DESIRED_STATE rotation payload outcomes

### DIFF
--- a/crates/sonde-gateway/src/rotation_engine.rs
+++ b/crates/sonde-gateway/src/rotation_engine.rs
@@ -175,7 +175,10 @@ impl RotationEngine {
 
         if let Some(ref payload) = state.rotation_payload {
             // Errors from DESIRED_STATE rotation are silently discarded per spec.
-            let _ = self.handle_rotation_payload(payload, false).await;
+            match self.handle_rotation_payload(payload, false).await {
+                Ok(()) => info!("DESIRED_STATE rotation payload applied successfully"),
+                Err(e) => warn!(reason = %e, "DESIRED_STATE rotation payload rejected"),
+            }
         }
 
         if state_changed {

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -2139,6 +2139,10 @@ message SubmitRotationResponse { bool accepted = 1; string error = 2; }
 ```
 
 Both gRPC and DESIRED_STATE rotation paths converge on the same handler.
+DESIRED_STATE rotation failures are logged at `warn` level with the
+rejection reason (e.g., `"rotation payload error: DecryptionFailed"`,
+`"rate-limited"`, `"rotation already in progress"`).  Successes are
+logged at `info` level.
 
 ### 23.13  KDF and salt — client-side only (GW-2020, GW-2021)
 


### PR DESCRIPTION
Replace silent \let _ =\ discard in \handle_desired_state\ with explicit match that logs:
- \info\ on successful rotation application
- \warn\ with rejection reason on failure (e.g., \otation payload error: DecryptionFailed\, \ate-limited\, \otation already in progress\)

**Motivation:** When the Azure handler repeatedly relays a \otation_payload\ that the gateway cannot apply (e.g., epoch-bound decryption failure after rotation already completed), the gateway produces no log output, making the issue invisible.

**Changes:**
- \crates/sonde-gateway/src/rotation_engine.rs\: \handle_desired_state\ now logs outcomes
- \docs/gateway-design.md\ §23.12: documents the logging behaviour