### PR TITLE
web-ui: add sensor data export for csv and jsonl

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -1066,9 +1066,13 @@ function tableQueryUrl(tableName) {
   return `${tableBaseUrl(tableName)}()`;
 }
 
+function escapeODataStringLiteral(value) {
+  return String(value).replaceAll("'", "''");
+}
+
 function entityUrl(tableName, partitionKey, rowKey) {
-  const encodedPartition = encodeURIComponent(String(partitionKey).replaceAll("'", "''"));
-  const encodedRow = encodeURIComponent(String(rowKey).replaceAll("'", "''"));
+  const encodedPartition = encodeURIComponent(escapeODataStringLiteral(partitionKey));
+  const encodedRow = encodeURIComponent(escapeODataStringLiteral(rowKey));
   return `https://${CONFIG.storageAccount}.table.core.windows.net/${tableName}(PartitionKey='${encodedPartition}',RowKey='${encodedRow}')`;
 }
 
@@ -1652,7 +1656,7 @@ function reverseTimestampHex(ms) {
 function sensorDataFilter(partitionKey, startMs, endMs) {
   const rkStart = reverseTimestampHex(endMs);
   const rkEnd = reverseTimestampHex(startMs);
-  return `PartitionKey eq '${partitionKey}' and RowKey ge '${rkStart}' and RowKey le '${rkEnd}~'`;
+  return `PartitionKey eq '${escapeODataStringLiteral(partitionKey)}' and RowKey ge '${rkStart}' and RowKey le '${rkEnd}~'`;
 }
 
 function initializeSensorExportRange() {

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -1647,6 +1647,7 @@ const TIME_RANGE_MS = {
   '24h': 24 * 60 * 60 * 1000,
   '7d': 7 * 24 * 60 * 60 * 1000,
 };
+const SENSOR_EXPORT_MAX_PAGES_PER_PARTITION = 1000;
 
 function reverseTimestampHex(ms) {
   const max = BigInt('0xffffffffffffffff');
@@ -1715,13 +1716,18 @@ function updateSensorExportControls() {
 
 async function querySensorDataRange(partitionKeys, startMs, endMs, options = {}) {
   const token = await getToken();
-  const { topPerPage = 1000, maxPagesPerPartition = 1 } = options;
+  const {
+    topPerPage = 1000,
+    maxPagesPerPartition = 1,
+    requireComplete = false,
+  } = options;
 
   const fetchPartition = async (pk) => {
     const filter = sensorDataFilter(pk, startMs, endMs);
     let nextPartitionKey = null;
     let nextRowKey = null;
     const entities = [];
+    const seenContinuationTokens = new Set();
 
     for (let page = 0; page < maxPagesPerPartition; page++) {
       const url = new URL(tableQueryUrl(CONFIG.sensorDataTable));
@@ -1758,6 +1764,19 @@ async function querySensorDataRange(partitionKeys, startMs, endMs, options = {})
       if (!nextPartitionKey) {
         break;
       }
+      const continuationToken = `${nextPartitionKey}\n${nextRowKey || ''}`;
+      if (seenContinuationTokens.has(continuationToken)) {
+        throw new Error(
+          `Sensor export failed: Azure Tables returned a repeated continuation token for node partition ${pk}. Try again or narrow the export time range.`
+        );
+      }
+      seenContinuationTokens.add(continuationToken);
+    }
+
+    if (requireComplete && nextPartitionKey) {
+      throw new Error(
+        `Sensor export failed: Azure Tables returned more than ${maxPagesPerPartition} page(s) for node partition ${pk}. Narrow the export time range and try again.`
+      );
     }
 
     return entities;
@@ -1845,7 +1864,8 @@ async function exportSensorData(partitionKeys) {
   try {
     const rows = await querySensorDataRange(partitionKeys, startMs, endMs, {
       topPerPage: null,
-      maxPagesPerPartition: Number.POSITIVE_INFINITY,
+      maxPagesPerPartition: SENSOR_EXPORT_MAX_PAGES_PER_PARTITION,
+      requireComplete: true,
     });
     const content = format === 'csv' ? buildSensorExportCsv(rows) : buildSensorExportJsonl(rows);
     const blob = new Blob([content], {

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -198,7 +198,6 @@ function exportEnvironment(env) {
   };
   const json = JSON.stringify(data, null, 2);
   const blob = new Blob([json], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
 
   const safeName = (env.name || '')
     .replace(/[/\\:*?"<>|\x00-\x1F\x7F]/g, '-')
@@ -206,6 +205,11 @@ function exportEnvironment(env) {
     .trim();
   const filename = safeName ? `${safeName}.json` : 'sonde-environment.json';
 
+  downloadBlob(filename, blob);
+}
+
+function downloadBlob(filename, blob) {
+  const url = URL.createObjectURL(blob);
   const anchor = document.createElement('a');
   anchor.href = url;
   anchor.download = filename;
@@ -1627,6 +1631,11 @@ const SENSOR_STATE = {
   selectedSeries: new Set(),
   seriesInitialized: false,
   autoRefresh: false,
+  exportStartMs: null,
+  exportEndMs: null,
+  exportFormat: 'jsonl',
+  exportBusy: false,
+  exportMessage: null,
 };
 
 const TIME_RANGE_MS = {
@@ -1640,35 +1649,114 @@ function reverseTimestampHex(ms) {
   return (max - BigInt(ms)).toString(16).padStart(16, '0');
 }
 
-async function querySensorData(partitionKeys, timeRangeMs) {
+function sensorDataFilter(partitionKey, startMs, endMs) {
+  const rkStart = reverseTimestampHex(endMs);
+  const rkEnd = reverseTimestampHex(startMs);
+  return `PartitionKey eq '${partitionKey}' and RowKey ge '${rkStart}' and RowKey le '${rkEnd}~'`;
+}
+
+function initializeSensorExportRange() {
+  if (Number.isFinite(SENSOR_STATE.exportStartMs) && Number.isFinite(SENSOR_STATE.exportEndMs)) {
+    return;
+  }
+  const endMs = Date.now();
+  SENSOR_STATE.exportEndMs = endMs;
+  SENSOR_STATE.exportStartMs = endMs - TIME_RANGE_MS['24h'];
+}
+
+function formatDateTimeLocalInput(timestampMs) {
+  if (!Number.isFinite(timestampMs)) {
+    return '';
+  }
+  const date = new Date(timestampMs);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+function parseDateTimeLocalInput(value) {
+  if (!value) {
+    return null;
+  }
+  const timestampMs = new Date(value).getTime();
+  return Number.isFinite(timestampMs) ? timestampMs : null;
+}
+
+function setSensorExportMessage(kind, text) {
+  SENSOR_STATE.exportMessage = { kind, text };
+  const host = contentEl.querySelector('#sensor-export-status');
+  if (host) {
+    host.innerHTML = messageHtml(SENSOR_STATE.exportMessage);
+  }
+}
+
+function updateSensorExportControls() {
+  const startInput = document.getElementById('sensor-export-start');
+  const endInput = document.getElementById('sensor-export-end');
+  const formatSelect = document.getElementById('sensor-export-format');
+  const exportButton = document.getElementById('sensor-export-button');
+  const disabled = SENSOR_STATE.exportBusy;
+
+  if (startInput) startInput.disabled = disabled;
+  if (endInput) endInput.disabled = disabled;
+  if (formatSelect) formatSelect.disabled = disabled;
+  if (exportButton) {
+    exportButton.disabled = disabled;
+    exportButton.textContent = disabled ? 'Exporting…' : 'Export';
+  }
+}
+
+async function querySensorDataRange(partitionKeys, startMs, endMs, options = {}) {
   const token = await getToken();
-  const now = Date.now();
-  const start = now - timeRangeMs;
-  const rkStart = reverseTimestampHex(now);
-  const rkEnd = reverseTimestampHex(start);
+  const { topPerPage = 1000, maxPagesPerPartition = 1 } = options;
 
   const fetchPartition = async (pk) => {
-    const filter = `PartitionKey eq '${pk}' and RowKey ge '${rkStart}' and RowKey le '${rkEnd}~'`;
-    const url = new URL(tableQueryUrl(CONFIG.sensorDataTable));
-    url.searchParams.set('$filter', filter);
-    url.searchParams.set('$top', '1000');
+    const filter = sensorDataFilter(pk, startMs, endMs);
+    let nextPartitionKey = null;
+    let nextRowKey = null;
+    const entities = [];
 
-    const response = await fetch(url.toString(), {
-      method: 'GET',
-      headers: {
-        Accept: 'application/json;odata=nometadata',
-        Authorization: `Bearer ${token}`,
-        'x-ms-version': '2019-02-02',
-      },
-    });
+    for (let page = 0; page < maxPagesPerPartition; page++) {
+      const url = new URL(tableQueryUrl(CONFIG.sensorDataTable));
+      url.searchParams.set('$filter', filter);
+      if (topPerPage != null) {
+        url.searchParams.set('$top', String(topPerPage));
+      }
+      if (nextPartitionKey) {
+        url.searchParams.set('NextPartitionKey', nextPartitionKey);
+        if (nextRowKey) url.searchParams.set('NextRowKey', nextRowKey);
+      }
 
-    if (!response.ok) {
-      const text = await response.text();
-      throw new Error(`SensorData query failed (${response.status}): ${text}`);
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json;odata=nometadata',
+          Authorization: `Bearer ${token}`,
+          'x-ms-version': '2019-02-02',
+        },
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`SensorData query failed (${response.status}): ${text}`);
+      }
+
+      const payload = await response.json();
+      if (Array.isArray(payload.value)) {
+        entities.push(...payload.value);
+      }
+
+      nextPartitionKey = response.headers.get('x-ms-continuation-NextPartitionKey');
+      nextRowKey = response.headers.get('x-ms-continuation-NextRowKey');
+      if (!nextPartitionKey) {
+        break;
+      }
     }
 
-    const payload = await response.json();
-    return Array.isArray(payload.value) ? payload.value : [];
+    return entities;
   };
 
   const allEntities = [];
@@ -1681,6 +1769,90 @@ async function querySensorData(partitionKeys, timeRangeMs) {
     }
   }
   return allEntities;
+}
+
+function parseSensorReadingsForExport(decodedReadings) {
+  if (!decodedReadings || decodedReadings === '') {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(decodedReadings);
+  } catch {
+    throw new Error('Sensor export failed: `decoded_readings` is not valid JSON.');
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Sensor export failed: `decoded_readings` must be a JSON object.');
+  }
+  return parsed;
+}
+
+function csvEscape(value) {
+  const text = value == null ? '' : String(value);
+  return /[",\r\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function sensorExportFilename(format) {
+  return `sensor-data.${format}`;
+}
+
+function buildSensorExportCsv(rows) {
+  const header = ['timestamp_ms', 'node_id', 'program_hash', 'raw_payload', 'decoded_readings_json'];
+  const lines = [header.join(',')];
+  const sorted = [...rows].sort((a, b) => (Number(a.timestamp_ms) || 0) - (Number(b.timestamp_ms) || 0));
+  for (const row of sorted) {
+    lines.push([
+      csvEscape(row.timestamp_ms || ''),
+      csvEscape(row.node_id || ''),
+      csvEscape(row.program_hash || ''),
+      csvEscape(row.raw_payload || ''),
+      csvEscape(row.decoded_readings || ''),
+    ].join(','));
+  }
+  return lines.join('\r\n');
+}
+
+function buildSensorExportJsonl(rows) {
+  const sorted = [...rows].sort((a, b) => (Number(a.timestamp_ms) || 0) - (Number(b.timestamp_ms) || 0));
+  return sorted.map((row) => JSON.stringify({
+    timestamp_ms: row.timestamp_ms || '',
+    node_id: row.node_id || '',
+    program_hash: row.program_hash || '',
+    raw_payload: row.raw_payload || '',
+    decoded_readings: parseSensorReadingsForExport(row.decoded_readings),
+  })).join('\n');
+}
+
+async function exportSensorData(partitionKeys) {
+  const startMs = SENSOR_STATE.exportStartMs;
+  const endMs = SENSOR_STATE.exportEndMs;
+  const format = SENSOR_STATE.exportFormat;
+
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+    throw new Error('Select both export start and end times.');
+  }
+  if (startMs > endMs) {
+    throw new Error('Export start time must be earlier than or equal to the end time.');
+  }
+
+  SENSOR_STATE.exportBusy = true;
+  updateSensorExportControls();
+
+  try {
+    const rows = await querySensorDataRange(partitionKeys, startMs, endMs, {
+      topPerPage: null,
+      maxPagesPerPartition: Number.POSITIVE_INFINITY,
+    });
+    const content = format === 'csv' ? buildSensorExportCsv(rows) : buildSensorExportJsonl(rows);
+    const blob = new Blob([content], {
+      type: format === 'csv' ? 'text/csv;charset=utf-8' : 'application/x-ndjson',
+    });
+    downloadBlob(sensorExportFilename(format), blob);
+    setSensorExportMessage('success', `Exported ${rows.length} sensor row(s) as .${format}.`);
+  } finally {
+    SENSOR_STATE.exportBusy = false;
+    updateSensorExportControls();
+  }
 }
 
 function parseSensorReadings(decodedReadings) {
@@ -2087,6 +2259,7 @@ async function renderSensorData() {
   }
 
   try {
+    initializeSensorExportRange();
     const actualRows = await queryTable(CONFIG.actualStateTable, '');
     const latestActual = latestByPartition(filterNodeRows(actualRows)).sort((a, b) =>
       String(a.node_id || '').localeCompare(String(b.node_id || ''))
@@ -2094,21 +2267,16 @@ async function renderSensorData() {
 
     const nodeIdMap = new Map(latestActual.map((r) => [r.PartitionKey, r.node_id]));
     const partitionKeys = latestActual.map((r) => r.PartitionKey);
-
-    if (partitionKeys.length === 0) {
-      renderCard('Sensor Data', '<p class="muted">No nodes have reported state yet.</p>');
-      if (SENSOR_STATE.autoRefresh) {
-        setAutoRefresh(async () => {
-          if (APP.activeTab === 'sensor-data') {
-            await renderSensorData();
-          }
-        });
-      }
-      return;
-    }
+    const hasKnownNodes = partitionKeys.length > 0;
 
     const rangeMs = TIME_RANGE_MS[SENSOR_STATE.timeRange] || TIME_RANGE_MS['24h'];
-    const sensorRows = await querySensorData(partitionKeys, rangeMs);
+    const now = Date.now();
+    const sensorRows = hasKnownNodes
+      ? await querySensorDataRange(partitionKeys, now - rangeMs, now, {
+          topPerPage: 1000,
+          maxPagesPerPartition: 1,
+        })
+      : [];
     const allSeries = extractSeries(sensorRows, nodeIdMap);
 
     // Prune stale and non-plottable selections before auto-selection
@@ -2157,6 +2325,9 @@ async function renderSensorData() {
     }).join('');
 
     const autoRefreshChecked = SENSOR_STATE.autoRefresh ? ' checked' : '';
+    const exportStartValue = formatDateTimeLocalInput(SENSOR_STATE.exportStartMs);
+    const exportEndValue = formatDateTimeLocalInput(SENSOR_STATE.exportEndMs);
+    const exportBusyAttr = SENSOR_STATE.exportBusy ? ' disabled' : '';
 
     renderCard('Sensor Data', `
       <div class="panel sensor-controls">
@@ -2171,6 +2342,27 @@ async function renderSensorData() {
             <input type="checkbox" id="sensor-auto-refresh"${autoRefreshChecked}> Auto-refresh
           </label>
         </div>
+        <div class="sensor-export-panel">
+          <div class="sensor-export-row">
+            <label class="sensor-export-field">
+              <span>Export start</span>
+              <input type="datetime-local" id="sensor-export-start" value="${escapeHtml(exportStartValue)}"${exportBusyAttr}>
+            </label>
+            <label class="sensor-export-field">
+              <span>Export end</span>
+              <input type="datetime-local" id="sensor-export-end" value="${escapeHtml(exportEndValue)}"${exportBusyAttr}>
+            </label>
+            <label class="sensor-export-field">
+              <span>Format</span>
+              <select id="sensor-export-format"${exportBusyAttr}>
+                <option value="jsonl"${SENSOR_STATE.exportFormat === 'jsonl' ? ' selected' : ''}>.jsonl</option>
+                <option value="csv"${SENSOR_STATE.exportFormat === 'csv' ? ' selected' : ''}>.csv</option>
+              </select>
+            </label>
+            <button type="button" class="secondary" id="sensor-export-button"${exportBusyAttr}>${SENSOR_STATE.exportBusy ? 'Exporting…' : 'Export'}</button>
+          </div>
+          <div id="sensor-export-status">${messageHtml(SENSOR_STATE.exportMessage)}</div>
+        </div>
         ${allSeries.length > 0 ? `
           <details class="sensor-series-picker" open>
             <summary><strong>Series</strong> (${allSeries.length} available, max 20 plotted)</summary>
@@ -2179,15 +2371,18 @@ async function renderSensorData() {
         ` : ''}
       </div>
       <div class="panel">
-        ${SENSOR_STATE.viewMode === 'graph'
-          ? '<div class="sensor-chart-area chart-container"><p class="muted">Rendering chart…</p></div>'
-          : renderSensorTable(sensorRows, nodeIdMap)}
+        ${!hasKnownNodes
+          ? '<p class="muted">No nodes have reported state yet.</p>'
+          : SENSOR_STATE.viewMode === 'graph'
+            ? '<div class="sensor-chart-area chart-container"><p class="muted">Rendering chart…</p></div>'
+            : renderSensorTable(sensorRows, nodeIdMap)}
       </div>
     `);
 
-    if (SENSOR_STATE.viewMode === 'graph') {
+    if (hasKnownNodes && SENSOR_STATE.viewMode === 'graph') {
       renderSensorChart(allSeries);
     }
+    updateSensorExportControls();
 
     // Attach event handlers
     for (const btn of contentEl.querySelectorAll('.sensor-range-btn')) {
@@ -2242,6 +2437,41 @@ async function renderSensorData() {
           });
         } else {
           clearRefresh();
+        }
+      });
+    }
+
+    const exportStartInput = document.getElementById('sensor-export-start');
+    if (exportStartInput) {
+      exportStartInput.addEventListener('change', () => {
+        SENSOR_STATE.exportStartMs = parseDateTimeLocalInput(exportStartInput.value);
+      });
+    }
+
+    const exportEndInput = document.getElementById('sensor-export-end');
+    if (exportEndInput) {
+      exportEndInput.addEventListener('change', () => {
+        SENSOR_STATE.exportEndMs = parseDateTimeLocalInput(exportEndInput.value);
+      });
+    }
+
+    const exportFormatSelect = document.getElementById('sensor-export-format');
+    if (exportFormatSelect) {
+      exportFormatSelect.addEventListener('change', () => {
+        SENSOR_STATE.exportFormat = exportFormatSelect.value === 'csv' ? 'csv' : 'jsonl';
+      });
+    }
+
+    const exportButton = document.getElementById('sensor-export-button');
+    if (exportButton) {
+      exportButton.addEventListener('click', async () => {
+        SENSOR_STATE.exportStartMs = parseDateTimeLocalInput(exportStartInput?.value || '');
+        SENSOR_STATE.exportEndMs = parseDateTimeLocalInput(exportEndInput?.value || '');
+        SENSOR_STATE.exportFormat = exportFormatSelect?.value === 'csv' ? 'csv' : 'jsonl';
+        try {
+          await exportSensorData(partitionKeys);
+        } catch (error) {
+          setSensorExportMessage('error', parseErrorPayload(error, 'Sensor export failed.'));
         }
       });
     }
@@ -2540,11 +2770,23 @@ function showEnvironmentForm(existingEnv) {
   });
 }
 
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    APP,
+    CONFIG,
+    buildSensorExportCsv,
+    buildSensorExportJsonl,
+    parseSensorReadingsForExport,
+    querySensorDataRange,
+    sensorDataFilter,
+  };
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   // MSAL loginPopup() opens a popup that loads this SPA.  The popup only needs
   // MSAL to process the auth response — skip full app init to avoid unnecessary
   // API calls and rendering.
-  if (window.opener && window.opener !== window) {
+  if ((window.opener && window.opener !== window) || window.__SONDE_TEST__ === true) {
     return;
   }
   init().catch((error) => renderError('Application failed to start', error));

--- a/deploy/web-ui/style.css
+++ b/deploy/web-ui/style.css
@@ -131,6 +131,25 @@ code { font-family: Consolas, "Courier New", monospace; }
   background: var(--accent);
   color: #fff;
 }
+.sensor-export-panel {
+  display: grid;
+  gap: 0.5rem;
+}
+.sensor-export-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: end;
+}
+.sensor-export-field {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 12rem;
+}
+.sensor-export-field select,
+.sensor-export-field input {
+  min-width: 0;
+}
 .sensor-series-picker { margin-top: 0.25rem; }
 .sensor-series-grid {
   display: flex;

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -306,7 +306,7 @@ default); set to the empty string to omit the custom domain redirect URI.
 
 ## 10. Sensor Data (WEB-0700)
 
-> **Requirements:** WEB-0700, WEB-0701, WEB-0702, WEB-0703
+> **Requirements:** WEB-0700, WEB-0701, WEB-0702, WEB-0703, WEB-0704
 
 ### 10.1  Data source
 
@@ -333,7 +333,7 @@ separate line on a time-series chart. The X-axis is time (derived from
 `timestamp_ms`); the Y-axis is the reading value.
 
 **Controls:**
-- Time range selector: Last 1h, 24h, 7d, custom.
+- Time range selector: Last 1h, 24h, 7d.
 - Auto-refresh toggle with configurable interval (default 30s).
 - Hover tooltip: timestamp, node ID, reading name, value.
 - Series selector: checkboxes to choose which (node, program, reading)
@@ -395,6 +395,39 @@ Overrides are stored in `localStorage` under the key
 Overrides survive page reloads and browser restarts. They are scoped to
 the browser origin (per localStorage rules) and are not shared across
 devices.
+
+### 10.5  Sensor data export (WEB-0704)
+
+The Sensor Data tab includes a separate export panel for downloading sensor
+rows over a custom start/end time range without changing the graph/table
+display state.
+
+**Controls:**
+- Start time and end time inputs (`datetime-local`)
+- Format selector with `.jsonl` and `.csv`
+- Export button
+
+**Behavior:**
+- The export range is validated client-side before querying. Missing values or
+  `start > end` are rejected with an inline error message and no network call.
+- Export scope is **all sensor-data rows in the chosen export range** across
+  all known node partitions. It does not depend on the graph view mode, graph
+  preset range, or series picker selection.
+- Export queries reuse the same authenticated Azure Tables access model as the
+  rest of the SPA. For each node partition, the SPA issues a filtered range
+  query and follows Azure Table continuation tokens until the partition's
+  matching rows are exhausted.
+- The export action surfaces success/failure status in the Sensor Data view.
+
+**File formats:**
+- **CSV:** Header row
+  `timestamp_ms,node_id,program_hash,raw_payload,decoded_readings_json`. The
+  `decoded_readings_json` column contains the original JSON string from the
+  table row, or the empty string when the source row has no decoded readings.
+- **JSONL:** One JSON object per line with keys `timestamp_ms`, `node_id`,
+  `program_hash`, `raw_payload`, and `decoded_readings`. The
+  `decoded_readings` value is the parsed JSON object when present, otherwise
+  `null`.
 
 ---
 

--- a/docs/web-ui-requirements.md
+++ b/docs/web-ui-requirements.md
@@ -805,6 +805,38 @@ modal dialog.
 
 ---
 
+### WEB-0704  Sensor Data Export
+
+**Priority:** Must
+**Source:** User request (2026-06-08), web-ui-design.md §10.5
+**Confidence:** High
+
+**Description:**
+The SPA MUST allow operators to export sensor-data rows from a custom
+start/end time range as either `.jsonl` or `.csv`.
+
+**Acceptance criteria:**
+
+1. The Sensor Data tab provides export controls with a start time, end time,
+   format selector, and export action.
+2. The export range is independent of the graph/table view toggle, graph
+   time-range selector, and series selection state.
+3. Export queries all matching sensor-data rows across all known node
+   partitions for the selected time range.
+4. Export follows Azure Table continuation tokens so rows beyond the first
+   page are included in the downloaded file.
+5. CSV export writes one header row and one data row per sensor-data entity
+   with columns `timestamp_ms`, `node_id`, `program_hash`, `raw_payload`, and
+   `decoded_readings_json`.
+6. JSONL export writes one JSON object per line with fields `timestamp_ms`,
+   `node_id`, `program_hash`, `raw_payload`, and `decoded_readings`.
+7. Rows with empty `decoded_readings` export as an empty `decoded_readings_json`
+   CSV column and `decoded_readings: null` in JSONL.
+8. The export range is validated before querying; invalid or inverted ranges
+   are rejected with operator-visible feedback.
+
+---
+
 ## 12  Environment Manager (WEB-0800)
 
 ### WEB-0800  Runtime Environment Configuration

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -92,6 +92,7 @@ and verifies one or more acceptance criteria.
 | WEB-0701 | T-WEB-0702, T-WEB-0703, T-WEB-0706, T-WEB-0713, T-WEB-0714, T-WEB-0715, T-WEB-0702b, T-WEB-0703b |
 | WEB-0702 | T-WEB-0704, T-WEB-0705, T-WEB-0704b, T-WEB-0704c |
 | WEB-0703 | T-WEB-0707, T-WEB-0708, T-WEB-0709, T-WEB-0710, T-WEB-0711, T-WEB-0712, T-WEB-0707b |
+| WEB-0704 | T-WEB-0716, T-WEB-0717, T-WEB-0718, T-WEB-0719, T-WEB-0720, T-WEB-0721, T-WEB-0722 |
 | WEB-0800 | T-WEB-0801, T-WEB-0802, T-WEB-0803, T-WEB-0804, T-WEB-0805, T-WEB-0806 |
 | WEB-0801 | T-WEB-0802 |
 | WEB-0802 | T-WEB-0806, T-WEB-0807, T-WEB-0808, T-WEB-0809 |
@@ -241,6 +242,13 @@ and verifies one or more acceptance criteria.
 | T-WEB-0710 | WEB-0703 | Unit suffix appears in tooltip values and Y-axis title when all series share the same suffix | Manual | Planned |
 | T-WEB-0711 | WEB-0703 | Overrides persist across page reloads via `localStorage` | Manual | Planned |
 | T-WEB-0712 | WEB-0703 | Reset to Default clears overrides and restores original label/scale | Manual | Planned |
+| T-WEB-0716 | WEB-0704 | Sensor Data tab exposes export start/end controls, format selector, and Export action | Manual/E2E | Planned |
+| T-WEB-0717 | WEB-0704 | JSONL export writes one JSON object per line with the required five fields and `decoded_readings: null` for empty rows | Manual/E2E | Planned |
+| T-WEB-0718 | WEB-0704 | CSV export writes the required header and preserves the raw JSON string in `decoded_readings_json` | Manual/E2E | Planned |
+| T-WEB-0719 | WEB-0704 | Export obeys the custom export range but ignores graph preset range, current view mode, and series selection | Manual/E2E | Planned |
+| T-WEB-0720 | WEB-0704 | Export follows Azure Table continuation tokens so ranges with more than 1000 rows per node export completely | Unit (JS) | Pass |
+| T-WEB-0721 | WEB-0704 | Missing or inverted export start/end values are rejected with operator-visible feedback and no file download | Manual | Planned |
+| T-WEB-0722 | WEB-0704 | Export includes matching rows from multiple known node partitions within the selected range | Manual/E2E | Planned |
 
 ### 5.8  Environment Manager
 

--- a/tests/web-ui-app.test.js
+++ b/tests/web-ui-app.test.js
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 sonde contributors
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { webcrypto } = require('node:crypto');
+
+function makeStorage() {
+  const store = new Map();
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+    key(index) {
+      return [...store.keys()][index] || null;
+    },
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+function makeElement() {
+  return {
+    innerHTML: '',
+    textContent: '',
+    title: '',
+    value: '',
+    checked: false,
+    disabled: false,
+    dataset: {},
+    style: {},
+    focus() {},
+    remove() {},
+    appendChild() {},
+    removeChild() {},
+    addEventListener() {},
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    classList: { toggle() {} },
+  };
+}
+
+global.window = {
+  __SONDE_TEST__: true,
+  opener: null,
+  location: { origin: 'https://example.test', pathname: '/', hash: '' },
+};
+global.document = {
+  addEventListener() {},
+  getElementById() { return makeElement(); },
+  querySelectorAll() { return []; },
+  createElement() { return makeElement(); },
+  body: makeElement(),
+};
+global.localStorage = makeStorage();
+global.sessionStorage = makeStorage();
+global.crypto = webcrypto;
+global.atob = (value) => Buffer.from(value, 'base64').toString('binary');
+global.btoa = (value) => Buffer.from(value, 'binary').toString('base64');
+
+const app = require(path.resolve(__dirname, '..', 'deploy', 'web-ui', 'app.js'));
+
+test('sensorDataFilter uses reverse-timestamp bounds for the requested range', () => {
+  const max = BigInt('0xffffffffffffffff');
+  const startMs = 1_000;
+  const endMs = 2_000;
+  const expectedStart = (max - BigInt(endMs)).toString(16).padStart(16, '0');
+  const expectedEnd = (max - BigInt(startMs)).toString(16).padStart(16, '0');
+
+  assert.equal(
+    app.sensorDataFilter('n:abc', startMs, endMs),
+    `PartitionKey eq 'n:abc' and RowKey ge '${expectedStart}' and RowKey le '${expectedEnd}~'`,
+  );
+});
+
+test('buildSensorExportCsv emits header, sorts by timestamp, and escapes JSON payloads', () => {
+  const csv = app.buildSensorExportCsv([
+    {
+      timestamp_ms: '2000',
+      node_id: 'node-b',
+      program_hash: 'bb',
+      raw_payload: 'plain',
+      decoded_readings: '{"temp_mc":25000}',
+    },
+    {
+      timestamp_ms: '1000',
+      node_id: 'node-a',
+      program_hash: 'aa',
+      raw_payload: 'raw,1',
+      decoded_readings: '{"temp_mc":"9007199254740993"}',
+    },
+  ]);
+
+  const lines = csv.split('\r\n');
+  assert.equal(lines[0], 'timestamp_ms,node_id,program_hash,raw_payload,decoded_readings_json');
+  assert.equal(lines[1], '1000,node-a,aa,"raw,1","{""temp_mc"":""9007199254740993""}"');
+  assert.equal(lines[2], '2000,node-b,bb,plain,"{""temp_mc"":25000}"');
+});
+
+test('buildSensorExportJsonl emits parsed readings objects and null for empty readings', () => {
+  const jsonl = app.buildSensorExportJsonl([
+    {
+      timestamp_ms: '2000',
+      node_id: 'node-b',
+      program_hash: 'bb',
+      raw_payload: 'plain',
+      decoded_readings: '',
+    },
+    {
+      timestamp_ms: '1000',
+      node_id: 'node-a',
+      program_hash: 'aa',
+      raw_payload: 'raw',
+      decoded_readings: '{"temp_mc":"9007199254740993"}',
+    },
+  ]);
+
+  const lines = jsonl.split('\n').map((line) => JSON.parse(line));
+  assert.deepEqual(lines[0], {
+    timestamp_ms: '1000',
+    node_id: 'node-a',
+    program_hash: 'aa',
+    raw_payload: 'raw',
+    decoded_readings: { temp_mc: '9007199254740993' },
+  });
+  assert.deepEqual(lines[1], {
+    timestamp_ms: '2000',
+    node_id: 'node-b',
+    program_hash: 'bb',
+    raw_payload: 'plain',
+    decoded_readings: null,
+  });
+});
+
+test('parseSensorReadingsForExport rejects invalid JSON', () => {
+  assert.throws(
+    () => app.parseSensorReadingsForExport('not-json'),
+    /decoded_readings.*valid JSON/i,
+  );
+});
+
+test('querySensorDataRange follows continuation tokens until a partition is exhausted', async () => {
+  const originalFetch = global.fetch;
+  app.CONFIG.storageAccount = 'exampleacct';
+  app.APP.account = { username: 'test@example.com' };
+  app.APP.msalApp = {
+    async acquireTokenSilent() {
+      return { accessToken: 'token-123' };
+    },
+    setActiveAccount() {},
+  };
+
+  const urls = [];
+  const authHeaders = [];
+  global.fetch = async (url, options) => {
+    urls.push(url);
+    authHeaders.push(options.headers.Authorization);
+    const parsed = new URL(url);
+    const nextPartitionKey = parsed.searchParams.get('NextPartitionKey');
+
+    if (!nextPartitionKey) {
+      return {
+        ok: true,
+        async json() {
+          return { value: [{ timestamp_ms: '1000', node_id: 'node-a' }] };
+        },
+        async text() {
+          return '';
+        },
+        headers: {
+          get(name) {
+            if (name === 'x-ms-continuation-NextPartitionKey') return 'page-2';
+            if (name === 'x-ms-continuation-NextRowKey') return 'row-2';
+            return null;
+          },
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      async json() {
+        return { value: [{ timestamp_ms: '2000', node_id: 'node-a' }] };
+      },
+      async text() {
+        return '';
+      },
+      headers: { get() { return null; } },
+    };
+  };
+
+  try {
+    const rows = await app.querySensorDataRange(['n:abc'], 1_000, 2_000, {
+      topPerPage: 1000,
+      maxPagesPerPartition: Number.POSITIVE_INFINITY,
+    });
+
+    assert.equal(rows.length, 2);
+    assert.equal(new URL(urls[0]).searchParams.get('$top'), '1000');
+    assert.equal(new URL(urls[1]).searchParams.get('NextPartitionKey'), 'page-2');
+    assert.equal(new URL(urls[1]).searchParams.get('NextRowKey'), 'row-2');
+    assert.deepEqual(authHeaders, ['Bearer token-123', 'Bearer token-123']);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/tests/web-ui-app.test.js
+++ b/tests/web-ui-app.test.js
@@ -81,6 +81,19 @@ test('sensorDataFilter uses reverse-timestamp bounds for the requested range', (
   );
 });
 
+test('sensorDataFilter escapes single quotes in partition keys', () => {
+  const max = BigInt('0xffffffffffffffff');
+  const startMs = 1_000;
+  const endMs = 2_000;
+  const expectedStart = (max - BigInt(endMs)).toString(16).padStart(16, '0');
+  const expectedEnd = (max - BigInt(startMs)).toString(16).padStart(16, '0');
+
+  assert.equal(
+    app.sensorDataFilter("n:o'hare", startMs, endMs),
+    `PartitionKey eq 'n:o''hare' and RowKey ge '${expectedStart}' and RowKey le '${expectedEnd}~'`,
+  );
+});
+
 test('buildSensorExportCsv emits header, sorts by timestamp, and escapes JSON payloads', () => {
   const csv = app.buildSensorExportCsv([
     {

--- a/tests/web-ui-app.test.js
+++ b/tests/web-ui-app.test.js
@@ -213,7 +213,7 @@ test('querySensorDataRange follows continuation tokens until a partition is exha
   try {
     const rows = await app.querySensorDataRange(['n:abc'], 1_000, 2_000, {
       topPerPage: 1000,
-      maxPagesPerPartition: Number.POSITIVE_INFINITY,
+      maxPagesPerPartition: 10,
     });
 
     assert.equal(rows.length, 2);
@@ -221,6 +221,48 @@ test('querySensorDataRange follows continuation tokens until a partition is exha
     assert.equal(new URL(urls[1]).searchParams.get('NextPartitionKey'), 'page-2');
     assert.equal(new URL(urls[1]).searchParams.get('NextRowKey'), 'row-2');
     assert.deepEqual(authHeaders, ['Bearer token-123', 'Bearer token-123']);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('querySensorDataRange rejects repeated continuation tokens for complete exports', async () => {
+  const originalFetch = global.fetch;
+  app.CONFIG.storageAccount = 'exampleacct';
+  app.APP.account = { username: 'test@example.com' };
+  app.APP.msalApp = {
+    async acquireTokenSilent() {
+      return { accessToken: 'token-123' };
+    },
+    setActiveAccount() {},
+  };
+
+  global.fetch = async () => ({
+    ok: true,
+    async json() {
+      return { value: [{ timestamp_ms: '1000', node_id: 'node-a' }] };
+    },
+    async text() {
+      return '';
+    },
+    headers: {
+      get(name) {
+        if (name === 'x-ms-continuation-NextPartitionKey') return 'page-2';
+        if (name === 'x-ms-continuation-NextRowKey') return 'row-2';
+        return null;
+      },
+    },
+  });
+
+  try {
+    await assert.rejects(
+      () => app.querySensorDataRange(['n:abc'], 1_000, 2_000, {
+        topPerPage: 1000,
+        maxPagesPerPartition: 10,
+        requireComplete: true,
+      }),
+      /repeated continuation token/i,
+    );
   } finally {
     global.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- add Sensor Data export controls with a custom start/end range
- support .jsonl and .csv downloads for operator-facing sensor fields
- follow Azure Table continuation tokens so export includes all matching rows
- update the web UI requirements, design, and validation docs
- add Node-based regression tests for export formatting and pagination

## Validation
- node --check deploy\\web-ui\\app.js
- node --test tests\\web-ui-app.test.js
- cargo fmt --all
- cargo build --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace