### PR TITLE
Add dashboard device data export

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -232,6 +232,13 @@ const APP = {
   sensorChart: null,
   rotationFormOpen: null, // gateway ID when rotation form is expanded (WEB-1002)
 };
+const DASHBOARD_EXPORT_STATE = {
+  startMs: null,
+  endMs: null,
+  format: 'jsonl',
+  busy: false,
+  message: null,
+};
 
 const contentEl = document.getElementById('content');
 const authControlsEl = document.getElementById('auth-controls');
@@ -1190,8 +1197,11 @@ async function renderDashboard() {
     const gatewayDesiredRows = latestByPartition(filterGatewayRows(desiredRows));
     const gatewayCardHtml = await renderGatewayStatusCard(gatewayRows, gatewayDesiredRows);
 
-    const latestActual = latestByPartition(filterNodeRows(actualRows)).sort((left, right) => String(left.node_id || '').localeCompare(String(right.node_id || '')));
+    const nodeRows = filterNodeRows(actualRows);
+    const latestActual = latestByPartition(nodeRows).sort((left, right) => String(left.node_id || '').localeCompare(String(right.node_id || '')));
+    const nodePartitionKeys = [...new Set(nodeRows.map((row) => row.PartitionKey).filter(Boolean))];
     const desiredByPartition = new Map(latestByPartition(filterNodeRows(desiredRows)).map((row) => [row.PartitionKey, row]));
+    initializeDashboardExportRange();
 
     const rowsHtml = latestActual.map((actual) => {
       const desired = desiredByPartition.get(actual.PartitionKey);
@@ -1220,8 +1230,33 @@ async function renderDashboard() {
       `;
     }).join('');
 
+    const exportStartValue = formatDateTimeLocalInput(DASHBOARD_EXPORT_STATE.startMs);
+    const exportEndValue = formatDateTimeLocalInput(DASHBOARD_EXPORT_STATE.endMs);
+    const exportBusyAttr = DASHBOARD_EXPORT_STATE.busy ? ' disabled' : '';
+
     renderCard('Dashboard', `
       ${gatewayCardHtml}
+      <div class="panel dashboard-export-panel">
+        <div class="dashboard-export-row">
+          <label class="dashboard-export-field">
+            <span>Export start</span>
+            <input type="datetime-local" id="dashboard-export-start" value="${escapeHtml(exportStartValue)}"${exportBusyAttr}>
+          </label>
+          <label class="dashboard-export-field">
+            <span>Export end</span>
+            <input type="datetime-local" id="dashboard-export-end" value="${escapeHtml(exportEndValue)}"${exportBusyAttr}>
+          </label>
+          <label class="dashboard-export-field">
+            <span>Format</span>
+            <select id="dashboard-export-format"${exportBusyAttr}>
+              <option value="jsonl"${DASHBOARD_EXPORT_STATE.format === 'jsonl' ? ' selected' : ''}>.jsonl</option>
+              <option value="csv"${DASHBOARD_EXPORT_STATE.format === 'csv' ? ' selected' : ''}>.csv</option>
+            </select>
+          </label>
+          <button type="button" class="secondary" id="dashboard-export-button"${exportBusyAttr}>${DASHBOARD_EXPORT_STATE.busy ? 'Exporting…' : 'Export'}</button>
+        </div>
+        <div id="dashboard-export-status">${messageHtml(DASHBOARD_EXPORT_STATE.message)}</div>
+      </div>
       <div class="table-wrap">
         <table>
           <thead>
@@ -1238,10 +1273,47 @@ async function renderDashboard() {
               <th>Status</th>
             </tr>
           </thead>
-          <tbody>${rowsHtml || '<tr><td colspan="9" class="muted">No node state found.</td></tr>'}</tbody>
+          <tbody>${rowsHtml || '<tr><td colspan="10" class="muted">No node state found.</td></tr>'}</tbody>
         </table>
       </div>
     `);
+
+    updateDashboardExportControls();
+
+    const exportStartInput = document.getElementById('dashboard-export-start');
+    if (exportStartInput) {
+      exportStartInput.addEventListener('change', () => {
+        DASHBOARD_EXPORT_STATE.startMs = parseDateTimeLocalInput(exportStartInput.value);
+      });
+    }
+
+    const exportEndInput = document.getElementById('dashboard-export-end');
+    if (exportEndInput) {
+      exportEndInput.addEventListener('change', () => {
+        DASHBOARD_EXPORT_STATE.endMs = parseDateTimeLocalInput(exportEndInput.value);
+      });
+    }
+
+    const exportFormatSelect = document.getElementById('dashboard-export-format');
+    if (exportFormatSelect) {
+      exportFormatSelect.addEventListener('change', () => {
+        DASHBOARD_EXPORT_STATE.format = exportFormatSelect.value === 'csv' ? 'csv' : 'jsonl';
+      });
+    }
+
+    const exportButton = document.getElementById('dashboard-export-button');
+    if (exportButton) {
+      exportButton.addEventListener('click', async () => {
+        DASHBOARD_EXPORT_STATE.startMs = parseDateTimeLocalInput(exportStartInput?.value || '');
+        DASHBOARD_EXPORT_STATE.endMs = parseDateTimeLocalInput(exportEndInput?.value || '');
+        DASHBOARD_EXPORT_STATE.format = exportFormatSelect?.value === 'csv' ? 'csv' : 'jsonl';
+        try {
+          await exportDeviceData(nodePartitionKeys);
+        } catch (error) {
+          setDashboardExportMessage('error', parseErrorPayload(error, 'Device export failed.'));
+        }
+      });
+    }
 
     // Attach inline rotation form handlers (WEB-1002, WEB-1009).
     attachRotationFormHandlers(gatewayRows);
@@ -1654,10 +1726,18 @@ function reverseTimestampHex(ms) {
   return (max - BigInt(ms)).toString(16).padStart(16, '0');
 }
 
-function sensorDataFilter(partitionKey, startMs, endMs) {
+function historyTableFilter(partitionKey, startMs, endMs) {
   const rkStart = reverseTimestampHex(endMs);
   const rkEnd = reverseTimestampHex(startMs);
   return `PartitionKey eq '${escapeODataStringLiteral(partitionKey)}' and RowKey ge '${rkStart}' and RowKey le '${rkEnd}~'`;
+}
+
+function sensorDataFilter(partitionKey, startMs, endMs) {
+  return historyTableFilter(partitionKey, startMs, endMs);
+}
+
+function actualStateFilter(partitionKey, startMs, endMs) {
+  return historyTableFilter(partitionKey, startMs, endMs);
 }
 
 function initializeSensorExportRange() {
@@ -1715,22 +1795,32 @@ function updateSensorExportControls() {
 }
 
 async function querySensorDataRange(partitionKeys, startMs, endMs, options = {}) {
+  return queryPartitionedTableRange(CONFIG.sensorDataTable, partitionKeys, startMs, endMs, {
+    ...options,
+    filterBuilder: sensorDataFilter,
+    repeatedTokenLabel: 'Sensor export failed',
+  });
+}
+
+async function queryPartitionedTableRange(tableName, partitionKeys, startMs, endMs, options = {}) {
   const token = await getToken();
   const {
     topPerPage = 1000,
     maxPagesPerPartition = 1,
     requireComplete = false,
+    filterBuilder = historyTableFilter,
+    repeatedTokenLabel = 'History export failed',
   } = options;
 
   const fetchPartition = async (pk) => {
-    const filter = sensorDataFilter(pk, startMs, endMs);
+    const filter = filterBuilder(pk, startMs, endMs);
     let nextPartitionKey = null;
     let nextRowKey = null;
     const entities = [];
     const seenContinuationTokens = new Set();
 
     for (let page = 0; page < maxPagesPerPartition; page++) {
-      const url = new URL(tableQueryUrl(CONFIG.sensorDataTable));
+      const url = new URL(tableQueryUrl(tableName));
       url.searchParams.set('$filter', filter);
       if (topPerPage != null) {
         url.searchParams.set('$top', String(topPerPage));
@@ -1751,7 +1841,7 @@ async function querySensorDataRange(partitionKeys, startMs, endMs, options = {})
 
       if (!response.ok) {
         const text = await response.text();
-        throw new Error(`SensorData query failed (${response.status}): ${text}`);
+        throw new Error(`Table query failed for ${tableName} (${response.status}): ${text}`);
       }
 
       const payload = await response.json();
@@ -1767,7 +1857,7 @@ async function querySensorDataRange(partitionKeys, startMs, endMs, options = {})
       const continuationToken = `${nextPartitionKey}\n${nextRowKey || ''}`;
       if (seenContinuationTokens.has(continuationToken)) {
         throw new Error(
-          `Sensor export failed: Azure Tables returned a repeated continuation token for node partition ${pk}. Try again or narrow the export time range.`
+          `${repeatedTokenLabel}: Azure Tables returned a repeated continuation token for node partition ${pk}. Try again or narrow the export time range.`
         );
       }
       seenContinuationTokens.add(continuationToken);
@@ -1775,7 +1865,7 @@ async function querySensorDataRange(partitionKeys, startMs, endMs, options = {})
 
     if (requireComplete && nextPartitionKey) {
       throw new Error(
-        `Sensor export failed: Azure Tables returned more than ${maxPagesPerPartition} page(s) for node partition ${pk}. Narrow the export time range and try again.`
+        `${repeatedTokenLabel}: Azure Tables returned more than ${maxPagesPerPartition} page(s) for node partition ${pk}. Narrow the export time range and try again.`
       );
     }
 
@@ -1792,6 +1882,14 @@ async function querySensorDataRange(partitionKeys, startMs, endMs, options = {})
     }
   }
   return allEntities;
+}
+
+async function queryActualStateRange(partitionKeys, startMs, endMs, options = {}) {
+  return queryPartitionedTableRange(CONFIG.actualStateTable, partitionKeys, startMs, endMs, {
+    ...options,
+    filterBuilder: actualStateFilter,
+    repeatedTokenLabel: 'Device export failed',
+  });
 }
 
 function parseSensorReadingsForExport(decodedReadings) {
@@ -1817,6 +1915,121 @@ function csvEscape(value) {
 
 function sensorExportFilename(format) {
   return `sensor-data.${format}`;
+}
+
+function initializeDashboardExportRange() {
+  if (Number.isFinite(DASHBOARD_EXPORT_STATE.startMs) && Number.isFinite(DASHBOARD_EXPORT_STATE.endMs)) {
+    return;
+  }
+  const endMs = Date.now();
+  DASHBOARD_EXPORT_STATE.endMs = endMs;
+  DASHBOARD_EXPORT_STATE.startMs = endMs - TIME_RANGE_MS['24h'];
+}
+
+function setDashboardExportMessage(kind, text) {
+  DASHBOARD_EXPORT_STATE.message = { kind, text };
+  const host = contentEl.querySelector('#dashboard-export-status');
+  if (host) {
+    host.innerHTML = messageHtml(DASHBOARD_EXPORT_STATE.message);
+  }
+}
+
+function updateDashboardExportControls() {
+  const startInput = document.getElementById('dashboard-export-start');
+  const endInput = document.getElementById('dashboard-export-end');
+  const formatSelect = document.getElementById('dashboard-export-format');
+  const exportButton = document.getElementById('dashboard-export-button');
+  const disabled = DASHBOARD_EXPORT_STATE.busy;
+
+  if (startInput) startInput.disabled = disabled;
+  if (endInput) endInput.disabled = disabled;
+  if (formatSelect) formatSelect.disabled = disabled;
+  if (exportButton) {
+    exportButton.disabled = disabled;
+    exportButton.textContent = disabled ? 'Exporting…' : 'Export';
+  }
+}
+
+function buildDeviceExportCsv(rows) {
+  const header = [
+    'timestamp_ms',
+    'node_id',
+    'battery_mv',
+    'wake_rssi_dbm',
+    'firmware_version',
+    'firmware_abi_version',
+    'observed_schedule_interval_s',
+    'observed_current_program_hash',
+    'observed_assigned_program_hash',
+  ];
+  const lines = [header.join(',')];
+  const sorted = [...rows].sort((a, b) => (Number(a.timestamp_ms) || 0) - (Number(b.timestamp_ms) || 0));
+  for (const row of sorted) {
+    lines.push([
+      csvEscape(row.timestamp_ms ?? ''),
+      csvEscape(row.node_id ?? ''),
+      csvEscape(row.battery_mv ?? ''),
+      csvEscape(row.wake_rssi_dbm ?? ''),
+      csvEscape(row.firmware_version ?? ''),
+      csvEscape(row.firmware_abi_version ?? ''),
+      csvEscape(row.observed_schedule_interval_s ?? ''),
+      csvEscape(row.observed_current_program_hash ?? ''),
+      csvEscape(row.observed_assigned_program_hash ?? ''),
+    ].join(','));
+  }
+  return lines.join('\r\n');
+}
+
+function buildDeviceExportJsonl(rows) {
+  const sorted = [...rows].sort((a, b) => (Number(a.timestamp_ms) || 0) - (Number(b.timestamp_ms) || 0));
+  return sorted.map((row) => JSON.stringify({
+    timestamp_ms: row.timestamp_ms ?? null,
+    node_id: row.node_id ?? null,
+    battery_mv: row.battery_mv ?? null,
+    wake_rssi_dbm: row.wake_rssi_dbm ?? null,
+    firmware_version: row.firmware_version ?? null,
+    firmware_abi_version: row.firmware_abi_version ?? null,
+    observed_schedule_interval_s: row.observed_schedule_interval_s ?? null,
+    observed_current_program_hash: row.observed_current_program_hash ?? null,
+    observed_assigned_program_hash: row.observed_assigned_program_hash ?? null,
+  })).join('\n');
+}
+
+function deviceExportFilename(format) {
+  return `device-data.${format}`;
+}
+
+async function exportDeviceData(partitionKeys) {
+  const startMs = DASHBOARD_EXPORT_STATE.startMs;
+  const endMs = DASHBOARD_EXPORT_STATE.endMs;
+  const format = DASHBOARD_EXPORT_STATE.format;
+
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) {
+    throw new Error('Select both export start and end times.');
+  }
+  if (startMs > endMs) {
+    throw new Error('Export start time must be earlier than or equal to the end time.');
+  }
+
+  DASHBOARD_EXPORT_STATE.busy = true;
+  updateDashboardExportControls();
+
+  try {
+    const rows = await queryActualStateRange(partitionKeys, startMs, endMs, {
+      topPerPage: null,
+      maxPagesPerPartition: SENSOR_EXPORT_MAX_PAGES_PER_PARTITION,
+      requireComplete: true,
+    });
+    const content = format === 'csv' ? buildDeviceExportCsv(rows) : buildDeviceExportJsonl(rows);
+    const blob = new Blob([content], {
+      type: format === 'csv' ? 'text/csv;charset=utf-8' : 'application/x-ndjson',
+    });
+    downloadBlob(deviceExportFilename(format), blob);
+    setDashboardExportMessage('success', `Exported ${rows.length} device row(s) as .${format}.`);
+  } finally {
+    DASHBOARD_EXPORT_STATE.busy = false;
+    updateDashboardExportControls();
+  }
 }
 
 function buildSensorExportCsv(rows) {
@@ -2800,7 +3013,11 @@ if (typeof module !== 'undefined' && module.exports) {
     CONFIG,
     buildSensorExportCsv,
     buildSensorExportJsonl,
+    buildDeviceExportCsv,
+    buildDeviceExportJsonl,
     parseSensorReadingsForExport,
+    actualStateFilter,
+    queryActualStateRange,
     querySensorDataRange,
     sensorDataFilter,
   };

--- a/deploy/web-ui/style.css
+++ b/deploy/web-ui/style.css
@@ -131,23 +131,28 @@ code { font-family: Consolas, "Courier New", monospace; }
   background: var(--accent);
   color: #fff;
 }
-.sensor-export-panel {
+.sensor-export-panel,
+.dashboard-export-panel {
   display: grid;
   gap: 0.5rem;
 }
-.sensor-export-row {
+.sensor-export-row,
+.dashboard-export-row {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
   align-items: end;
 }
-.sensor-export-field {
+.sensor-export-field,
+.dashboard-export-field {
   display: grid;
   gap: 0.25rem;
   min-width: 12rem;
 }
 .sensor-export-field select,
-.sensor-export-field input {
+.sensor-export-field input,
+.dashboard-export-field select,
+.dashboard-export-field input {
   min-width: 0;
 }
 .sensor-series-picker { margin-top: 0.25rem; }

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -51,7 +51,44 @@ deploy/web-ui/
   - **Program divergence**: When a desired-state row exists for the node, divergence is flagged if the desired program hash differs from the actual current program hash. Missing, null, or empty `desired_assigned_program_hash` is treated as "no program desired" — so a node that still reports a current program hash is diverged until it confirms clearing. When no desired-state row exists at all, program divergence is not flagged (node is unmanaged).
   - **Schedule divergence**: Flagged when `desired_schedule_interval_s` is set and differs from `observed_schedule_interval_s`.
 - Auto-refresh every 30s by default (configurable).
-- Columns: Node ID, Battery (mV), Firmware, ABI Version, Schedule (s), Current Program Hash, Assigned Program Hash, Last Seen, Status (aligned/diverged).
+- Columns: Node ID, Battery (mV), RSSI, Firmware, ABI Version, Schedule (s), Current Program Hash, Assigned Program Hash, Last Seen, Status (aligned/diverged).
+
+### 4.1  Dashboard device-data export (WEB-0105)
+
+The Dashboard includes a separate export panel for downloading historical
+device-data rows from the append-only `actualstate` table. This is an
+export-only diagnostics feature; it does not add a second dashboard view or a
+new Azure table.
+
+**Controls:**
+- Start time and end time inputs (`datetime-local`)
+- Format selector with `.jsonl` and `.csv`
+- Export button
+
+**Behavior:**
+- The export range is validated client-side before querying. Missing values or
+  `start > end` are rejected with an inline error message and no network call.
+- Export scope is **all matching historical actual-state rows in the chosen
+  export range** across all known node partitions. It is not limited to the
+  latest row per node shown in the dashboard table.
+- Export queries reuse the same authenticated Azure Tables access model as the
+  rest of the SPA. For each node partition, the SPA issues a filtered range
+  query against `actualstate` and follows Azure Table continuation tokens until
+  the partition's matching rows are exhausted.
+- The export action surfaces success/failure status in the Dashboard view.
+- Dashboard auto-refresh continues to own the latest-state table only. The
+  export operation snapshots the operator-selected time range and does not
+  derive its result set from the deduplicated dashboard rows.
+
+**File formats:**
+- **CSV:** Header row
+  `timestamp_ms,node_id,battery_mv,wake_rssi_dbm,firmware_version,firmware_abi_version,observed_schedule_interval_s,observed_current_program_hash,observed_assigned_program_hash`.
+  Missing optional fields are written as empty fields.
+- **JSONL:** One JSON object per line with keys `timestamp_ms`, `node_id`,
+  `battery_mv`, `wake_rssi_dbm`, `firmware_version`, `firmware_abi_version`,
+  `observed_schedule_interval_s`, `observed_current_program_hash`, and
+  `observed_assigned_program_hash`. Missing optional fields are written as
+  `null`.
 
 ---
 

--- a/docs/web-ui-requirements.md
+++ b/docs/web-ui-requirements.md
@@ -110,12 +110,12 @@ Table. Each node is represented by the most recent row per `PartitionKey`
 
 **Description:**
 The dashboard table MUST display the following columns: Node ID, Battery (mV),
-Firmware, ABI Version, Schedule (s), Current Program Hash, Assigned Program
-Hash, Last Seen, Status.
+RSSI, Firmware, ABI Version, Schedule (s), Current Program Hash, Assigned
+Program Hash, Last Seen, Status.
 
 **Acceptance criteria:**
 
-1. All nine columns are present in the table header.
+1. All ten columns are present in the table header.
 2. Program hashes are displayed as truncated 8-character hex with a full-hash tooltip.
 3. "Last Seen" displays a relative time string (e.g., "5m ago").
 4. Missing values display "—".
@@ -155,6 +155,46 @@ cross-referencing the `desiredstate` table.
 3. When no desired-state row exists for a node, the node shows "Aligned" (unmanaged node).
 4. When `desired_schedule_interval_s` is set and differs from `observed_schedule_interval_s`, the node shows "Diverged."
 5. The Schedule column tooltip shows both observed and desired values.
+
+---
+
+### WEB-0105  Dashboard Device-Data Export
+
+**Priority:** Must
+**Source:** User request (2026-06-09), web-ui-design.md §4.1
+**Confidence:** High
+
+**Description:**
+The Dashboard tab MUST allow operators to export historical device-data rows
+from the append-only `actualstate` table over a custom start/end time range as
+either `.jsonl` or `.csv`. This export is for historical device diagnostics and
+MUST include battery and WAKE RSSI observations over time without introducing a
+new table or a new dashboard-style diagnostics view.
+
+**Acceptance criteria:**
+
+1. The Dashboard tab provides device-data export controls with a start time, end
+   time, format selector, and export action.
+2. The export queries historical `actualstate` rows across all known node
+   partitions for the selected time range; it is not limited to the latest row
+   currently shown in the dashboard table.
+3. The export follows Azure Table continuation tokens so rows beyond the first
+   page are included in the downloaded file.
+4. CSV export writes one header row and one data row per matching actual-state
+   entity with columns `timestamp_ms`, `node_id`, `battery_mv`,
+   `wake_rssi_dbm`, `firmware_version`, `firmware_abi_version`,
+   `observed_schedule_interval_s`, `observed_current_program_hash`, and
+   `observed_assigned_program_hash`.
+5. JSONL export writes one JSON object per line with fields `timestamp_ms`,
+   `node_id`, `battery_mv`, `wake_rssi_dbm`, `firmware_version`,
+   `firmware_abi_version`, `observed_schedule_interval_s`,
+   `observed_current_program_hash`, and `observed_assigned_program_hash`.
+6. Missing optional numeric or string fields export as empty CSV fields and
+   `null` JSON values.
+7. The export range is validated before querying; missing or inverted ranges are
+   rejected with operator-visible feedback.
+8. The export behavior is independent of dashboard auto-refresh and the
+   dashboard's latest-only deduplicated table view.
 
 ---
 

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -56,6 +56,7 @@ and verifies one or more acceptance criteria.
 | WEB-0102 | T-WEB-0102, T-WEB-0102b, T-WEB-0102c |
 | WEB-0103 | T-WEB-0103, T-WEB-0103b |
 | WEB-0104 | T-WEB-0104, T-WEB-0105, T-WEB-0106, T-WEB-0107, T-WEB-0108 |
+| WEB-0105 | T-WEB-0109, T-WEB-0110, T-WEB-0111, T-WEB-0112, T-WEB-0113, T-WEB-0114, T-WEB-0115 |
 | WEB-0201 | T-WEB-0201, T-WEB-0201b, T-WEB-0201c |
 | WEB-0202 | T-WEB-0202, T-WEB-0202b, T-WEB-0202c |
 | WEB-0203 | T-WEB-0203, T-WEB-0203b |
@@ -129,7 +130,7 @@ and verifies one or more acceptance criteria.
 | T-WEB-0101 | WEB-0101 | SPA renders node table from `actualstate` query | Manual/E2E | Planned |
 | T-WEB-0101b | WEB-0101 | Nodes sorted alphabetically by `node_id` | Manual/E2E | Planned |
 | T-WEB-0101c | WEB-0101 | Empty `actualstate` table displays "No node state found." | Manual/E2E | Planned |
-| T-WEB-0102 | WEB-0102 | All nine required columns displayed | Manual/E2E | Planned |
+| T-WEB-0102 | WEB-0102 | All ten required columns displayed | Manual/E2E | Planned |
 | T-WEB-0102b | WEB-0102 | Program hashes truncated to 8-char hex with full-hash tooltip | Manual/E2E | Planned |
 | T-WEB-0102c | WEB-0102 | "Last Seen" shows relative time (e.g., "5m ago") | Manual/E2E | Planned |
 | T-WEB-0103 | WEB-0103 | Auto-refresh polls at configured interval (30s default) | Manual | Planned |
@@ -137,6 +138,13 @@ and verifies one or more acceptance criteria.
 | T-WEB-0104 | WEB-0104 | Divergence indicator shown when desired-state row exists and actual differs from desired | Manual/E2E | Planned |
 | T-WEB-0105 | WEB-0104 | Unassigned program (desired row exists, program hash empty/missing) shows Diverged while node still reports a current program | Manual/E2E | Planned |
 | T-WEB-0106 | WEB-0104 | Node with no desired-state row shows Aligned even if actual state reports a program | Manual/E2E | Planned |
+| T-WEB-0109 | WEB-0105 | Dashboard exposes device-data export start/end controls, format selector, and Export action | Manual/E2E | Planned |
+| T-WEB-0110 | WEB-0105 | JSONL device-data export writes one JSON object per line with the required historical actual-state fields and `null` for missing optional values | Manual/E2E | Planned |
+| T-WEB-0111 | WEB-0105 | CSV device-data export writes the required header and empty fields for missing optional values | Manual/E2E | Planned |
+| T-WEB-0112 | WEB-0105 | Device-data export includes multiple historical `actualstate` rows for the same node within the selected range, not just the dashboard's latest row | Manual/E2E | Planned |
+| T-WEB-0113 | WEB-0105 | Device-data export follows Azure Table continuation tokens so ranges with more than 1000 rows per node export completely | Unit (JS) | Planned |
+| T-WEB-0114 | WEB-0105 | Missing or inverted device-data export start/end values are rejected with operator-visible feedback and no file download | Manual | Planned |
+| T-WEB-0115 | WEB-0105 | Device-data export includes matching rows from multiple known node partitions within the selected range and is unaffected by dashboard auto-refresh | Manual/E2E | Planned |
 
 ### 5.2  Desired State
 

--- a/tests/web-ui-app.test.js
+++ b/tests/web-ui-app.test.js
@@ -94,6 +94,19 @@ test('sensorDataFilter escapes single quotes in partition keys', () => {
   );
 });
 
+test('actualStateFilter uses reverse-timestamp bounds for the requested range', () => {
+  const max = BigInt('0xffffffffffffffff');
+  const startMs = 1_000;
+  const endMs = 2_000;
+  const expectedStart = (max - BigInt(endMs)).toString(16).padStart(16, '0');
+  const expectedEnd = (max - BigInt(startMs)).toString(16).padStart(16, '0');
+
+  assert.equal(
+    app.actualStateFilter('n:abc', startMs, endMs),
+    `PartitionKey eq 'n:abc' and RowKey ge '${expectedStart}' and RowKey le '${expectedEnd}~'`,
+  );
+});
+
 test('buildSensorExportCsv emits header, sorts by timestamp, and escapes JSON payloads', () => {
   const csv = app.buildSensorExportCsv([
     {
@@ -150,6 +163,92 @@ test('buildSensorExportJsonl emits parsed readings objects and null for empty re
     program_hash: 'bb',
     raw_payload: 'plain',
     decoded_readings: null,
+  });
+});
+
+test('buildDeviceExportCsv emits header, sorts by timestamp, and leaves missing values empty', () => {
+  const csv = app.buildDeviceExportCsv([
+    {
+      timestamp_ms: '2000',
+      node_id: 'node-b',
+      battery_mv: '3300',
+      wake_rssi_dbm: '-61',
+      firmware_version: '1.2.3',
+      firmware_abi_version: '4',
+      observed_schedule_interval_s: '300',
+      observed_current_program_hash: 'bb',
+      observed_assigned_program_hash: '',
+    },
+    {
+      timestamp_ms: '1000',
+      node_id: 'node-a',
+      battery_mv: '',
+      wake_rssi_dbm: '',
+      firmware_version: '',
+      firmware_abi_version: '',
+      observed_schedule_interval_s: '',
+      observed_current_program_hash: '',
+      observed_assigned_program_hash: '',
+    },
+  ]);
+
+  const lines = csv.split('\r\n');
+  assert.equal(
+    lines[0],
+    'timestamp_ms,node_id,battery_mv,wake_rssi_dbm,firmware_version,firmware_abi_version,observed_schedule_interval_s,observed_current_program_hash,observed_assigned_program_hash',
+  );
+  assert.equal(lines[1], '1000,node-a,,,,,,,');
+  assert.equal(lines[2], '2000,node-b,3300,-61,1.2.3,4,300,bb,');
+});
+
+test('buildDeviceExportJsonl emits null for missing optional values', () => {
+  const jsonl = app.buildDeviceExportJsonl([
+    {
+      timestamp_ms: '2000',
+      node_id: 'node-b',
+      battery_mv: null,
+      wake_rssi_dbm: null,
+      firmware_version: null,
+      firmware_abi_version: null,
+      observed_schedule_interval_s: null,
+      observed_current_program_hash: null,
+      observed_assigned_program_hash: null,
+    },
+    {
+      timestamp_ms: '1000',
+      node_id: 'node-a',
+      battery_mv: '3300',
+      wake_rssi_dbm: '-58',
+      firmware_version: '1.0.0',
+      firmware_abi_version: '2',
+      observed_schedule_interval_s: '120',
+      observed_current_program_hash: 'aa',
+      observed_assigned_program_hash: 'ab',
+    },
+  ]);
+
+  const lines = jsonl.split('\n').map((line) => JSON.parse(line));
+  assert.deepEqual(lines[0], {
+    timestamp_ms: '1000',
+    node_id: 'node-a',
+    battery_mv: '3300',
+    wake_rssi_dbm: '-58',
+    firmware_version: '1.0.0',
+    firmware_abi_version: '2',
+    observed_schedule_interval_s: '120',
+    observed_current_program_hash: 'aa',
+    observed_assigned_program_hash: 'ab',
+  });
+  assert.deepEqual(lines[1], {
+    timestamp_ms: '2000',
+    node_id: 'node-b',
+    battery_mv: null,
+    wake_rssi_dbm: null,
+    firmware_version: null,
+    firmware_abi_version: null,
+    observed_schedule_interval_s: null,
+    observed_current_program_hash: null,
+    observed_assigned_program_hash: null,
   });
 });
 
@@ -221,6 +320,69 @@ test('querySensorDataRange follows continuation tokens until a partition is exha
     assert.equal(new URL(urls[1]).searchParams.get('NextPartitionKey'), 'page-2');
     assert.equal(new URL(urls[1]).searchParams.get('NextRowKey'), 'row-2');
     assert.deepEqual(authHeaders, ['Bearer token-123', 'Bearer token-123']);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('queryActualStateRange follows continuation tokens until a partition is exhausted', async () => {
+  const originalFetch = global.fetch;
+  app.CONFIG.storageAccount = 'exampleacct';
+  app.APP.account = { username: 'test@example.com' };
+  app.APP.msalApp = {
+    async acquireTokenSilent() {
+      return { accessToken: 'token-123' };
+    },
+    setActiveAccount() {},
+  };
+
+  const urls = [];
+  global.fetch = async (url) => {
+    urls.push(url);
+    const parsed = new URL(url);
+    const nextPartitionKey = parsed.searchParams.get('NextPartitionKey');
+
+    if (!nextPartitionKey) {
+      return {
+        ok: true,
+        async json() {
+          return { value: [{ timestamp_ms: '1000', node_id: 'node-a', battery_mv: '3300' }] };
+        },
+        async text() {
+          return '';
+        },
+        headers: {
+          get(name) {
+            if (name === 'x-ms-continuation-NextPartitionKey') return 'page-2';
+            if (name === 'x-ms-continuation-NextRowKey') return 'row-2';
+            return null;
+          },
+        },
+      };
+    }
+
+    return {
+      ok: true,
+      async json() {
+        return { value: [{ timestamp_ms: '2000', node_id: 'node-a', battery_mv: '3200' }] };
+      },
+      async text() {
+        return '';
+      },
+      headers: { get() { return null; } },
+    };
+  };
+
+  try {
+    const rows = await app.queryActualStateRange(['n:abc'], 1_000, 2_000, {
+      topPerPage: 1000,
+      maxPagesPerPartition: 10,
+    });
+
+    assert.equal(rows.length, 2);
+    assert.ok(urls[0].includes('/actualstate()'));
+    assert.equal(new URL(urls[1]).searchParams.get('NextPartitionKey'), 'page-2');
+    assert.equal(new URL(urls[1]).searchParams.get('NextRowKey'), 'row-2');
   } finally {
     global.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- add Dashboard export controls for historical device data from ctualstate
- export battery and WAKE RSSI diagnostics as .jsonl or .csv
- keep scope export-only: no new tab, no new Azure table

## Traceability
- requirements: add WEB-0105 for Dashboard device-data export and align WEB-0102 with the existing RSSI column
- design: specify Dashboard export behavior, paging, range validation, and file formats
- validation: add T-WEB-0109 through T-WEB-0115 for the new export path
- implementation: wire Dashboard export state/controls, reuse paged Azure Table range queries, and add targeted Node tests

## Verification
- 
ode --test tests/web-ui-app.test.js

## Audits
- specification audit: PASS
- implementation audit: PASS