### PR TITLE
fix: default SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN to https://sondeplatform.com

### DIFF
--- a/deploy/azure-bootstrap/bootstrap.sh
+++ b/deploy/azure-bootstrap/bootstrap.sh
@@ -248,9 +248,12 @@ github_pages_path="${SONDE_AZURE_GITHUB_PAGES_PATH:-/sonde/}"
 github_pages_path="/$(printf '%s' "$github_pages_path" | sed 's|^/||;s|/$||')/"
 # shellcheck disable=SC2016 — $cert/$uris are jq variable refs, not shell.
 redirect_uris="$(printf '%s' "${github_pages_origin}${github_pages_path}")"
-if [ "${SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN+set}" = "set" ] && [ -n "$SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN" ]; then
+# Default to sondeplatform.com to match Bicep's customDomainOrigin default.
+# Set SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN="" to opt out.
+custom_domain_origin="${SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN-https://sondeplatform.com}"
+if [ -n "$custom_domain_origin" ]; then
     # Strip trailing slash then append exactly one
-    custom_origin="$(printf '%s' "$SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN" | sed 's|/$||')"
+    custom_origin="$(printf '%s' "$custom_domain_origin" | sed 's|/$||')"
     spa_body="$(jq -n -c \
         --arg cert "$COMPANION_CERT_BASE64" \
         --arg certName "sonde-azure-companion" \

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -298,7 +298,9 @@ Both CORS origins are parameterized via `githubPagesOrigin` and
 `customDomainOrigin` parameters in `main.bicep`, with Sonde-specific defaults.
 SPA redirect URIs are configured via CLI using `SONDE_AZURE_GITHUB_PAGES_ORIGIN`,
 `SONDE_AZURE_GITHUB_PAGES_PATH`, and `SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN`
-environment variables.
+environment variables. `SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN` defaults to
+`https://sondeplatform.com` (matching the Bicep `customDomainOrigin` parameter
+default); set to the empty string to omit the custom domain redirect URI.
 
 ---
 

--- a/docs/web-ui-requirements.md
+++ b/docs/web-ui-requirements.md
@@ -1021,6 +1021,7 @@ origins and SPA redirect URIs.
 1. CORS origins include `https://alan-jowett.github.io` and `https://sondeplatform.com`.
 2. SPA redirect URIs include `https://alan-jowett.github.io/sonde/` and `https://sondeplatform.com/`.
 3. Origins are parameterized via Bicep parameters.
+4. The bootstrap script defaults `SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN` to `https://sondeplatform.com`, matching the Bicep `customDomainOrigin` default. An operator may opt out by setting it to the empty string.
 
 ---
 

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -293,6 +293,7 @@ and verifies one or more acceptance criteria.
 | T-WEB-0901c | WEB-0901 | Manual trigger (`workflow_dispatch`) is supported | Infrastructure | Planned |
 | T-WEB-0902 | WEB-0902 | Bicep includes GitHub Pages and `sondeplatform.com` in CORS origins and SPA redirect URIs | Infrastructure | Planned |
 | T-WEB-0902b | WEB-0902 | CORS origins parameterized via Bicep parameters | Infrastructure | Planned |
+| T-WEB-0902c | WEB-0902 | Bootstrap script defaults custom domain origin to `https://sondeplatform.com` when `SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN` is unset | Inspection | Planned |
 
 ### 5.10  Cross-Cutting
 


### PR DESCRIPTION
## Summary

Aligns `bootstrap.sh` with the Bicep `customDomainOrigin` default by defaulting `SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN` to `https://sondeplatform.com`. Previously, the custom domain SPA redirect URI was only added when the env var was explicitly set, causing MSAL login failures from `sondeplatform.com`.

## Changes

### Implementation
- **`deploy/azure-bootstrap/bootstrap.sh`** — Default `custom_domain_origin` to `https://sondeplatform.com` when `SONDE_AZURE_CUSTOM_DOMAIN_ORIGIN` is unset. Empty string opts out.

### Specifications
- **`docs/web-ui-requirements.md`** — Added WEB-0902 AC-4.
- **`docs/web-ui-design.md`** — Documented default and opt-out in section 9.5.
- **`docs/web-ui-validation.md`** — Added T-WEB-0902c inspection test.

## Traceability

| Requirement | Design | Validation | Implementation |
|---|---|---|---|
| WEB-0902 AC-4 | Design §9.5 | T-WEB-0902c | `bootstrap.sh:251-253` |

Fixes #1106
