### PR TITLE
test-programs: remove pf_trace_printk from BMP280 to fit 4KB limit

### DIFF
--- a/test-programs/bmp280_sensor.c
+++ b/test-programs/bmp280_sensor.c
@@ -130,42 +130,27 @@ int program(struct sonde_context *ctx)
 {
     __u8 chip_id = 0;
     int rc = bmp280_read_bytes(BMP280_REG_CHIP_ID, &chip_id, 1);
-    if (rc < 0 || chip_id != BMP280_CHIP_ID) {
-        char err[] = "bmp280: device not found\n";
-        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
+    if (rc < 0 || chip_id != BMP280_CHIP_ID)
         return 0;
-    }
 
     __u8 calib[BMP280_CALIB_LEN];
     rc = bmp280_read_bytes(BMP280_REG_CALIB_START, calib, sizeof(calib));
-    if (rc < 0) {
-        char err[] = "bmp280: calib read failed\n";
-        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
+    if (rc < 0)
         return 0;
-    }
 
     __u8 ctrl_meas_write[2] = { BMP280_REG_CTRL_MEAS, BMP280_CTRL_MEAS_FORCED };
     rc = i2c_write(BMP280_HANDLE, ctrl_meas_write, sizeof(ctrl_meas_write));
-    if (rc < 0) {
-        char err[] = "bmp280: trigger failed\n";
-        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
+    if (rc < 0)
         return 0;
-    }
 
     rc = delay_us(BMP280_CONVERSION_US);
-    if (rc < 0) {
-        char err[] = "bmp280: delay failed\n";
-        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
+    if (rc < 0)
         return 0;
-    }
 
     __u8 raw[BMP280_RAW_LEN];
     rc = bmp280_read_bytes(BMP280_REG_PRESS_MSB, raw, sizeof(raw));
-    if (rc < 0) {
-        char err[] = "bmp280: raw read failed\n";
-        bpf_trace_printk(err, (__u32)(sizeof(err) - 1));
+    if (rc < 0)
         return 0;
-    }
 
     __s32 adc_p = (__s32)(((__u32)raw[0] << 12) |
                           ((__u32)raw[1] << 4) |


### PR DESCRIPTION
## Summary

The BMP280 BPF program image was 4670 bytes, exceeding the 4096-byte resident program limit enforced by the node flash partition (ND-0500 AC4).

## Changes

Remove all pf_trace_printk calls and their error string literals from mp280_sensor.c. Error paths now silently return 0, consistent with the protocol's silent-discard design.

## Size Impact

| Metric | Before | After | Saved |
|--------|--------|-------|-------|
| \sonde\ section | 1848 B | 1216 B | **632 B** |
| \.rodata\ (strings) | 136 B | 12 B | **124 B** |
| Total node code | 3528 B | 2772 B | **756 B** |
| Instructions | 481 | 416 | **65** |

The CBOR image produced by \ingest_elf()\ should now fit comfortably within the 4096-byte limit.

## What's preserved

- Chip ID verification
- Calibration read
- Forced measurement trigger + delay
- Raw ADC burst read
- Full integer compensation (temperature + pressure)
- 22-byte payload with \send_async\/\send\ fallback
- Decoder section (unchanged)