### PR TITLE
fix(gateway): stamp `master_key_id`/`master_key_epoch` at INSERT time (GW-2001 AC-6)

### DIFF
--- a/crates/sonde-e2e/src/harness.rs
+++ b/crates/sonde-e2e/src/harness.rs
@@ -50,19 +50,15 @@ pub struct E2eTestEnv {
     pub pending_commands: Option<PendingCommandMap>,
 }
 
-impl Default for E2eTestEnv {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl E2eTestEnv {
     /// Create a fresh in-memory test environment.
-    pub fn new() -> Self {
+    pub async fn new() -> Self {
         let storage = Arc::new(
             SqliteStorage::in_memory(Zeroizing::new([0x42u8; 32]))
                 .expect("failed to create in-memory SQLite storage"),
         );
+        // Initialise master key metadata so that INSERT paths can stamp rows.
+        storage.init_master_key_id().await.unwrap();
         let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
         let pending_commands: PendingCommandMap = Arc::new(RwLock::new(HashMap::new()));
         let gateway = Arc::new(Gateway::new_with_pending(
@@ -87,11 +83,13 @@ impl E2eTestEnv {
     /// Create an environment with a handler router for APP_DATA tests.
     ///
     /// `handler_cmd` is the path to the handler binary and its arguments.
-    pub fn new_with_handler(handler_cmd: &str, handler_args: &[&str]) -> Self {
+    pub async fn new_with_handler(handler_cmd: &str, handler_args: &[&str]) -> Self {
         let storage = Arc::new(
             SqliteStorage::in_memory(Zeroizing::new([0x42u8; 32]))
                 .expect("failed to create in-memory SQLite storage"),
         );
+        // Initialise master key metadata so that INSERT paths can stamp rows.
+        storage.init_master_key_id().await.unwrap();
         let config = HandlerConfig {
             matchers: vec![ProgramMatcher::Any],
             command: handler_cmd.to_string(),

--- a/crates/sonde-e2e/tests/aead_e2e_tests.rs
+++ b/crates/sonde-e2e/tests/aead_e2e_tests.rs
@@ -77,7 +77,7 @@ fn make_program_from_bytecode(bytecode: &[u8]) -> (ProgramRecord, Vec<u8>) {
 /// - Gateway updates node telemetry after a successful AEAD exchange.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_001_nop_wake_cycle() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x50; 32];
     env.register_node("aead-nop", 1, psk).await;
 
@@ -125,7 +125,7 @@ async fn t_e2e_001_nop_wake_cycle() {
 /// second WAKE even though no resident BPF program executes.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_002b_consecutive_wake_cycles() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x55; 32];
     env.register_node("aead-multi", 1, psk).await;
 
@@ -173,7 +173,7 @@ async fn t_e2e_002b_consecutive_wake_cycles() {
 async fn t_e2e_002c_app_data_fire_and_forget() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x51; 32];
     env.register_node("aead-appdata", 1, psk).await;
 
@@ -208,7 +208,7 @@ async fn t_e2e_002c_app_data_fire_and_forget() {
 /// exhausts its retries and sleeps.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_003_wrong_psk_rejected() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     env.register_node("aead-wrong", 1, [0xAA; 32]).await;
 
     // Node has a different PSK.
@@ -247,7 +247,7 @@ async fn t_e2e_003_wrong_psk_rejected() {
 /// no response, eventually exhausting retries.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_004_tampered_frame_discarded() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x53; 32];
     env.register_node("aead-tamper", 1, psk).await;
 
@@ -389,7 +389,7 @@ async fn t_e2e_030_app_data_round_trip_with_handler() {
     let receipt_dir = tempfile::tempdir().unwrap();
     let stub = env!("CARGO_BIN_EXE_stub_handler");
     let receipt_path = receipt_dir.path().to_str().unwrap();
-    let env = E2eTestEnv::new_with_handler(stub, &["--receipt-dir", receipt_path]);
+    let env = E2eTestEnv::new_with_handler(stub, &["--receipt-dir", receipt_path]).await;
 
     let psk = [0x30; 32];
     let (program, hash) = make_send_recv_program();
@@ -446,7 +446,8 @@ async fn t_e2e_031_app_data_fire_and_forget_with_handler() {
     let receipt_dir = tempfile::tempdir().unwrap();
     let stub = env!("CARGO_BIN_EXE_stub_handler");
     let receipt_path = receipt_dir.path().to_str().unwrap();
-    let env = E2eTestEnv::new_with_handler(stub, &["--no-reply", "--receipt-dir", receipt_path]);
+    let env =
+        E2eTestEnv::new_with_handler(stub, &["--no-reply", "--receipt-dir", receipt_path]).await;
 
     let psk = [0x31; 32];
     let (program, hash) = make_send_program_0102();
@@ -505,7 +506,7 @@ async fn t_e2e_032_app_data_aead_end_to_end() {
     let receipt_dir = tempfile::tempdir().unwrap();
     let stub = env!("CARGO_BIN_EXE_stub_handler");
     let receipt_path = receipt_dir.path().to_str().unwrap();
-    let env = E2eTestEnv::new_with_handler(stub, &["--receipt-dir", receipt_path]);
+    let env = E2eTestEnv::new_with_handler(stub, &["--receipt-dir", receipt_path]).await;
 
     let psk = [0x32; 32];
     let (program, hash) = make_send_program_dead();
@@ -577,7 +578,7 @@ async fn t_e2e_033_live_reload_handler_add() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
     // Start with no handlers.
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
 
     let psk = [0x33; 32];
     let (program, hash) = make_send_program();
@@ -661,7 +662,7 @@ async fn t_e2e_034_live_reload_handler_remove() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
     let stub = env!("CARGO_BIN_EXE_stub_handler");
-    let env = E2eTestEnv::new_with_handler(stub, &[]);
+    let env = E2eTestEnv::new_with_handler(stub, &[]).await;
 
     let psk = [0x34; 32];
     let (program, hash) = make_send_program();
@@ -737,7 +738,7 @@ async fn t_e2e_034_live_reload_handler_remove() {
 /// gateway (RustCryptoAead) and node (NodeAead) for a single wake cycle.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_002_aead_authentication_round_trip() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0xAA; 32];
     env.register_node("aead-002", 1, psk).await;
 
@@ -768,7 +769,7 @@ async fn t_e2e_002_aead_authentication_round_trip() {
 async fn t_e2e_010_full_program_update_cycle() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x10; 32];
     env.register_node("prog-update", 1, psk).await;
 
@@ -812,7 +813,7 @@ async fn t_e2e_010_full_program_update_cycle() {
 async fn t_e2e_011_program_already_current_nop() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x11; 32];
     env.register_node("prog-current", 1, psk).await;
 
@@ -856,7 +857,7 @@ async fn t_e2e_011_program_already_current_nop() {
 async fn t_e2e_020_update_schedule_via_admin() {
     use sonde_gateway::engine::PendingCommand;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x20; 32];
     env.register_node("sched-node", 1, psk).await;
 
@@ -882,7 +883,7 @@ async fn t_e2e_020_update_schedule_via_admin() {
 async fn t_e2e_021_reboot_via_admin() {
     use sonde_gateway::engine::PendingCommand;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x21; 32];
     env.register_node("reboot-node", 1, psk).await;
 
@@ -906,7 +907,7 @@ async fn t_e2e_022_run_ephemeral_via_admin() {
     use sonde_gateway::engine::PendingCommand;
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x22; 32];
     env.register_node("eph-node", 1, psk).await;
 
@@ -981,7 +982,7 @@ async fn t_e2e_022_run_ephemeral_via_admin() {
 /// T-E2E-040 — Unknown node silent discard.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_040_unknown_node_silent_discard() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x40; 32];
     let mut node = NodeProxy::new(99, psk);
     let stats = node.run_wake_cycle(&env);
@@ -999,7 +1000,7 @@ async fn t_e2e_040_unknown_node_silent_discard() {
 async fn t_e2e_041_sequence_number_enforcement() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x41; 32];
     env.register_node("seq-node", 1, psk).await;
 

--- a/crates/sonde-e2e/tests/e2e_tests.rs
+++ b/crates/sonde-e2e/tests/e2e_tests.rs
@@ -76,7 +76,7 @@ use sonde_pair::validation::compute_key_hint;
 /// storage after a simulated restart.
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_060_gateway_identity_persistence() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
 
     // Reload from storage — simulates restart.
@@ -103,7 +103,7 @@ async fn t_e2e_061_phone_registration() {
     use sonde_pair::types;
     use std::sync::Arc;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
 
@@ -162,7 +162,7 @@ async fn t_e2e_061_phone_registration() {
 async fn t_e2e_062_node_ble_provisioning() {
     use sonde_node::ble_pairing::{handle_node_provision, NodeProvision, NODE_ACK_SUCCESS};
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -218,7 +218,7 @@ async fn t_e2e_062_node_ble_provisioning() {
 /// Covers: T-N909, T-N912, T-N915
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_063_peer_request_ack() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -289,7 +289,7 @@ async fn t_e2e_063_peer_request_ack() {
 /// Covers: T-N915, T-N916
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_064_onboarding_to_wake() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -353,7 +353,7 @@ async fn t_e2e_064_onboarding_to_wake() {
 /// Covers: T-N913, T-N916
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_065_deferred_erasure() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -409,7 +409,7 @@ async fn t_e2e_065_deferred_erasure() {
 /// Covers: T-N917
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_066_self_healing() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -479,7 +479,7 @@ async fn t_e2e_066_self_healing() {
 /// Covers: T-N911
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_067_agent_revocation() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -547,7 +547,7 @@ async fn t_e2e_067_agent_revocation() {
 async fn t_e2e_068_factory_reset_reprovision() {
     use sonde_node::key_store::KeyStore;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -644,7 +644,7 @@ async fn t_e2e_068_factory_reset_reprovision() {
 /// Covers: T-N200
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_069_multi_node() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -747,7 +747,7 @@ async fn t_e2e_069_multi_node() {
 async fn t_e2e_070_full_use_case() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
 
     // 1. Gateway identity.
     let identity = setup_gateway_identity(&env.storage).await;
@@ -819,7 +819,7 @@ async fn t_e2e_070_full_use_case() {
 /// Covers: GW-1215
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_063a_stale_timestamp_discarded() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -905,7 +905,7 @@ async fn t_e2e_063b_key_hint_mismatch_discarded() {
     use sonde_pair::rng::{OsRng, RngProvider};
     use sonde_protocol::{encode_frame, FrameHeader, MSG_PEER_REQUEST};
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -998,7 +998,7 @@ async fn t_e2e_063b_key_hint_mismatch_discarded() {
 /// Covers: GW-1216
 #[tokio::test(flavor = "multi_thread")]
 async fn t_e2e_063c_duplicate_node_id_discarded() {
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -1106,7 +1106,7 @@ async fn t_e2e_063d_wrong_peer_ack_nonce_rejected() {
     use sonde_node::peer_request::verify_peer_ack;
     use sonde_protocol::decode_frame;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
     let (phone_psk, phone_key_hint) =
@@ -1184,7 +1184,7 @@ async fn t_e2e_063e_sonde_pair_gateway_integration() {
     use sonde_pair::rng::OsRng;
     use std::sync::Arc;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let identity = setup_gateway_identity(&env.storage).await;
     let rf_channel = 6u8;
 
@@ -1274,7 +1274,7 @@ async fn t_e2e_063e_sonde_pair_gateway_integration() {
 async fn t_e2e_083_instruction_budget_enforcement() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x83; 32];
     env.register_node("budget-node", 1, psk).await;
 
@@ -1342,7 +1342,7 @@ async fn t_e2e_081_ephemeral_restrictions() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
     use sonde_protocol::MapDef;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x80; 32];
     env.register_node("ephemeral-restrict-node", 1, psk).await;
 
@@ -1487,7 +1487,7 @@ async fn t_e2e_080_map_access_through_full_stack() {
     use sonde_node::sonde_bpf_adapter::SondeBpfInterpreter;
     use sonde_protocol::MapDef;
 
-    let env = E2eTestEnv::new();
+    let env = E2eTestEnv::new().await;
     let psk = [0x88; 32];
     env.register_node("map-node", 1, psk).await;
 

--- a/crates/sonde-e2e/tests/modem_bridge_tests.rs
+++ b/crates/sonde-e2e/tests/modem_bridge_tests.rs
@@ -302,7 +302,7 @@ struct ModemBridgeEnv {
 
 impl ModemBridgeEnv {
     async fn new() -> Self {
-        let e2e = E2eTestEnv::new();
+        let e2e = E2eTestEnv::new().await;
         let (gateway_client, gateway_server) = duplex(4096);
         let pipe_serial = PipeSerial::new(gateway_server);
 

--- a/crates/sonde-gateway/src/sqlite_storage.rs
+++ b/crates/sonde-gateway/src/sqlite_storage.rs
@@ -267,6 +267,64 @@ fn decrypt_phone_psk(
         .map_err(|_| StorageError::Internal("decrypted phone psk is not 32 bytes".into()))
 }
 
+/// Read the current `master_key_id` (BLOB) and `master_key_epoch` (i64) from
+/// `gateway_config`.  Returns an error if either value is absent — callers
+/// MUST NOT insert PSK records before `init_master_key_id` has run (GW-2001 AC-6).
+fn read_current_key_metadata(conn: &Connection) -> Result<(Vec<u8>, i64), StorageError> {
+    let id_hex: String = conn
+        .query_row(
+            "SELECT value FROM gateway_config WHERE key = 'master_key_id'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_err)?
+        .ok_or_else(|| {
+            StorageError::Internal(
+                "master_key_id not initialised in gateway_config; \
+                 init_master_key_id must be called before inserting PSK records"
+                    .into(),
+            )
+        })?;
+    let epoch_str: String = conn
+        .query_row(
+            "SELECT value FROM gateway_config WHERE key = 'master_key_epoch'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_err)?
+        .ok_or_else(|| {
+            StorageError::Internal(
+                "master_key_epoch not initialised in gateway_config; \
+                 init_master_key_id must be called before inserting PSK records"
+                    .into(),
+            )
+        })?;
+    let id_bytes = hex::decode(&id_hex).map_err(|e| {
+        StorageError::Internal(format!(
+            "gateway_config master_key_id is not valid hex: {e}"
+        ))
+    })?;
+    if id_bytes.len() != 32 {
+        return Err(StorageError::Internal(format!(
+            "gateway_config master_key_id must be 32 bytes, got {}",
+            id_bytes.len()
+        )));
+    }
+    let epoch: i64 = epoch_str.parse().map_err(|e| {
+        StorageError::Internal(format!(
+            "gateway_config master_key_epoch is not a valid i64: {e}"
+        ))
+    })?;
+    if epoch < 1 {
+        return Err(StorageError::Internal(format!(
+            "gateway_config master_key_epoch must be >= 1, got {epoch}"
+        )));
+    }
+    Ok((id_bytes, epoch))
+}
+
 fn migrate_program_source_filenames(conn: &mut Connection) -> Result<(), StorageError> {
     let needs_migration: bool = conn
         .query_row(
@@ -2281,12 +2339,15 @@ impl Storage for SqliteStorage {
                 ))
             })?;
             let tx = conn.unchecked_transaction().map_err(map_err)?;
+            // GW-2001 AC-6: stamp current master_key_id/epoch on every INSERT.
+            let (mk_id, mk_epoch) = read_current_key_metadata(&tx)?;
             tx.execute(
                 "INSERT INTO nodes (node_id, key_hint, psk, assigned_program_hash, \
                  current_program_hash, desired_schedule_interval_s, schedule_interval_s, \
                  firmware_abi_version, last_battery_mv, last_seen_epoch_s, rf_channel, \
-                 sensors_json, registered_by_phone_id, firmware_version, key_version) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15) \
+                 sensors_json, registered_by_phone_id, firmware_version, key_version, \
+                 master_key_id, master_key_epoch) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17) \
                  ON CONFLICT(node_id) DO UPDATE SET \
                  key_hint = excluded.key_hint, \
                  psk = excluded.psk, \
@@ -2301,7 +2362,9 @@ impl Storage for SqliteStorage {
                  sensors_json = excluded.sensors_json, \
                  registered_by_phone_id = excluded.registered_by_phone_id, \
                  firmware_version = excluded.firmware_version, \
-                 key_version = excluded.key_version",
+                 key_version = excluded.key_version, \
+                 master_key_id = excluded.master_key_id, \
+                 master_key_epoch = excluded.master_key_epoch",
                 params![
                     record.node_id,
                     record.key_hint as u32,
@@ -2318,6 +2381,8 @@ impl Storage for SqliteStorage {
                     record.registered_by_phone_id,
                     record.firmware_version,
                     key_version_i64,
+                    mk_id,
+                    mk_epoch,
                 ],
             )
             .map_err(map_err)?;
@@ -2378,13 +2443,16 @@ impl Storage for SqliteStorage {
                     record.key_version
                 ))
             })?;
+            // GW-2001 AC-6: stamp current master_key_id/epoch on every INSERT.
+            let (mk_id, mk_epoch) = read_current_key_metadata(conn)?;
             let rows = conn
                 .execute(
                     "INSERT OR IGNORE INTO nodes (node_id, key_hint, psk, assigned_program_hash, \
                      current_program_hash, desired_schedule_interval_s, schedule_interval_s, \
                      firmware_abi_version, last_battery_mv, last_seen_epoch_s, rf_channel, \
-                     sensors_json, registered_by_phone_id, firmware_version, key_version) \
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                     sensors_json, registered_by_phone_id, firmware_version, key_version, \
+                     master_key_id, master_key_epoch) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                     params![
                         record.node_id,
                         record.key_hint as u32,
@@ -2401,6 +2469,8 @@ impl Storage for SqliteStorage {
                         record.registered_by_phone_id,
                         record.firmware_version,
                         key_version_i64,
+                        mk_id,
+                        mk_epoch,
                     ],
                 )
                 .map_err(map_err)?;
@@ -2651,6 +2721,9 @@ impl Storage for SqliteStorage {
             conn.execute_batch("BEGIN IMMEDIATE").map_err(map_err)?;
 
             let result = (|| -> Result<(), StorageError> {
+                // GW-2001 AC-6: read key metadata once per transaction.
+                let (mk_id, mk_epoch) = read_current_key_metadata(conn)?;
+
                 conn.execute("DELETE FROM nodes", []).map_err(map_err)?;
                 conn.execute("DELETE FROM programs", []).map_err(map_err)?;
 
@@ -2683,8 +2756,9 @@ impl Storage for SqliteStorage {
                     conn.execute(
                         "INSERT INTO nodes (node_id, key_hint, psk, assigned_program_hash, \
                          current_program_hash, desired_schedule_interval_s, schedule_interval_s, \
-                         firmware_abi_version, last_battery_mv, last_seen_epoch_s, firmware_version, key_version) \
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                         firmware_abi_version, last_battery_mv, last_seen_epoch_s, firmware_version, key_version, \
+                         master_key_id, master_key_epoch) \
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                         params![
                             &record.node_id,
                             record.key_hint,
@@ -2698,6 +2772,8 @@ impl Storage for SqliteStorage {
                             Option::<i64>::None,
                             record.firmware_version,
                             key_version_i64,
+                            &mk_id,
+                            mk_epoch,
                         ],
                     )
                     .map_err(map_err)?;
@@ -2953,17 +3029,23 @@ impl Storage for SqliteStorage {
             conn.execute_batch("BEGIN IMMEDIATE").map_err(map_err)?;
 
             let result = (|| -> Result<u32, StorageError> {
+                // GW-2001 AC-6: stamp current master_key_id/epoch on every INSERT.
+                let (mk_id, mk_epoch) = read_current_key_metadata(conn)?;
+
                 // Insert with a placeholder PSK to get the auto-increment id.
                 conn.execute(
                     "INSERT INTO phone_psks \
-                     (phone_key_hint, psk, label, issued_at_epoch_s, status, key_version) \
-                     VALUES (?1, X'00', ?2, ?3, ?4, ?5)",
+                     (phone_key_hint, psk, label, issued_at_epoch_s, status, key_version, \
+                     master_key_id, master_key_epoch) \
+                     VALUES (?1, X'00', ?2, ?3, ?4, ?5, ?6, ?7)",
                     params![
                         record.phone_key_hint as u32,
                         &record.label,
                         issued_at,
                         record.status.to_string(),
                         key_version_i64,
+                        mk_id,
+                        mk_epoch,
                     ],
                 )
                 .map_err(map_err)?;
@@ -3047,6 +3129,9 @@ impl Storage for SqliteStorage {
             conn.execute_batch("BEGIN IMMEDIATE").map_err(map_err)?;
 
             let result = (|| -> Result<(), StorageError> {
+                // GW-2001 AC-6: read key metadata once per transaction.
+                let (mk_id, mk_epoch) = read_current_key_metadata(conn)?;
+
                 conn.execute("DELETE FROM phone_psks", [])
                     .map_err(map_err)?;
 
@@ -3062,14 +3147,17 @@ impl Storage for SqliteStorage {
                     // Insert with a placeholder PSK to get the auto-increment id.
                     conn.execute(
                         "INSERT INTO phone_psks \
-                         (phone_key_hint, psk, label, issued_at_epoch_s, status, key_version) \
-                         VALUES (?1, X'00', ?2, ?3, ?4, ?5)",
+                         (phone_key_hint, psk, label, issued_at_epoch_s, status, key_version, \
+                         master_key_id, master_key_epoch) \
+                         VALUES (?1, X'00', ?2, ?3, ?4, ?5, ?6, ?7)",
                         params![
                             record.phone_key_hint as u32,
                             &record.label,
                             issued_at,
                             record.status.to_string(),
                             key_version_i64,
+                            &mk_id,
+                            mk_epoch,
                         ],
                     )
                     .map_err(map_err)?;
@@ -3366,6 +3454,7 @@ mod tests {
     #[tokio::test]
     async fn test_node_crud() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
 
         // Initially empty.
         assert!(store.list_nodes().await.unwrap().is_empty());
@@ -3514,6 +3603,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_nodes_by_key_hint() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
 
         store.upsert_node(&make_node("a", 10)).await.unwrap();
         store.upsert_node(&make_node("b", 10)).await.unwrap();
@@ -3541,6 +3631,7 @@ mod tests {
         // First open: write data.
         {
             let store = SqliteStorage::open(&db_path, test_key()).unwrap();
+            store.init_master_key_id().await.unwrap();
             store.upsert_node(&make_node("p1", 5)).await.unwrap();
             store.store_program(&make_program(0xAA)).await.unwrap();
         }
@@ -3556,6 +3647,7 @@ mod tests {
     #[tokio::test]
     async fn test_upsert_overwrites() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
 
         let mut node = make_node("u1", 1);
         node.desired_schedule_interval_s = Some(30);
@@ -3787,6 +3879,7 @@ mod tests {
         // Create a database with a node encrypted under the test key.
         {
             let store = SqliteStorage::open(&db_path, test_key()).unwrap();
+            store.init_master_key_id().await.unwrap();
             store.upsert_node(&make_node("node-a", 1)).await.unwrap();
         }
 
@@ -3804,6 +3897,7 @@ mod tests {
     #[tokio::test]
     async fn test_replace_state_encrypts_psks() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
 
         // Seed with an existing node that will be replaced.
         store.upsert_node(&make_node("old", 1)).await.unwrap();
@@ -3948,6 +4042,7 @@ mod tests {
     #[tokio::test]
     async fn test_phone_psk_store_and_list() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
 
         // No PSKs initially.
         assert!(store.list_phone_psks().await.unwrap().is_empty());
@@ -3970,6 +4065,7 @@ mod tests {
     #[tokio::test]
     async fn test_phone_psk_lookup_by_key_hint() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
 
         // Store two PSKs with different hints and one with colliding hint.
         store
@@ -4002,6 +4098,7 @@ mod tests {
     #[tokio::test]
     async fn test_phone_psk_revocation() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
 
         let phone_id = store
             .store_phone_psk(&make_phone_psk(42, "Revokable"))
@@ -4023,6 +4120,7 @@ mod tests {
     #[tokio::test]
     async fn test_phone_psk_delete() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
 
         let phone_id = store
             .store_phone_psk(&make_phone_psk(42, "Deletable"))
@@ -4048,6 +4146,7 @@ mod tests {
         let phone_id;
         {
             let store = SqliteStorage::open(&db_path, test_key()).unwrap();
+            store.init_master_key_id().await.unwrap();
             phone_id = store.store_phone_psk(&record).await.unwrap();
         }
 
@@ -4069,6 +4168,7 @@ mod tests {
     #[tokio::test]
     async fn test_negative_node_key_version_is_rejected() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
         store.upsert_node(&make_node("n1", 42)).await.unwrap();
         store
             .with_conn(|conn| {
@@ -4086,6 +4186,7 @@ mod tests {
     #[tokio::test]
     async fn test_negative_phone_key_version_is_rejected_in_list() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
         let phone_id = store
             .store_phone_psk(&make_phone_psk(42, "Corrupt list"))
             .await
@@ -4109,6 +4210,7 @@ mod tests {
     #[tokio::test]
     async fn test_negative_phone_key_version_is_rejected_by_key_hint_lookup() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
         let phone_id = store
             .store_phone_psk(&make_phone_psk(77, "Corrupt lookup"))
             .await
@@ -4132,6 +4234,7 @@ mod tests {
     #[tokio::test]
     async fn test_legacy_battery_storage_is_ignored_and_preserved() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
         let node = make_node("batt1", 0xBB);
         store.upsert_node(&node).await.unwrap();
 
@@ -4186,6 +4289,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_node_wake_metadata_preserves_psk_ciphertext() {
         let store = SqliteStorage::in_memory(test_key()).unwrap();
+        store.init_master_key_id().await.unwrap();
         let node = make_node("wake-meta", 0xBC);
         store.upsert_node(&node).await.unwrap();
 

--- a/crates/sonde-gateway/tests/escrow.rs
+++ b/crates/sonde-gateway/tests/escrow.rs
@@ -281,17 +281,16 @@ fn map_get(map: &[(i128, Value)], key: i128) -> Option<&Value> {
 /// Verifies:
 /// 1. No `master_key_id` or `master_key_epoch` on fresh DB.
 /// 2. After `init_master_key_id()`, `SHA-256(master_key)` and epoch=1 are set.
-/// 3. All existing PSK records are backfilled.
+/// 3. PSK records inserted after init carry the current master_key_id.
 /// 4. On restart (re-call), the same values are returned.
+///
+/// Note: backfill of legacy PSK records (inserted without master_key_id via raw
+/// SQL) is covered by `test_init_master_key_id_backfills_existing_nodes` in
+/// sqlite_storage unit tests.
 #[tokio::test]
 async fn test_t2000_master_key_identification() {
     let master_key = Zeroizing::new([0x42u8; 32]);
     let store = Arc::new(SqliteStorage::in_memory(master_key).unwrap());
-
-    // Pre-populate with nodes before init_master_key_id.
-    register_test_node(&store, "node-alpha", 100).await;
-    register_test_node(&store, "node-beta", 200).await;
-    register_phone_psk(&store, 0, 300).await;
 
     // Step 1-2: Verify no master_key_id/epoch before init.
     let config_id = store.get_config("master_key_id").await.unwrap();
@@ -316,26 +315,30 @@ async fn test_t2000_master_key_identification() {
     // Step 5: Verify epoch = 1.
     assert_eq!(epoch, 1);
 
-    // Step 6: Verify all existing node PSK records are backfilled.
+    // Step 6 (GW-2001 AC-6): Nodes/phones inserted AFTER init carry master_key_id.
+    register_test_node(&store, "node-alpha", 100).await;
+    register_test_node(&store, "node-beta", 200).await;
+    register_phone_psk(&store, 0, 300).await;
+
     let escrow = store.list_node_escrow_state().await.unwrap();
     assert_eq!(escrow.len(), 2);
     for node in &escrow {
         assert_eq!(
             node.master_key_id,
             key_id.to_vec(),
-            "node {} should have master_key_id backfilled",
+            "node {} should have master_key_id set by INSERT",
             node.node_id
         );
     }
 
-    // Step 6b: Verify phone PSK records are also backfilled (loadable after init).
+    // Step 6b: Verify phone PSK records also carry master_key_id.
     let phones = store.list_phone_psks().await.unwrap();
-    assert_eq!(phones.len(), 1, "phone PSK should be backfilled");
+    assert_eq!(phones.len(), 1, "phone PSK should be present");
     // Phone PSK must be loadable (decrypt succeeds with current master key).
     assert_ne!(
         phones[0].psk.as_ref(),
         &[0u8; 32],
-        "phone PSK must be non-zero after backfill"
+        "phone PSK must be non-zero"
     );
 
     // Step 7: Restart — verify same values are returned.
@@ -363,12 +366,12 @@ async fn test_t2000_master_key_identification() {
 async fn test_t2001_gateway_actual_state_publication() {
     let (store, identity) = setup_test_storage().await;
 
-    // Register nodes BEFORE init_master_key_id so the backfill sets master_key_id.
-    register_test_node(&store, "node-1", 101).await;
-    register_test_node(&store, "node-2", 202).await;
-
+    // GW-2001 AC-6: init_master_key_id BEFORE registering nodes.
     let (key_id, epoch) = store.init_master_key_id().await.unwrap();
     let _code = store.init_rotation_code().await.unwrap();
+
+    register_test_node(&store, "node-1", 101).await;
+    register_test_node(&store, "node-2", 202).await;
 
     let event_hub = Arc::new(ConnectorEventHub::default());
     let (mut client, _handle) =
@@ -605,13 +608,13 @@ async fn test_t2002_desired_state_channel_change() {
 async fn test_t2006c_phone_psks_not_escrowed() {
     let (store, identity) = setup_test_storage().await;
 
-    // Register nodes and phone PSK BEFORE init_master_key_id for backfill.
+    // GW-2001 AC-6: init_master_key_id BEFORE registering nodes/phones.
+    let (_key_id, epoch) = store.init_master_key_id().await.unwrap();
+    let code = store.init_rotation_code().await.unwrap();
+
     register_test_node(&store, "node-x", 100).await;
     register_test_node(&store, "node-y", 200).await;
     register_phone_psk(&store, 0, 400).await;
-
-    let (_key_id, epoch) = store.init_master_key_id().await.unwrap();
-    let code = store.init_rotation_code().await.unwrap();
 
     let event_hub = Arc::new(ConnectorEventHub::default());
     let (mut client, _handle) =
@@ -1125,7 +1128,9 @@ async fn test_t2014_periodic_gateway_actual_state_heartbeat() {
 async fn test_t2005a_wake_actual_state_includes_escrow_fields() {
     let (store, _identity) = setup_test_storage().await;
 
-    // Register the node BEFORE init_master_key_id so the backfill sets master_key_id.
+    // GW-2001 AC-6: init_master_key_id BEFORE registering nodes.
+    let (key_id, _epoch) = store.init_master_key_id().await.unwrap();
+
     let key_hint: u16 = 0x4242;
     let psk = [0x42u8; 32];
     let node_id = "escrow-wake-node";
@@ -1145,8 +1150,6 @@ async fn test_t2005a_wake_actual_state_includes_escrow_fields() {
         key_version: 0,
     };
     store.upsert_node(&record).await.unwrap();
-
-    let (key_id, _epoch) = store.init_master_key_id().await.unwrap();
 
     // Build a Gateway that uses SqliteStorage for both Storage trait and escrow lookups.
     let pending_commands = Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
@@ -1237,5 +1240,136 @@ async fn test_t2005a_wake_actual_state_includes_escrow_fields() {
         mk_id,
         key_id.to_vec(),
         "master_key_id must match current key"
+    );
+}
+
+// ── T-2005b: Node added after init has escrow in ACTUAL_STATE ────────
+
+/// T-2005b: Node added after `init_master_key_id` has escrow in ACTUAL_STATE
+/// (GW-2001 AC-6, GW-2005 AC-4).
+///
+/// Verifies that a node registered AFTER `init_master_key_id` (simulating
+/// post-startup pairing) has:
+/// 1. Non-NULL `master_key_id` in the persisted DB row.
+/// 2. Non-null escrow fields in the ACTUAL_STATE emitted on WAKE.
+#[tokio::test]
+async fn test_t2005b_post_init_node_has_escrow_in_actual_state() {
+    let (store, _identity) = setup_test_storage().await;
+
+    // Step 1: init_master_key_id FIRST (simulating normal gateway startup).
+    let (key_id, _epoch) = store.init_master_key_id().await.unwrap();
+
+    // Step 2: Register a node AFTER init (simulating post-startup pairing).
+    let key_hint: u16 = 0xBEEF;
+    let psk = [0x42u8; 32];
+    let node_id = "post-init-node";
+    let record = NodeRecord {
+        node_id: node_id.to_string(),
+        key_hint,
+        psk,
+        assigned_program_hash: None,
+        current_program_hash: None,
+        desired_schedule_interval_s: Some(60),
+        schedule_interval_s: 60,
+        firmware_abi_version: Some(1),
+        firmware_version: Some("0.1.0".to_string()),
+        rf_channel: Some(1),
+        sensors: vec![],
+        registered_by_phone_id: None,
+        key_version: 0,
+    };
+    store.upsert_node(&record).await.unwrap();
+
+    // Step 3: Verify the persisted DB row has non-NULL master_key_id.
+    let escrow = store.get_node_escrow_by_id(node_id).await.unwrap().unwrap();
+    assert_eq!(
+        escrow.master_key_id,
+        key_id.to_vec(),
+        "post-init node must have master_key_id stamped by INSERT"
+    );
+    assert!(
+        !escrow.master_key_id.is_empty(),
+        "master_key_id must be non-empty"
+    );
+
+    // Step 4: Build a Gateway and send a valid WAKE.
+    let pending_commands = Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+    let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
+    let handler_router = Arc::new(tokio::sync::RwLock::new(HandlerRouter::new(Vec::new())));
+    let mut gateway = Gateway::new_with_pending(
+        store.clone() as Arc<dyn Storage>,
+        pending_commands,
+        session_manager,
+        handler_router,
+    );
+    gateway.set_sqlite_storage(store.clone()).await;
+
+    let event_hub = gateway.connector_event_hub();
+    let (mut client, _handle) =
+        spawn_connector(event_hub.clone(), store.clone() as Arc<dyn Storage>).await;
+
+    let program_hash = vec![0x00; 32];
+    let header = FrameHeader {
+        key_hint,
+        msg_type: MSG_WAKE,
+        nonce: 1,
+    };
+    let wake_msg = NodeMessage::Wake {
+        firmware_abi_version: 1,
+        program_hash: program_hash.clone(),
+        battery_mv: 3300,
+        firmware_version: "0.1.0".into(),
+        blob: None,
+    };
+    let cbor = wake_msg.encode().unwrap();
+    let frame = encode_frame(&header, &cbor, &psk, &GatewayAead, &RustCryptoSha256).unwrap();
+
+    let peer: PeerAddress = b"post-init-peer".to_vec();
+    let _response = gateway.process_frame(&frame, peer).await;
+
+    // Step 5: Read the ACTUAL_STATE and verify escrow fields.
+    let node_frame = read_framed(&mut client).await;
+    let node_map = decode_cbor_map(&node_frame);
+
+    let msg_type: i128 = match map_get(&node_map, 1).unwrap() {
+        Value::Integer(i) => (*i).into(),
+        other => panic!("expected integer msg_type, got {other:?}"),
+    };
+    assert_eq!(msg_type, MSG_TYPE_ACTUAL_STATE as i128);
+
+    let entity_kind = match map_get(&node_map, 2).unwrap() {
+        Value::Text(s) => s.clone(),
+        other => panic!("expected text entity_kind, got {other:?}"),
+    };
+    assert_eq!(entity_kind, "node");
+
+    // Verify encrypted_psk (key 12) is present and 60 bytes.
+    let encrypted_psk = match map_get(&node_map, 12).unwrap() {
+        Value::Bytes(b) => b.clone(),
+        other => panic!("expected bytes encrypted_psk (key 12), got {other:?}"),
+    };
+    assert_eq!(
+        encrypted_psk.len(),
+        60,
+        "encrypted_psk must be 60 bytes for post-init node"
+    );
+
+    // Verify escrow_key_hint (key 13) matches the node's key_hint.
+    let escrow_kh: i128 = match map_get(&node_map, 13).unwrap() {
+        Value::Integer(i) => (*i).into(),
+        other => panic!("expected integer escrow_key_hint (key 13), got {other:?}"),
+    };
+    assert_eq!(escrow_kh, key_hint as i128);
+
+    // Verify master_key_id (key 14) is 32 bytes and matches.
+    let mk_id = match map_get(&node_map, 14).unwrap() {
+        Value::Bytes(b) => b.clone(),
+        other => panic!("expected bytes master_key_id (key 14), got {other:?}"),
+    };
+    assert_eq!(mk_id.len(), 32, "master_key_id must be 32 bytes");
+    assert_eq!(
+        mk_id,
+        key_id.to_vec(),
+        "master_key_id must match current key for post-init node"
     );
 }

--- a/crates/sonde-gateway/tests/handler_config.rs
+++ b/crates/sonde-gateway/tests/handler_config.rs
@@ -62,8 +62,11 @@ struct AdminHarness {
 }
 
 impl AdminHarness {
-    fn new_sqlite() -> Self {
-        let storage: Arc<dyn Storage> = Arc::new(SqliteStorage::in_memory(test_key()).unwrap());
+    async fn new_sqlite() -> Self {
+        let sqlite = SqliteStorage::in_memory(test_key()).unwrap();
+        // GW-2001 AC-6: init_master_key_id before any PSK inserts.
+        sqlite.init_master_key_id().await.unwrap();
+        let storage: Arc<dyn Storage> = Arc::new(sqlite);
         let pending_commands: Arc<RwLock<HashMap<String, Vec<PendingCommand>>>> =
             Arc::new(RwLock::new(HashMap::new()));
         let session_manager = Arc::new(SessionManager::new(Duration::from_secs(30)));
@@ -527,7 +530,7 @@ async fn t1400_handler_working_dir_round_trip() {
 
 #[tokio::test]
 async fn t1401_handler_crud_via_admin_api() {
-    let h = AdminHarness::new_sqlite();
+    let h = AdminHarness::new_sqlite().await;
 
     // 1. ListHandlers returns empty.
     let list = h
@@ -734,7 +737,7 @@ handlers:
 
 #[tokio::test]
 async fn t1406_state_export_import_with_handlers() {
-    let h = AdminHarness::new_sqlite();
+    let h = AdminHarness::new_sqlite().await;
 
     // Add two handlers with distinct reply_timeout_ms.
     h.admin
@@ -771,7 +774,7 @@ async fn t1406_state_export_import_with_handlers() {
         .data;
 
     // Create a second gateway with different handlers.
-    let h2 = AdminHarness::new_sqlite();
+    let h2 = AdminHarness::new_sqlite().await;
     h2.admin
         .add_handler(Request::new(AddHandlerRequest {
             program_hash: HASH_B.to_string(),
@@ -831,7 +834,7 @@ async fn t1406_state_export_import_with_handlers() {
 
 #[tokio::test]
 async fn t1406a_state_import_backwards_compatibility() {
-    let h = AdminHarness::new_sqlite();
+    let h = AdminHarness::new_sqlite().await;
 
     // Add two handlers to the target gateway.
     h.admin
@@ -856,7 +859,7 @@ async fn t1406a_state_import_backwards_compatibility() {
         .unwrap();
 
     // Export state from a "legacy" gateway with no handlers.
-    let legacy = AdminHarness::new_sqlite();
+    let legacy = AdminHarness::new_sqlite().await;
     let exported = legacy
         .admin
         .export_state(Request::new(ExportStateRequest {
@@ -892,7 +895,7 @@ async fn t1406a_state_import_backwards_compatibility() {
 
 #[tokio::test]
 async fn t1407_handler_add_program_hash_validation() {
-    let h = AdminHarness::new_sqlite();
+    let h = AdminHarness::new_sqlite().await;
 
     // 1. Invalid string.
     let err = h
@@ -967,7 +970,7 @@ async fn t1407_handler_add_program_hash_validation() {
 
 #[tokio::test]
 async fn t1407_program_hash_case_normalization() {
-    let h = AdminHarness::new_sqlite();
+    let h = AdminHarness::new_sqlite().await;
 
     // Add with uppercase hex.
     let upper = HASH_A.to_uppercase();

--- a/crates/sonde-gateway/tests/key_provider.rs
+++ b/crates/sonde-gateway/tests/key_provider.rs
@@ -224,6 +224,7 @@ async fn t0603k_wrong_master_key_detected_at_startup() {
     // Open with key A and register a node so there's encrypted data.
     {
         let storage = SqliteStorage::open(db_str, key_a).unwrap();
+        storage.init_master_key_id().await.unwrap();
         let node = sonde_gateway::registry::NodeRecord::new("test-node".into(), 0x1234, [0xAA; 32]);
         storage.upsert_node(&node).await.unwrap();
     }

--- a/docs/gateway-design.md
+++ b/docs/gateway-design.md
@@ -1992,7 +1992,23 @@ use the same path. The WAKE path queries per-node escrow data from
 `SqliteStorage::get_node_escrow_by_id()`; the post-rotation path uses
 the bulk `list_node_escrow_state()` to re-emit all nodes efficiently.
 When `sqlite_storage` is unavailable or the node's `master_key_id`
-is NULL, escrow fields are emitted as `null`.
+is NULL, escrow fields are emitted as `null`.  NULL `master_key_id`
+is a defensive fallback for unavailable storage or pre-existing
+legacy rows — normal INSERT/UPDATE paths MUST NOT produce NULL
+`master_key_id` (GW-2001 AC-6).
+
+**INSERT-time stamping (GW-2001 AC-6):**  `upsert_node`,
+`insert_node_if_not_exists`, and `replace_state` read the current
+`master_key_id` and `master_key_epoch` from `gateway_config` inside
+the same transaction and include them in every `INSERT INTO nodes`.
+`upsert_node` uses `INSERT … ON CONFLICT DO UPDATE` and MUST also
+repair `master_key_id`/`master_key_epoch` in the conflict branch.
+`replace_state` reads key metadata once after `BEGIN IMMEDIATE` and
+applies the same values to every inserted row.  Phone PSK paths
+(`insert_phone_psk`, bulk replacement in `replace_state`) follow the
+same rule.  If `gateway_config` does not contain `master_key_id`
+(i.e. `init_master_key_id` has not been called), all INSERT paths
+MUST return an error.
 
 ### 23.7  Master key rotation (GW-2006, GW-2007, GW-2013)
 

--- a/docs/gateway-requirements.md
+++ b/docs/gateway-requirements.md
@@ -2589,6 +2589,14 @@ MUST compute `master_key_id` from the `KeyProvider`-loaded key, set
    from the current master key.
 4. Existing PSK records are backfilled on first startup.
 5. Values are stable across restarts (not regenerated).
+6. Every `INSERT` into `nodes` or `phone_psks` MUST include the current
+   `master_key_id` and `master_key_epoch` read from `gateway_config`
+   within the same transaction. `INSERT … ON CONFLICT DO UPDATE` MUST
+   also repair `master_key_id` and `master_key_epoch` to current values.
+   If `gateway_config` does not yet contain `master_key_id` (i.e.
+   `init_master_key_id` has not run), the INSERT MUST return an error.
+   Nodes and phone PSKs MUST never be persisted with a NULL
+   `master_key_id`.
 
 ---
 

--- a/docs/gateway-validation.md
+++ b/docs/gateway-validation.md
@@ -4453,6 +4453,28 @@ A configurable stub handler process (or in-process mock) that:
 
 ---
 
+### T-2005b  Node added after `init_master_key_id` has escrow in ACTUAL_STATE
+
+**Traces to:** GW-2001 (AC-6), GW-2005 (AC-4)
+
+**Steps:**
+1. Start gateway, call `init_master_key_id` (simulating normal startup).
+2. Register a new node via `upsert_node` AFTER `init_master_key_id`.
+3. Verify the persisted node row has non-NULL `master_key_id` (32 bytes)
+   and `master_key_epoch` ≥ 1 matching `gateway_config`.
+4. Send a valid WAKE from the newly registered node.
+5. Consume the node ACTUAL_STATE emitted in response.
+6. Verify `encrypted_psk` (key 12) is a 60-byte bstr.
+7. Verify `escrow_key_hint` (key 13) matches the node's `key_hint`.
+8. Verify `master_key_id` (key 14) is a 32-byte bstr matching the
+   current master key ID.
+
+**Expected:**
+1. Node registered after startup has non-NULL `master_key_id` in storage.
+2. Node ACTUAL_STATE from a WAKE includes all three non-null escrow fields.
+
+---
+
 ### T-2006  Declarative node recovery
 
 **Traces to:** GW-2009 (AC-1, AC-2, AC-4, AC-5)
@@ -4753,11 +4775,11 @@ by existing handler tests.
 | GW-1905 | T-1900a, T-1903a |
 | GW-1906 | T-1906 |
 | GW-2000 | T-2001 |
-| GW-2001 | T-2000 |
+| GW-2001 | T-2000, T-2005b |
 | GW-2002 | T-2003 |
 | GW-2003 | T-2001, T-2011, T-2012, T-2013, T-2014, T-2016, T-2016a |
 | GW-2004 | T-2002 |
-| GW-2005 | T-2001, T-2005a, T-2006c |
+| GW-2005 | T-2001, T-2005a, T-2005b, T-2006c |
 | GW-2006 | T-2004, T-2004a |
 | GW-2007 | T-2005, T-2009 |
 | GW-2008 | T-2007 |


### PR DESCRIPTION
## Summary

Fixes the spec gap in GW-2001 where `master_key_id`/`master_key_epoch` were not stamped at INSERT time, causing post-startup nodes to permanently have NULL escrow metadata. This meant `engine.rs` dropped escrow fields from ACTUAL_STATE, so the Azure actual-state table never received escrowed key data for nodes paired after gateway startup.

## Root Cause

`init_master_key_id` was spec'd as a first-startup backfill only. All five INSERT paths (`upsert_node`, `insert_node_if_not_exists`, `replace_state`, `store_phone_psk`, `replace_phone_psks`) omitted the `master_key_id` and `master_key_epoch` columns. Nodes added after the backfill had permanently NULL values.

## Changes

### Spec (3 files)
- **GW-2001 AC-6** (gateway-requirements.md): every INSERT must stamp `master_key_id`/`master_key_epoch`, fail-closed if `init_master_key_id` hasn't run
- **S23.6** (gateway-design.md): INSERT-time stamping paragraph, NULL escrow as defensive-only fallback
- **T-2005b** (gateway-validation.md): test case + traceability table update

### Implementation (2 files)
- `read_current_key_metadata()` helper with shape validation (32-byte key, epoch >= 1)
- All 5 INSERT paths stamped; `upsert_node` ON CONFLICT repairs stale metadata

### Tests (6 files)
- T-2005b: post-init node has escrow in ACTUAL_STATE
- 4 escrow tests reordered, 16 unit tests + handler/key_provider tests fixed
- E2E harness calls `init_master_key_id` in constructors

## Verification

- `cargo test --workspace` — all pass
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all` — clean

## Traceability

| Requirement | Test |
|---|---|
| GW-2001 AC-6 | T-2000, T-2005b |
| GW-2005 AC-4 | T-2005a, T-2005b |