### PR TITLE
Fix azure handler key_hint recovery filter

### DIFF
--- a/crates/sonde-azure-handler/src/lib.rs
+++ b/crates/sonde-azure-handler/src/lib.rs
@@ -1212,8 +1212,7 @@ impl HandlerStore for AzureTablesStore {
         &self,
         key_hint: u64,
     ) -> Result<Vec<NodeEscrowRecord>, HandlerError> {
-        let filter =
-            format!("PartitionKey ge 'n:' and PartitionKey lt 'n;' and key_hint eq {key_hint}L");
+        let filter = node_key_hint_filter(key_hint);
         let mut stream = self
             .actual_state_table
             .query()
@@ -2112,6 +2111,10 @@ fn history_row_process_nonce() -> Result<u64, HandlerError> {
 
 fn partition_filter(partition_key: &str) -> String {
     format!("PartitionKey eq '{partition_key}'")
+}
+
+fn node_key_hint_filter(key_hint: u64) -> String {
+    format!("PartitionKey ge 'n:' and PartitionKey lt 'n;' and key_hint eq {key_hint}")
 }
 
 fn decode_optional_program_hash(
@@ -5041,6 +5044,14 @@ mod tests {
         assert_eq!(rows[0].encrypted_psk, Some(psk_blob));
         assert_eq!(rows[0].escrow_key_hint, Some(1234));
         assert_eq!(rows[0].master_key_id, Some(master_key_id));
+    }
+
+    #[test]
+    fn node_key_hint_filter_uses_untyped_numeric_literal() {
+        assert_eq!(
+            node_key_hint_filter(24564),
+            "PartitionKey ge 'n:' and PartitionKey lt 'n;' and key_hint eq 24564"
+        );
     }
 
     // --- T-AZH-0602: Missing key_hint recovery ---


### PR DESCRIPTION
## Summary
- remove the L suffix from the Azure Tables key_hint OData filter used for node escrow recovery
- route the filter through a helper and add a regression test for the generated query string
- preserve the existing recovery flow while making the live Azure row lookup match the stored key_hint values

## Validation
- cargo fmt --all
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace -- -D warnings