### PR TITLE
Add Sensor Data preferences to environment export

### DIFF
--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -19,6 +19,7 @@ const ENV_ACTIVE_KEY = 'sonde_active_environment';
 const LEGACY_SERIES_OVERRIDES_KEY = 'sonde_series_overrides';
 const SENSOR_VIEW_MODES = new Set(['graph', 'table']);
 const SENSOR_TIME_RANGES = new Set(['1h', '24h', '7d']);
+const BLOCKED_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function createDefaultSensorDataPreferences() {
   return {
@@ -55,6 +56,9 @@ function normalizeSeriesOverrides(rawOverrides) {
   }
   const normalized = {};
   for (const [seriesKey, entry] of Object.entries(rawOverrides)) {
+    if (BLOCKED_OBJECT_KEYS.has(seriesKey)) {
+      continue;
+    }
     const normalizedEntry = normalizeSeriesOverrideEntry(entry);
     if (normalizedEntry) {
       normalized[seriesKey] = normalizedEntry;
@@ -119,6 +123,9 @@ function validateImportedSensorDataPreferences(rawPreferences) {
     }
     const overrides = {};
     for (const [seriesKey, entry] of Object.entries(rawPreferences.seriesOverrides)) {
+      if (BLOCKED_OBJECT_KEYS.has(seriesKey)) {
+        throw new Error(`\`sensorData.seriesOverrides.${seriesKey}\` uses a reserved key.`);
+      }
       if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
         throw new Error(`\`sensorData.seriesOverrides.${seriesKey}\` must be an object.`);
       }

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -16,13 +16,179 @@ const CONFIG = {
 
 const ENV_STORAGE_KEY = 'sonde_environments';
 const ENV_ACTIVE_KEY = 'sonde_active_environment';
+const LEGACY_SERIES_OVERRIDES_KEY = 'sonde_series_overrides';
+const SENSOR_VIEW_MODES = new Set(['graph', 'table']);
+const SENSOR_TIME_RANGES = new Set(['1h', '24h', '7d']);
+
+function createDefaultSensorDataPreferences() {
+  return {
+    viewMode: 'graph',
+    timeRange: '24h',
+    selectedSeries: [],
+    selectedSeriesInitialized: false,
+    seriesOverrides: {},
+  };
+}
+
+function normalizeSeriesOverrideEntry(entry) {
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+    return null;
+  }
+  const displayName = typeof entry.displayName === 'string' ? entry.displayName : '';
+  const unitSuffix = typeof entry.unitSuffix === 'string' ? entry.unitSuffix : '';
+  const scaleDivisor = typeof entry.scaleDivisor === 'number' && Number.isFinite(entry.scaleDivisor)
+    ? entry.scaleDivisor
+    : 0;
+  if (!displayName && !unitSuffix && scaleDivisor === 0) {
+    return null;
+  }
+  return {
+    displayName,
+    scaleDivisor,
+    unitSuffix,
+  };
+}
+
+function normalizeSeriesOverrides(rawOverrides) {
+  if (typeof rawOverrides !== 'object' || rawOverrides === null || Array.isArray(rawOverrides)) {
+    return {};
+  }
+  const normalized = {};
+  for (const [seriesKey, entry] of Object.entries(rawOverrides)) {
+    const normalizedEntry = normalizeSeriesOverrideEntry(entry);
+    if (normalizedEntry) {
+      normalized[seriesKey] = normalizedEntry;
+    }
+  }
+  return normalized;
+}
+
+function sanitizeSensorDataPreferences(rawPreferences) {
+  const defaults = createDefaultSensorDataPreferences();
+  if (typeof rawPreferences !== 'object' || rawPreferences === null || Array.isArray(rawPreferences)) {
+    return defaults;
+  }
+  return {
+    viewMode: SENSOR_VIEW_MODES.has(rawPreferences.viewMode) ? rawPreferences.viewMode : defaults.viewMode,
+    timeRange: SENSOR_TIME_RANGES.has(rawPreferences.timeRange) ? rawPreferences.timeRange : defaults.timeRange,
+    selectedSeries: Array.isArray(rawPreferences.selectedSeries)
+      ? rawPreferences.selectedSeries.filter((value) => typeof value === 'string')
+      : [],
+    selectedSeriesInitialized: typeof rawPreferences.selectedSeriesInitialized === 'boolean'
+      ? rawPreferences.selectedSeriesInitialized
+      : Array.isArray(rawPreferences.selectedSeries),
+    seriesOverrides: normalizeSeriesOverrides(rawPreferences.seriesOverrides),
+  };
+}
+
+function validateImportedSensorDataPreferences(rawPreferences) {
+  if (rawPreferences === undefined) {
+    return createDefaultSensorDataPreferences();
+  }
+  if (typeof rawPreferences !== 'object' || rawPreferences === null || Array.isArray(rawPreferences)) {
+    throw new Error('`sensorData` must be a JSON object.');
+  }
+
+  const preferences = createDefaultSensorDataPreferences();
+
+  if ('viewMode' in rawPreferences) {
+    if (typeof rawPreferences.viewMode !== 'string' || !SENSOR_VIEW_MODES.has(rawPreferences.viewMode)) {
+      throw new Error('`sensorData.viewMode` must be `graph` or `table`.');
+    }
+    preferences.viewMode = rawPreferences.viewMode;
+  }
+
+  if ('timeRange' in rawPreferences) {
+    if (typeof rawPreferences.timeRange !== 'string' || !SENSOR_TIME_RANGES.has(rawPreferences.timeRange)) {
+      throw new Error('`sensorData.timeRange` must be one of `1h`, `24h`, or `7d`.');
+    }
+    preferences.timeRange = rawPreferences.timeRange;
+  }
+
+  if ('selectedSeries' in rawPreferences) {
+    if (!Array.isArray(rawPreferences.selectedSeries) || rawPreferences.selectedSeries.some((value) => typeof value !== 'string')) {
+      throw new Error('`sensorData.selectedSeries` must be an array of strings.');
+    }
+    preferences.selectedSeries = [...rawPreferences.selectedSeries];
+    preferences.selectedSeriesInitialized = true;
+  }
+
+  if ('seriesOverrides' in rawPreferences) {
+    if (typeof rawPreferences.seriesOverrides !== 'object' || rawPreferences.seriesOverrides === null || Array.isArray(rawPreferences.seriesOverrides)) {
+      throw new Error('`sensorData.seriesOverrides` must be an object.');
+    }
+    const overrides = {};
+    for (const [seriesKey, entry] of Object.entries(rawPreferences.seriesOverrides)) {
+      if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+        throw new Error(`\`sensorData.seriesOverrides.${seriesKey}\` must be an object.`);
+      }
+      if ('displayName' in entry && typeof entry.displayName !== 'string') {
+        throw new Error(`\`sensorData.seriesOverrides.${seriesKey}.displayName\` must be a string.`);
+      }
+      if ('unitSuffix' in entry && typeof entry.unitSuffix !== 'string') {
+        throw new Error(`\`sensorData.seriesOverrides.${seriesKey}.unitSuffix\` must be a string.`);
+      }
+      if ('scaleDivisor' in entry && (typeof entry.scaleDivisor !== 'number' || !Number.isFinite(entry.scaleDivisor))) {
+        throw new Error(`\`sensorData.seriesOverrides.${seriesKey}.scaleDivisor\` must be a finite number.`);
+      }
+      const normalizedEntry = normalizeSeriesOverrideEntry(entry);
+      if (normalizedEntry) {
+        overrides[seriesKey] = normalizedEntry;
+      }
+    }
+    preferences.seriesOverrides = overrides;
+  }
+
+  return preferences;
+}
+
+function normalizeEnvironmentRecord(env) {
+  return {
+    name: typeof env?.name === 'string' ? env.name : '',
+    clientId: typeof env?.clientId === 'string' ? env.clientId : '',
+    tenantId: typeof env?.tenantId === 'string' ? env.tenantId : '',
+    storageAccount: typeof env?.storageAccount === 'string' ? env.storageAccount : '',
+    functionAppName: typeof env?.functionAppName === 'string' ? env.functionAppName : '',
+    sensorData: sanitizeSensorDataPreferences(env?.sensorData),
+  };
+}
+
+function buildEnvironmentExportData(env) {
+  const normalizedEnv = normalizeEnvironmentRecord(env);
+  return {
+    version: 1,
+    name: normalizedEnv.name,
+    clientId: normalizedEnv.clientId,
+    tenantId: normalizedEnv.tenantId,
+    storageAccount: normalizedEnv.storageAccount,
+    functionAppName: normalizedEnv.functionAppName,
+    sensorData: {
+      viewMode: normalizedEnv.sensorData.viewMode,
+      timeRange: normalizedEnv.sensorData.timeRange,
+      ...(normalizedEnv.sensorData.selectedSeriesInitialized
+        ? { selectedSeries: normalizedEnv.sensorData.selectedSeries }
+        : {}),
+      seriesOverrides: normalizedEnv.sensorData.seriesOverrides,
+    },
+  };
+}
+
+function loadLegacySeriesOverrides() {
+  try {
+    const raw = localStorage.getItem(LEGACY_SERIES_OVERRIDES_KEY);
+    if (!raw) return {};
+    return normalizeSeriesOverrides(JSON.parse(raw));
+  } catch {
+    return {};
+  }
+}
 
 function loadEnvironments() {
   try {
     const raw = localStorage.getItem(ENV_STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
+    return Array.isArray(parsed) ? parsed.map(normalizeEnvironmentRecord) : [];
   } catch {
     return [];
   }
@@ -30,7 +196,7 @@ function loadEnvironments() {
 
 function saveEnvironments(envs) {
   try {
-    localStorage.setItem(ENV_STORAGE_KEY, JSON.stringify(envs));
+    localStorage.setItem(ENV_STORAGE_KEY, JSON.stringify(envs.map(normalizeEnvironmentRecord)));
     return true;
   } catch {
     return false;
@@ -63,13 +229,47 @@ function applyEnvironment(env) {
   CONFIG.functionAppName = env.functionAppName || '';
 }
 
+function activateEnvironmentState(name, env) {
+  clearRefresh();
+  resetTransientSensorDataState();
+  setActiveEnvironmentName(name);
+  applyEnvironment(env);
+  applySensorDataPreferences(env?.sensorData);
+  APP.msalApp = null;
+  APP.account = null;
+  clearMsalSessionStorage();
+  updateEnvironmentIndicator();
+}
+
 function loadActiveEnvironment() {
-  const envs = loadEnvironments();
+  let envs = loadEnvironments();
   const activeName = getActiveEnvironmentName();
-  const env = envs.find((e) => e.name === activeName) || envs[0] || null;
+  let env = envs.find((e) => e.name === activeName) || envs[0] || null;
   if (env) {
     setActiveEnvironmentName(env.name);
+    const legacyOverrides = loadLegacySeriesOverrides();
+    if (Object.keys(legacyOverrides).length > 0 && Object.keys(env.sensorData.seriesOverrides).length === 0) {
+      const envIndex = envs.findIndex((entry) => entry.name === env.name);
+      if (envIndex >= 0) {
+        const migratedEnv = normalizeEnvironmentRecord(envs[envIndex]);
+        migratedEnv.sensorData.seriesOverrides = legacyOverrides;
+        const migratedEnvs = [...envs];
+        migratedEnvs[envIndex] = migratedEnv;
+        if (saveEnvironments(migratedEnvs)) {
+          envs = migratedEnvs;
+          env = migratedEnv;
+          try {
+            localStorage.removeItem(LEGACY_SERIES_OVERRIDES_KEY);
+          } catch {
+            // Storage may be unavailable; keep using environment-scoped preferences.
+          }
+        } else {
+          showViewMessage('error', 'Failed to migrate Sensor Data preferences. Browser storage may be disabled or full.');
+        }
+      }
+    }
     applyEnvironment(env);
+    applySensorDataPreferences(env.sensorData);
   }
   return env;
 }
@@ -138,6 +338,7 @@ function handleImportedJson(text) {
   };
   const validationError = validateEnvironmentFields(fields);
   if (validationError) throw new Error(validationError);
+  const sensorData = validateImportedSensorDataPreferences(data.sensorData);
 
   let name = typeof data.name === 'string' ? data.name.trim() : '';
   if (!name) {
@@ -162,7 +363,7 @@ function handleImportedJson(text) {
     }
   }
 
-  const envData = { name, ...fields };
+  const envData = { name, ...fields, sensorData };
   const idx = envs.findIndex((e) => e.name === name);
   if (idx >= 0) {
     envs[idx] = envData;
@@ -188,14 +389,7 @@ function handleImportedJson(text) {
 }
 
 function exportEnvironment(env) {
-  const data = {
-    version: 1,
-    name: env.name || '',
-    clientId: env.clientId || '',
-    tenantId: env.tenantId || '',
-    storageAccount: env.storageAccount || '',
-    functionAppName: env.functionAppName || '',
-  };
+  const data = buildEnvironmentExportData(env);
   const json = JSON.stringify(data, null, 2);
   const blob = new Blob([json], { type: 'application/json' });
 
@@ -1656,28 +1850,20 @@ async function renderPrograms() {
 
 // 8. Sensor Data Tab (WEB-0700)
 
-// Series display overrides persisted in localStorage.
-// Shape: { [seriesKey]: { displayName, scaleDivisor, unitSuffix } }
-const SERIES_OVERRIDES_KEY = 'sonde_series_overrides';
+// Series display overrides are stored with the active environment's Sensor Data
+// preferences rather than in a global key.
 
 function loadSeriesOverrides() {
-  try {
-    const raw = localStorage.getItem(SERIES_OVERRIDES_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw);
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
-    return parsed;
-  } catch { return {}; }
+  const envs = loadEnvironments();
+  const activeName = getActiveEnvironmentName();
+  const env = envs.find((entry) => entry.name === activeName) || envs[0] || null;
+  return env ? normalizeSeriesOverrides(env.sensorData.seriesOverrides) : {};
 }
 
 function saveSeriesOverrides(overrides) {
-  try {
-    localStorage.setItem(SERIES_OVERRIDES_KEY, JSON.stringify(overrides));
-  } catch {
-    // Storage disabled or quota exceeded — surface to caller via return value
-    return false;
-  }
-  return true;
+  return updateActiveEnvironmentSensorData((sensorData) => {
+    sensorData.seriesOverrides = normalizeSeriesOverrides(overrides);
+  });
 }
 
 function getSeriesDisplayLabel(series, overrides) {
@@ -1699,6 +1885,72 @@ function getSeriesUnitSuffix(seriesKey, overrides) {
   const ov = overrides || loadSeriesOverrides();
   const o = ov[seriesKey];
   return (o && o.unitSuffix) ? o.unitSuffix : '';
+}
+
+function applySensorDataPreferences(preferences) {
+  const normalized = sanitizeSensorDataPreferences(preferences);
+  SENSOR_STATE.timeRange = normalized.timeRange;
+  SENSOR_STATE.viewMode = normalized.viewMode;
+  SENSOR_STATE.selectedSeries = new Set(normalized.selectedSeries);
+  SENSOR_STATE.seriesInitialized = normalized.selectedSeriesInitialized === true;
+}
+
+function updateActiveEnvironmentSensorData(updater) {
+  const activeName = getActiveEnvironmentName();
+  if (!activeName) {
+    return false;
+  }
+  const envs = loadEnvironments();
+  const envIndex = envs.findIndex((entry) => entry.name === activeName);
+  if (envIndex < 0) {
+    return false;
+  }
+  const nextEnv = normalizeEnvironmentRecord(envs[envIndex]);
+  const nextSensorData = sanitizeSensorDataPreferences(nextEnv.sensorData);
+  updater(nextSensorData);
+  nextEnv.sensorData = nextSensorData;
+  const nextEnvs = [...envs];
+  nextEnvs[envIndex] = nextEnv;
+  return saveEnvironments(nextEnvs);
+}
+
+function persistActiveSensorDataPreferences() {
+  const currentOverrides = loadSeriesOverrides();
+  return updateActiveEnvironmentSensorData((sensorData) => {
+    sensorData.viewMode = SENSOR_VIEW_MODES.has(SENSOR_STATE.viewMode) ? SENSOR_STATE.viewMode : 'graph';
+    sensorData.timeRange = SENSOR_TIME_RANGES.has(SENSOR_STATE.timeRange) ? SENSOR_STATE.timeRange : '24h';
+    sensorData.selectedSeries = [...SENSOR_STATE.selectedSeries].filter((value) => typeof value === 'string');
+    sensorData.selectedSeriesInitialized = SENSOR_STATE.seriesInitialized === true || sensorData.selectedSeries.length > 0;
+    sensorData.seriesOverrides = normalizeSeriesOverrides(currentOverrides);
+  });
+}
+
+function persistActiveSensorDataPreferencesOrWarn() {
+  if (persistActiveSensorDataPreferences()) {
+    return true;
+  }
+  showViewMessage('error', 'Failed to save Sensor Data preferences. Browser storage may be disabled or full.');
+  return false;
+}
+
+function resetTransientSensorDataState() {
+  SENSOR_STATE.autoRefresh = false;
+  SENSOR_STATE.exportStartMs = null;
+  SENSOR_STATE.exportEndMs = null;
+  SENSOR_STATE.exportFormat = 'jsonl';
+  SENSOR_STATE.exportBusy = false;
+  SENSOR_STATE.exportMessage = null;
+}
+
+function pruneUnavailableSelectedSeries(selectedSeries, currentPlottableKeys) {
+  let changed = false;
+  for (const key of [...selectedSeries]) {
+    if (!currentPlottableKeys.has(key)) {
+      selectedSeries.delete(key);
+      changed = true;
+    }
+  }
+  return changed;
 }
 
 const SENSOR_STATE = {
@@ -2520,23 +2772,17 @@ async function renderSensorData() {
     const currentPlottableKeys = new Set(
       allSeries.filter((s) => s.points.length > 0).map((s) => s.key)
     );
-    const sizeBefore = SENSOR_STATE.selectedSeries.size;
-    for (const key of [...SENSOR_STATE.selectedSeries]) {
-      if (!currentPlottableKeys.has(key)) {
-        SENSOR_STATE.selectedSeries.delete(key);
-      }
-    }
-    const prunedCount = sizeBefore - SENSOR_STATE.selectedSeries.size;
-    if (SENSOR_STATE.selectedSeries.size === 0 && prunedCount > 0) {
-      SENSOR_STATE.seriesInitialized = false;
-    }
-
+    let selectionChanged = pruneUnavailableSelectedSeries(SENSOR_STATE.selectedSeries, currentPlottableKeys);
     if (!SENSOR_STATE.seriesInitialized && currentPlottableKeys.size > 0) {
       SENSOR_STATE.seriesInitialized = true;
       const plottable = allSeries.filter((s) => s.points.length > 0);
       for (const s of plottable.slice(0, Math.min(plottable.length, 5))) {
         SENSOR_STATE.selectedSeries.add(s.key);
       }
+      selectionChanged = true;
+    }
+    if (selectionChanged) {
+      persistActiveSensorDataPreferencesOrWarn();
     }
 
     const timeRangeButtons = Object.keys(TIME_RANGE_MS).map((range) => {
@@ -2625,6 +2871,7 @@ async function renderSensorData() {
     for (const btn of contentEl.querySelectorAll('.sensor-range-btn')) {
       btn.addEventListener('click', async () => {
         SENSOR_STATE.timeRange = btn.dataset.range;
+        persistActiveSensorDataPreferencesOrWarn();
         await renderSensorData();
       });
     }
@@ -2632,6 +2879,7 @@ async function renderSensorData() {
     for (const btn of contentEl.querySelectorAll('.sensor-view-btn')) {
       btn.addEventListener('click', async () => {
         SENSOR_STATE.viewMode = btn.dataset.view;
+        persistActiveSensorDataPreferencesOrWarn();
         await renderSensorData();
       });
     }
@@ -2648,6 +2896,7 @@ async function renderSensorData() {
         } else {
           SENSOR_STATE.selectedSeries.delete(cb.value);
         }
+        persistActiveSensorDataPreferencesOrWarn();
         if (SENSOR_STATE.viewMode === 'graph') {
           renderSensorChart(allSeries);
         }
@@ -2808,15 +3057,9 @@ function clearMsalSessionStorage() {
 }
 
 async function switchEnvironment(name) {
-  clearRefresh();
-  setActiveEnvironmentName(name);
   const envs = loadEnvironments();
   const env = envs.find((e) => e.name === name);
-  applyEnvironment(env);
-  APP.msalApp = null;
-  APP.account = null;
-  clearMsalSessionStorage();
-  updateEnvironmentIndicator();
+  activateEnvironmentState(name, env);
   await initMsal();
   await renderActiveTab();
 }
@@ -2903,6 +3146,8 @@ function showEnvironmentManager() {
         } else {
           clearRefresh();
           setActiveEnvironmentName('');
+          applySensorDataPreferences(createDefaultSensorDataPreferences());
+          resetTransientSensorDataState();
           CONFIG.msalClientId = '';
           CONFIG.msalAuthority = '';
           CONFIG.storageAccount = '';
@@ -2981,7 +3226,14 @@ function showEnvironmentForm(existingEnv) {
       return;
     }
 
-    const envData = { name, clientId, tenantId, storageAccount, functionAppName };
+    const envData = {
+      name,
+      clientId,
+      tenantId,
+      storageAccount,
+      functionAppName,
+      sensorData: existingEnv?.sensorData || createDefaultSensorDataPreferences(),
+    };
     if (isEdit) {
       const idx = envs.findIndex((e) => e.name === name);
       if (idx >= 0) envs[idx] = envData;
@@ -3019,7 +3271,20 @@ if (typeof module !== 'undefined' && module.exports) {
     actualStateFilter,
     queryActualStateRange,
     querySensorDataRange,
+    buildEnvironmentExportData,
+    activateEnvironmentState,
+    createDefaultSensorDataPreferences,
+    handleImportedJson,
+    loadActiveEnvironment,
+    loadEnvironments,
+    normalizeEnvironmentRecord,
+    persistActiveSensorDataPreferences,
+    pruneUnavailableSelectedSeries,
+    sanitizeSensorDataPreferences,
     sensorDataFilter,
+    SENSOR_STATE,
+    saveSeriesOverrides,
+    validateImportedSensorDataPreferences,
   };
 }
 

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -2780,6 +2780,10 @@ async function renderSensorData() {
       allSeries.filter((s) => s.points.length > 0).map((s) => s.key)
     );
     let selectionChanged = pruneUnavailableSelectedSeries(SENSOR_STATE.selectedSeries, currentPlottableKeys);
+    if (selectionChanged && SENSOR_STATE.selectedSeries.size === 0) {
+      SENSOR_STATE.seriesInitialized = false;
+    }
+
     if (!SENSOR_STATE.seriesInitialized && currentPlottableKeys.size > 0) {
       SENSOR_STATE.seriesInitialized = true;
       const plottable = allSeries.filter((s) => s.points.length > 0);

--- a/deploy/web-ui/app.js
+++ b/deploy/web-ui/app.js
@@ -1940,6 +1940,21 @@ function persistActiveSensorDataPreferencesOrWarn() {
   return false;
 }
 
+function clearPersistedSelectedSeriesPreference() {
+  return updateActiveEnvironmentSensorData((sensorData) => {
+    sensorData.selectedSeries = [];
+    sensorData.selectedSeriesInitialized = false;
+  });
+}
+
+function clearPersistedSelectedSeriesPreferenceOrWarn() {
+  if (clearPersistedSelectedSeriesPreference()) {
+    return true;
+  }
+  showViewMessage('error', 'Failed to save Sensor Data preferences. Browser storage may be disabled or full.');
+  return false;
+}
+
 function resetTransientSensorDataState() {
   SENSOR_STATE.autoRefresh = false;
   SENSOR_STATE.exportStartMs = null;
@@ -2779,9 +2794,17 @@ async function renderSensorData() {
     const currentPlottableKeys = new Set(
       allSeries.filter((s) => s.points.length > 0).map((s) => s.key)
     );
+    const hadExplicitSelectionPreference = SENSOR_STATE.seriesInitialized;
     let selectionChanged = pruneUnavailableSelectedSeries(SENSOR_STATE.selectedSeries, currentPlottableKeys);
     if (selectionChanged && SENSOR_STATE.selectedSeries.size === 0) {
       SENSOR_STATE.seriesInitialized = false;
+    }
+    if (selectionChanged && hadExplicitSelectionPreference) {
+      if (SENSOR_STATE.selectedSeries.size === 0) {
+        clearPersistedSelectedSeriesPreferenceOrWarn();
+      } else {
+        persistActiveSensorDataPreferencesOrWarn();
+      }
     }
 
     if (!SENSOR_STATE.seriesInitialized && currentPlottableKeys.size > 0) {
@@ -2790,10 +2813,6 @@ async function renderSensorData() {
       for (const s of plottable.slice(0, Math.min(plottable.length, 5))) {
         SENSOR_STATE.selectedSeries.add(s.key);
       }
-      selectionChanged = true;
-    }
-    if (selectionChanged) {
-      persistActiveSensorDataPreferencesOrWarn();
     }
 
     const timeRangeButtons = Object.keys(TIME_RANGE_MS).map((range) => {
@@ -3285,6 +3304,7 @@ if (typeof module !== 'undefined' && module.exports) {
     buildEnvironmentExportData,
     activateEnvironmentState,
     createDefaultSensorDataPreferences,
+    clearPersistedSelectedSeriesPreference,
     handleImportedJson,
     loadActiveEnvironment,
     loadEnvironments,

--- a/docs/web-ui-design.md
+++ b/docs/web-ui-design.md
@@ -421,17 +421,52 @@ A **Reset to Default** button clears overrides for the series.
 
 #### Persistence
 
-Overrides are stored in `localStorage` under the key
-`sonde_series_overrides` as a JSON object keyed by series key
+Overrides are stored in the active environment's `sensorData.seriesOverrides`
+map as a JSON object keyed by series key
 (`partitionKey|programHash|readingName`). Each entry has the shape:
 
 ```json
 { "displayName": "string", "scaleDivisor": number, "unitSuffix": "string" }
 ```
 
-Overrides survive page reloads and browser restarts. They are scoped to
-the browser origin (per localStorage rules) and are not shared across
-devices.
+Overrides survive page reloads and browser restarts. They are scoped to the
+active environment and round-trip through the environment import/export schema.
+
+### 10.4b  Sensor Data preference persistence (WEB-0705)
+
+The Sensor Data tab persists operator preferences as part of the active
+environment record rather than in a global Sensor Data storage bucket.
+
+**Persisted fields:**
+- `viewMode` — `graph` or `table`
+- `timeRange` — one of the supported preset ranges (`1h`, `24h`, `7d`)
+- `selectedSeries` — array of series keys
+  (`partitionKey|programHash|readingName`)
+- `selectedSeriesInitialized` — internal local-storage-only boolean that
+  distinguishes "no explicit series selection has been saved yet" from
+  "the operator intentionally saved an empty selection"
+- `seriesOverrides` — the WEB-0703 per-series override map
+
+**Behavior:**
+- Sensor Data preference changes are saved back into the active environment's
+  object in `sonde_environments`.
+- When the SPA loads or the user switches environments, the Sensor Data tab
+  restores the active environment's saved preferences before rendering.
+- Export/import distinguishes between omitted and empty `selectedSeries`:
+  omitting the field means "no explicit selection has been saved yet, so use the
+  default initial auto-selection behavior", while `selectedSeries: []` means
+  "preserve an intentionally empty graph selection".
+- If a saved `selectedSeries` entry does not correspond to any currently
+  available series, the renderer prunes it without error.
+- Export-form fields (`start`, `end`, `format`), status banners, and other
+  transient Sensor Data UI state are not persisted.
+
+**Legacy migration:**
+- On the first run after this feature ships, if the active environment has no
+  `sensorData.seriesOverrides` data but the legacy global
+  `sonde_series_overrides` key exists, the SPA copies those overrides into the
+  active environment and then stops using the legacy global key for normal
+  reads/writes.
 
 ### 10.5  Sensor data export (WEB-0704)
 
@@ -491,7 +526,14 @@ Each environment is a JSON object stored in `localStorage`:
   "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "storageAccount": "mystorageaccount",
-  "functionAppName": "sonde-decoder-xxxx"
+  "functionAppName": "sonde-decoder-xxxx",
+  "sensorData": {
+    "viewMode": "graph",
+    "timeRange": "24h",
+    "selectedSeries": [],
+    "selectedSeriesInitialized": false,
+    "seriesOverrides": {}
+  }
 }
 ```
 
@@ -514,16 +556,30 @@ for forward compatibility:
   "clientId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "tenantId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
   "storageAccount": "mystorageaccount",
-  "functionAppName": "sonde-decoder-xxxx"
+  "functionAppName": "sonde-decoder-xxxx",
+  "sensorData": {
+    "viewMode": "graph",
+    "timeRange": "24h",
+    "selectedSeries": [],
+    "seriesOverrides": {}
+  }
 }
 ```
 
 The `version` field MUST be integer `1`. Files with any other version value are
-rejected. Extra properties beyond the defined schema are silently ignored to
-allow forward-compatible extensions.
+rejected. The `sensorData` object is optional on import for backward
+compatibility with previously exported files and Azure companion bootstrap
+output; when omitted, the SPA uses default Sensor Data preferences. Within
+`sensorData`, `selectedSeries` is also optional: omission means no explicit
+selection has been saved yet, while an empty array preserves an intentional
+empty selection. The local-storage-only `selectedSeriesInitialized` flag is not
+serialized into the import/export file; omission versus presence of
+`selectedSeries` carries that distinction on the wire. Extra properties beyond
+the defined schema are silently ignored to allow forward-compatible extensions.
 
 The Azure companion bootstrap emits this file as `web-ui-environment.json` with
-`name` set to empty string — the SPA prompts the user for a name during import.
+`name` set to empty string and no `sensorData` object — the SPA prompts the
+user for a name during import and fills in default Sensor Data preferences.
 
 ### 11.3 Authority Derivation
 
@@ -557,19 +613,27 @@ accepting `.json` files. After selection:
    file version" error.
 3. Validate the four data fields using the same rules as the manual form
    (WEB-0802).
-4. If `name` is blank/missing, show a name input prompt before saving.
-5. If `name` matches an existing environment, show a conflict dialog offering
+4. If a `sensorData` object is present, validate `viewMode`, `timeRange`,
+   `selectedSeries`, and each `seriesOverrides` entry. Reject invalid
+   preference shapes instead of partially importing them.
+5. If `sensorData` is absent, initialize it to the default preference object.
+6. If `name` is blank/missing, show a name input prompt before saving.
+7. If `name` matches an existing environment, show a conflict dialog offering
    "Overwrite" or "Rename" options.
-6. If overwriting the active environment, trigger the full re-initialization
+8. Import overwrite semantics are replace, not merge: the imported
+   `sensorData` object replaces the destination environment's saved Sensor Data
+   preferences.
+9. If overwriting the active environment, trigger the full re-initialization
    sequence (WEB-0806): clear MSAL state, re-create MSAL instance, re-render.
-7. Save the environment to `localStorage` and refresh the environment list.
+10. Save the environment to `localStorage` and refresh the environment list.
 
 **Export (WEB-0808):** Each row's Export button serializes the environment to a
 JSON file using the import/export schema (§11.2b) and triggers a browser
 download. The filename is derived from the environment name with characters
 unsafe for filesystems (slashes, colons, control characters) replaced by
 hyphens. If the sanitized name is empty, the fallback `sonde-environment.json`
-is used.
+is used. Export always includes the environment's current `sensorData`
+preferences object.
 
 **Header indicator:** The active environment name is displayed in the top bar
 next to a ⚙ gear button that opens the environment manager modal.
@@ -584,7 +648,9 @@ When the user switches to a different environment:
 4. The active MSAL account is cleared
 5. MSAL-related `sessionStorage` keys are cleared (keys starting with `msal.` or containing `.login.` or `.acquireToken.`) — other session data is preserved
 6. A new MSAL instance is initialized with the new environment's credentials
-7. The active tab is re-rendered
+7. The active environment's `sensorData` preferences are loaded into the Sensor
+   Data view state
+8. The active tab is re-rendered
 
 ---
 

--- a/docs/web-ui-requirements.md
+++ b/docs/web-ui-requirements.md
@@ -839,7 +839,7 @@ modal dialog.
 3. Custom display name replaces the default label in series picker, chart legend, and tooltip.
 4. Scale divisor transforms plotted values (e.g., 1000 converts 21500 → 21.5).
 5. Unit suffix appears in tooltip values and Y-axis title (when all series share the same suffix).
-6. Overrides persist in `localStorage` under `sonde_series_overrides`.
+6. Overrides persist as part of the active environment's Sensor Data preferences and round-trip through environment export/import.
 7. Reset to Default clears overrides and restores original label/scale.
 8. The dialog has focus trapping and closes on Escape.
 
@@ -877,6 +877,37 @@ start/end time range as either `.jsonl` or `.csv`.
 
 ---
 
+### WEB-0705  Sensor Data Preference Persistence
+
+**Priority:** Should
+**Source:** User request (2026-06-12), web-ui-design.md §10.4b
+**Confidence:** High
+
+**Description:**
+The SPA MUST persist operator Sensor Data display preferences with each
+environment so they survive page reloads, environment export/import, and
+self-hosted SPA updates.
+
+**Acceptance criteria:**
+
+1. Each environment stores a Sensor Data preferences object containing `viewMode`,
+   preset `timeRange`, `selectedSeries`, and per-series display overrides.
+2. `viewMode` persists only the graph/table preference; export-form inputs,
+   export status messages, and other transient UI state are not persisted.
+3. Switching environments activates that environment's saved Sensor Data
+   preferences without reusing preferences from a different environment.
+4. Imported environment files that omit Sensor Data preferences remain valid and
+   use default Sensor Data preferences after import.
+5. On first run after upgrading from the legacy global storage model, the SPA
+   migrates any existing `sonde_series_overrides` data into the active
+   environment's per-series overrides.
+6. Export/import distinguishes between an omitted `selectedSeries` field
+   ("use the default initial auto-selection behavior") and a present empty
+   `selectedSeries: []` field ("preserve an intentionally empty series
+   selection").
+
+---
+
 ## 12  Environment Manager (WEB-0800)
 
 ### WEB-0800  Runtime Environment Configuration
@@ -892,8 +923,11 @@ without redeployment. Environments are stored in `localStorage`.
 **Acceptance criteria:**
 
 1. No deploy-time configuration file is required for normal operation.
-2. Each environment stores: name, clientId, tenantId, storageAccount, functionAppName.
+2. Each environment stores: name, clientId, tenantId, storageAccount,
+   functionAppName, and Sensor Data preferences.
 3. Environments are persisted in `localStorage` under `sonde_environments`.
+4. Sensor Data preferences are scoped to their environment and do not leak
+   across environment switches.
 
 ---
 
@@ -909,7 +943,7 @@ Adding an environment MUST persist all fields to `localStorage` under the
 
 **Acceptance criteria:**
 
-1. All five fields (name, clientId, tenantId, storageAccount, functionAppName) are stored.
+1. All environment fields, including Sensor Data preferences, are stored.
 2. The environment is retrievable after page reload.
 
 ---
@@ -990,12 +1024,22 @@ when the `name` field is blank, and handles conflicts with existing environments
 2. Clicking Import opens a file picker accepting `.json` files.
 3. The file MUST contain `version` equal to integer `1`; files with missing, non-numeric, zero, or greater-than-1 version values are rejected with an error message.
 4. The four data fields (`clientId`, `tenantId`, `storageAccount`, `functionAppName`) are validated using the same rules as WEB-0802.
-5. If `name` is blank or missing, a name prompt is shown before saving.
-6. If `name` conflicts with an existing environment, a prompt offers overwrite or rename.
-7. Overwriting the active environment triggers the full re-initialization sequence defined by WEB-0806.
-8. Successfully imported environments appear in the environment list and are persisted to `localStorage`.
-9. Non-JSON files, files with missing required fields, and files with a top-level type other than object are rejected with a descriptive error message.
-10. Extra JSON properties beyond the defined schema are ignored.
+5. If an optional `sensorData` object is present, `viewMode` is limited to
+   `graph` or `table`, `timeRange` is limited to the supported preset values,
+   `selectedSeries` is an array of strings, and each per-series override value
+   has `displayName` string, finite numeric `scaleDivisor`, and `unitSuffix`
+   string fields when present.
+6. If `sensorData` is absent, or if `sensorData.selectedSeries` is absent, the
+   imported environment uses default Sensor Data preferences for the missing
+   portion.
+7. If `name` is blank or missing, a name prompt is shown before saving.
+8. If `name` conflicts with an existing environment, a prompt offers overwrite or rename.
+9. Importing over an existing environment replaces that environment's Sensor
+   Data preferences with the imported values.
+10. Overwriting the active environment triggers the full re-initialization sequence defined by WEB-0806.
+11. Successfully imported environments appear in the environment list and are persisted to `localStorage`.
+12. Non-JSON files, files with missing required fields, and files with a top-level type other than object are rejected with a descriptive error message.
+13. Extra JSON properties beyond the defined schema are ignored.
 
 ---
 
@@ -1015,7 +1059,8 @@ import-compatible schema.
 1. Each environment row has an Export button alongside Use, Edit, and Delete.
 2. Clicking Export triggers a browser download of a `.json` file.
 3. The filename is derived from the environment name with unsafe filesystem characters replaced; if the result is empty, the fallback filename `sonde-environment.json` is used.
-4. The exported file contains `version` (integer 1) and all five fields (`name`, `clientId`, `tenantId`, `storageAccount`, `functionAppName`).
+4. The exported file contains `version` (integer 1), the five environment
+   connection fields, and the environment's Sensor Data preferences.
 5. The exported file is valid for re-import via WEB-0807.
 
 ---
@@ -1055,6 +1100,8 @@ re-initialize authentication and refresh the active tab.
 5. MSAL-related `sessionStorage` keys are cleared (not all session storage).
 6. A new MSAL instance is initialized with the new environment's credentials.
 7. The active tab is re-rendered.
+8. The active environment's Sensor Data preferences are loaded before the
+   Sensor Data tab is rendered again.
 
 ---
 

--- a/docs/web-ui-validation.md
+++ b/docs/web-ui-validation.md
@@ -93,16 +93,17 @@ and verifies one or more acceptance criteria.
 | WEB-0701 | T-WEB-0702, T-WEB-0703, T-WEB-0706, T-WEB-0713, T-WEB-0714, T-WEB-0715, T-WEB-0702b, T-WEB-0703b |
 | WEB-0702 | T-WEB-0704, T-WEB-0705, T-WEB-0704b, T-WEB-0704c |
 | WEB-0703 | T-WEB-0707, T-WEB-0708, T-WEB-0709, T-WEB-0710, T-WEB-0711, T-WEB-0712, T-WEB-0707b |
+| WEB-0705 | T-WEB-0723, T-WEB-0724, T-WEB-0725, T-WEB-0726, T-WEB-0802b |
 | WEB-0704 | T-WEB-0716, T-WEB-0717, T-WEB-0718, T-WEB-0719, T-WEB-0720, T-WEB-0721, T-WEB-0722 |
-| WEB-0800 | T-WEB-0801, T-WEB-0802, T-WEB-0803, T-WEB-0804, T-WEB-0805, T-WEB-0806 |
+| WEB-0800 | T-WEB-0801, T-WEB-0802, T-WEB-0802b, T-WEB-0803, T-WEB-0804, T-WEB-0805, T-WEB-0806 |
 | WEB-0801 | T-WEB-0802 |
 | WEB-0802 | T-WEB-0806, T-WEB-0807, T-WEB-0808, T-WEB-0809 |
 | WEB-0803 | T-WEB-0801, T-WEB-0801b, T-WEB-0818 |
 | WEB-0804 | T-WEB-0805, T-WEB-0805b, T-WEB-0805c |
-| WEB-0807 | T-WEB-0810, T-WEB-0811, T-WEB-0812, T-WEB-0813, T-WEB-0814, T-WEB-0815, T-WEB-0819, T-WEB-0820, T-WEB-0821, T-WEB-0822 |
+| WEB-0807 | T-WEB-0810, T-WEB-0810b, T-WEB-0810c, T-WEB-0811, T-WEB-0812, T-WEB-0813, T-WEB-0814, T-WEB-0815, T-WEB-0815b, T-WEB-0819, T-WEB-0820, T-WEB-0821, T-WEB-0822 |
 | WEB-0808 | T-WEB-0816, T-WEB-0816b, T-WEB-0816c, T-WEB-0817 |
 | WEB-0805 | T-WEB-0804, T-WEB-0804b |
-| WEB-0806 | T-WEB-0803, T-WEB-0803b, T-WEB-0803c, T-WEB-0803d, T-WEB-0803d2, T-WEB-0803e, T-WEB-0803f, T-WEB-0803g |
+| WEB-0806 | T-WEB-0803, T-WEB-0803b, T-WEB-0803c, T-WEB-0803d, T-WEB-0803d2, T-WEB-0803e, T-WEB-0803f, T-WEB-0803g, T-WEB-0803h |
 | WEB-0901 | T-WEB-0901, T-WEB-0901b, T-WEB-0901c |
 | WEB-0902 | T-WEB-0902, T-WEB-0902b |
 | WEB-1001 | T-WEB-1001, T-WEB-1001b, T-WEB-1001c, T-WEB-1001d |
@@ -248,7 +249,7 @@ and verifies one or more acceptance criteria.
 | T-WEB-0708 | WEB-0703 | Custom display name replaces default label in series picker, chart legend, and tooltip | Manual | Planned |
 | T-WEB-0709 | WEB-0703 | Scale divisor transforms plotted values (e.g., 1000 converts 21500 → 21.5) | Manual | Planned |
 | T-WEB-0710 | WEB-0703 | Unit suffix appears in tooltip values and Y-axis title when all series share the same suffix | Manual | Planned |
-| T-WEB-0711 | WEB-0703 | Overrides persist across page reloads via `localStorage` | Manual | Planned |
+| T-WEB-0711 | WEB-0703 | Per-series display overrides persist with the active environment across page reloads | Manual | Planned |
 | T-WEB-0712 | WEB-0703 | Reset to Default clears overrides and restores original label/scale | Manual | Planned |
 | T-WEB-0716 | WEB-0704 | Sensor Data tab exposes export start/end controls, format selector, and Export action | Manual/E2E | Planned |
 | T-WEB-0717 | WEB-0704 | JSONL export writes one JSON object per line with the required five fields and `decoded_readings: null` for empty rows | Manual/E2E | Planned |
@@ -257,6 +258,10 @@ and verifies one or more acceptance criteria.
 | T-WEB-0720 | WEB-0704 | Export follows Azure Table continuation tokens so ranges with more than 1000 rows per node export completely | Unit (JS) | Pass |
 | T-WEB-0721 | WEB-0704 | Missing or inverted export start/end values are rejected with operator-visible feedback and no file download | Manual | Planned |
 | T-WEB-0722 | WEB-0704 | Export includes matching rows from multiple known node partitions within the selected range | Manual/E2E | Planned |
+| T-WEB-0723 | WEB-0705 | Graph/table mode and preset Sensor Data time range persist with the environment across reload and export/import | Manual | Planned |
+| T-WEB-0724 | WEB-0705 | Selected series are environment-scoped and unavailable saved series are ignored without error when rendering | Unit (JS) | Pass |
+| T-WEB-0725 | WEB-0705 | Export/import preserves explicit empty `selectedSeries: []` while treating omitted `selectedSeries` as the default initial auto-selection behavior | Unit (JS) | Pass |
+| T-WEB-0726 | WEB-0705 | Environment activation clears transient Sensor Data export state and auto-refresh instead of carrying it across environments | Unit (JS) | Pass |
 
 ### 5.8  Environment Manager
 
@@ -265,6 +270,7 @@ and verifies one or more acceptance criteria.
 | T-WEB-0801 | WEB-0803 | First load with no environments shows full-screen setup modal; main UI is inaccessible | Manual | Planned |
 | T-WEB-0801b | WEB-0803 | Setup modal cannot be closed without adding an environment (no Close button) | Manual | Planned |
 | T-WEB-0802 | WEB-0801 | Adding an environment persists all fields to `localStorage` under `sonde_environments` | Manual | Planned |
+| T-WEB-0802b | WEB-0800 | First run after upgrade migrates legacy `sonde_series_overrides` into the active environment's Sensor Data preferences | Manual | Planned |
 | T-WEB-0803 | WEB-0806 | Switching environment re-initializes MSAL, clears session, and refreshes active tab | Manual | Planned |
 | T-WEB-0803b | WEB-0806 | Auto-refresh timer cleared on environment switch | Manual | Planned |
 | T-WEB-0803c | WEB-0806 | `CONFIG` fields updated from selected environment | Manual | Planned |
@@ -273,6 +279,7 @@ and verifies one or more acceptance criteria.
 | T-WEB-0803e | WEB-0806 | Active MSAL account cleared on switch | Manual | Planned |
 | T-WEB-0803f | WEB-0806 | Only MSAL-related `sessionStorage` keys cleared (other session data preserved) | Manual | Planned |
 | T-WEB-0803g | WEB-0806 | Active tab re-rendered after switch | Manual | Planned |
+| T-WEB-0803h | WEB-0806 | Switching environments loads that environment's saved Sensor Data preferences before the Sensor Data tab re-renders | Unit (JS) | Pass |
 | T-WEB-0804 | WEB-0805 | Active environment name displayed in header bar | Manual | Planned |
 | T-WEB-0804b | WEB-0805 | Environment indicator updates when environment is switched | Manual | Planned |
 | T-WEB-0805 | WEB-0804 | Edit and delete operations on environments work correctly | Manual | Planned |
@@ -284,16 +291,19 @@ and verifies one or more acceptance criteria.
 
 | Test ID | Requirement | Description | Method | Status |
 |---|---|---|---|---|
-| T-WEB-0810 | WEB-0807 | Importing a valid `.json` file with all fields adds the environment to the list | Manual | Planned |
+| T-WEB-0810 | WEB-0807 | Importing a valid `.json` file with all required connection fields adds the environment to the list | Manual | Planned |
+| T-WEB-0810b | WEB-0807 | Importing a valid `sensorData` object restores view mode, preset time range, selected series, and per-series overrides | Manual | Planned |
+| T-WEB-0810c | WEB-0807 | Importing a legacy environment file without `sensorData` succeeds and initializes default Sensor Data preferences | Manual | Planned |
 | T-WEB-0811 | WEB-0807 | Importing a file with blank `name` prompts user for a name before saving | Manual | Planned |
 | T-WEB-0812 | WEB-0807 | Importing a file with a name that conflicts with an existing environment offers overwrite or rename | Manual | Planned |
 | T-WEB-0813 | WEB-0807 | Importing a file with `version` other than `1` (missing, zero, greater) is rejected with error | Manual | Planned |
 | T-WEB-0814 | WEB-0807, WEB-0802 | Importing a file with invalid field values (bad GUID, wrong storage account format) is rejected | Manual | Planned |
 | T-WEB-0815 | WEB-0807 | Overwriting the active environment via import triggers MSAL re-initialization | Manual | Planned |
-| T-WEB-0816 | WEB-0808 | Export button downloads a `.json` file with `version: 1` and all five fields | Manual | Planned |
+| T-WEB-0815b | WEB-0807 | Import overwrite replaces, rather than merges, the destination environment's saved Sensor Data preferences | Manual | Planned |
+| T-WEB-0816 | WEB-0808 | Export button downloads a `.json` file with `version: 1`, the five environment fields, and the `sensorData` object | Manual | Planned |
 | T-WEB-0816b | WEB-0808 | Export of an environment with unsafe filename characters (slashes, colons) produces a sanitized filename | Manual | Planned |
 | T-WEB-0816c | WEB-0808 | Export of an environment whose sanitized name is empty uses fallback `sonde-environment.json` | Manual | Planned |
-| T-WEB-0817 | WEB-0807, WEB-0808 | Exported file round-trips through import: export → import into fresh browser → environment is functional | Manual | Planned |
+| T-WEB-0817 | WEB-0807, WEB-0808 | Exported file round-trips through import: export → import into fresh browser → environment connection fields and Sensor Data preferences are preserved | Manual | Planned |
 | T-WEB-0818 | WEB-0803 | First-load setup modal includes Import button and accepts environment file | Manual | Planned |
 | T-WEB-0819 | WEB-0807 | Importing a non-JSON file (e.g., plain text, binary) is rejected with a descriptive error | Manual | Planned |
 | T-WEB-0820 | WEB-0807 | Importing a JSON file with top-level array, null, or string is rejected | Manual | Planned |

--- a/tests/web-ui-app.test.js
+++ b/tests/web-ui-app.test.js
@@ -77,6 +77,8 @@ const app = require(path.resolve(__dirname, '..', 'deploy', 'web-ui', 'app.js'))
 
 test.beforeEach(() => {
   resetStorages();
+  global.window.confirm = () => false;
+  global.window.prompt = () => null;
   app.SENSOR_STATE.timeRange = '24h';
   app.SENSOR_STATE.viewMode = 'graph';
   app.SENSOR_STATE.selectedSeries = new Set();
@@ -623,6 +625,14 @@ test('validateImportedSensorDataPreferences rejects malformed selectedSeries arr
   assert.throws(
     () => app.validateImportedSensorDataPreferences({ selectedSeries: ['ok', 42] }),
     /selectedSeries/,
+  );
+});
+
+test('validateImportedSensorDataPreferences rejects reserved series override keys', () => {
+  const payload = JSON.parse('{"seriesOverrides":{"__proto__":{"displayName":"bad"}}}');
+  assert.throws(
+    () => app.validateImportedSensorDataPreferences(payload),
+    /reserved key/,
   );
 });
 

--- a/tests/web-ui-app.test.js
+++ b/tests/web-ui-app.test.js
@@ -678,6 +678,35 @@ test('persistActiveSensorDataPreferences stores environment-scoped Sensor Data v
   });
 });
 
+test('clearPersistedSelectedSeriesPreference restores default-selection semantics', () => {
+  localStorage.setItem('sonde_environments', JSON.stringify([
+    {
+      name: 'prod',
+      clientId: '11111111-1111-1111-1111-111111111111',
+      tenantId: '22222222-2222-2222-2222-222222222222',
+      storageAccount: 'prodstorage',
+      functionAppName: 'prod-func',
+      sensorData: {
+        viewMode: 'graph',
+        timeRange: '24h',
+        selectedSeries: ['stale-series'],
+        selectedSeriesInitialized: true,
+        seriesOverrides: {},
+      },
+    },
+  ]));
+  localStorage.setItem('sonde_active_environment', 'prod');
+
+  assert.equal(app.clearPersistedSelectedSeriesPreference(), true);
+  assert.deepEqual(app.loadEnvironments()[0].sensorData, {
+    viewMode: 'graph',
+    timeRange: '24h',
+    selectedSeries: [],
+    selectedSeriesInitialized: false,
+    seriesOverrides: {},
+  });
+});
+
 test('buildEnvironmentExportData includes environment-scoped Sensor Data preferences', () => {
   assert.deepEqual(
     app.buildEnvironmentExportData({

--- a/tests/web-ui-app.test.js
+++ b/tests/web-ui-app.test.js
@@ -774,6 +774,20 @@ test('pruneUnavailableSelectedSeries removes stale saved selections without touc
   assert.deepEqual([...selectedSeries], ['keep']);
 });
 
+test('pruning all stale saved selections re-enables default auto-selection behavior', () => {
+  app.SENSOR_STATE.selectedSeries = new Set(['stale-series']);
+  app.SENSOR_STATE.seriesInitialized = true;
+
+  const changed = app.pruneUnavailableSelectedSeries(app.SENSOR_STATE.selectedSeries, new Set());
+  if (changed && app.SENSOR_STATE.selectedSeries.size === 0) {
+    app.SENSOR_STATE.seriesInitialized = false;
+  }
+
+  assert.equal(changed, true);
+  assert.deepEqual([...app.SENSOR_STATE.selectedSeries], []);
+  assert.equal(app.SENSOR_STATE.seriesInitialized, false);
+});
+
 test('buildEnvironmentExportData and import validation distinguish omitted and empty selectedSeries', () => {
   const defaultExport = app.buildEnvironmentExportData({
     name: 'prod',

--- a/tests/web-ui-app.test.js
+++ b/tests/web-ui-app.test.js
@@ -41,6 +41,7 @@ function makeElement() {
     remove() {},
     appendChild() {},
     removeChild() {},
+    insertAdjacentHTML() {},
     addEventListener() {},
     querySelector() { return null; },
     querySelectorAll() { return []; },
@@ -48,10 +49,17 @@ function makeElement() {
   };
 }
 
+function resetStorages() {
+  global.localStorage = makeStorage();
+  global.sessionStorage = makeStorage();
+}
+
 global.window = {
   __SONDE_TEST__: true,
   opener: null,
   location: { origin: 'https://example.test', pathname: '/', hash: '' },
+  prompt: () => null,
+  confirm: () => false,
 };
 global.document = {
   addEventListener() {},
@@ -60,13 +68,28 @@ global.document = {
   createElement() { return makeElement(); },
   body: makeElement(),
 };
-global.localStorage = makeStorage();
-global.sessionStorage = makeStorage();
+resetStorages();
 global.crypto = webcrypto;
 global.atob = (value) => Buffer.from(value, 'base64').toString('binary');
 global.btoa = (value) => Buffer.from(value, 'binary').toString('base64');
 
 const app = require(path.resolve(__dirname, '..', 'deploy', 'web-ui', 'app.js'));
+
+test.beforeEach(() => {
+  resetStorages();
+  app.SENSOR_STATE.timeRange = '24h';
+  app.SENSOR_STATE.viewMode = 'graph';
+  app.SENSOR_STATE.selectedSeries = new Set();
+  app.SENSOR_STATE.seriesInitialized = false;
+  app.SENSOR_STATE.autoRefresh = false;
+  app.SENSOR_STATE.exportStartMs = null;
+  app.SENSOR_STATE.exportEndMs = null;
+  app.SENSOR_STATE.exportFormat = 'jsonl';
+  app.SENSOR_STATE.exportBusy = false;
+  app.SENSOR_STATE.exportMessage = null;
+  app.APP.account = null;
+  app.APP.msalApp = null;
+});
 
 test('sensorDataFilter uses reverse-timestamp bounds for the requested range', () => {
   const max = BigInt('0xffffffffffffffff');
@@ -428,4 +451,345 @@ test('querySensorDataRange rejects repeated continuation tokens for complete exp
   } finally {
     global.fetch = originalFetch;
   }
+});
+
+test('loadActiveEnvironment migrates legacy series overrides into the active environment', () => {
+  localStorage.setItem('sonde_environments', JSON.stringify([
+    {
+      name: 'prod',
+      clientId: 'client',
+      tenantId: 'tenant',
+      storageAccount: 'storage',
+      functionAppName: 'func',
+    },
+  ]));
+  localStorage.setItem('sonde_active_environment', 'prod');
+  localStorage.setItem('sonde_series_overrides', JSON.stringify({
+    'n:abc|deadbeef|temp_mc': {
+      displayName: 'Office Temperature',
+      scaleDivisor: 1000,
+      unitSuffix: '°C',
+    },
+  }));
+
+  const env = app.loadActiveEnvironment();
+  const stored = app.loadEnvironments();
+
+  assert.equal(env.name, 'prod');
+  assert.deepEqual(stored[0].sensorData.seriesOverrides, {
+    'n:abc|deadbeef|temp_mc': {
+      displayName: 'Office Temperature',
+      scaleDivisor: 1000,
+      unitSuffix: '°C',
+    },
+  });
+  assert.equal(localStorage.getItem('sonde_series_overrides'), null);
+  assert.equal(app.SENSOR_STATE.viewMode, 'graph');
+  assert.equal(app.SENSOR_STATE.timeRange, '24h');
+});
+
+test('handleImportedJson overwrites sensorData preferences instead of merging them', () => {
+  global.window.confirm = () => true;
+  localStorage.setItem('sonde_environments', JSON.stringify([
+    {
+      name: 'other',
+      clientId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      tenantId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      storageAccount: 'otherstorage',
+      functionAppName: 'other-func',
+      sensorData: {
+        viewMode: 'graph',
+        timeRange: '24h',
+        selectedSeries: ['keep-me'],
+        seriesOverrides: {
+          'old|series|key': { displayName: 'Old', scaleDivisor: 1, unitSuffix: 'x' },
+        },
+      },
+    },
+    {
+      name: 'prod',
+      clientId: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      tenantId: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      storageAccount: 'prodstorage',
+      functionAppName: 'prod-func',
+      sensorData: {
+        viewMode: 'graph',
+        timeRange: '24h',
+        selectedSeries: ['old-series'],
+        seriesOverrides: {
+          'old-series': { displayName: 'Old', scaleDivisor: 10, unitSuffix: 'x' },
+        },
+      },
+    },
+  ]));
+  localStorage.setItem('sonde_active_environment', 'other');
+
+  app.handleImportedJson(JSON.stringify({
+    version: 1,
+    name: 'prod',
+    clientId: '11111111-1111-1111-1111-111111111111',
+    tenantId: '22222222-2222-2222-2222-222222222222',
+    storageAccount: 'importedprod',
+    functionAppName: 'imported-func',
+    sensorData: {
+      viewMode: 'table',
+      timeRange: '7d',
+      selectedSeries: ['new-series'],
+      selectedSeriesInitialized: true,
+      seriesOverrides: {
+        'new-series': {
+          displayName: 'Imported',
+          scaleDivisor: 1000,
+          unitSuffix: '°C',
+        },
+      },
+    },
+  }));
+
+  const prod = app.loadEnvironments().find((env) => env.name === 'prod');
+  assert.equal(prod.storageAccount, 'importedprod');
+  assert.deepEqual(prod.sensorData, {
+    viewMode: 'table',
+    timeRange: '7d',
+    selectedSeries: ['new-series'],
+    selectedSeriesInitialized: true,
+    seriesOverrides: {
+      'new-series': {
+        displayName: 'Imported',
+        scaleDivisor: 1000,
+        unitSuffix: '°C',
+      },
+    },
+  });
+});
+
+test('handleImportedJson initializes default sensorData preferences when omitted', () => {
+  app.handleImportedJson(JSON.stringify({
+    version: 1,
+    name: 'prod',
+    clientId: '11111111-1111-1111-1111-111111111111',
+    tenantId: '22222222-2222-2222-2222-222222222222',
+    storageAccount: 'prodstorage',
+    functionAppName: 'prod-func',
+  }));
+
+  assert.deepEqual(app.loadEnvironments()[0].sensorData, app.createDefaultSensorDataPreferences());
+});
+
+test('handleImportedJson preserves an explicit empty selectedSeries preference', () => {
+  localStorage.setItem('sonde_environments', JSON.stringify([
+    {
+      name: 'other',
+      clientId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      tenantId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      storageAccount: 'otherstorage',
+      functionAppName: 'other-func',
+      sensorData: app.createDefaultSensorDataPreferences(),
+    },
+  ]));
+  localStorage.setItem('sonde_active_environment', 'other');
+
+  app.handleImportedJson(JSON.stringify({
+    version: 1,
+    name: 'prod',
+    clientId: '11111111-1111-1111-1111-111111111111',
+    tenantId: '22222222-2222-2222-2222-222222222222',
+    storageAccount: 'prodstorage',
+    functionAppName: 'prod-func',
+    sensorData: {
+      viewMode: 'graph',
+      timeRange: '24h',
+      selectedSeries: [],
+      seriesOverrides: {},
+    },
+  }));
+
+  localStorage.setItem('sonde_active_environment', 'prod');
+  app.loadActiveEnvironment();
+
+  const prod = app.loadEnvironments().find((env) => env.name === 'prod');
+  assert.deepEqual(prod.sensorData, {
+    viewMode: 'graph',
+    timeRange: '24h',
+    selectedSeries: [],
+    selectedSeriesInitialized: true,
+    seriesOverrides: {},
+  });
+  assert.deepEqual([...app.SENSOR_STATE.selectedSeries], []);
+  assert.equal(app.SENSOR_STATE.seriesInitialized, true);
+});
+
+test('validateImportedSensorDataPreferences rejects malformed selectedSeries arrays', () => {
+  assert.throws(
+    () => app.validateImportedSensorDataPreferences({ selectedSeries: ['ok', 42] }),
+    /selectedSeries/,
+  );
+});
+
+test('persistActiveSensorDataPreferences stores environment-scoped Sensor Data view state', () => {
+  localStorage.setItem('sonde_environments', JSON.stringify([
+    {
+      name: 'prod',
+      clientId: '11111111-1111-1111-1111-111111111111',
+      tenantId: '22222222-2222-2222-2222-222222222222',
+      storageAccount: 'prodstorage',
+      functionAppName: 'prod-func',
+      sensorData: app.createDefaultSensorDataPreferences(),
+    },
+  ]));
+  localStorage.setItem('sonde_active_environment', 'prod');
+
+  assert.equal(app.saveSeriesOverrides({
+    'n:abc|deadbeef|temp_mc': {
+      displayName: 'Temp',
+      scaleDivisor: 1000,
+      unitSuffix: '°C',
+    },
+  }), true);
+
+  app.SENSOR_STATE.viewMode = 'table';
+  app.SENSOR_STATE.timeRange = '7d';
+  app.SENSOR_STATE.selectedSeries = new Set(['n:abc|deadbeef|temp_mc']);
+
+  assert.equal(app.persistActiveSensorDataPreferences(), true);
+
+  assert.deepEqual(app.loadEnvironments()[0].sensorData, {
+    viewMode: 'table',
+    timeRange: '7d',
+    selectedSeries: ['n:abc|deadbeef|temp_mc'],
+    selectedSeriesInitialized: true,
+    seriesOverrides: {
+      'n:abc|deadbeef|temp_mc': {
+        displayName: 'Temp',
+        scaleDivisor: 1000,
+        unitSuffix: '°C',
+      },
+    },
+  });
+});
+
+test('buildEnvironmentExportData includes environment-scoped Sensor Data preferences', () => {
+  assert.deepEqual(
+    app.buildEnvironmentExportData({
+      name: 'prod',
+      clientId: '11111111-1111-1111-1111-111111111111',
+      tenantId: '22222222-2222-2222-2222-222222222222',
+      storageAccount: 'prodstorage',
+      functionAppName: 'prod-func',
+      sensorData: {
+        viewMode: 'table',
+        timeRange: '1h',
+        selectedSeries: ['series-a'],
+        seriesOverrides: {
+          'series-a': { displayName: 'Series A', scaleDivisor: 2, unitSuffix: 'V' },
+        },
+      },
+    }),
+    {
+      version: 1,
+      name: 'prod',
+      clientId: '11111111-1111-1111-1111-111111111111',
+      tenantId: '22222222-2222-2222-2222-222222222222',
+      storageAccount: 'prodstorage',
+      functionAppName: 'prod-func',
+      sensorData: {
+        viewMode: 'table',
+        timeRange: '1h',
+        selectedSeries: ['series-a'],
+        seriesOverrides: {
+          'series-a': { displayName: 'Series A', scaleDivisor: 2, unitSuffix: 'V' },
+        },
+      },
+    },
+  );
+});
+
+test('activateEnvironmentState loads saved Sensor Data preferences for the selected environment', () => {
+  app.SENSOR_STATE.timeRange = '24h';
+  app.SENSOR_STATE.viewMode = 'graph';
+  app.SENSOR_STATE.selectedSeries = new Set(['old-series']);
+  app.SENSOR_STATE.seriesInitialized = true;
+
+  app.activateEnvironmentState('prod', {
+    name: 'prod',
+    clientId: '11111111-1111-1111-1111-111111111111',
+    tenantId: '22222222-2222-2222-2222-222222222222',
+    storageAccount: 'prodstorage',
+    functionAppName: 'prod-func',
+    sensorData: {
+      viewMode: 'table',
+      timeRange: '7d',
+      selectedSeries: ['new-series'],
+      selectedSeriesInitialized: true,
+      seriesOverrides: {},
+    },
+  });
+
+  assert.equal(app.CONFIG.storageAccount, 'prodstorage');
+  assert.equal(app.SENSOR_STATE.viewMode, 'table');
+  assert.equal(app.SENSOR_STATE.timeRange, '7d');
+  assert.deepEqual([...app.SENSOR_STATE.selectedSeries], ['new-series']);
+  assert.equal(app.SENSOR_STATE.seriesInitialized, true);
+});
+
+test('activateEnvironmentState resets transient Sensor Data state on environment switch', () => {
+  app.SENSOR_STATE.autoRefresh = true;
+  app.SENSOR_STATE.exportStartMs = 111;
+  app.SENSOR_STATE.exportEndMs = 222;
+  app.SENSOR_STATE.exportFormat = 'csv';
+  app.SENSOR_STATE.exportBusy = true;
+  app.SENSOR_STATE.exportMessage = { kind: 'error', text: 'stale' };
+
+  app.activateEnvironmentState('prod', {
+    name: 'prod',
+    clientId: '11111111-1111-1111-1111-111111111111',
+    tenantId: '22222222-2222-2222-2222-222222222222',
+    storageAccount: 'prodstorage',
+    functionAppName: 'prod-func',
+    sensorData: app.createDefaultSensorDataPreferences(),
+  });
+
+  assert.equal(app.SENSOR_STATE.autoRefresh, false);
+  assert.equal(app.SENSOR_STATE.exportStartMs, null);
+  assert.equal(app.SENSOR_STATE.exportEndMs, null);
+  assert.equal(app.SENSOR_STATE.exportFormat, 'jsonl');
+  assert.equal(app.SENSOR_STATE.exportBusy, false);
+  assert.equal(app.SENSOR_STATE.exportMessage, null);
+});
+
+test('pruneUnavailableSelectedSeries removes stale saved selections without touching valid ones', () => {
+  const selectedSeries = new Set(['keep', 'drop']);
+  const changed = app.pruneUnavailableSelectedSeries(selectedSeries, new Set(['keep']));
+  assert.equal(changed, true);
+  assert.deepEqual([...selectedSeries], ['keep']);
+});
+
+test('buildEnvironmentExportData and import validation distinguish omitted and empty selectedSeries', () => {
+  const defaultExport = app.buildEnvironmentExportData({
+    name: 'prod',
+    clientId: '11111111-1111-1111-1111-111111111111',
+    tenantId: '22222222-2222-2222-2222-222222222222',
+    storageAccount: 'prodstorage',
+    functionAppName: 'prod-func',
+    sensorData: app.createDefaultSensorDataPreferences(),
+  });
+  assert.equal('selectedSeries' in defaultExport.sensorData, false);
+  assert.equal(app.validateImportedSensorDataPreferences(defaultExport.sensorData).selectedSeriesInitialized, false);
+
+  const emptySelectionExport = app.buildEnvironmentExportData({
+    name: 'prod',
+    clientId: '11111111-1111-1111-1111-111111111111',
+    tenantId: '22222222-2222-2222-2222-222222222222',
+    storageAccount: 'prodstorage',
+    functionAppName: 'prod-func',
+    sensorData: {
+      viewMode: 'graph',
+      timeRange: '24h',
+      selectedSeries: [],
+      selectedSeriesInitialized: true,
+      seriesOverrides: {},
+    },
+  });
+  assert.deepEqual(emptySelectionExport.sensorData.selectedSeries, []);
+  assert.equal(app.validateImportedSensorDataPreferences(emptySelectionExport.sensorData).selectedSeriesInitialized, true);
 });


### PR DESCRIPTION
## Summary
- export and import environment-scoped Sensor Data preferences with each web UI environment
- migrate legacy `sonde_series_overrides` into the active environment and preserve explicit empty `selectedSeries`
- reset transient Sensor Data export/auto-refresh state on environment activation and add JS regression coverage

## Traceability
- Requirements: `WEB-0703`, `WEB-0705`, `WEB-0800`, `WEB-0801`, `WEB-0806`, `WEB-0807`, `WEB-0808`
- Design: `docs/web-ui-design.md` sections `10.4`, `10.4b`, `11.2`, `11.2b`, `11.5`
- Validation: updated `docs/web-ui-validation.md` plus `node --test tests/web-ui-app.test.js`

## Audit
- Phase 6 implementation audit passed after fixing empty-vs-omitted `selectedSeries`, traceability gaps, and transient Sensor Data state leakage across environment switches.