### PR TITLE
feat(gateway): emit escrow fields on every node ACTUAL_STATE (GW-2005)

### DIFF
--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -359,7 +359,6 @@ impl ConnectorEventHub {
         self.tx.receiver_count()
     }
 
-    #[allow(clippy::too_many_arguments)]
     /// Emit ACTUAL_STATE for a node with escrow fields (GW-2005).
     #[allow(clippy::too_many_arguments)]
     pub fn emit_actual_state_for_node_with_escrow(

--- a/crates/sonde-gateway/src/connector.rs
+++ b/crates/sonde-gateway/src/connector.rs
@@ -360,36 +360,7 @@ impl ConnectorEventHub {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn emit_actual_state_for_node(
-        &self,
-        node_id: String,
-        current_program_hash: Vec<u8>,
-        assigned_program_hash: Option<Vec<u8>>,
-        schedule_interval_s: u32,
-        battery_mv: u32,
-        firmware_abi_version: u32,
-        firmware_version: String,
-        timestamp_ms: u64,
-        wake_rssi_dbm: Option<i8>,
-    ) {
-        let _ = self.tx.send(ConnectorOutboundMessage::ActualState {
-            entity_kind: "node",
-            entity_id: node_id,
-            current_program_hash: Some(current_program_hash),
-            assigned_program_hash,
-            schedule_interval_s: Some(schedule_interval_s),
-            battery_mv: Some(battery_mv),
-            firmware_abi_version: Some(firmware_abi_version),
-            firmware_version: Some(firmware_version),
-            timestamp_ms,
-            encrypted_psk_escrow: None,
-            escrow_key_hint: None,
-            master_key_id: None,
-            wake_rssi_dbm,
-        });
-    }
-
-    /// Emit ACTUAL_STATE for a node with escrow blob (GW-2003).
+    /// Emit ACTUAL_STATE for a node with escrow fields (GW-2005).
     #[allow(clippy::too_many_arguments)]
     pub fn emit_actual_state_for_node_with_escrow(
         &self,

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1209,7 +1209,7 @@ impl Gateway {
             }
         }
 
-        // 4b. Emit node ACTUAL_STATE with escrow fields (GW-2005).
+        // 4a. Emit node ACTUAL_STATE with escrow fields (GW-2005).
         let (encrypted_psk_escrow, escrow_key_hint, escrow_master_key_id) =
             match &self.sqlite_storage {
                 Some(sqlite) => match sqlite.get_node_escrow_by_id(&node.node_id).await {
@@ -1269,7 +1269,7 @@ impl Gateway {
                 rssi,
             );
 
-        // 4a. Emit node_online EVENT to handlers (GW-0507)
+        // 4b. Emit node_online EVENT to handlers (GW-0507)
         {
             let process_refs = self.handler_router.read().await.clone_all_process_refs();
             // Lock released — broadcast events without holding router lock.

--- a/crates/sonde-gateway/src/engine.rs
+++ b/crates/sonde-gateway/src/engine.rs
@@ -1209,17 +1209,65 @@ impl Gateway {
             }
         }
 
-        self.connector_event_hub.emit_actual_state_for_node(
-            node.node_id.clone(),
-            program_hash.clone(),
-            updated_node.assigned_program_hash.clone(),
-            updated_node.schedule_interval_s,
-            battery_mv,
-            firmware_abi_version,
-            updated_node.firmware_version.clone().unwrap_or_default(),
-            timestamp_ms,
-            rssi,
-        );
+        // 4b. Emit node ACTUAL_STATE with escrow fields (GW-2005).
+        let (encrypted_psk_escrow, escrow_key_hint, escrow_master_key_id) =
+            match &self.sqlite_storage {
+                Some(sqlite) => match sqlite.get_node_escrow_by_id(&node.node_id).await {
+                    Ok(Some(escrow)) => {
+                        if escrow.master_key_id.is_empty() {
+                            warn!(
+                                node_id = %node.node_id,
+                                "node escrow state unavailable (master_key_id is NULL)"
+                            );
+                            (None, None, None)
+                        } else {
+                            (
+                                Some(escrow.encrypted_psk),
+                                Some(escrow.key_hint),
+                                Some(escrow.master_key_id),
+                            )
+                        }
+                    }
+                    Ok(None) => {
+                        warn!(
+                            node_id = %node.node_id,
+                            "node not found in storage for escrow lookup"
+                        );
+                        (None, None, None)
+                    }
+                    Err(e) => {
+                        warn!(
+                            node_id = %node.node_id,
+                            error = %e,
+                            "failed to query node escrow state for ACTUAL_STATE"
+                        );
+                        (None, None, None)
+                    }
+                },
+                None => {
+                    warn!(
+                        node_id = %node.node_id,
+                        "sqlite storage unavailable for ACTUAL_STATE escrow lookup"
+                    );
+                    (None, None, None)
+                }
+            };
+
+        self.connector_event_hub
+            .emit_actual_state_for_node_with_escrow(
+                node.node_id.clone(),
+                program_hash.clone(),
+                updated_node.assigned_program_hash.clone(),
+                updated_node.schedule_interval_s,
+                battery_mv,
+                firmware_abi_version,
+                updated_node.firmware_version.clone().unwrap_or_default(),
+                timestamp_ms,
+                encrypted_psk_escrow,
+                escrow_key_hint,
+                escrow_master_key_id,
+                rssi,
+            );
 
         // 4a. Emit node_online EVENT to handlers (GW-0507)
         {

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1745,6 +1745,51 @@ impl SqliteStorage {
         .await
     }
 
+    /// Look up escrow metadata for a single node by ID (GW-2005).
+    ///
+    /// Returns `None` if the node does not exist. Used by the engine to
+    /// populate escrow fields in every node ACTUAL_STATE emission.
+    pub async fn get_node_escrow_by_id(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<NodeEscrowRecord>, StorageError> {
+        let node_id = node_id.to_string();
+        self.with_conn(move |conn| {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT node_id, key_hint, psk, master_key_id, \
+                     schedule_interval_s, firmware_abi_version, firmware_version, \
+                     current_program_hash, assigned_program_hash, last_battery_mv \
+                     FROM nodes WHERE node_id = ?1",
+                )
+                .map_err(map_err)?;
+            let mut rows = stmt
+                .query_map(params![node_id], |row| {
+                    let kh: u32 = row.get(1)?;
+                    Ok(NodeEscrowRecord {
+                        node_id: row.get(0)?,
+                        key_hint: u16::try_from(kh)
+                            .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(1, kh as i64))?,
+                        encrypted_psk: row.get(2)?,
+                        master_key_id: row.get::<_, Option<Vec<u8>>>(3)?.unwrap_or_default(),
+                        schedule_interval_s: row.get(4)?,
+                        firmware_abi_version: row.get::<_, Option<u32>>(5)?.unwrap_or(0),
+                        firmware_version: row.get::<_, Option<String>>(6)?.unwrap_or_default(),
+                        current_program_hash: row.get::<_, Option<Vec<u8>>>(7)?.unwrap_or_default(),
+                        assigned_program_hash: row.get(8)?,
+                        last_battery_mv: row.get::<_, Option<u32>>(9)?.unwrap_or(0),
+                    })
+                })
+                .map_err(map_err)?;
+            match rows.next() {
+                Some(Ok(record)) => Ok(Some(record)),
+                Some(Err(e)) => Err(map_err(e)),
+                None => Ok(None),
+            }
+        })
+        .await
+    }
+
     /// Check whether a rotation is currently in progress (pending_rotation exists).
     pub async fn is_rotation_in_progress(&self) -> Result<bool, StorageError> {
         self.with_conn(|conn| {

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -1760,7 +1760,7 @@ impl SqliteStorage {
                     "SELECT node_id, key_hint, psk, master_key_id, \
                      schedule_interval_s, firmware_abi_version, firmware_version, \
                      current_program_hash, assigned_program_hash, last_battery_mv \
-                     FROM nodes WHERE node_id = ?1",
+                     FROM nodes WHERE node_id = ?1 LIMIT 1",
                 )
                 .map_err(map_err)?;
             let mut rows = stmt

--- a/crates/sonde-gateway/tests/escrow.rs
+++ b/crates/sonde-gateway/tests/escrow.rs
@@ -4,7 +4,7 @@
 //! Integration tests for PSK escrow, master key identification, and ACTUAL_STATE
 //! publication (GW-2001, GW-2003, GW-2004, GW-2005).
 //!
-//! Test IDs: T-2000, T-2001, T-2002, T-2006c, T-2011, T-2012, T-2014.
+//! Test IDs: T-2000, T-2001, T-2002, T-2005a, T-2006c, T-2011, T-2012, T-2014.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,17 +20,21 @@ use sonde_gateway::connector::{
 };
 use sonde_gateway::engine::Gateway;
 use sonde_gateway::gateway_identity::GatewayIdentity;
+use sonde_gateway::handler::HandlerRouter;
 use sonde_gateway::phone_trust::{PhonePskRecord, PhonePskStatus};
 use sonde_gateway::registry::NodeRecord;
 use sonde_gateway::rotation_engine::RotationEngine;
+use sonde_gateway::session::SessionManager;
 use sonde_gateway::sqlite_storage::SqliteStorage;
 use sonde_gateway::storage::Storage;
-use sonde_gateway::RustCryptoSha256;
+use sonde_gateway::transport::PeerAddress;
+use sonde_gateway::{GatewayAead, RustCryptoSha256};
 
 use aes_gcm::aead::{Aead, KeyInit, Payload};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 use hkdf::Hkdf;
 use sha2::{Digest, Sha256};
+use sonde_protocol::{encode_frame, FrameHeader, NodeMessage, MSG_WAKE};
 use x25519_dalek::PublicKey as X25519PublicKey;
 
 // ── helpers ──────────────────────────────────────────────────────
@@ -1107,5 +1111,131 @@ async fn test_t2014_periodic_gateway_actual_state_heartbeat() {
         map_get(&heartbeat_map, 2),
         Some(&Value::Text("gateway".to_string())),
         "heartbeat ACTUAL_STATE must have entity_kind = gateway"
+    );
+}
+
+// ── T-2005a: WAKE ACTUAL_STATE includes escrow fields ────────
+
+/// T-2005a: WAKE ACTUAL_STATE includes escrow fields (GW-2005 AC-4).
+///
+/// Verifies that a valid WAKE from a registered node produces a node
+/// ACTUAL_STATE that includes `encrypted_psk` (key 12, 60 bytes),
+/// `escrow_key_hint` (key 13), and `master_key_id` (key 14, 32 bytes).
+#[tokio::test]
+async fn test_t2005a_wake_actual_state_includes_escrow_fields() {
+    let (store, _identity) = setup_test_storage().await;
+
+    // Register the node BEFORE init_master_key_id so the backfill sets master_key_id.
+    let key_hint: u16 = 0x4242;
+    let psk = [0x42u8; 32];
+    let node_id = "escrow-wake-node";
+    let record = NodeRecord {
+        node_id: node_id.to_string(),
+        key_hint,
+        psk,
+        assigned_program_hash: None,
+        current_program_hash: None,
+        desired_schedule_interval_s: Some(60),
+        schedule_interval_s: 60,
+        firmware_abi_version: Some(1),
+        firmware_version: Some("0.1.0".to_string()),
+        rf_channel: Some(1),
+        sensors: vec![],
+        registered_by_phone_id: None,
+        key_version: 0,
+    };
+    store.upsert_node(&record).await.unwrap();
+
+    let (key_id, _epoch) = store.init_master_key_id().await.unwrap();
+
+    // Build a Gateway that uses SqliteStorage for both Storage trait and escrow lookups.
+    let pending_commands = Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+    let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+    let handler_router = Arc::new(tokio::sync::RwLock::new(HandlerRouter::new(Vec::new())));
+    let mut gateway = Gateway::new_with_pending(
+        store.clone() as Arc<dyn Storage>,
+        pending_commands,
+        session_manager,
+        handler_router,
+    );
+    gateway.set_sqlite_storage(store.clone()).await;
+
+    let event_hub = gateway.connector_event_hub();
+    let (mut client, _handle) =
+        spawn_connector(event_hub.clone(), store.clone() as Arc<dyn Storage>).await;
+
+    // Build and send a valid WAKE frame.
+    let program_hash = vec![0x00; 32];
+    let header = FrameHeader {
+        key_hint,
+        msg_type: MSG_WAKE,
+        nonce: 1,
+    };
+    let wake_msg = NodeMessage::Wake {
+        firmware_abi_version: 1,
+        program_hash: program_hash.clone(),
+        battery_mv: 3300,
+        firmware_version: "0.1.0".into(),
+        blob: None,
+    };
+    let cbor = wake_msg.encode().unwrap();
+    let frame = encode_frame(&header, &cbor, &psk, &GatewayAead, &RustCryptoSha256).unwrap();
+
+    let peer: PeerAddress = b"escrow-wake-peer".to_vec();
+    let _response = gateway.process_frame(&frame, peer).await;
+
+    // Read the node ACTUAL_STATE from the connector.
+    let node_frame = read_framed(&mut client).await;
+    let node_map = decode_cbor_map(&node_frame);
+
+    // Verify msg_type = ACTUAL_STATE.
+    let msg_type: i128 = match map_get(&node_map, 1).unwrap() {
+        Value::Integer(i) => (*i).into(),
+        other => panic!("expected integer msg_type, got {other:?}"),
+    };
+    assert_eq!(msg_type, MSG_TYPE_ACTUAL_STATE as i128);
+
+    // Verify entity_kind = "node".
+    let entity_kind = match map_get(&node_map, 2).unwrap() {
+        Value::Text(s) => s.clone(),
+        other => panic!("expected text entity_kind, got {other:?}"),
+    };
+    assert_eq!(entity_kind, "node");
+
+    // Verify entity_id matches the node_id.
+    let entity_id = match map_get(&node_map, 3).unwrap() {
+        Value::Text(s) => s.clone(),
+        other => panic!("expected text entity_id, got {other:?}"),
+    };
+    assert_eq!(entity_id, node_id);
+
+    // Verify encrypted_psk (key 12) is present and 60 bytes.
+    let encrypted_psk = match map_get(&node_map, 12).unwrap() {
+        Value::Bytes(b) => b.clone(),
+        other => panic!("expected bytes encrypted_psk (key 12), got {other:?}"),
+    };
+    assert_eq!(
+        encrypted_psk.len(),
+        60,
+        "encrypted_psk must be 60 bytes (12B nonce + 32B ciphertext + 16B tag)"
+    );
+
+    // Verify escrow_key_hint (key 13) matches the node's key_hint.
+    let escrow_kh: i128 = match map_get(&node_map, 13).unwrap() {
+        Value::Integer(i) => (*i).into(),
+        other => panic!("expected integer escrow_key_hint (key 13), got {other:?}"),
+    };
+    assert_eq!(escrow_kh, key_hint as i128);
+
+    // Verify master_key_id (key 14) is 32 bytes and matches the current key ID.
+    let mk_id = match map_get(&node_map, 14).unwrap() {
+        Value::Bytes(b) => b.clone(),
+        other => panic!("expected bytes master_key_id (key 14), got {other:?}"),
+    };
+    assert_eq!(mk_id.len(), 32, "master_key_id must be 32 bytes");
+    assert_eq!(
+        mk_id,
+        key_id.to_vec(),
+        "master_key_id must match current key"
     );
 }

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1988,8 +1988,9 @@ The `ConnectorEventHub` provides a single emission method
 (`emit_actual_state_for_node_with_escrow`) that always accepts escrow
 fields. There is no separate "no-escrow" convenience method — all
 ACTUAL_STATE emissions (WAKE, registration, rotation, reconnection)
-use the same path. The engine queries per-node escrow data from
-`SqliteStorage::get_node_escrow_by_id()` at each emission point.
+use the same path. The WAKE path queries per-node escrow data from
+`SqliteStorage::get_node_escrow_by_id()`; the post-rotation path uses
+the bulk `list_node_escrow_state()` to re-emit all nodes efficiently.
 When `sqlite_storage` is unavailable or the node's `master_key_id`
 is NULL, escrow fields are emitted as `null`.
 

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1230,6 +1230,13 @@ written to durable gateway storage.
 The payload also includes `wake_rssi_dbm` (CBOR key 28) when the modem supplies
 RSSI metadata; the field is null when the transport does not provide RSSI.
 
+The node actual-state payload also includes the PSK escrow fields
+(`encrypted_psk`, `escrow_key_hint`, `master_key_id`) as defined in §23.6.
+The gateway queries the node's escrow data from storage on each WAKE to
+populate these fields. When `sqlite_storage` is unavailable or the node's
+`master_key_id` is NULL, the engine emits ACTUAL_STATE with null escrow
+fields and logs a warning.
+
 ### 13A.4  External transport boundary and loss signaling
 
 The gateway does not know whether the external control-plane transport is Azure
@@ -1976,6 +1983,15 @@ Encrypted with `AES-256-GCM(master_key, nonce, psk, aad=node_id_utf8)`.
 
 Phone PSKs are NOT escrowed. They are rotated locally but never emitted
 via ACTUAL_STATE.
+
+The `ConnectorEventHub` provides a single emission method
+(`emit_actual_state_for_node_with_escrow`) that always accepts escrow
+fields. There is no separate "no-escrow" convenience method — all
+ACTUAL_STATE emissions (WAKE, registration, rotation, reconnection)
+use the same path. The engine queries per-node escrow data from
+`SqliteStorage::get_node_escrow_by_id()` at each emission point.
+When `sqlite_storage` is unavailable or the node's `master_key_id`
+is NULL, escrow fields are emitted as `null`.
 
 ### 23.7  Master key rotation (GW-2006, GW-2007, GW-2013)
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2696,14 +2696,20 @@ Node ACTUAL_STATE MUST include three escrow fields: `encrypted_psk`
 and `master_key_id` (key 14, bstr 32 bytes). Phone PSKs are NOT escrowed
 (phone ACTUAL_STATE is never emitted).
 
-Escrow fields are emitted on node registration, after key rotation, and
-on connector reconnection.
+Every node ACTUAL_STATE emission MUST include keys 12, 13, and 14 with
+valid non-null escrow values when the node's escrow state is available in
+storage. When escrow data is unavailable (e.g. `master_key_id` is NULL
+in storage for a pre-migration node), the fields are emitted as `null`.
 
 **Acceptance criteria:**
 
 1. Node ACTUAL_STATE includes keys 12, 13, 14.
 2. Phone ACTUAL_STATE is never emitted.
 3. After rotation, all node escrow fields re-emitted with new master_key_id.
+4. Every node WAKE produces an ACTUAL_STATE that includes non-null escrow
+   fields when node escrow state is available.
+5. When node escrow state is unavailable, ACTUAL_STATE is still emitted
+   with null escrow fields (WAKE handling is not aborted).
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4486,6 +4486,25 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-2005a  WAKE ACTUAL_STATE includes escrow fields
+
+**Traces to:** GW-2005 (AC-4)
+
+**Steps:**
+1. Start gateway with identity, master key, and one registered node.
+2. Connect a mock connector consumer.
+3. Send a valid WAKE from the registered node.
+4. Consume the node ACTUAL_STATE emitted in response to the WAKE.
+5. Verify `encrypted_psk` (key 12) is a 60-byte bstr.
+6. Verify `escrow_key_hint` (key 13) matches the node's `key_hint`.
+7. Verify `master_key_id` (key 14) is a 32-byte bstr matching the
+   current master key ID.
+
+**Expected:**
+1. Node ACTUAL_STATE from a WAKE includes all three escrow fields.
+
+---
+
 ### T-2006c  Phone PSKs not escrowed
 
 **Traces to:** GW-2005 (AC-2)
@@ -4738,7 +4757,7 @@ by existing handler tests.
 | GW-2002 | T-2003 |
 | GW-2003 | T-2001, T-2011, T-2012, T-2013, T-2014, T-2016, T-2016a |
 | GW-2004 | T-2002 |
-| GW-2005 | T-2001, T-2006c |
+| GW-2005 | T-2001, T-2005a, T-2006c |
 | GW-2006 | T-2004, T-2004a |
 | GW-2007 | T-2005, T-2009 |
 | GW-2008 | T-2007 |

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4434,6 +4434,25 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-2005a  WAKE ACTUAL_STATE includes escrow fields
+
+**Traces to:** GW-2005 (AC-4)
+
+**Steps:**
+1. Start gateway with identity, master key, and one registered node.
+2. Connect a mock connector consumer.
+3. Send a valid WAKE from the registered node.
+4. Consume the node ACTUAL_STATE emitted in response to the WAKE.
+5. Verify `encrypted_psk` (key 12) is a 60-byte bstr.
+6. Verify `escrow_key_hint` (key 13) matches the node's `key_hint`.
+7. Verify `master_key_id` (key 14) is a 32-byte bstr matching the
+   current master key ID.
+
+**Expected:**
+1. Node ACTUAL_STATE from a WAKE includes all three escrow fields.
+
+---
+
 ### T-2006  Declarative node recovery
 
 **Traces to:** GW-2009 (AC-1, AC-2, AC-4, AC-5)
@@ -4483,25 +4502,6 @@ A configurable stub handler process (or in-process mock) that:
 
 **Expected:**
 1. PSKs from a different key era are rejected.
-
----
-
-### T-2005a  WAKE ACTUAL_STATE includes escrow fields
-
-**Traces to:** GW-2005 (AC-4)
-
-**Steps:**
-1. Start gateway with identity, master key, and one registered node.
-2. Connect a mock connector consumer.
-3. Send a valid WAKE from the registered node.
-4. Consume the node ACTUAL_STATE emitted in response to the WAKE.
-5. Verify `encrypted_psk` (key 12) is a 60-byte bstr.
-6. Verify `escrow_key_hint` (key 13) matches the node's `key_hint`.
-7. Verify `master_key_id` (key 14) is a 32-byte bstr matching the
-   current master key ID.
-
-**Expected:**
-1. Node ACTUAL_STATE from a WAKE includes all three escrow fields.
 
 ---
 


### PR DESCRIPTION
## Summary

Every node ACTUAL_STATE emission now includes PSK escrow fields (\ncrypted_psk\, \scrow_key_hint\, \master_key_id\) — not only after key rotation.

## Changes

### Code
- **\sqlite_storage.rs\**: Add \get_node_escrow_by_id()\ — single-row PK lookup for per-node escrow data
- **\connector.rs\**: Remove \mit_actual_state_for_node()\ (no-escrow convenience method) — all callers now use \mit_actual_state_for_node_with_escrow()\
- **\ngine.rs\**: \handle_wake_core\ queries escrow data from \sqlite_storage\ and populates escrow fields on every WAKE emission. When escrow is unavailable (no \sqlite_storage\, NULL \master_key_id\, or lookup error), ACTUAL_STATE is still emitted with null escrow fields and a warning is logged.

### Specifications
- **GW-2005** (gateway-requirements.md): Amend description — escrow fields emitted on every node ACTUAL_STATE emission. Add AC-4 (WAKE includes escrow) and AC-5 (graceful null when unavailable).
- **Design §13A.3 + §23.6** (gateway-design.md): Document per-WAKE escrow emission path and single emission method.
- **Validation** (gateway-validation.md): Add T-2005a test case (WAKE → verify escrow fields). Update traceability matrix.

## Testing
- All gateway tests pass (138 tests across 10 test binaries)
- \cargo clippy --workspace -- -D warnings\ clean
- \cargo fmt --all\ applied